### PR TITLE
Accelerate GUI startup

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -170,7 +170,8 @@ class Node(object):
         Get a ordered dictionary of nodes.
         pass a class type to receive a certain type of node
         """
-        return odict([(k,n) for k,n in self._nodes.items() if (isinstance(n, typ) and ((exc is None) or (not isinstance(n, exc))) and (hidden or n.hidden == False))])
+        return odict([(k,n) for k,n in self._nodes.items() \
+            if (isinstance(n, typ) and ((exc is None) or (not isinstance(n, exc))) and (hidden or n.hidden == False))])
 
     @Pyro4.expose
     @property
@@ -186,7 +187,7 @@ class Node(object):
         """
         Return an OrderedDict of the variables but not commands (which are a subclass of Variable
         """
-        return self._getNodes(typ=pr.BaseVariable,exc=pr.BaseCommand)
+        return self.getNodes(typ=pr.BaseVariable,exc=pr.BaseCommand)
 
     @Pyro4.expose
     @property
@@ -208,7 +209,7 @@ class Node(object):
         """
         Return an OrderedDict of the Commands that are children of this Node
         """
-        return self._getNodes(pr.BaseCommand)
+        return self.getNodes(pr.BaseCommand)
 
     @Pyro4.expose
     @property
@@ -216,7 +217,7 @@ class Node(object):
         """
         Return an OrderedDict of the Devices that are children of this Node
         """
-        return self._getNodes(pr.Device)
+        return self.getNodes(pr.Device)
 
     @Pyro4.expose
     @property

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -164,12 +164,13 @@ class Node(object):
         for i in range(number):
             self.add(nodeClass(name='{:s}[{:d}]'.format(name, i), offset=offset+(i*stride), **kwargs))
 
-    def _getNodes(self,typ):
+    @Pyro4.expose
+    def getNodes(self,typ,hidden=True):
         """
         Get a ordered dictionary of nodes.
         pass a class type to receive a certain type of node
         """
-        return odict([(k,n) for k,n in self._nodes.items() if isinstance(n, typ)])
+        return odict([(k,n) for k,n in self._nodes.items() if (isinstance(n, typ) and (hidden or n.hidden == False))])
 
     @Pyro4.expose
     @property

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -165,12 +165,12 @@ class Node(object):
             self.add(nodeClass(name='{:s}[{:d}]'.format(name, i), offset=offset+(i*stride), **kwargs))
 
     @Pyro4.expose
-    def getNodes(self,typ,hidden=True):
+    def getNodes(self,typ,exc=None,hidden=True):
         """
         Get a ordered dictionary of nodes.
         pass a class type to receive a certain type of node
         """
-        return odict([(k,n) for k,n in self._nodes.items() if (isinstance(n, typ) and (hidden or n.hidden == False))])
+        return odict([(k,n) for k,n in self._nodes.items() if (isinstance(n, typ) and ((exc is None) or (not isinstance(n, exc))) and (hidden or n.hidden == False))])
 
     @Pyro4.expose
     @property
@@ -186,8 +186,7 @@ class Node(object):
         """
         Return an OrderedDict of the variables but not commands (which are a subclass of Variable
         """
-        return odict([(k,n) for k,n in self._nodes.items()
-                      if isinstance(n, pr.BaseVariable) and not isinstance(n, pr.BaseCommand)])
+        return self._getNodes(typ=pr.BaseVariable,exc=pr.BaseCommand)
 
     @Pyro4.expose
     @property

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -114,21 +114,17 @@ class CommandWidget(QWidget):
     def addTreeItems(self,tree,d):
 
         # First create commands
-        for key,val in d.commands.items():
-        #for key,val in d.commands.iteritems():
-            if not val.hidden:
-                self.commands.append(CommandLink(parent=tree,command=val))
+        for key,val in d.getNodes(typ=pr.BaseCommand,hidden=False).items():
+            self.commands.append(CommandLink(parent=tree,command=val))
 
         # Then create devices
-        #for key,val in d.devices.iteritems():
-        for key,val in d.devices.items():
-            if not val.hidden:
-                w = QTreeWidgetItem(tree)
-                w.setText(0,val.name)
-                w.setExpanded(True)
-                self.addTreeItems(w,val)
+        for key,val in d.getNodes(typ=pr.Device,hidden=False).items():
+            w = QTreeWidgetItem(tree)
+            w.setText(0,val.name)
+            w.setExpanded(True)
+            self.addTreeItems(w,val)
 
-                self.devList.append({'dev':val,'item':w})
+            self.devList.append({'dev':val,'item':w})
 
     def setExpanded(self):
         for e in self.devList:

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -114,11 +114,11 @@ class CommandWidget(QWidget):
     def addTreeItems(self,tree,d):
 
         # First create commands
-        for key,val in d.getNodes(typ=pr.BaseCommand,hidden=False).items():
+        for key,val in d.getNodes(typ=pyrogue.BaseCommand,hidden=False).items():
             self.commands.append(CommandLink(parent=tree,command=val))
 
         # Then create devices
-        for key,val in d.getNodes(typ=pr.Device,hidden=False).items():
+        for key,val in d.getNodes(typ=pyrogue.Device,hidden=False).items():
             w = QTreeWidgetItem(tree)
             w.setText(0,val.name)
             w.setExpanded(True)

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -27,51 +27,63 @@ import pyrogue
 class CommandLink(QObject):
     """Bridge between the pyrogue tree and the display element"""
 
-    def __init__(self,*,parent,command):
+    def __init__(self,*,tree,parent,command,expand):
         QObject.__init__(self)
-        self.command = command
+        self._command = command
+        self._parent  = parent
+        self._tree    = tree
+        self._widget  = None
+        self._pb      = None
 
-        item = QTreeWidgetItem(parent)
-        parent.addChild(item)
-        item.setText(0,command.name)
-        item.setText(1,command.typeStr)
+        self._item = QTreeWidgetItem(parent)
+        self._item.setText(0,command.name)
+        self._item.setText(1,command.typeStr)
 
-        pb = QPushButton('Execute')
-        item.treeWidget().setItemWidget(item,2,pb)
-        pb.clicked.connect(self.execPressed)
+        if expand:
+            self.setup(None)
+        else:
+            self._tree.itemExpanded.connect(self.setup)
 
-        if command.arg:
-            if command.disp == 'enum' and command.enum is not None:
-                self.widget = QComboBox()
-                for i in command.enum:
-                    self.widget.addItem(command.enum[i])
+    def setup(self,item):
+        if self._pb is not None or (item is not None and item != self._parent):
+            return
 
-            elif command.disp == 'range':
-                self.widget = QSpinBox();
-                self.widget.setMinimum(command.minimum)
-                self.widget.setMaximum(command.maximum)
+        self._pb = QPushButton('Execute')
+        self._tree.setItemWidget(self._item,2,self._pb)
+        self._pb.clicked.connect(self.execPressed)
+
+        if self._command.arg:
+            if self._command.disp == 'enum' and self._command.enum is not None:
+                self._widget = QComboBox()
+                for i in self._command.enum:
+                    self._widget.addItem(self._command.enum[i])
+
+            elif self._command.disp == 'range':
+                self._widget = QSpinBox();
+                self._widget.setMinimum(self._command.minimum)
+                self._widget.setMaximum(self._command.maximum)
 
             else:
-                self.widget = QLineEdit()
-            
-            item.treeWidget().setItemWidget(item,3,self.widget)
-        else:
-            self.widget = None
+                self._widget = QLineEdit()
+
+            self._tree.setItemWidget(self._item,3,self._widget)
+
+        for i in range(0,3):
+            self._tree.resizeColumnToContents(i)
 
     def execPressed(self):
-        if self.widget != None:
-            value = str(self.widget.text())
+        if self._widget is not None:
+            value = str(self._widget.text())
         else:
             value=None
 
-        if self.command.arg:
+        if self._command.arg:
             try:
-                self.command.call(self.command.parseDisp(value))
+                self._command.call(self._command.parseDisp(value))
             except Exception:
                 pass
         else:
-            self.command.call()
-            
+            self._command.call()
 
 class CommandWidget(QWidget):
     def __init__(self, *, group, parent=None):
@@ -104,29 +116,22 @@ class CommandWidget(QWidget):
         r = QTreeWidgetItem(self.top)
         r.setText(0,root.name)
         r.setExpanded(True)
-        self.addTreeItems(r,root)
+        self.addTreeItems(r,root,True)
 
-        for i in range(0,3):
-            self.tree.resizeColumnToContents(i)
-
-        self.setExpanded()
-
-    def addTreeItems(self,tree,d):
+    def addTreeItems(self,parent,d,expand):
 
         # First create commands
         for key,val in d.getNodes(typ=pyrogue.BaseCommand,hidden=False).items():
-            self.commands.append(CommandLink(parent=tree,command=val))
+            self.commands.append(CommandLink(tree=self.tree,parent=parent,command=val,expand=expand))
 
         # Then create devices
         for key,val in d.getNodes(typ=pyrogue.Device,hidden=False).items():
-            w = QTreeWidgetItem(tree)
+            if not val.expand:
+                expand = False
+
+            w = QTreeWidgetItem(parent)
             w.setText(0,val.name)
-            w.setExpanded(True)
-            self.addTreeItems(w,val)
-
+            w.setExpanded(expand)
+            self.addTreeItems(w,val,expand)
             self.devList.append({'dev':val,'item':w})
-
-    def setExpanded(self):
-        for e in self.devList:
-            e['item'].setExpanded(e['dev'].expand)
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -307,16 +307,14 @@ class SystemWidget(QWidget):
         ###################
         # Data Controllers
         ###################
-        for key,val in root.devices.items():
-            if isinstance(val,pyrogue.DataWriter):
-                self.holders.append(DataLink(layout=tl,writer=val))
+        for key,val in root.getNodes(typ=pyrogue.DataWriter,hidden=True).items():
+            self.holders.append(DataLink(layout=tl,writer=val))
 
         ###################
         # Run Controllers
         ###################
-        for key,val in root.devices.items():
-            if isinstance(val,pyrogue.RunControl):
-                self.holders.append(ControlLink(layout=tl,control=val))
+        for key,val in root.getNodes(typ=pyrogue.RunControl,hidden=True).items():
+            self.holders.append(ControlLink(layout=tl,control=val))
 
         ###################
         # System Log

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -172,11 +172,11 @@ class VariableWidget(QWidget):
     def addTreeItems(self,tree,d):
 
         # First create variables
-        for key,val in d.getNodes(typ=pr.BaseVariable,exc=pr.BaseCommand,hidden=False).items():
+        for key,val in d.getNodes(typ=pyrogue.BaseVariable,exc=pyrogue.BaseCommand,hidden=False).items():
             var = VariableLink(parent=tree,variable=val)
 
         # Then create devices
-        for key,val in d.getNodes(typ=pr.Device,hidden=False).items():
+        for key,val in d.getNodes(typ=pyrogue.Device,hidden=False).items():
             w = QTreeWidgetItem(tree)
             w.setText(0,val.name)
             w.setExpanded(True)

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -172,22 +172,17 @@ class VariableWidget(QWidget):
     def addTreeItems(self,tree,d):
 
         # First create variables
-        for key,val in d.getNodes(typ=pr.BaseVariable,hidden=False).items():
-        #for key,val in d.variables.iteritems():
-        for key,val in d.variables.items():
-            if not val.hidden:
-                var = VariableLink(parent=tree,variable=val)
+        for key,val in d.getNodes(typ=pr.BaseVariable,exc=pr.BaseCommand,hidden=False).items():
+            var = VariableLink(parent=tree,variable=val)
 
         # Then create devices
-        #for key,val in d.devices.iteritems():
-        for key,val in d.devices.items():
-            if not val.hidden:
-                w = QTreeWidgetItem(tree)
-                w.setText(0,val.name)
-                w.setExpanded(True)
-                self.addTreeItems(w,val)
+        for key,val in d.getNodes(typ=pr.Device,hidden=False).items():
+            w = QTreeWidgetItem(tree)
+            w.setText(0,val.name)
+            w.setExpanded(True)
+            self.addTreeItems(w,val)
 
-                self.devList.append({'dev':val,'item':w})
+            self.devList.append({'dev':val,'item':w})
 
     def setExpanded(self):
         for e in self.devList:

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -172,6 +172,7 @@ class VariableWidget(QWidget):
     def addTreeItems(self,tree,d):
 
         # First create variables
+        for key,val in d.getNodes(typ=pr.BaseVariable,hidden=False).items():
         #for key,val in d.variables.iteritems():
         for key,val in d.variables.items():
             if not val.hidden:

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -28,69 +28,83 @@ import threading
 class VariableLink(QObject):
     """Bridge between the pyrogue tree and the display element"""
 
-    def __init__(self,*,parent,variable):
+    def __init__(self,*,tree,parent,variable,expand):
         QObject.__init__(self)
-        self.variable = variable
-        self._inEdit = False
-        self._swSet = False
-        self._lock = threading.Lock()
+        self._variable = variable
+        self._lock     = threading.Lock()
+        self._parent   = parent
+        self._tree     = tree
+        self._inEdit   = False
+        self._swSet    = False
+        self._widget   = None
 
-        item = QTreeWidgetItem(parent)
-        parent.addChild(item)
-        item.setText(0,variable.name)
-        item.setText(1,variable.mode)
-        item.setText(2,variable.typeStr) # Fix this. Should show base and size
+        self._item = QTreeWidgetItem(parent)
+        self._item.setText(0,variable.name)
+        self._item.setText(1,variable.mode)
+        self._item.setText(2,variable.typeStr) # Fix this. Should show base and size
 
         if variable.units:
-           item.setText(4,str(variable.units))
+            self._item.setText(4,str(variable.units))
 
-        if variable.disp == 'enum' and variable.enum is not None and variable.mode=='RW':
-            #print('VariableLink: variable: {} , enum: {}'.format(variable, variable.enum))
-            self.widget = QComboBox()
-            self.widget.activated.connect(self.guiChanged)
-            self.connect(self,SIGNAL('updateGui'),self.widget.setCurrentIndex)
-
-            for i in variable.enum:
-                self.widget.addItem(variable.enum[i])
-
-        elif variable.disp == 'range':
-            self.widget = QSpinBox();
-            self.widget.setMinimum(variable.minimum)
-            self.widget.setMaximum(variable.maximum)
-            self.widget.valueChanged.connect(self.guiChanged)
-            self.connect(self,SIGNAL('updateGui'),self.widget.setValue)
-
-        else:
-            self.widget = QLineEdit()
-            self.widget.returnPressed.connect(self.returnPressed)
-            self.widget.textEdited.connect(self.valueChanged)
-            self.connect(self,SIGNAL('updateGui'),self.widget.setText)
-
-        if variable.mode == 'RO':
-            self.widget.setReadOnly(True)
-
-        item.treeWidget().setItemWidget(item,3,self.widget)
         variable.addListener(self)
 
-        self.varListener(None,variable.value(),variable.valueDisp())
+        if expand:
+            self.setup(None)
+        else:
+            self._tree.itemExpanded.connect(self.setup)
+
+    def setup(self,item):
+        with self._lock:
+            if self._widget is not None or (item is not None and item != self._parent):
+                return
+
+            if self._variable.disp == 'enum' and self._variable.enum is not None and self._variable.mode != 'RO':
+                self._widget = QComboBox()
+                self._widget.activated.connect(self.guiChanged)
+                self.connect(self,SIGNAL('updateGui'),self._widget.setCurrentIndex)
+
+                for i in self._variable.enum:
+                    self._widget.addItem(self._variable.enum[i])
+
+            elif self._variable.disp == 'range':
+                self._widget = QSpinBox();
+                self._widget.setMinimum(self._variable.minimum)
+                self._widget.setMaximum(self._variable.maximum)
+                self._widget.valueChanged.connect(self.guiChanged)
+                self.connect(self,SIGNAL('updateGui'),self._widget.setValue)
+
+            else:
+                self._widget = QLineEdit()
+                self._widget.returnPressed.connect(self.returnPressed)
+                self._widget.textEdited.connect(self.valueChanged)
+                self.connect(self,SIGNAL('updateGui'),self._widget.setText)
+
+            if self._variable.mode == 'RO':
+                self._widget.setReadOnly(True)
+
+            self._tree.setItemWidget(self._item,3,self._widget)
+        self.varListener(None,self._variable.value(),self._variable.valueDisp())
+
+        for i in range(0,4):
+            self._tree.resizeColumnToContents(i)
 
     @Pyro4.expose
     def varListener(self, var, value, disp):
         #print('{} varListener ( {} {} )'.format(self.variable, type(value), value))
         with self._lock:
-            if self._inEdit is True:
+            if self._widget is None or self._inEdit is True:
                 return
 
             self._swSet = True
 
-            if isinstance(self.widget, QComboBox):
-                if self.widget.currentIndex() != self.widget.findText(disp):
-                    self.emit(SIGNAL("updateGui"), self.widget.findText(disp))
-            elif isinstance(self.widget, QSpinBox):
-                if self.widget.value != value:
+            if isinstance(self._widget, QComboBox):
+                if self._widget.currentIndex() != self._widget.findText(disp):
+                    self.emit(SIGNAL("updateGui"), self._widget.findText(disp))
+            elif isinstance(self._widget, QSpinBox):
+                if self._widget.value != value:
                     self.emit(SIGNAL("updateGui"), value)
             else:
-                if self.widget.text() != disp:
+                if self._widget.text() != disp:
                     self.emit(SIGNAL("updateGui"), disp)
 
             self._swSet = False
@@ -99,29 +113,29 @@ class VariableLink(QObject):
         self._inEdit = True
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
-        self.widget.setPalette(p)
+        self._widget.setPalette(p)
 
     def returnPressed(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.white)
-        self.widget.setPalette(p)
+        self._widget.setPalette(p)
 
-        self.guiChanged(self.widget.text())
+        self.guiChanged(self._widget.text())
         self._inEdit = False
-        self.emit(SIGNAL("updateGui"), self.variable.valueDisp())
+        self.emit(SIGNAL("updateGui"), self._variable.valueDisp())
 
     def guiChanged(self, value):
         if self._swSet:
             return
 
-        if self.variable.disp == 'enum':
+        if self._variable.disp == 'enum':
             # For enums, value will be index of selected item
             # Need to call itemText to convert to string
-            self.variable.setDisp(self.widget.itemText(value))
+            self._variable.setDisp(self._widget.itemText(value))
 
         else:
             # For non enums, value will be string entered in box
-            self.variable.setDisp(value)
+            self._variable.setDisp(value)
 
 
 class VariableWidget(QWidget):
@@ -158,33 +172,27 @@ class VariableWidget(QWidget):
         r = QTreeWidgetItem(self.top)
         r.setText(0,root.name)
         r.setExpanded(True)
-        self.addTreeItems(r,root)
-
-        for i in range(0,4):
-            self.tree.resizeColumnToContents(i)
-
-        self.setExpanded()
+        self.addTreeItems(r,root,True)
 
     def readPressed(self):
         for root in self.roots:
             root.ReadAll()
 
-    def addTreeItems(self,tree,d):
+    def addTreeItems(self,parent,d,expand):
 
         # First create variables
         for key,val in d.getNodes(typ=pyrogue.BaseVariable,exc=pyrogue.BaseCommand,hidden=False).items():
-            var = VariableLink(parent=tree,variable=val)
+            var = VariableLink(tree=self.tree,parent=parent,variable=val,expand=expand)
 
         # Then create devices
         for key,val in d.getNodes(typ=pyrogue.Device,hidden=False).items():
-            w = QTreeWidgetItem(tree)
-            w.setText(0,val.name)
-            w.setExpanded(True)
-            self.addTreeItems(w,val)
+            if not val.expand:
+                expand = False
 
+            w = QTreeWidgetItem(parent)
+            w.setText(0,val.name)
+            w.setExpanded(expand)
+            self.addTreeItems(w,val,expand)
             self.devList.append({'dev':val,'item':w})
 
-    def setExpanded(self):
-        for e in self.devList:
-            e['item'].setExpanded(e['dev'].expand)
 

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -329,6 +329,7 @@ void rhp::PgpCard::runThread() {
 
          // Select returns with available buffer
          if ( select(fd_+1,&fds,NULL,NULL,&tout) > 0 ) {
+            printf("Select fired for lane %i vc %i\n",lane_,vc_);
 
             // Zero copy buffers were not allocated or zero copy is disabled
             if ( zeroCopyEn_ == false || rawBuff_ == NULL ) {
@@ -360,13 +361,16 @@ void rhp::PgpCard::runThread() {
                frame->setError(error | frame->getError());
                frame->appendBuffer(buff);
                buff.reset();
+               printf("Got buffer\n");
 
                // If continue flag is not set, push frame and get a new empty frame
                if ( cont == 0 ) {
+                  printf("Got frame\n");
                   sendFrame(frame);
                   frame = ris::Frame::create();
                }
             }
+            printf("Empty read\n");
          }
          boost::this_thread::interruption_point();
       }

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -329,7 +329,6 @@ void rhp::PgpCard::runThread() {
 
          // Select returns with available buffer
          if ( select(fd_+1,&fds,NULL,NULL,&tout) > 0 ) {
-            printf("Select fired for lane %i vc %i\n",lane_,vc_);
 
             // Zero copy buffers were not allocated or zero copy is disabled
             if ( zeroCopyEn_ == false || rawBuff_ == NULL ) {
@@ -361,16 +360,13 @@ void rhp::PgpCard::runThread() {
                frame->setError(error | frame->getError());
                frame->appendBuffer(buff);
                buff.reset();
-               printf("Got buffer\n");
 
                // If continue flag is not set, push frame and get a new empty frame
                if ( cont == 0 ) {
-                  printf("Got frame\n");
                   sendFrame(frame);
                   frame = ris::Frame::create();
                }
             }
-            printf("Empty read\n");
          }
          boost::this_thread::interruption_point();
       }


### PR DESCRIPTION
There are two pieces to accelerate GUI startup.

First I updated the getNodes() method to filter on class type, with optional exclusion of other types. This is needed for getting variables that are not also commands. This method also now allows you to exclude hidden variables as well. Performing this filtering on the server side will accelerate this process when using a remote GUI over Pyro.

Second I updated the GUI so that the various widgets are not added to the tree until it is expanded. This greatly accelerates GUI startup but does not show any lag when expanding tree sections for the first time. GUI startup can then be accelerated by setting expand=False for some sections of the tree.

In one test I did these changes decreased the GUI startup time from 50 seconds to 4.