### PR TITLE
Improved Version Tracking, auto maintenance increment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,12 @@
 # ----------------------------------------------------------------------------
 
 
-VER_MAJOR := $(shell git describe --tags | awk -F'[Vv.-]' '{print $$2}')
-VER_MINOR := $(shell git describe --tags | awk -F'[Vv.-]' '{print $$3}')
-VER_MAINT := $(shell git describe --tags | awk -F'[Vv.-]' '{print $$4}')
-VERSION   := "$(VER_MAJOR).$(VER_MINOR).$(VER_MAINT)"
+VERSION  := $(shell git describe --tags)
 
 # Variables
 CC       := g++
-DEF      := -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_MAINT=$(VER_MAINT)
-CFLAGS   := -Wall `python3-config --cflags | sed s/-Wstrict-prototypes//` -fno-strict-aliasing
+DEF      := -DVERSION=\"$(VERSION)\"
+CFLAGS   := -Wall `python3-config --cflags | sed s/-Wstrict-prototypes//` -fno-strict-aliasing -Wno-deprecated-declarations
 CFLAGS   += -I$(BOOST_PATH)/include -I$(PWD)/include -I$(PWD)/drivers/include -std=c++0x -fPIC
 LFLAGS   := `python3-config --ldflags` -lboost_thread -lboost_python3 -lboost_system
 LFLAGS   += -L`python3-config --prefix`/lib/ -L$(BOOST_PATH)/lib -lbz2
@@ -61,11 +58,11 @@ clean:
 
 # Compile sources with headers
 %.o: %.cpp %.h 
-	@echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
+	echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
 
 # Compile sources without headers
 %.o: %.cpp 
