### PR TITLE
Fixed command calls

### DIFF
--- a/python/pyrogue/_pyrogue.py
+++ b/python/pyrogue/_pyrogue.py
@@ -405,13 +405,13 @@ class Node(object):
                 if isinstance(self._nodes[key],Device):
                     self._nodes[key]._setOrExec(value,writeEach,modes)
 
-                # Set value if variable with enabled mode
-                elif isinstance(self._nodes[key],Variable) and (self._nodes[key].mode in modes):
-                    self._nodes[key].set(value,writeEach)
-
                 # Execute if command
                 elif isinstance(self._nodes[key],Command):
                     self._nodes[key](value)
+
+                # Set value if variable with enabled mode
+                elif isinstance(self._nodes[key],Variable) and (self._nodes[key].mode in modes):
+                    self._nodes[key].set(value,writeEach)
 
 
 class VariableError(Exception):


### PR DESCRIPTION
When command became a sub-class of variable, command execution over the pyre interface broke. This was due to the setOrExec call checking first if an object was an instance of variable before checking if it was a command. 