### PR TITLE
Allow pythonic construction of pyrogue.Root()

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -45,6 +45,14 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     to be stored in data files.
     """
 
+    def __enter__(self):
+        """Root enter."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Root exit."""
+        self.stop()
+
     def __init__(self, *, name, description):
         """Init the node with passed attributes"""
 


### PR DESCRIPTION
By adding __enter__ and __exit__ one can do things like:

with pyrogue.Root(name='ePixBoard', description='ePix10ka Board') as ePixBoard:
	...
	ePixBoard.add(fpga)
	...
	# ePixBoard.stop()  # no need to call stop anymore