### PR TITLE
ESROGUE-60 and other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@
 # ----------------------------------------------------------------------------
 
 VER_MAJOR := 2
-VER_MINOR := 1
-VER_MAINT := 1
+VER_MINOR := 2
+VER_MAINT := 0
 
 # Variables
 CC       := g++

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -26,6 +26,7 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/python.hpp>
 #include <boost/thread.hpp>
+#include <rogue/Logging.h>
 
 namespace rogue {
    namespace interfaces {
@@ -51,9 +52,6 @@ namespace rogue {
 
                //! Transaction size
                uint32_t tSize;
-
-               //! Transaction id
-               uint32_t tId;
          };
 
          //! Slave container
@@ -82,6 +80,9 @@ namespace rogue {
 
                //! Transaction error
                uint32_t error_;
+
+               //! Log
+               rogue::Logging * log_;
 
             protected:
 

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -41,6 +41,9 @@ namespace rogue {
                //! Transaction start time
                struct timeval endTime;
 
+               //! Transaction start time
+               struct timeval startTime;
+
                //! Transaction python buffer
                Py_buffer pyBuf;
 

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -143,7 +143,8 @@ namespace rogue {
                uint32_t reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type);
 
                //! Post a transaction, called locally, forwarded to slave, python version
-               uint32_t reqTransactionPy(uint64_t address, boost::python::object p, uint32_t type);
+               // size and offset are optional to use a slice within the python buffer
+               uint32_t reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type);
 
                //! End current transaction, ensures data pointer is not update and de-allocates python buffer
                void endTransaction(uint32_t id);

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -95,6 +95,9 @@ namespace rogue {
                //! Reset transaction data
                void rstTransaction(uint32_t id, uint32_t error, bool notify);
 
+               //! Request transaction
+               uint32_t intTransaction(uint64_t address, rogue::interfaces::memory::MasterTransaction *tran, uint32_t type);
+
             public:
 
                //! Create a master container

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -137,7 +137,7 @@ namespace rogue {
                void setError(uint32_t error);
 
                //! Set timeout
-               void setTimeout(uint32_t timeout);
+               void setTimeout(uint64_t timeout);
 
                //! Post a transaction, called locally, forwarded to slave, data pointer is optional
                uint32_t reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type);

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -147,11 +147,12 @@ class BaseBlock(object):
 
 class LocalBlock(BaseBlock):
     def __init__(self, *, variable, localSet, localGet, value):
-        BaseBlock.__init__(self, name=variable.name, mode=variable.mode, device=variable.parent)
+        BaseBlock.__init__(self, name=variable.path, mode=variable.mode, device=variable.parent)
 
         self._localSet = localSet
         self._localGet = localGet
         self._variable = variable
+        self._variables = [variable] # Used by poller
         self._value = value
 
 
@@ -322,7 +323,7 @@ class RegisterBlock(RemoteBlock):
         Initialize memory block class.
         Pass initial variable.
         """
-        super().__init__(name=variable.name, mode=variable.mode, device=variable.parent, offset=variable.offset)
+        super().__init__(name=variable.path, mode=variable.mode, device=variable.parent, offset=variable.offset)
 
         self._variables = []
         self._addVariable(variable)

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -137,7 +137,7 @@ class BaseBlock(object):
         with self._lock:
             doUpdate = update and self._doUpdate
             self._doUpdate = False
-            for x in range(0,self._lockCnt): self._lock.release()
+            for x in range(self._lockCnt): self._lock.release()
             self._lockCnt = 0
 
         # Update variables outside of lock
@@ -145,7 +145,7 @@ class BaseBlock(object):
 
     def _resetTransaction(self):
         with self._lock:
-            for x in range(0,self._lockCnt): self._lock.release()
+            for x in range(self._lockCnt): self._lock.release()
             self._lockCnt = 0
 
     def _updated(self):
@@ -305,7 +305,7 @@ class RemoteBlock(BaseBlock, rim.Master):
             if self._doVerify:
                 self._verifyWr = False
 
-                for x in range(0,self._size):
+                for x in range(self._size):
                     if (self._vData[x] & self._mData[x]) != (self._bData[x] & self._mData[x]):
                         msg  = ('Local='    + ''.join(f'{x:#02x}' for x in self._bData))
                         msg += ('. Verify=' + ''.join(f'{x:#02x}' for x in self._vData))
@@ -317,7 +317,7 @@ class RemoteBlock(BaseBlock, rim.Master):
             doUpdate = update and self._doUpdate
             self._doUpdate = False
 
-            for x in range(0,self._lockCnt): self._lock.release()
+            for x in range(self._lockCnt): self._lock.release()
             self._lockCnt = 0
 
         # Update variables outside of lock
@@ -326,7 +326,7 @@ class RemoteBlock(BaseBlock, rim.Master):
     def _resetTransaction(self):
         with self._lock:
             self._endTransaction(0)
-            for x in range(0,self._lockCnt): self._lock.release()
+            for x in range(self._lockCnt): self._lock.release()
             self._lockCnt = 0
 
 class RegisterBlock(RemoteBlock):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -251,15 +251,15 @@ class RemoteBlock(BaseBlock, rim.Master):
         """
         with self._lock:
 
-        # Check for invalid combinations or disabled device
-        if (self._device.enable.value() is not True) or \
-           (type == rim.Write  and (self.mode == 'RO')) or \
-           (type == rim.Post   and (self.mode == 'RO')) or \
-           (type == rim.Read   and (self.mode == 'WO')) or \
-           (type == rim.Verify and (self.mode == 'WO' or \
-                                    self.mode == 'RO' or \
-                                    self._verifyWr == False)):
-            return
+            # Check for invalid combinations or disabled device
+            if (self._device.enable.value() is not True) or \
+               (type == rim.Write  and (self.mode == 'RO')) or \
+               (type == rim.Post   and (self.mode == 'RO')) or \
+               (type == rim.Read   and (self.mode == 'WO')) or \
+               (type == rim.Verify and (self.mode == 'WO' or \
+                                        self.mode == 'RO' or \
+                                        self._verifyWr == False)):
+                return
 
             self._waitTransaction(0)
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -443,45 +443,6 @@ class RegisterBlock(RemoteBlock):
         self._log.debug(f'Block {self._name} _update called')
         for v in self._variables:
             v._updated()
-
-# Is this even used?????
-class MemoryBlock(RemoteBlock):
-
-    def __init__(self, *, name, mode, device, offset):
-        """device is expected to be a MemoryDevice"""
-
-        super().__init__(name=name, mode=mode, device=device, offset=offset)
-        self._bulkEn = True
-        self._verifyEn = True
-
-    def set(self, values):
-
-        with self._lock:
-            self._waitTransaction(0)
-            size = len(values)*self._device._stride
-
-            if size > self._maxSize:
-                raise BlockError(self, "Tried to call set with transaction that is too big")
-
-            self._bData = b''.join( self._device._base.toBlock(v, self._device._bitStride) for v in values)
-            self._vData = bytearray(len(self._bData))
-            self._vDataMask = bytearray(0xff for x in range(len(self._bData)))
-            self._size = len(self._bData)
-
-
-#     def _doneTransaction(self, tid, error):
-#         with self._lock:
-#             if self._device.Verify.value():
-#                 self._verifyWr = False
-#                 if self._vData != self._bData:
-#                     self.error = rim.VerifyError
-
-#             if self.error == 0 and self._verifyWr is False:
-#                 self._bData = bytearray()
-#                 self._vData = bytearray()
-#                 self._mData = bytearray()   
-                
-                
                
 
 def setBitToBytes(ba, bitOffset, value):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -287,7 +287,7 @@ class RemoteBlock(BaseBlock, rim.Master):
         tData = self._vData if self._doVerify else self._bData
 
         # Start transaction
-        self._reqTransaction(self.offset,tData,type)
+        self._reqTransaction(self.offset,tData,0,0,type)
 
 
     def _checkTransaction(self, update):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -263,7 +263,7 @@ class RemoteBlock(BaseBlock, rim.Master):
         tData = None
 
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             self._log.debug(f'len bData = {len(self._bData)}, vData = {len(self._vData)}, mData = {len(self._mData)}')
 
@@ -286,7 +286,7 @@ class RemoteBlock(BaseBlock, rim.Master):
     def _checkTransaction(self, update):
         doUpdate = False
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             # Error
             err = self.error
@@ -343,7 +343,7 @@ class RegisterBlock(RemoteBlock):
         Offset sets the starting point in the block array.
         """
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
             self._value = value
             self._stale = True
 
@@ -368,7 +368,7 @@ class RegisterBlock(RemoteBlock):
         bytearray is returned
         """
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             # Access is fully byte aligned
             if len(var.bitOffset) == 1 and (var.bitOffset[0] % 8) == 0 and (var.bitSize[0] % 8) == 0:
@@ -392,7 +392,7 @@ class RegisterBlock(RemoteBlock):
         """
 
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             # Return false if offset does not match
             if len(self._variables) != 0 and var.offset != self._variables[0].offset:
@@ -453,7 +453,7 @@ class MemoryBlock(RemoteBlock):
     def set(self, values):
 
         with self._lock:
-            self._waitTransaction()
+            self._waitTransaction(0)
             self._stale = True
             size = len(values)*self._device._stride
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -423,6 +423,8 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         for block in self._blocks:
             block.timeout = timeout
 
+        super(rim::Master,self)._setTimeout(timeout*1000000)
+
         for key,value in self._nodes.items():
             if isinstance(value,Device):
                 value._setTimeout(timeout)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -385,6 +385,8 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         Set timeout value on all devices & blocks
         """
 
+        self._setTimeout(timeout * 1000000)
+
         for block in self._blocks:
             block.timeout = timeout
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -305,7 +305,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for i in range(offset, offset+len(ldata), maxTxnSize):
                 ldataSlice = ba[i:min(i+maxTxnSize, len(ba))]
                 sliceOffset = i | self.offset
-                self._reqTransaction(sliceOffset,ldataSlice,rogue.interfaces.memory.Write)
+                self._reqTransaction(sliceOffset,ldataSlice,0,0,rogue.interfaces.memory.Write)
                 self._waitTransaction(0)
 
                 if self._getError() > 0:
@@ -332,7 +332,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for i in range(offset, offset+len(ldata), maxTxnSize):
                 ldataSlice = ldata[i:min(i+maxTxnSize, len(ldata))]
                 sliceOffset = i | self.offset
-                self._reqTransaction(sliceOffset,ldataSlice,rogue.interfaces.memory.Read)
+                self._reqTransaction(sliceOffset,ldataSlice,0,0,rogue.interfaces.memory.Read)
                 self._waitTransaction(0)
                 ldata[i:min(i+maxTxnSize, len(ldata))] = ldataSlice
                 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -309,9 +309,6 @@ class Device(pr.Node,rim.Hub):
 
             return ldata
 
- #    def _backgroundRawWrite(offset, data, base=pr.UInt, stride=4, wordBitSize=0):
-#         self.__rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Write):
-
     def _rawWrite(self, offset, data, base=pr.UInt, stride=4, wordBitSize=0):
         with self._memLock:
             self._rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Write)
@@ -321,9 +318,6 @@ class Device(pr.Node,rim.Hub):
                 raise pr.MemoryError (name=self.name, address=sliceOffset|self.address, error=self._getError())
 
         
- #    def _backgroundRawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=0, data=None, txnType=rim.Read):
-#         self.__rawTxnChunker(offset, data, base, stride, wordBitSize, txnType):
-        
     def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=0, data=None):
         with self._memLock:
             ldata = self._rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Read)
@@ -331,6 +325,8 @@ class Device(pr.Node,rim.Hub):
 
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=sliceOffset|self.address, error=self._getError())
+
+            mask = 2**wordBitSize-1
 
             if size == 1:
                 return base.fromBlock(ldata)&mask

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -220,9 +220,9 @@ class Device(pr.Node,rim.Hub):
                     if block.bulkEn:
                         block.backgroundTransaction(rim.Write)
 
