### PR TITLE
run count write=false

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -598,6 +598,6 @@ class RunControl(Device):
             if self._cmd is not None:
                 self._cmd()
 
-            self.runCount.set(self.runCount.value() + 1)
+            self.runCount.set(self.runCount.value() + 1,write=False)
         #print("Thread stop")
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -563,7 +563,7 @@ class RunControl(Device):
         self.add(pr.LocalVariable(
             name='runCount',
             value=0,
-            mode='RW',
+            mode='RO',
             pollInterval=1,
             description='Run Counter updated by run thread.'))
 


### PR DESCRIPTION
Needed to avoid GUI lockups due to excessive update callbacks.