### PR TITLE
Clear any errors at start of new transaction

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -325,6 +325,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                 return
 
             self._waitTransaction(0)
+            self.error = 0
 
             # Move staged write data to block. Clear stale.
             if type == rim.Write or type == rim.Post:


### PR DESCRIPTION
This fixes the bug where multiple timeout errors stack up and keep appearing on later transactions.