-        if recurse:
-            for key,value in self.devices.items():
-                value.writeBlocks(force=force, recurse=True)
+            if recurse:
+                for key,value in self.devices.items():
+                    value.writeBlocks(force=force, recurse=True)
 
     def verifyBlocks(self, recurse=True, variable=None):
         """
@@ -238,9 +238,9 @@ class Device(pr.Node,rim.Hub):
                 if block.bulkEn:
                     block.backgroundTransaction(rim.Verify)
 
-        if recurse:
-            for key,value in self.devices.items():
-                value.verifyBlocks(recurse=True)
+            if recurse:
+                for key,value in self.devices.items():
+                    value.verifyBlocks(recurse=True)
 
     def readBlocks(self, recurse=True, variable=None):
         """
@@ -257,9 +257,9 @@ class Device(pr.Node,rim.Hub):
                 if block.bulkEn:
                     block.backgroundTransaction(rim.Read)
 
-        if recurse:
-            for key,value in self.devices.items():
-                value.readBlocks(recurse=True)
+            if recurse:
+                for key,value in self.devices.items():
+                    value.readBlocks(recurse=True)
 
     def checkBlocks(self, recurse=True, variable=None):
         """Check errors in all blocks and generate variable update nofifications"""
@@ -273,9 +273,9 @@ class Device(pr.Node,rim.Hub):
             for block in self._blocks:
                 block._checkTransaction()
 
