### PR TITLE
Esrogue 91

### DIFF
--- a/python/pyrogue/epics.py
+++ b/python/pyrogue/epics.py
@@ -22,6 +22,7 @@ import threading
 import pyrogue
 import time
 import pcaspy
+import ctypes
 
 try:
    import queue
@@ -187,6 +188,10 @@ class EpicsCaServer(object):
                     value = d['enums'][e['value']]
                 else:
                     value = e['value']
+
+                # Check if value is unsigned. If so, cast it
+                if v.base is pyrogue.UInt:
+                    value = ctypes.c_uint(value).value
 
                 if self._isCommand(v):
                     # Process command requests

--- a/python/pyrogue/epics.py
+++ b/python/pyrogue/epics.py
@@ -207,9 +207,11 @@ class EpicsCaServer(object):
                     # Process normal register write requests
 
                     # EPICS uses 32-bit signed integers
-                    # So, check if the register value is unsigned, and cast the value if so
-                    if v.base is pyrogue.UInt:
-                        value = ctypes.c_uint(value).value
+                    # So, check if the register value is unsigned, and cast the value if so.
+                    # Check if it is a RemoteVariable as LocalVariables don't have base property. 
+                    if isinstance(v, pyrogue.RemoteVariable):
+                        if v.base is pyrogue.UInt:
+                            value = ctypes.c_uint(value).value
 
                     v.setDisp(value)
 


### PR DESCRIPTION
As EPICS uses only signed 32-bit integers, we need to cast the values when the rogue variables use unsigned value instead. 