### PR TITLE
Moved req transaction in lock scope. start timer after return

### DIFF
--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -5,7 +5,6 @@
  * ----------------------------------------------------------------------------
  * File       : Controller.h
  * Created    : 2017-01-07
- * Last update: 2017-01-07
  * ----------------------------------------------------------------------------
  * Description:
  * RSSI Controller
@@ -60,6 +59,9 @@ namespace rogue {
                // Interfaces
                boost::shared_ptr<rogue::protocols::rssi::Transport> tran_;
                boost::shared_ptr<rogue::protocols::rssi::Application> app_;
+
+               // Is server
+               bool server_;
 
                // Receive tracking
                uint32_t dropCount_;
@@ -117,7 +119,7 @@ namespace rogue {
                static boost::shared_ptr<rogue::protocols::rssi::Controller> 
                   create ( uint32_t segSize,
                            boost::shared_ptr<rogue::protocols::rssi::Transport> tran,
-                           boost::shared_ptr<rogue::protocols::rssi::Application> app );
+                           boost::shared_ptr<rogue::protocols::rssi::Application> app, bool server );
 
                //! Setup class in python
                static void setup_python();
@@ -125,7 +127,7 @@ namespace rogue {
                //! Creator
                Controller( uint32_t segSize,
                            boost::shared_ptr<rogue::protocols::rssi::Transport> tran,
-                           boost::shared_ptr<rogue::protocols::rssi::Application> app );
+                           boost::shared_ptr<rogue::protocols::rssi::Application> app, bool server );
 
                //! Destructor
                ~Controller();

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -1,0 +1,91 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : RSSI Server Class
+ * ----------------------------------------------------------------------------
+ * File       : Server.h
+ * Created    : 2017-06-13
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_PROTOCOLS_RSSI_SERVER_H__
+#define __ROGUE_PROTOCOLS_RSSI_SERVER_H__
+#include <boost/python.hpp>
+#include <boost/thread.hpp>
+#include <stdint.h>
+
+namespace rogue {
+   namespace protocols {
+      namespace rssi {
+
+         class Transport;
+         class Application;
+         class Controller;
+
+         //! RSSI Server Class
+         class Server {
+
+               //! Transport module
+               boost::shared_ptr<rogue::protocols::rssi::Transport> tran_;
+
+               //! Application module
+               boost::shared_ptr<rogue::protocols::rssi::Application> app_;
+
+               //! Server module
+               boost::shared_ptr<rogue::protocols::rssi::Controller> cntl_;
+
+            public:
+
+               //! Class creation
+               static boost::shared_ptr<rogue::protocols::rssi::Server> create (uint32_t segSize);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Creator
+               Server(uint32_t segSize);
+
+               //! Destructor
+               ~Server();
+
+               //! Get transport interface
+               boost::shared_ptr<rogue::protocols::rssi::Transport> transport();
+
+               //! Application module
+               boost::shared_ptr<rogue::protocols::rssi::Application> application();
+
+               //! Get state
+               bool getOpen();
+
+               //! Get Down Count
+               uint32_t getDownCount();
+
+               //! Get Drop Count
+               uint32_t getDropCount();
+
+               //! Get Retran Count
+               uint32_t getRetranCount();
+
+               //! Get Busy
+               bool getBusy();
+
+               //! Set timeout in microseconds for frame transmits
+               void setTimeout(uint32_t timeout);
+
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::protocols::rssi::Server> ServerPtr;
+
+      }
+   }
+};
+
+#endif
+

--- a/include/rogue/protocols/srp/SrpV0.h
+++ b/include/rogue/protocols/srp/SrpV0.h
@@ -26,6 +26,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/memory/Slave.h>
+#include <rogue/Logging.h>
 
 namespace rogue {
    namespace protocols {
@@ -39,6 +40,8 @@ namespace rogue {
          class SrpV0 : public rogue::interfaces::stream::Master,
                        public rogue::interfaces::stream::Slave,
                        public rogue::interfaces::memory::Slave {
+
+               rogue::Logging * log_;
 
             public:
 

--- a/include/rogue/protocols/srp/SrpV3.h
+++ b/include/rogue/protocols/srp/SrpV3.h
@@ -26,6 +26,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/memory/Slave.h>
+#include <rogue/Logging.h>
 
 namespace rogue {
    namespace protocols {
@@ -39,6 +40,9 @@ namespace rogue {
          class SrpV3 : public rogue::interfaces::stream::Master,
                        public rogue::interfaces::stream::Slave,
                        public rogue::interfaces::memory::Slave {
+
+
+               rogue::Logging * log_;
 
             public:
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -386,13 +386,15 @@ class MemoryBlock(BaseBlock, rogue.interfaces.memory.Master):
             self._doVerify = (type == rogue.interfaces.memory.Verify)
             self._doUpdate = (type == rogue.interfaces.memory.Read)
             self._error    = 0
-            self._tranTime = time.time()
 
             # Set data pointer
             tData = self._vData if self._doVerify else self._bData
 
-        # Start transaction outside of lock
-        self._reqTransaction(self._variables[0].offset,tData,type)
+            # Start transaction
+            self._reqTransaction(self._variables[0].offset,tData,type)
+
+            # Start timer after return
+            self._tranTime = time.time()
 
     def _doneTransaction(self,tid,error):
         """

--- a/python/pyrogue/protocols.py
+++ b/python/pyrogue/protocols.py
@@ -40,8 +40,6 @@ class UdpRssiPack(pr.Device):
         self._rssi.application()._setSlave(self._pack.transport())
         self._pack.transport()._setSlave(self._rssi.application())
 
-        self._log = pyrogue.logInit(self)
-
         self.add(pr.LocalVariable(name='rssiOpen',        mode='RO', value=0, pollInterval=1, getFunction=self.getRssiOpen))
         self.add(pr.LocalVariable(name='rssiDownCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDownCount))
         self.add(pr.LocalVariable(name='rssiDropCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDropCount))

--- a/python/pyrogue/protocols.py
+++ b/python/pyrogue/protocols.py
@@ -16,15 +16,16 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import pyrogue
+import pyrogue as pr
 import rogue.protocols.udp
 import rogue.protocols.rssi
 import rogue.protocols.packetizer
 import time
 
-class UdpRssiPack(object):
+class UdpRssiPack(pr.Device):
 
-    def __init__(self,host,port,size,wait=True):
+    def __init__(self,host,port,size,wait=True, **kwargs):
+        super(self.__class__, self).__init__(**kwargs)
         self._host = host
         self._port = port
         self._size = size
@@ -41,6 +42,13 @@ class UdpRssiPack(object):
 
         self._log = pyrogue.logInit(self)
 
+        self.add(pr.LocalVariable(name='rssiOpen',        mode='RO', value=0, pollInterval=1, getFunction=self.getRssiOpen))
+        self.add(pr.LocalVariable(name='rssiDownCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDownCount))
+        self.add(pr.LocalVariable(name='rssiDropCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDropCount))
+        self.add(pr.LocalVariable(name='rssiRetranCount', mode='RO', value=0, pollInterval=1, getFunction=self.getRssiRetranCount))
+        self.add(pr.LocalVariable(name='packDropCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getPackDropCount))
+        self.add(pr.LocalVariable(name='getRssiBusy',     mode='RO', value=0, pollInterval=1, getFunction=self.getRssiBusy))
+
         if wait:
             curr = int(time.time())
             last = curr
@@ -55,21 +63,21 @@ class UdpRssiPack(object):
     def application(self,dest):
         return(self._pack.application(dest))
 
-    def getRssiOpen(self):
+    def getRssiOpen(self,dev=None,cmd=None):
         return(self._rssi.getOpen())
 
-    def getRssiDownCount(self):
+    def getRssiDownCount(self,dev=None,cmd=None):
         return(self._rssi.getDownCount())
 
-    def getRssiDropCount(self):
+    def getRssiDropCount(self,dev=None,cmd=None):
         return(self._rssi.getDropCount())
 
-    def getRssiRetranCount(self):
+    def getRssiRetranCount(self,dev=None,cmd=None):
         return(self._rssi.getRetranCount())
 
-    def getPackDropCount(self):
+    def getPackDropCount(self,dev=None,cmd=None):
         return(self._pack.getDropCount())
 
-    def getRssiBusy(self):
+    def getRssiBusy(self,dev=None,cmd=None):
         return(self._rssi.getBusy())
 

--- a/python/pyrogue/protocols.py
+++ b/python/pyrogue/protocols.py
@@ -40,12 +40,12 @@ class UdpRssiPack(pr.Device):
         self._rssi.application()._setSlave(self._pack.transport())
         self._pack.transport()._setSlave(self._rssi.application())
 
-        self.add(pr.LocalVariable(name='rssiOpen',        mode='RO', value=0, pollInterval=1, getFunction=self.getRssiOpen))
-        self.add(pr.LocalVariable(name='rssiDownCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDownCount))
-        self.add(pr.LocalVariable(name='rssiDropCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getRssiDropCount))
-        self.add(pr.LocalVariable(name='rssiRetranCount', mode='RO', value=0, pollInterval=1, getFunction=self.getRssiRetranCount))
-        self.add(pr.LocalVariable(name='packDropCount',   mode='RO', value=0, pollInterval=1, getFunction=self.getPackDropCount))
-        self.add(pr.LocalVariable(name='getRssiBusy',     mode='RO', value=0, pollInterval=1, getFunction=self.getRssiBusy))
+        self.add(pr.LocalVariable(name='rssiOpen',        mode='RO', value=0, pollInterval=1, localGet=self.getRssiOpen))
+        self.add(pr.LocalVariable(name='rssiDownCount',   mode='RO', value=0, pollInterval=1, localGet=self.getRssiDownCount))
+        self.add(pr.LocalVariable(name='rssiDropCount',   mode='RO', value=0, pollInterval=1, localGet=self.getRssiDropCount))
+        self.add(pr.LocalVariable(name='rssiRetranCount', mode='RO', value=0, pollInterval=1, localGet=self.getRssiRetranCount))
+        self.add(pr.LocalVariable(name='packDropCount',   mode='RO', value=0, pollInterval=1, localGet=self.getPackDropCount))
+        self.add(pr.LocalVariable(name='getRssiBusy',     mode='RO', value=0, pollInterval=1, localGet=self.getRssiBusy))
 
         if wait:
             curr = int(time.time())

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -31,15 +31,15 @@ class PrbsRx(pyrogue.Device):
 
         self.add(pyrogue.LocalVariable(name='rxErrors', description='RX Error Count',
                                        base='uint', mode='RO', pollInterval=1, value=0,
-                                       getFunction='value = dev._prbs.getRxErrors()'))
+                                       localGet='value = dev._prbs.getRxErrors()'))
 
         self.add(pyrogue.LocalVariable(name='rxCount', description='RX Count',
                                        base='uint', mode='RO', pollInterval=1, value=0,
-                                       getFunction='value = dev._prbs.getRxCount()'))
+                                       localGet='value = dev._prbs.getRxCount()'))
 
         self.add(pyrogue.LocalVariable(name='rxBytes', description='RX Bytes',
                                        base='uint', mode='RO', pollInterval=1, value=0,
-                                       getFunction='value = dev._prbs.getRxBytes()'))
+                                       localGet='value = dev._prbs.getRxBytes()'))
 
         self.add(pyrogue.LocalCommand(name='resetCount',description='Reset counters',
                                       function='dev._prbs.resetCount()'))
@@ -61,19 +61,19 @@ class PrbsTx(pyrogue.Device):
                                        base='uint', mode='RW', value=0))
 
         self.add(pyrogue.LocalVariable(name='txEnable', description='PRBS Run Enable', base='bool', mode='RW',
-                                       value=0, setFunction=self._txEnable))
+                                       value=0, localSet=self._txEnable))
 
         self.add(pyrogue.LocalCommand(name='genFrame',description='Generate a single frame',
                                       function='dev._prbs.genFrame(dev.txSize.value())'))
 
         self.add(pyrogue.LocalVariable(name='txErrors', description='TX Error Count', base='uint', mode='RO', pollPeriod = 1,
-                                       value=0, getFunction='value = dev._prbs.getTxErrors()'))
+                                       value=0, localGet='value = dev._prbs.getTxErrors()'))
 
         self.add(pyrogue.LocalVariable(name='txCount', description='TX Count', base='uint', mode='RO', pollPeriod = 1,
-                                       value=0, getFunction='value = dev._prbs.getTxCount()'))
+                                       value=0, localGet='value = dev._prbs.getTxCount()'))
 
         self.add(pyrogue.LocalVariable(name='txBytes', description='TX Bytes', base='uint', mode='RO', pollPeriod = 1,
-                                       value=0, getFunction='value = dev._prbs.getTxBytes()'))
+                                       value=0, localGet='value = dev._prbs.getTxBytes()'))
 
         self.add(pyrogue.LocalCommand(name='resetCount',description='Reset counters',
                                       function='dev._prbs.resetCount()'))

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -40,8 +40,8 @@ namespace bp  = boost::python;
 //! Class creation
 rpr::ControllerPtr rpr::Controller::create ( uint32_t segSize, 
                                              rpr::TransportPtr tran, 
-                                             rpr::ApplicationPtr app ) {
-   rpr::ControllerPtr r = boost::make_shared<rpr::Controller>(segSize,tran,app);
+                                             rpr::ApplicationPtr app, bool server ) {
+   rpr::ControllerPtr r = boost::make_shared<rpr::Controller>(segSize,tran,app,server);
    return(r);
 }
 
@@ -50,9 +50,10 @@ void rpr::Controller::setup_python() {
 }
 
 //! Creator
-rpr::Controller::Controller ( uint32_t segSize, rpr::TransportPtr tran, rpr::ApplicationPtr app ) {
-   app_  = app;
-   tran_ = tran;
+rpr::Controller::Controller ( uint32_t segSize, rpr::TransportPtr tran, rpr::ApplicationPtr app, bool server ) {
+   app_    = app;
+   tran_   = tran;
+   server_ = server;
 
    timeout_ = 0;
 

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -1,13 +1,9 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : RSSI Client Class
+ * Title      : RSSI Server Class
  * ----------------------------------------------------------------------------
- * File       : Client.h
- * Created    : 2017-01-07
- * Last update: 2017-01-07
- * ----------------------------------------------------------------------------
- * Description:
- * UDP Client
+ * File       : Server.h
+ * Created    : 2017-06-13
  * ----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -18,7 +14,7 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <rogue/protocols/rssi/Client.h>
+#include <rogue/protocols/rssi/Server.h>
 #include <rogue/protocols/rssi/Transport.h>
 #include <rogue/protocols/rssi/Application.h>
 #include <rogue/protocols/rssi/Controller.h>
@@ -31,79 +27,79 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 
 //! Class creation
-rpr::ClientPtr rpr::Client::create (uint32_t segSize) {
-   rpr::ClientPtr r = boost::make_shared<rpr::Client>(segSize);
+rpr::ServerPtr rpr::Server::create (uint32_t segSize) {
+   rpr::ServerPtr r = boost::make_shared<rpr::Server>(segSize);
    return(r);
 }
 
-void rpr::Client::setup_python() {
+void rpr::Server::setup_python() {
 
-   bp::class_<rpr::Client, rpr::ClientPtr, boost::noncopyable >("Client",bp::init<uint32_t>())
-      .def("create",         &rpr::Client::create)
+   bp::class_<rpr::Server, rpr::ServerPtr, boost::noncopyable >("Server",bp::init<uint32_t>())
+      .def("create",         &rpr::Server::create)
       .staticmethod("create")
-      .def("transport",      &rpr::Client::transport)
-      .def("application",    &rpr::Client::application)
-      .def("getOpen",        &rpr::Client::getOpen)
-      .def("getDownCount",   &rpr::Client::getDownCount)
-      .def("getDropCount",   &rpr::Client::getDropCount)
-      .def("getRetranCount", &rpr::Client::getRetranCount)
-      .def("getBusy",        &rpr::Client::getBusy)
+      .def("transport",      &rpr::Server::transport)
+      .def("application",    &rpr::Server::application)
+      .def("getOpen",        &rpr::Server::getOpen)
+      .def("getDownCount",   &rpr::Server::getDownCount)
+      .def("getDropCount",   &rpr::Server::getDropCount)
+      .def("getRetranCount", &rpr::Server::getRetranCount)
+      .def("getBusy",        &rpr::Server::getBusy)
    ;
 
 }
 
 //! Creator
-rpr::Client::Client (uint32_t segSize) {
+rpr::Server::Server (uint32_t segSize) {
    app_   = rpr::Application::create();
    tran_  = rpr::Transport::create();
-   cntl_  = rpr::Controller::create(segSize,tran_,app_,false);
+   cntl_  = rpr::Controller::create(segSize,tran_,app_,true);
 
    app_->setController(cntl_);
    tran_->setController(cntl_);
 }
 
 //! Destructor
-rpr::Client::~Client() { 
+rpr::Server::~Server() { 
    cntl_->stop();
 }
 
 //! Get transport interface
-rpr::TransportPtr rpr::Client::transport() {
+rpr::TransportPtr rpr::Server::transport() {
    return(tran_);
 }
 
 //! Application module
-rpr::ApplicationPtr rpr::Client::application() {
+rpr::ApplicationPtr rpr::Server::application() {
    return(app_);
 }
 
 //! Get state
-bool rpr::Client::getOpen() {
+bool rpr::Server::getOpen() {
    return(cntl_->getOpen());
 }
 
 //! Get Down Count
-uint32_t rpr::Client::getDownCount() {
+uint32_t rpr::Server::getDownCount() {
    return(cntl_->getDownCount());
 }
 
 //! Get Drop Count
-uint32_t rpr::Client::getDropCount() {
+uint32_t rpr::Server::getDropCount() {
    return(cntl_->getDropCount());
 }
 
 //! Get Retran Count
-uint32_t rpr::Client::getRetranCount() {
+uint32_t rpr::Server::getRetranCount() {
    return(cntl_->getRetranCount());
 }
 
 //! Get busy
-bool rpr::Client::getBusy() {
+bool rpr::Server::getBusy() {
    return(cntl_->getBusy());
 }
 
 //! Set timeout for frame transmits in microseconds
-void rpr::Client::setTimeout(uint32_t timeout) {
+void rpr::Server::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
 }
 

--- a/src/rogue/protocols/rssi/module.cpp
+++ b/src/rogue/protocols/rssi/module.cpp
@@ -25,6 +25,7 @@
 #include <rogue/protocols/rssi/Application.h>
 #include <rogue/protocols/rssi/Controller.h>
 #include <rogue/protocols/rssi/Client.h>
+#include <rogue/protocols/rssi/Server.h>
 #include <rogue/protocols/rssi/Header.h>
 #include <rogue/protocols/rssi/Transport.h>
 
@@ -45,6 +46,7 @@ void rpr::setup_module() {
    rpr::Application::setup_python();
    rpr::Controller::setup_python();
    rpr::Client::setup_python();
+   rpr::Server::setup_python();
    rpr::Header::setup_python();
    rpr::Transport::setup_python();
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -28,6 +28,7 @@
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/protocols/srp/SrpV0.h>
+#include <rogue/Logging.h>
 
 namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
@@ -51,7 +52,9 @@ void rps::SrpV0::setup_python() {
 }
 
 //! Creator with version constant
-rps::SrpV0::SrpV0() : ris::Master(), ris::Slave(), rim::Slave(4,2048) { }
+rps::SrpV0::SrpV0() : ris::Master(), ris::Slave(), rim::Slave(4,2048) { 
+   log_ = new rogue::Logging("SrpV0");
+}
 
 //! Deconstructor
 rps::SrpV0::~SrpV0() {}
@@ -117,6 +120,7 @@ void rps::SrpV0::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t addr
    if ( type == rim::Post ) master->doneTransaction(id,0);
    else addMaster(id,master);
 
+   log_->debug("Send frame for id=0x%08x, addr 0x%08x. Size=%i, type=%i",id,address,size,type);
    sendFrame(frame);
 }
 
@@ -134,6 +138,8 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract id from frame
    frame->read(&id,0,4);
+
+   log_->debug("Recv frame for id=0x%08x",id);
 
    // Find master
    if ( ! validMaster(id) ) return; // Bad id or post, drop frame

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -28,6 +28,7 @@
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/protocols/srp/SrpV3.h>
+#include <rogue/Logging.h>
 
 namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
@@ -55,7 +56,9 @@ void rps::SrpV3::setup_python() {
 }
 
 //! Creator with version constant
-rps::SrpV3::SrpV3() : ris::Master(), ris::Slave(), rim::Slave(4,2^32) { }
+rps::SrpV3::SrpV3() : ris::Master(), ris::Slave(), rim::Slave(4,2^32) { 
+   log_ = new rogue::Logging("SrpV3");
+}
 
 //! Deconstructor
 rps::SrpV3::~SrpV3() {}
@@ -127,6 +130,7 @@ void rps::SrpV3::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t addr
    if ( type == rim::Post ) master->doneTransaction(id,0);
    else addMaster(id,master);
 
+   log_->debug("Send frame for id=0x%08x, addr 0x%08x. Size=%i, type=%i",id,address,size,type);
    sendFrame(frame);
 }
 
@@ -144,6 +148,8 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract id from frame
    frame->read(&id,4,4);
+
+   log_->debug("Recv frame for id=0x%08x",id);
 
    // Find master
    if ( ! validMaster(id) ) return; // Bad id or post, drop frame


### PR DESCRIPTION
This breaks my general rule of only holding one lock at a time but I think it is necessary (_reqTransaction will grab a lock). The lock on block should not be released until the transaction gets queued. Otherwise if the queue blocks other processes can start a transaction on the block in parallel. Also the timer should not start until the transaction is queued.