-        if recurse:
-            for key,value in self.devices.items():
-                    value.checkBlocks(recurse=True)
+            if recurse:
+                for key,value in self.devices.items():
+                        value.checkBlocks(recurse=True)
 
     def _rawTxnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=0, txnType=rim.Write):
         if wordBitSize > stride*8:
@@ -287,11 +287,11 @@ class Device(pr.Node,rim.Hub):
         mask = 2**wordBitSize-1
         
         if txnType == rim.Write:
-        if isinstance(data, bytearray):
-            ldata = data
-        elif isinstance(data, collections.Iterable):
+            if isinstance(data, bytearray):
+                ldata = data
+            elif isinstance(data, collections.Iterable):
                 ldata = b''.join(base.toBlock(word&mask, stride*8) for word in data)
-        else:
+            else:
                 ldata = base.toBlock(data&mask, stride*8)
 
         else:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -290,7 +290,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
         with self._rawLock:
             self._reqTransaction(address|self.offset,ldata,rogue.interfaces.memory.Write)
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=address|self.address, error=self._getError())
@@ -305,7 +305,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         with self._rawLock:
 
             self._reqTransaction(address|self.offset,ldata,rogue.interfaces.memory.Read)
-            self._waitTransaction()
+            self._waitTransaction(0)
 
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=address|self.address, error=self._getError())

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -99,7 +99,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         # Blocks
         self._blocks    = []
         self._memBase   = memBase
-        self._memLock   = pr.MemoryLock()
+        self._memLock   = threading.RLock()
 
         # Connect to memory slave
         if memBase: self._setSlave(memBase)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -283,7 +283,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         
         if isinstance(data, bytearray):
             ldata = data
-        elif isinstance(data, Iterable):
+        elif isinstance(data, collections.Iterable):
             ldata = b''.join(model.toBlock(word, stride*8) for word in data)
         else:
             ldata = model.toBlock(data, stride*8)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -365,6 +365,9 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
         self._buildBlocks()
 
+        for v in self.variables.values():
+            v._updatePollInterval()
+
     def _devReset(self,rstType):
         """Generate a count, soft or hard reset"""
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -416,7 +416,7 @@ class Device(pr.Node,rim.Hub):
         for block in self._blocks:
             block.timeout = timeout
 
-        super(rim.Master,self)._setTimeout(timeout*1000000)
+        rim.Master._setTimeout(self, timeout*1000000)
 
         for key,value in self._nodes.items():
             if isinstance(value,Device):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -284,9 +284,9 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         if isinstance(data, bytearray):
             ldata = data
         elif isinstance(data, Iterable):
-            ldata = b''.join(model.toBlock(word, stride) for word in data)
+            ldata = b''.join(model.toBlock(word, stride*8) for word in data)
         else:
-            ldata = model.toBlock(data, stride)
+            ldata = model.toBlock(data, stride*8)
 
         with self._rawLock:
             self._reqTransaction(address|self.offset,ldata,rogue.interfaces.memory.Write)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -13,7 +13,7 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import rogue.interfaces.memory
+import rogue.interfaces.memory as rim
 import collections
 import datetime
 import functools as ft
@@ -76,7 +76,7 @@ class DeviceError(Exception):
     """ Exception for device manipulation errors."""
     pass
 