-	@echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
+	echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
 
 # Compile Shared Library
 $(PYLIB): $(LIB_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,11 @@ clean:
 
 # Compile sources with headers
 %.o: %.cpp %.h 
-	echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
+	@echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
 
 # Compile sources without headers
 %.o: %.cpp 
-	echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
+	@echo "Compiling $@"; $(CC) -c $(CFLAGS) $(DEF) -o $@ $<
 
 # Compile Shared Library
 $(PYLIB): $(LIB_OBJ)

--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -27,13 +27,17 @@ namespace rogue {
    //! Version
    class Version {
 
+         static void init   ();
          static void extract(std::string compare, uint32_t *major, uint32_t *minor, uint32_t *maint);
 
-      public:
+         //static const std::string _version = VERSION;
+         static const char _version[];
 
-         static const uint32_t Major = VER_MAJOR;
-         static const uint32_t Minor = VER_MINOR;
-         static const uint32_t Maint = VER_MAINT;
+         static uint32_t _major;
+         static uint32_t _minor;
+         static uint32_t _maint;
+
+      public:
 
          Version() {}
 
@@ -46,6 +50,10 @@ namespace rogue {
          static void minVersion(std::string compare);
 
          static void setup_python();
+
+         static uint32_t getMajor ();
+         static uint32_t getMinor ();
+         static uint32_t getMaint ();
    };
 }
 

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -21,11 +21,27 @@
 #include <rogue/GeneralError.h>
 #include <string>
 
-const uint32_t rogue::Version::Major;
-const uint32_t rogue::Version::Minor;
-const uint32_t rogue::Version::Maint;
+const char rogue::Version::_version[] = VERSION;
+uint32_t   rogue::Version::_major     = 0;
+uint32_t   rogue::Version::_minor     = 0;
+uint32_t   rogue::Version::_maint     = 0;
 
 namespace bp = boost::python;
+
+void rogue::Version::init() {
+   uint32_t diff;
+   char     dump[100];
+   int32_t  ret;
+
+   ret = sscanf(_version,"v%i.%i.%i-%i-%s",&_major,&_minor,&_maint,&diff,dump);
+
+   if ( ret != 3 && ret != 5 ) {
+      printf("In = %s, Maj = %i, Min = %i, Mnt = %i, Diff=%i, Ret = %i\n",_version,_major,_minor,_maint,diff,ret);
+      throw(rogue::GeneralError("Version:init","Invalid compiled version string"));
+   }
+
+   if ( ret == 5 ) _maint += diff;
+}
 
 void rogue::Version::extract(std::string compare, uint32_t *major, uint32_t *minor, uint32_t *maint) {
    if ( sscanf(compare.c_str(),"%i.%i.%i",major,minor,maint) != 3 )
@@ -33,33 +49,48 @@ void rogue::Version::extract(std::string compare, uint32_t *major, uint32_t *min
 }
 
 std::string rogue::Version::current() {
-   char buffer[100];
-
-   sprintf(buffer,"%i.%i.%i", rogue::Version::Major, rogue::Version::Minor, rogue::Version::Maint);
-   return(std::string(buffer));
+   std::string ret = _version;
+   return ret;
 }
 
 bool rogue::Version::greaterThanEqual(std::string compare) {
-   uint32_t major, minor, maint;
-   extract(compare,&major,&minor,&maint);
-   if ( major != Major ) return(Major > major);
-   if ( minor != Minor ) return(Minor > minor);
-   if ( maint != Maint ) return(Maint > maint);
+   uint32_t cmajor, cminor, cmaint;
+   init();
+   extract(compare,&cmajor,&cminor,&cmaint);
+   if ( cmajor != _major ) return(_major > cmajor);
+   if ( cminor != _minor ) return(_minor > cminor);
+   if ( cmaint != _maint ) return(_maint > cmaint);
    return(true);
 }
 
 bool rogue::Version::lessThan(std::string compare) {
-   uint32_t major, minor, maint;
-   extract(compare,&major,&minor,&maint);
-   if ( major != Major ) return(Major < major);
-   if ( minor != Minor ) return(Minor < minor);
-   if ( maint != Maint ) return(Maint < maint);
+   uint32_t cmajor, cminor, cmaint;
+   init();
+   extract(compare,&cmajor,&cminor,&cmaint);
+   if ( cmajor != _major ) return(_major < cmajor);
+   if ( cminor != _minor ) return(_minor < cminor);
+   if ( cmaint != _maint ) return(_maint < cmaint);
    return(false);
 }
 
 void rogue::Version::minVersion(std::string compare) {
    if ( lessThan(compare) ) 
-      throw(rogue::GeneralError("Version:extract","Installed rogue is less than minimum version"));
+      throw(rogue::GeneralError("Version:minVersion","Installed rogue is less than minimum version"));
+}
+
+uint32_t rogue::Version::getMajor() {
+   init();
+   return _major;
+}
+
+uint32_t rogue::Version::getMinor() {
+   init();
+   return _minor;
+}
+
+uint32_t rogue::Version::getMaint() {
+   init();
+   return _maint;
 }
 
 void rogue::Version::setup_python() {
@@ -72,9 +103,12 @@ void rogue::Version::setup_python() {
       .staticmethod("lessThan")
       .def("minVersion", &rogue::Version::minVersion)
       .staticmethod("minVersion")
-      .def_readonly("Major",&rogue::Version::Major)
-      .def_readonly("Minor",&rogue::Version::Minor)
-      .def_readonly("Maint",&rogue::Version::Maint)
+      .def("major", &rogue::Version::getMajor)
+      .staticmethod("major")
+      .def("minor", &rogue::Version::getMinor)
+      .staticmethod("minor")
+      .def("maint", &rogue::Version::getMaint)
+      .staticmethod("maint")
    ;
 }
 


### PR DESCRIPTION
The maintenance field of the version will now be incremented by the relative commit offset. The full offset information is now printed at rogue startup:

In [1]: import rogue;
Rogue/pyrogue version v2.4.0-1-gdaa8319. https://github.com/slaclab/rogue
In [2]: rogue.Version.major()
Out[2]: 2
In [3]: rogue.Version.minor()
Out[3]: 4
In [4]: rogue.Version.maint()
Out[4]: 1
