### PR TITLE
Misc bugfixes

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -149,9 +149,6 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             if node._memBase is None:
                 node._setSlave(self)
 
-            # Build the device blocks
-            node._buildBlocks()
-
         # Call node add
         pr.Node.add(self,node)
 
@@ -315,6 +312,9 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             if not any(block._addVariable(n) for block in self._blocks):
                 self._log.debug("Adding new block {} at offset {:#02x}".format(n.name,n.offset))
                 self._blocks.append(pr.MemoryBlock(n))
+
+    def _rootAttached(self):
+        self._buildBlocks()
 
     def _devReset(self,rstType):
         """Generate a count, soft or hard reset"""

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -210,7 +210,7 @@ class BaseVariable(pr.Node):
             elif t == bool:
                 return str.lower(sValue) == "true"
             else:
-                return str
+                return sValue
             #return (parse.parse(self.disp, sValue)[0])
 
     @Pyro4.expose


### PR DESCRIPTION
BaseVariable.parseDisp was returning str (the class) instead of just passing the string though in the case where the nativeType is str.

Also now have Device._buildBlocks run in _rootAttached(), to be sure that the memBase chain is fully established and the maxTransactionSize known before making the blocks.