-class Device(pr.Node,rogue.interfaces.memory.Hub):
+class Device(pr.Node,rim.Hub):
     """Device class holder. TODO: Update comments"""
 
     def __init__(self, *,
@@ -94,7 +94,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             name = self.__class__.__name__
 
         # Hub.__init__ must be called first for _setSlave to work below
-        rogue.interfaces.memory.Hub.__init__(self,offset)
+        rim.Hub.__init__(self,offset)
 
         # Blocks
         self._blocks    = []
@@ -211,12 +211,12 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
         # Process local blocks.
         if variable is not None:
-            variable._block.backgroundTransaction(rogue.interfaces.memory.Write)
+            variable._block.backgroundTransaction(rim.Write)
         else:
             for block in self._blocks:
                 if force or block.stale:
                     if block.bulkEn:
-                        block.backgroundTransaction(rogue.interfaces.memory.Write)
+                        block.backgroundTransaction(rim.Write)
 
             if recurse:
                 for key,value in self.devices.items():
@@ -230,11 +230,11 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
         # Process local blocks.
         if variable is not None:
-            variable._block.backgroundTransaction(rogue.interfaces.memory.Verify)
+            variable._block.backgroundTransaction(rim.Verify)
         else:
             for block in self._blocks:
                 if block.bulkEn:
-                    block.backgroundTransaction(rogue.interfaces.memory.Verify)
+                    block.backgroundTransaction(rim.Verify)
 
             if recurse:
                 for key,value in self.devices.items():
@@ -249,11 +249,11 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
 
         # Process local blocks. 
         if variable is not None:
-            variable._block.backgroundTransaction(rogue.interfaces.memory.Read)
+            variable._block.backgroundTransaction(rim.Read)
         else:
             for block in self._blocks:
                 if block.bulkEn:
-                    block.backgroundTransaction(rogue.interfaces.memory.Read)
+                    block.backgroundTransaction(rim.Read)
 
             if recurse:
                 for key,value in self.devices.items():
@@ -305,7 +305,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for i in range(offset, offset+len(ldata), maxTxnSize):
                 ldataSlice = ba[i:min(i+maxTxnSize, len(ba))]
                 sliceOffset = i | self.offset
-                self._reqTransaction(sliceOffset,ldataSlice,0,0,rogue.interfaces.memory.Write)
+                self._reqTransaction(sliceOffset,ldataSlice,0,0,rim.Write)
                 self._waitTransaction(0)
 
                 if self._getError() > 0:
@@ -332,7 +332,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for i in range(offset, offset+len(ldata), maxTxnSize):
                 ldataSlice = ldata[i:min(i+maxTxnSize, len(ldata))]
                 sliceOffset = i | self.offset
-                self._reqTransaction(sliceOffset,ldataSlice,0,0,rogue.interfaces.memory.Read)
+                self._reqTransaction(sliceOffset,ldataSlice,0,0,rim.Read)
                 self._waitTransaction(0)
                 ldata[i:min(i+maxTxnSize, len(ldata))] = ldataSlice
                 
@@ -423,7 +423,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         for block in self._blocks:
             block.timeout = timeout
 
-        super(rim::Master,self)._setTimeout(timeout*1000000)
+        super(rim.Master,self)._setTimeout(timeout*1000000)
 
         for key,value in self._nodes.items():
             if isinstance(value,Device):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -279,14 +279,14 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             for key,value in self.devices.items():
                 value.checkBlocks(varUpdate=varUpdate, recurse=True)
 
-    def _rawWrite(self, address, data, model=pr.UInt, stride=4):
+    def _rawWrite(self, address, data, base=pr.UInt, stride=4):
         
         if isinstance(data, bytearray):
             ldata = data
         elif isinstance(data, collections.Iterable):
-            ldata = b''.join(model.toBlock(word, stride*8) for word in data)
+            ldata = b''.join(base.toBlock(word, stride*8) for word in data)
         else:
-            ldata = model.toBlock(data, stride*8)
+            ldata = base.toBlock(data, stride*8)
 
         with self._rawLock:
             self._reqTransaction(address|self.offset,ldata,rogue.interfaces.memory.Write)
@@ -295,7 +295,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=address|self.address, error=self._getError())
 
-    def _rawRead(self, address, size=1, model=pr.UInt, stride=4, bdata=None):
+    def _rawRead(self, address, size=1, base=pr.UInt, stride=4, bdata=None):
         
         if bdata is not None:
             ldata = bdata

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -284,15 +284,13 @@ class Device(pr.Node,rim.Hub):
         if wordBitSize == 0:
             wordBitSize = stride*8
 
-        mask = 2**wordBitSize-1
-        
         if txnType == rim.Write:
             if isinstance(data, bytearray):
                 ldata = data
             elif isinstance(data, collections.Iterable):
-                ldata = b''.join(base.toBlock(word&mask, stride*8) for word in data)
+                ldata = b''.join(base.toBlock(word, wordBitSize) for word in data)
             else:
-                ldata = base.toBlock(data&mask, stride*8)
+                ldata = base.toBlock(data, wordBitSize)
 
         else:
             if data is not None:
@@ -326,12 +324,10 @@ class Device(pr.Node,rim.Hub):
             if self._getError() > 0:
                 raise pr.MemoryError (name=self.name, address=sliceOffset|self.address, error=self._getError())
 
-            mask = 2**wordBitSize-1
-
             if size == 1:
-                return base.fromBlock(ldata)&mask
+                return base.fromBlock(ldata)
             else:
-                return [base.fromBlock(ldata[i:i+stride])&mask for i in range(0, len(ldata), stride)]
+                return [base.fromBlock(ldata[i:i+stride]) for i in range(0, len(ldata), stride)]
             
 
     def _buildBlocks(self):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -368,6 +368,7 @@ class Device(pr.Node,rogue.interfaces.memory.Hub):
         self._buildBlocks()
 
         for v in self.variables.values():
+            v._setDefault()
             v._updatePollInterval()
 
     def _devReset(self,rstType):

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -71,9 +71,10 @@ class MemoryDevice(pr.Device):
             self._setError(0)
 
             # Convert the read verfiy data back to the natic type
