### PR TITLE
Adding log filters to c++ logging

### DIFF
--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -26,21 +26,39 @@
 
 namespace rogue {
 
+   //! Filter
+   class LogFilter {
+      public:
+
+         std::string name_;
+         uint32_t level_;
+
+         LogFilter(std::string name, uint32_t level){
+            name_  = name;
+            level_ = level;
+         }
+   };
+
    //! Logging
    class Logging {
-         //boost::python::object _logging;
-         //boost::python::object _logger;
       
-         //! Logging level 
-         static uint32_t level_; 
+         //! Global Logging level 
+         static uint32_t gblLevel_; 
 
          //! Logging level lock
          static boost::mutex levelMtx_;
-         
-         char * name_;
+
+         //! List of filters
+         static std::vector <rogue::LogFilter *> filters_;
 
          void intLog ( uint32_t level, const char *format, va_list args);
-         
+
+         //! Local logging level
+         uint32_t level_;
+
+         //! Logger name
+         std::string name_;
+
       public:
 
          static const uint32_t Critical = 50;
@@ -49,10 +67,11 @@ namespace rogue {
          static const uint32_t Info     = 20;
          static const uint32_t Debug    = 10;
 
-         Logging (const char *name);
+         Logging (std::string name);
          ~Logging();
 
          static void setLevel(uint32_t level);
+         static void setFilter(std::string filter, uint32_t level);
 
          void log(uint32_t level, const char * fmt, ...);
          void critical(const char * fmt, ...);

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -34,6 +34,9 @@ uint32_t rogue::Logging::gblLevel_ = rogue::Logging::Error;
 // Logging level lock
 boost::mutex rogue::Logging::levelMtx_;
 
+// Filter list
+std::vector <rogue::LogFilter *> rogue::Logging::filters_;
+
 rogue::Logging::Logging(std::string name) {
    std::vector<rogue::LogFilter *>::iterator it;
 


### PR DESCRIPTION
I have added the ability to filter c++ logging. 

The existing method still exists which sets a global log level for the c++ code:

rogue.Logging.setLevel(rogue.Logging.Debug)

Now you can also filter logging based upon the module name. The names are hierarchical and you can filter at any level. Each module will select the lowest log level that matches its name:

rogue.Logging.setFilter("pyrogue.rssi",rogue.Logging.Info)
rogue.Logging.setFilter("pyrogue.rssi.Application",rogue.Logging.Debug)

The interface within c++ is still the same for creating logs. Adding logging which is not enabled is not a large performance hit as the logging filter is a quick if statement.

We will still need to add logging to c++ modules as we need them, as some of them were created before the logging utility existed. I have added more logging to srp, rssi and the packetizer.

Python logging still uses the standard python logging utility.





