### PR TITLE
Remove rawblock and fix bugs in last pull request

### DIFF
--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -55,9 +55,6 @@ namespace rogue {
                //! Destroy a hub
                ~Hub();
 
-               //! Get address
-               uint64_t getAddress();
-
                //! Return min access size to requesting master
                uint32_t doMinAccess();
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -272,6 +272,35 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for key,value in self.devices.items():
                 value.checkBlocks(varUpdate=varUpdate, recurse=True)
 
+    def rawWrite(self,address,value):
+        if isinstance(value,bytearray):
+            ldata = value
+        else:
+            ldata = value.to_bytes(4,'little',signed=False)
+
+        self._waitTransaction()
+        self._reqTransaction(address,ldata,rogue.interfaces.memory.Write)
+        self._waitTransaction()
+
+        if self._getError() > 0:
+            raise DeviceError("RawWrite error in device {}.  Error={}".format(self.name,self.error))
+
+    def rawRead(self,address,bdata=None):
+        if bdata:
+            ldata = bdata
+        else:
+            ldata = bytearray(4)
+
+        self._waitTransaction()
+        self._reqTransaction(address,ldata,rogue.interfaces.memory.Read)
+        self._waitTransaction()
+
+        if self._getError() > 0:
+            raise DeviceError("RawRead error in device {}.  Error={}".format(self.name,self.error))
+
+        elif bdata is None:
+            return int.from_bytes(ldata,'little',signed=False)
+
     def _buildBlocks(self):
         remVars = []
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -278,7 +278,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for key,value in self.devices.items():
                 value.checkBlocks(varUpdate=varUpdate, recurse=True)
 
-    def rawWrite(self,address,value):
+    def _rawWrite(self,address,value):
         with self._rawLock:
 
             if isinstance(value,bytearray):
@@ -292,7 +292,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=self.address, error=self._getError())
 
-    def rawRead(self,address,bdata=None):
+    def _rawRead(self,address,bdata=None):
         with self._rawLock:
             if bdata:
                 ldata = bdata

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -303,6 +303,9 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         if self._getError() > 0:
             raise pr.MemoryError (name=self.name, address=self.address, error=self._getError())
 
+        if bdata is None:
+            return int.from_bytes(ldata,'little',signed=False)
+
     def _buildBlocks(self):
         remVars = []
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -125,6 +125,11 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
     def expand(self):
         return self._expand
 
+    @Pyro4.expose
+    @property
+    def address(self):
+        return self._getAddress()
+
     def add(self,node):
         """
         Add node as sub-node in the object
@@ -283,7 +288,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         self._waitTransaction()
 
         if self._getError() > 0:
-            raise DeviceError("RawWrite error in device {}.  Error={}".format(self.name,self.error))
+            raise pr.MemoryError (name=self.name, address=self.address, error=self._getError())
 
     def rawRead(self,address,bdata=None):
         if bdata:
@@ -296,10 +301,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         self._waitTransaction()
 
         if self._getError() > 0:
-            raise DeviceError("RawRead error in device {}.  Error={}".format(self.name,self.error))
-
-        elif bdata is None:
-            return int.from_bytes(ldata,'little',signed=False)
+            raise pr.MemoryError (name=self.name, address=self.address, error=self._getError())
 
     def _buildBlocks(self):
         remVars = []

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -43,11 +43,6 @@ rim::Hub::Hub(uint64_t address) : Master (), Slave(0,0) {
 //! Destroy a block
 rim::Hub::~Hub() { }
 
-//! Get address
-uint64_t rim::Hub::getAddress() {
-   return(address_);
-}
-
 //! Return min access size to requesting master
 uint32_t rim::Hub::doMinAccess() {
    return(reqMinAccess());
@@ -80,7 +75,7 @@ void rim::Hub::setup_python() {
    bp::class_<rim::Hub, rim::HubPtr, bp::bases<rim::Master,rim::Slave>, boost::noncopyable>("Hub",bp::init<uint64_t>())
       .def("create", &rim::Hub::create)
       .staticmethod("create")
-      .def("_getAddress", &rim::Hub::getAddress)
+      .def("_getAddress", &rim::Hub::doOffset)
    ;
 
    bp::implicitly_convertible<rim::HubPtr, rim::MasterPtr>();

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -193,8 +193,6 @@ void rim::Master::reqTransactionPy(uint64_t address, boost::python::object p, ui
          tId_     = genId();
          id       = tId_;
          pyValid_ = true;
-
-         gettimeofday(&tranTime_,NULL);
       }
    }
    slave->doTransaction(id,shared_from_this(),address,size,type);
@@ -305,7 +303,6 @@ void rim::MasterWrap::doneTransaction(uint32_t id, uint32_t error) {
       if (boost::python::override pb = this->get_override("_doneTransaction")) {
          try {
             pb(id,error);
-            return;
          } catch (...) {
             PyErr_Print();
          }


### PR DESCRIPTION
rawBlock has been removed. It has been replaced with rawWrite and rawRead calls in the Device class.

So instead of creating the rawBlock object and calling write and read on it, simply call self.rawWrite and self.rawRead with the same api. Performance has improved a bit. ~12Khz at 10Gbps.

This also fixes a bug I found in the last pull request which was causing some memory transactions to have undefined errors. waitTransaction() was not truly waiting for the transaction to complete. 

recompile is required.