-            checkBlocks = {offset: [self._base.fromBlock(self.__mask(ba[i:i+self._stride]))
-                                          for i in range(0, len(ba), self._stride)
-                                          for offset, ba in self._verData.items()]}
+            checkBlocks = odict()
+            for offset, ba in self._verData.items():
+                for i in range(0, len(ba), self._stride):
+                    checkBlocks[offset] = self._base.fromBlock(self.__mask(ba[i:i+self._stride]))
 
             # Do verify if necessary
             if len(self._verBlocks) > 0:

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -1,4 +1,6 @@
 import pyrogue as pr
+import rogue.interfaces.memory as rim
+import threading
 
 class MemoryDevice(pr.Device):
     def __init__(self, base=pr.UInt, wordSize=4, stride=4, verify=True, **kwargs):
@@ -10,31 +12,73 @@ class MemoryDevice(pr.Device):
         self._stride = stride
         self._bitStride = stride*8
         self._verify = verify
+        self._txnSize = self._reqMaxAccess()        
+        self._segments = {} # Data parsed from yaml
+        self._wrTxns = {} # map of txnId and bytearrays
+        self._verTxns = {}
+
+        self._cond = threading.Condition()
+        self._txnPending = False
 
     def _buildBlocks(self):
         pass
 
     def _setOrExec(self, d, writeEach, modes):
-        """ Spin up a number of MemoryBlocks and set() them """
+        # Parse comma separated values at each offset (key) in d
+        with self._cond:
+            self._segments = {k: [self._base.fromString(s) for s in v.split(',')] for k, v in d.items()}
 
-        for offset, valueStr in d.items():
-            values = [self._base.fromString(i) for i in valueStr.split(',')]
-            size = len(values) * self._stride
-            blockSize = self._reqMaxAccess()
-            for i in range(offset, offset+size, blockSize):
-                print(f'Making MemoryBlock for {self.path} with offset {i}')
-                block = pr.MemoryBlock(name=f'{self.name}{i}', mode='RW', device=self, offset=i)
-                block.timeout = 10
-                self._blocks.append(block)
-                block.set(values[offset-i:min(len(values), offset-i+blockSize)])
-            
+
+    def writeBlocks(self, force=False, recurse=True, variable=None):
+        if not self.enable.get(): return
+
+        with self._cond:
+            self._cond.wait_for(self._txnPending==False)
+            self._txnPending = True
+
+            # transform each segment into a bytearray
+            arrays = {k: [b''.join(self._base.toBlock(v, self._bitStride))] for k, v in self._segments}            
+
+            # Issue as many transactions as are needed to cover each bytearray            
+            for offset, ba in arrays.items():
+                for i in range(offset, offset+len(ba), self._txnSize):
+                    baSlice = ba[i:min(i+self._txnSize, len(ba))]
+                    sliceOffset = i|self.offset
+                    self._reqTransaction(sliceOffset, baSlice, rim.Write)
+                    self._wrTxns[sliceOffset] = baSlice
+                    if self._verify:
+                        self._verTxns[sliceOffset] = bytearray(len(baSlice))
+        
+
+    def verifyBlocks(self, recurse=True, variable=None):
+        if not self.enable.get(): return
+        
+        with self._cond:
+            for offset, ba in self._verTxns.items():
+                self._reqTransaction(offset, ba, rim.Verify)
 
     def checkBlocks(self, varUpdate=True, recurse=True, variable=None):
-        print(f'Checking blocks in {self.path}, blocks: {self._blocks}')
-        pr.Device.checkBlocks(self, varUpdate=varUpdate, recurse=recurse, variable=variable)
+        with self._cond:
+            self._waitTransaction(0)
 
-        self._blocks = [b for b in self._blocks if b._verifyWr is False]
-        print(f'Checking blocks done {self.path}, blocks: {self._blocks}')        
+            # Error check?
+            error = self._getError()
+            self._setError(0)
+
+            # Do verify if necessary
+            if len(self._verTxns) > 0:
+                # Compare wrData with verData
+                if self._wrTxns != self._verTxns:
+                    msg = 'Local - Verify \n'
+                    msg += '\n'.join(f'{x:#02x} - {y:#02x}' for x,y in zip(self._wrTxns.values(), self._verTxns.values()))
+
+
+                # destroy the txn maps when done with verify
+                self._wrTxns = {}
+                self._verTxns = {}
+                self._txnPending = False
+                self._cond.notify()
+        
 
     def readBlocks(self, recurse=True, variable=None):
         pass

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -42,7 +42,12 @@ def byteCount(bits):
 # class Model(metaclass=ModelMeta):
 #     pass
 class Model(object):
-    pass
+
+    @staticmethod
+    def blockMask(bitSize, bitOffset=0):
+        # For now all models are little endian so we can get away with this
+        return int.to_bytes(2**bitSize << bitOffset, byteCount(bitSize+bitOffset), 'little', signed=False)
+
 
 @Pyro4.expose
 class UInt(Model):
@@ -70,6 +75,7 @@ class UInt(Model):
     @staticmethod
     def fromString(string):
         return int(string, 0)
+
 
     @classmethod
     def name(cls, bitSize):

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -79,7 +79,7 @@ class UInt(Model):
 @Pyro4.expose
 class Int(Model):
 
-    defaultdisp = '{:#x}'
+    defaultdisp = '{:d}'
     pytype = int
 
     @staticmethod

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -46,7 +46,8 @@ class Model(object):
     @staticmethod
     def blockMask(bitSize, bitOffset=0):
         # For now all models are little endian so we can get away with this
-        return int.to_bytes(2**bitSize << bitOffset, byteCount(bitSize+bitOffset), 'little', signed=False)
+        i = (2**bitSize-1) << bitOffset
+        return i.to_bytes(byteCount(bitSize+bitOffset), 'little', signed=False)
 
 
 @Pyro4.expose

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -60,7 +60,7 @@ class PollQueue(object):
 
     def updatePollInterval(self, var):
         with self._lock:
