### PR TITLE
Various features and bugfixes from hps-dev branch

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -121,12 +121,23 @@ class BaseCommand(pr.BaseVariable):
         cmd.set(1)
 
     @staticmethod
-    def postedTouch(cmd, arg):
-        if arg is not None:
-            cmd.post(arg)
-        else:
-            cmd.post(1)
+    def createPostedTouch(value):
+        def postedTouch(cmd):
+            cmd.post(value)
+        return postedTouch
 
+    @staticmethod
+    def postedTouch(cmd, arg):
+        cmd.post(arg)
+
+    @staticmethod
+    def postedTouchOne(cmd):
+        cmd.post(1)
+
+    @staticmethod
+    def postedTouchZero(cmd):
+        cmd.post(0)
+        
     def _setDict(self,d,writeEach,modes):
         pass
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -420,22 +420,21 @@ class Device(pr.Node,rim.Hub):
             if 'name' not in kwargs:
                 kwargs['name'] = func.__name__
 
-            fargs = inspect.getfullargspec(func).args
-
-            # Handle functions with the wrong arg name and genere warning
-            if len(fargs) > 0 and 'arg' not in fargs:
-                self._log.warning("Decorated init functions must have the parameter name 'arg': {}".format(self.path))
-
-                def newFunc(arg):
-                    return func(arg)
-
-                self.add(pr.LocalCommand(function=newFunc, **kwargs))
-            else:
-                self.add(pr.LocalCommand(function=func, **kwargs))
+            self.add(pr.LocalCommand(function=func, **kwargs))
 
             return func
         return _decorator
 
+    def linkedGet(self, **kwargs):
+        """ Decorator to add inline constructor functions as LinkVariable.linkedGet functions"""
+        def _decorator(func):
+            if 'name' not in kwargs:
+                kwargs['name'] = func.__name__
+
+            self.add(pr.LinkVariable(linkedGet=func, **kwargs))
+
+            return func
+        return _decorator
 
 class DataWriter(Device):
     """Special base class to control data files. TODO: Update comments"""

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -328,7 +328,7 @@ class Device(pr.Node,rim.Hub):
             self._waitTransaction(0)
 
             if self._getError() > 0:
-                raise pr.MemoryError (name=self.name, address=offsetffset|self.address, error=self._getError())
+                raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
 
             if numWords == 1:
                 return base.fromBytes(base.mask(ldata, wordBitSize))

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -212,9 +212,7 @@ class Device(pr.Node,rim.Hub):
 
     def enableChanged(self,value):
         if value is True:
-            self.writeBlocks(force=True, recurse=True, variable=None)
-            self.verifyBlocks(recurse=True, variable=None)
-            self.checkBlocks(recurse=True, variable=None)
+            self.writeAndVerifyBlocks(force=True, recurse=True, variable=None)
 
     def writeBlocks(self, force=False, recurse=True, variable=None):
         """
@@ -284,6 +282,12 @@ class Device(pr.Node,rim.Hub):
             if recurse:
                 for key,value in self.devices.items():
                         value.checkBlocks(recurse=True)
+
+    def writeAndVerifyBlocks(self, force=False, recurse=True, variable=None):
+        """Perform a write, verify and check. Usefull for committing any stale variables"""
+        self.writeBlocks(force=force, recurse=recurse, variable=variable)
+        self.verifyBlocks(recurse=recurse, variable=variable)
+        self.checkBlocks(recurse=recurse, variable=variable)
 
     def _rawTxnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):
         if wordBitSize > stride*8:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -319,7 +319,7 @@ class Device(pr.Node,rim.Hub):
             self._waitTransaction(0)
 
             if self._getError() > 0:
-                raise pr.MemoryError (name=self.name, address=sliceOffset|self.address, error=self._getError())
+                raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
 
         
     def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=32, data=None):
@@ -328,7 +328,7 @@ class Device(pr.Node,rim.Hub):
             self._waitTransaction(0)
 
             if self._getError() > 0:
-                raise pr.MemoryError (name=self.name, address=sliceOffset|self.address, error=self._getError())
+                raise pr.MemoryError (name=self.name, address=offsetffset|self.address, error=self._getError())
 
             if numWords == 1:
                 return base.fromBytes(base.mask(ldata, wordBitSize))

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -437,7 +437,7 @@ class Device(pr.Node,rim.Hub):
             return func
         return _decorator
 
-    def linkedGet(self, **kwargs):
+    def linkVariableGet(self, **kwargs):
         """ Decorator to add inline constructor functions as LinkVariable.linkedGet functions"""
         def _decorator(func):
             if 'name' not in kwargs:

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -92,6 +92,11 @@ class Node(object):
         return self._hidden
 
     @Pyro4.expose
+    @hidden.setter
+    def hidden(self, value):
+        self._hidden = value
+
+    @Pyro4.expose
     @property
     def path(self):
         return self._path


### PR DESCRIPTION
I've been accumulating a lot of fixes and such in project branches. It's probably a good idea to have occasional pulls back into master rather than a huge merge later. 

This PR will bring in the following features and bug fixes
* A decorator for making functions defined in DeviceSubclass.__init__() into LinkVariables. I'm not sure how useful this will turn out to be. In most cases its probably cleaner to declare a LinkVariable the normal way and use a lambda for its linkedGet.
```
def __init__(self, ...):
    ...
    # Create a new LinkVariable called 'GitHashShort' 
    # that shows the 7 most significant hex digits of a the full GitHash
    @self.linkVariableGet(dependencies=[self.GitHash], disp='{:07x})
    def GitHashShort():
        return self.GitHash.value() >> 132
```
* In _Command.py add `createPostedTouch()`, `postedTouchOne()` and `postedTouchZero()`
* In _Device.py add `writeAndVerifyBlocks()` for use instead of having to call all of `writeBlocks()`, `verifyBlocks()`, and `checkBlocks()`
* In _Device.py, the `command` decorator no longer check the number of args, as this is done automatically when the command function is called now.
* In _Node.py, the `hidden` property now has a public setter. It seems quite useful to be able to change the value of `hidden` after creation (but before `start()` is called).