### PR TITLE
updated decorator

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -349,18 +349,19 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             if 'name' not in kwargs:
                 kwargs['name'] = func.__name__
 
-            argCount = len(inspect.signature(func).parameters)
-            def newFuncArg(arg):
-                return func(arg)
-            def newFuncNoArg():
-                return func()
+            fargs = inspect.getfullargspec(func).args
 
-            if argCount == 0:
-                newFunc = newFuncNoArg
+            # Handle functions with the wrong arg name and genere warning
+            if len(fargs) > 0 and 'arg' not in fargs:
+                log.warning("Decorated init functions must have the parameter name 'arg': {}".format(self.path))
+
+                def newFunc(arg):
+                    return func(arg)
+
+                self.add(pr.LocalCommand(function=newFunc, **kwargs))
             else:
-                newFunc = newFuncArg
+                self.add(pr.LocalCommand(function=func, **kwargs))
 
-            self.add(pr.LocalCommand(function=newFunc, **kwargs))
             return func
         return _decorator
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -350,11 +350,16 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
                 kwargs['name'] = func.__name__
 
             argCount = len(inspect.signature(func).parameters)
-            def newFunc(val):
-                if argCount == 0:
-                    return func()
-                else:
-                    return func(val)
+            def newFuncArg(arg):
+                return func(val)
+            def newFuncNoArg():
+                return func()
+
+            if argCount == 0:
+                newFunc = newFuncNoArg
+            else:
+                newFunc = newFuncArg
+
             self.add(pr.LocalCommand(function=newFunc, **kwargs))
             return func
         return _decorator

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -351,7 +351,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
             argCount = len(inspect.signature(func).parameters)
             def newFuncArg(arg):
-                return func(val)
+                return func(arg)
             def newFuncNoArg():
                 return func()
 


### PR DESCRIPTION
The init decorator did not have the correct named args. Also the decorator forces the arg to be passed and will cause issues with the arg detection. This version corrects both.

I simpler fix which just returns the original func is possible if the original function has the correct arg names. Thoughts?