-            self._log.debug('updatePollInterval {} - {}'.format(var, var.pollInterval))
+            self._log.debug(f'updatePollInterval {var} - {var.pollInterval}')
             # Special case: Variable has no block and just depends on other variables
             # Then do update on each dependency instead
             if var._block is None:
@@ -104,10 +104,10 @@ class PollQueue(object):
                 readTime = self.peek().readTime
                 waitTime = (readTime - now).total_seconds()
                 with self._update:
-                    self._log.debug('Poll thread sleeping for {}'.format(waitTime))
+                    self._log.debug(f'Poll thread sleeping for {waitTime}')
                     self._update.wait(waitTime)
 
-            self._log.debug("Global reference count: %s" % (sys.getrefcount(None)))
+            self._log.debug(f'Global reference count: {sys.getrefcount(None)}')
 
             with self._lock:
                 # Stop the thread if someone set run to False
@@ -122,7 +122,7 @@ class PollQueue(object):
                 now = datetime.datetime.now()
                 blockEntries = []
                 for entry in self._expiredEntries(now):
-                    self._log.debug('Polling {}'.format(entry.block._variables))
+                    self._log.debug(f'Polling Block {entry.block.name}')
                     blockEntries.append(entry)
                     try:
                         entry.block.backgroundTransaction(rogue.interfaces.memory.Read)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -335,6 +335,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._log.info("Check root read")
             self.checkBlocks(varUpdate=False, recurse=True)
         except Exception as e:
+            self._resetBlocks()
             self._log.exception(e)
         self._log.info("Done root write")
 
@@ -348,6 +349,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._log.info("Check root read")
             self.checkBlocks(varUpdate=True, recurse=True)
         except Exception as e:
+            self._resetBlocks()
             self._log.exception(e)
         self._doneUpdatedVars()
         self._log.info("Done root read")

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -239,8 +239,8 @@ class BaseVariable(pr.Node):
             self.set(self._default, write=False)
 
     def _updatePollInterval(self):
-        if self._pollInterval > 0 and root._pollQueue is not None:
-            root._pollQueue.updatePollInterval(self)
+        if self._pollInterval > 0 and self.root._pollQueue is not None:
+            self.root._pollQueue.updatePollInterval(self)
 
     def _updated(self):
         """Variable has been updated. Inform listeners."""

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -241,6 +241,10 @@ class BaseVariable(pr.Node):
         if self._pollInterval > 0 and self.root._pollQueue is not None:
             self.root._pollQueue.updatePollInterval(self)
 
+    def _finishInit(self):
+        self._setDefault()
+        self._updatePollInterval()
+
     def _updated(self):
         """Variable has been updated. Inform listeners."""
         if self._update is False or self._root is None:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -364,13 +364,14 @@ class RemoteVariable(BaseVariable):
 
             if write and self._block.mode != 'RO':
                 self._parent.writeBlocks(force=False, recurse=False, variable=self)
-                self._parent.checkBlocks(varUpdate=False, recurse=False, variable=self)
 
                 if self._block.mode == 'RW':
                     self._parent.verifyBlocks(recurse=False, variable=self)
-                    self._parent.checkBlocks(varUpdate=False, recurse=False, variable=self)
+
+                self._parent.checkBlocks(varUpdate=False, recurse=False, variable=self)
 
         except Exception as e:
+            self._block.resetTransaction()
             self._log.exception(e)
 
     @Pyro4.expose
@@ -388,8 +389,10 @@ class RemoteVariable(BaseVariable):
 
             if self._block.mode != 'RO':
                 self._block.backgroundTransaction(rogue.interfaces.memory.Post)
+                self._block.checkTransaction(update=False)
 
         except Exception as e:
+            self._block.resetTransaction()
             self._log.exception(e)
 
     @Pyro4.expose
@@ -407,6 +410,7 @@ class RemoteVariable(BaseVariable):
             ret = self._block.get(self)
 
         except Exception as e:
+            self._block.resetTransaction()
             self._log.exception(e)
             return None
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -144,9 +144,8 @@ class BaseVariable(pr.Node):
     @pollInterval.setter
     def pollInterval(self, interval):
         self._pollInterval = interval
-        if isinstance(self._root, pr.Root) and self._root._pollQueue:
-            self._root._pollQueue.updatePollInterval(self)
-
+        self._updatePollInterval()
+        
     @property
     def dependencies(self):
         return self.__dependencies
@@ -239,6 +238,7 @@ class BaseVariable(pr.Node):
         if self._default is not None:
             self.set(self._default, write=False)
 
+    def _updatePollInterval(self):
         if self._pollInterval > 0 and root._pollQueue is not None:
             root._pollQueue.updatePollInterval(self)
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -353,6 +353,11 @@ class RemoteVariable(BaseVariable):
         return self._verify
 
     @Pyro4.expose
