### PR TITLE
Added 'find()' method to Node

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -219,7 +219,7 @@ class Node(object):
     def node(self, path):
         return self._nodes[path]
 
-    def find(self, *, recurse=True, typ=None, **kwargs):
+     def find(self, *, recurse=True, typ=None, **kwargs):
         """ 
         Find all child nodes that are a base class of 'typ'
         and whose properties match all of the kwargs.
@@ -235,16 +235,21 @@ class Node(object):
                 for prop, value in kwargs.items():
                     if not hasattr(node, prop):
                         break
+                    attr = getattr(node, prop)
                     if isinstance(value, str):
-                        if not re.match(value, getattr(node, prop)):
+                        if not re.match(value, attr):
                             break
-                    elif (value != getattr(node, prop)):
-                        break
+
+                    else:
+                        if inspect.ismethod(attr):
+                            attr = attr()
+                        if not value == attr:
+                            break
                 else:
                     found.append(node)
             if recurse:
                 found.extend(node.find(recurse=recurse, typ=typ, **kwargs))
-        return found    
+        return found
 
     def _rootAttached(self,parent,root):
         """Called once the root node is attached."""

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -219,6 +219,23 @@ class Node(object):
     def node(self, path):
         return self._nodes[path]
 
+    def find(self, name='.*', typ=None):
+        """ 
+        Find all Nodes in the tree that match 'name' regex and are an instance of 'typ' 
+        name defaults to match everything
+        typ defaults to match all pyroge.Node instances
+        """
+        
+        if typ is None:
+            typ = pr.Node
+
+        found = []
+        for k,n in self._nodes.items():
+            if (re.match(name, k)) and isinstance(n, typ):
+                found.append(n)
+            found.extend(n.find(name=name, typ=typ))
+        return found
+
     def _rootAttached(self,parent,root):
         """Called once the root node is attached."""
         self._parent = parent

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -219,7 +219,7 @@ class Node(object):
     def node(self, path):
         return self._nodes[path]
 
-     def find(self, *, recurse=True, typ=None, **kwargs):
+    def find(self, *, recurse=True, typ=None, **kwargs):
         """ 
         Find all child nodes that are a base class of 'typ'
         and whose properties match all of the kwargs.

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -219,22 +219,31 @@ class Node(object):
     def node(self, path):
         return self._nodes[path]
 
-    def find(self, name='.*', typ=None):
+    def find(self, typ=None, **kwargs):
         """ 
-        Find all Nodes in the tree that match 'name' regex and are an instance of 'typ' 
-        name defaults to match everything
-        typ defaults to match all pyroge.Node instances
+        Find all child nodes that are a base class of 'typ'
+        and whose properties match all of the kwargs.
+        For string properties, accepts regexes.
         """
-        
+    
         if typ is None:
             typ = pr.Node
 
         found = []
-        for k,n in self._nodes.items():
-            if (re.match(name, k)) and isinstance(n, typ):
-                found.append(n)
-            found.extend(n.find(name=name, typ=typ))
-        return found
+        for node in self._nodes.values():
+            if isinstance(node, typ):
+                for prop, value in kwargs.items():
+                    if not hasattr(node, prop):
+                        break
+                    if isinstance(value, str):
+                        if not re.match(value, getattr(node, prop)):
+                            break
+                    elif (value != getattr(node, prop)):
+                        break
+                else:
+                    found.append(node)
+            found.extend(node.find(typ=typ, **kwargs))
+        return found    
 
     def _rootAttached(self,parent,root):
         """Called once the root node is attached."""

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -219,7 +219,7 @@ class Node(object):
     def node(self, path):
         return self._nodes[path]
 
-    def find(self, typ=None, **kwargs):
+    def find(self, *, recurse=True, typ=None, **kwargs):
         """ 
         Find all child nodes that are a base class of 'typ'
         and whose properties match all of the kwargs.
@@ -242,7 +242,8 @@ class Node(object):
                         break
                 else:
                     found.append(node)
-            found.extend(node.find(typ=typ, **kwargs))
+            if recurse:
+                found.extend(node.find(recurse=recurse, typ=typ, **kwargs))
         return found    
 
     def _rootAttached(self,parent,root):


### PR DESCRIPTION
Can now find all Nodes at any level of the tree by name regex, base class, or both.