+    @property
+    def base(self):
+        return self._base
+
+    @Pyro4.expose
     def set(self, value, write=True):
         """
         Set the value and write to hardware if applicable

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -232,11 +232,10 @@ class BaseVariable(pr.Node):
     def nativeType(self):
         return type(self.value())
 
-    def _rootAttached(self,parent,root):
-        pr.Node._rootAttached(self,parent,root)
-
+    def _setDefault(self):
+        # Called by parent Device after _buildBlocks()
         if self._default is not None:
-            self.set(self._default, write=False)
+            self.setDisp(self._default, write=False)
 
     def _updatePollInterval(self):
         if self._pollInterval > 0 and self.root._pollQueue is not None:

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -204,16 +204,16 @@ uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p
    if ( PyObject_GetBuffer(p.ptr(),&(tran.pyBuf),PyBUF_SIMPLE) < 0 )
       throw(rogue::GeneralError("Master::reqTransactionPy","Python Buffer Error"));
 
-   if ( size == 0 ) size = tran.pyBuf.len;
+   if ( size == 0 ) tran.tSize = tran.pyBuf.len;
+   else tran.tSize = size;
 
-   if ( (size + offset) > tran.pyBuf.len ) {
+   if ( (tran.tSize + offset) > tran.pyBuf.len ) {
       PyBuffer_Release(&(tran.pyBuf));
-      throw(rogue::GeneralError::boundary("Master::reqTransactionPy",(size+offset),tran.pyBuf.len));
+      throw(rogue::GeneralError::boundary("Master::reqTransactionPy",(tran.tSize+offset),tran.pyBuf.len));
    }
 
    tran.pyValid = true;
    tran.tData   = ((uint8_t *)tran.pyBuf.buf) + offset;
-   tran.tSize   = size;
 
    return(intTransaction(address,&tran,type));
 }

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -69,26 +69,6 @@ uint32_t rim::Master::genId() {
    return(nid);
 }
 
-//! Reset transaction data, not python safe, needs lock
-void rim::Master::rstTransaction(uint32_t id, uint32_t error, bool notify) {
-   std::map<uint32_t, rogue::interfaces::memory::MasterTransaction>::iterator it;
-
-   it = tran_.find(id);
-   if ( it == tran_.end() ) {
-      log_->info("Reset transaction failed to find transaction id=%i",id);
-      return;
-   }
-
-   log_->debug("Resetting transaction id=%i",id);
-
-   if ( it->second.pyValid ) PyBuffer_Release(&(it->second.pyBuf));
-
-   tran_.erase(it);
-
-   if ( error != 0 ) error_ = error;
-   if ( notify ) cond_.notify_all();
-}
-
 //! Get transaaction count
 uint32_t rim::Master::tranCount() {
    rogue::GilRelease noGil;
@@ -167,12 +147,11 @@ void rim::Master::setTimeout(uint32_t timeout) {
    }
 }
 
-//! Post a transaction, called locally, forwarded to slave
-uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type) {
+uint32_t rim::Master::intTransaction(uint64_t address, rim::MasterTransaction *tran, uint32_t type) {
+   std::map<uint32_t, rim::MasterTransaction>::iterator it;
    struct timeval currTime;
    rim::SlavePtr slave;
    uint32_t id;
-   rim::MasterTransaction tran;
 
    {
       rogue::GilRelease noGil;
@@ -180,72 +159,76 @@ uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data
       slave = slave_;
       id    = genId();
 
-      memset(&(tran.pyBuf),0,sizeof(Py_buffer));
+      tran->endTime.tv_sec = 0;
+      tran->endTime.tv_usec = 0;
 
-      tran.pyValid = false;
-      tran.tData   = (uint8_t *)data;
-      tran.tSize   = size;
+      gettimeofday(&(tran->startTime),NULL);
 
-      tran.endTime.tv_sec = 0;
-      tran.endTime.tv_usec = 0;
-
-      gettimeofday(&(tran.startTime),NULL);
-
-      tran_[id] = tran;
+      tran_[id] = *tran;
    }
 
    log_->debug("Request transaction type=%i id=%i",type,id);
 
-   slave->doTransaction(id,shared_from_this(),address,size,type);
+   slave->doTransaction(id,shared_from_this(),address,tran->tSize,type);
 
+   // Update time after transaction is started, but not if transaction has already completed
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(mtx_);
 
-   gettimeofday(&currTime,NULL);
-   timeradd(&currTime,&sumTime_,&(tran.endTime));
-
-   tran_[id] = tran;
+   it = tran_.find(id);
+   if ( it != tran_.end() ) {
+      gettimeofday(&currTime,NULL);
+      timeradd(&currTime,&sumTime_,&(tran->endTime));
+      tran_[id] = *tran;
+   }
    return(id);
+}
+
+//! Post a transaction, called locally, forwarded to slave
+uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type) {
+   rim::MasterTransaction tran;
+
+   memset(&(tran.pyBuf),0,sizeof(Py_buffer));
+
+   tran.pyValid = false;
+   tran.tData   = (uint8_t *)data;
+   tran.tSize   = size;
+
+   return(intTransaction(address,&tran,type));
 }
 
 //! Post a transaction, called locally, forwarded to slave, python version
 uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p, uint32_t type) {
-   struct timeval currTime;
-   rim::SlavePtr slave;
-   uint32_t id = 0;
    rim::MasterTransaction tran;
 
-   {
-      rogue::GilRelease noGil;
-      boost::lock_guard<boost::mutex> lock(mtx_);
-      slave = slave_;
-      id    = genId();
+   if ( PyObject_GetBuffer(p.ptr(),&(tran.pyBuf),PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError("Master::reqTransactionPy","Python Buffer Error"));
 
-      if ( PyObject_GetBuffer(p.ptr(),&(tran.pyBuf),PyBUF_SIMPLE) < 0 )
-         throw(rogue::GeneralError("Master::reqTransactionPy","Python Buffer Error"));
+   tran.pyValid = true;
+   tran.tData   = (uint8_t *)tran.pyBuf.buf;
+   tran.tSize   = tran.pyBuf.len;
 
-      tran.pyValid = true;
-      tran.tData   = (uint8_t *)tran.pyBuf.buf;
-      tran.tSize   = tran.pyBuf.len;
+   return(intTransaction(address,&tran,type));
+}
 
-      tran.endTime.tv_sec = 0;
-      tran.endTime.tv_usec = 0;
+//! Reset transaction data, not python safe, needs lock
+void rim::Master::rstTransaction(uint32_t id, uint32_t error, bool notify) {
+   std::map<uint32_t, rim::MasterTransaction>::iterator it;
 
-      gettimeofday(&(tran.startTime),NULL);
-
-      tran_[id] = tran;
+   it = tran_.find(id);
+   if ( it == tran_.end() ) {
+      log_->info("Reset transaction failed to find transaction id=%i",id);
+      return;
    }
-   log_->debug("Request transaction type=%i id=%i",type,id);
-   slave->doTransaction(id,shared_from_this(),address,tran.tSize,type);
 
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
+   log_->debug("Resetting transaction id=%i",id);
 
-   gettimeofday(&currTime,NULL);
-   timeradd(&currTime,&sumTime_,&(tran.endTime));
+   if ( it->second.pyValid ) PyBuffer_Release(&(it->second.pyBuf));
 
-   tran_[id] = tran;
-   return(id);
+   tran_.erase(it);
+
+   if ( error != 0 ) error_ = error;
+   if ( notify ) cond_.notify_all();
 }
 
 //! End current transaction, ensures data pointer is not update and de-allocates python buffer
@@ -256,7 +239,7 @@ void rim::Master::endTransaction(uint32_t id) {
    log_->debug("End transaction id=%i",id);
 
    if ( id == 0 ) {
-      std::map<uint32_t, rogue::interfaces::memory::MasterTransaction>::iterator it;
+      std::map<uint32_t, rim::MasterTransaction>::iterator it;
       for ( it=tran_.begin(); it != tran_.end(); it++ ) rstTransaction(it->first,0,false);
    } else rstTransaction(id,0,false);
 }
@@ -274,7 +257,7 @@ void rim::Master::setTransactionData(uint32_t id, void *data, uint32_t offset, u
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(mtx_);
 
-   std::map<uint32_t, rogue::interfaces::memory::MasterTransaction>::iterator it;
+   std::map<uint32_t, rim::MasterTransaction>::iterator it;
 
    it = tran_.find(id);
    if ( it == tran_.end() ) {
@@ -304,7 +287,7 @@ void rim::Master::getTransactionData(uint32_t id, void *data, uint32_t offset, u
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(mtx_);
 
-   std::map<uint32_t, rogue::interfaces::memory::MasterTransaction>::iterator it;
+   std::map<uint32_t, rim::MasterTransaction>::iterator it;
 
    it = tran_.find(id);
    if ( it == tran_.end() ) {
@@ -376,7 +359,7 @@ void rim::MasterWrap::defDoneTransaction(uint32_t id, uint32_t error) {
 void rim::Master::waitTransaction(uint32_t id) {
    struct timeval currTime;
 
-   std::map<uint32_t, rogue::interfaces::memory::MasterTransaction>::iterator it;
+   std::map<uint32_t, rim::MasterTransaction>::iterator it;
 
    rogue::GilRelease noGil;
    boost::unique_lock<boost::mutex> lock(mtx_);

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -134,7 +134,7 @@ void rim::Master::setError(uint32_t error) {
 }
 
 //! Set timeout
-void rim::Master::setTimeout(uint32_t timeout) {
+void rim::Master::setTimeout(uint64_t timeout) {
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(mtx_);
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -337,6 +337,7 @@ void rim::Master::setup_python() {
 
 //! Transaction complete, called by slave when transaction is complete, error passed
 void rim::MasterWrap::doneTransaction(uint32_t id, uint32_t error) {
+   bool found = false;
    {
       rogue::ScopedGil gil;
 
@@ -346,8 +347,10 @@ void rim::MasterWrap::doneTransaction(uint32_t id, uint32_t error) {
          } catch (...) {
             PyErr_Print();
          }
+         found = true;
       }
    }
+   if ( !found ) rim::Master::doneTransaction(id,error);
 }
 
 //! Transaction complete, called by slave when transaction is complete, error passed

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -388,19 +388,15 @@ void rim::Master::waitTransaction(uint32_t id) {
    while (it != tran_.end()) {
 
       // Timeout?
-      if ( it->second.endTime.tv_sec != 0 && it->second.endTime.tv_usec != 0 ) {
-         gettimeofday(&currTime,NULL);
-         if ( timercmp(&currTime,&(it->second.endTime),>) ) {
-            log_->info("Transaction timeout id=%i start =%i:%i end=%i:%i curr=%i:%i",it->first,
-                  it->second.startTime.tv_sec, it->second.startTime.tv_usec,
-                  it->second.endTime.tv_sec,it->second.endTime.tv_usec,
-                  currTime.tv_sec,currTime.tv_usec);
-            rstTransaction(it->first,rim::TimeoutError,false);
-            break;
-         }
+      gettimeofday(&currTime,NULL);
+      if ( it->second.endTime.tv_sec != 0 && it->second.endTime.tv_usec != 0 && timercmp(&currTime,&(it->second.endTime),>) ) {
+         log_->info("Transaction timeout id=%i start =%i:%i end=%i:%i curr=%i:%i",it->first,
+               it->second.startTime.tv_sec, it->second.startTime.tv_usec,
+               it->second.endTime.tv_sec,it->second.endTime.tv_usec,
+               currTime.tv_sec,currTime.tv_usec);
+         rstTransaction(it->first,rim::TimeoutError,false);
       }
-
-      cond_.timed_wait(lock,boost::posix_time::microseconds(1000));
+      else cond_.timed_wait(lock,boost::posix_time::microseconds(1000));
 
       if ( id == 0 ) it = tran_.begin();
       else it = tran_.find(id);


### PR DESCRIPTION
This branch was nominally for ESROGUE-60, but a lot of other stuff ended up in it.

### ESROGUE-60
Created a new MemoryDevice that does all of its memory access via raw reads and writes rather than through Variables. Can be configured via YAML.

### ESROGUE-77
Raw writes and read can now be issued that are larger than the underlying maxAccess size. They will be split up into smaller chunks automatically.

### Low level changes
- Many performance tweaks in interfaces/memory/Master.cpp