### PR TITLE
Updates to how var updates are handled

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -203,7 +203,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def addVarListener(self,func):
         """
         Add a variable update listener function.
-        The variable, value and display string will be passed as an arg: func(var,value,disp)
+        The variable, value and display string will be passed as an arg: func(path,value,disp)
         """
         self._varListeners.append(func)
 
@@ -386,23 +386,23 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self.SystemLog.set(value='',write=False)
         self.SystemLog.updated()
 
-    def _varUpdated(self,var,value,disp):
+    def _varUpdated(self,path,value,disp):
         for func in self._varListeners:
             if hasattr(func,'varListener'):
-                func.varListener(var,value,disp)
+                func.varListener(path,value,disp)
             else:
-                func(var,value,disp)
+                func(path,value,disp)
 
         with self._updatedLock:
 
             # Log is active add to log
             if self._updatedDict is not None:
-                addPathToDict(self._updatedDict,var.path,disp)
+                addPathToDict(self._updatedDict,path,disp)
 
             # Otherwise act directly
             else:
                 d   = {}
-                addPathToDict(d,var.path,disp)
+                addPathToDict(d,path,disp)
                 yml = dictToYaml(d,default_flow_style=False)
                 self._sendYamlFrame(yml)
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -79,7 +79,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Variable update list
         self._updatedDict = None
-        self._updatedList = None
         self._updatedLock = threading.Lock()
 
         # Variable update listener
@@ -204,14 +203,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def addVarListener(self,func):
         """
         Add a variable update listener function.
-        The called function should take the following form:
-            func(yaml, list)
-                yaml = A yaml string containing updated variables and disp values
-                list = A list of variables with the following format for each entry
-                    {'path':path, 'value':rawValue, 'disp': dispValue}
+        The variable, value and display string will be passed as an arg: func(var,value,disp)
         """
-        with self._updatedLock:
-            self._varListeners.append(func)
+        self._varListeners.append(func)
 
     def getYaml(self,readFirst,modes=['RW']):
         """
@@ -292,18 +286,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         for key,value in self._nodes.items():
             value._setTimeout(timeout)
 
-    def _updateVarListeners(self, yml, l):
-        """Send update to listeners. Lock must be held."""
-        for tar in self._varListeners:
-            try:
-                if hasattr(tar,'rootListener'):
-                    tar.rootListener(yml,l)
-                else:
-                    tar(yml,l)
-            except Pyro4.errors.CommunicationError as e:
-                self._log.info("Pyro Disconnect. Removing callback")
-                self._varListeners.remove(tar)
-
     def _sendYamlFrame(self,yml):
         """
         Generate a frame containing the passed string.
@@ -326,19 +308,14 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Initialize the update tracking log before a bulk variable update"""
         with self._updatedLock:
             self._updatedDict = odict()
-            self._updatedList = []
 
     def _doneUpdatedVars(self):
         """Stream the results of a bulk variable update and update listeners"""
         with self._updatedLock:
             if self._updatedDict:
                 yml = dictToYaml(self._updatedDict,default_flow_style=False)
-
-                self._updateVarListeners(yml,self._updatedList)
                 self._sendYamlFrame(yml)
-
                 self._updatedDict = None
-                self._updatedList = None
 
     @pr.command(order=7, name='WriteAll', description='Write all values to the hardware')
     def _write(self):
@@ -410,23 +387,23 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.SystemLog.updated()
 
     def _varUpdated(self,var,value,disp):
-        entry = {'path':var.path,'value':value,'disp':disp}
+        for func in self._varListeners:
+            if hasattr(func,'varListener'):
+                func.varListener(var,value,disp)
+            else:
+                func(var,value,disp)
 
         with self._updatedLock:
 
             # Log is active add to log
             if self._updatedDict is not None:
                 addPathToDict(self._updatedDict,var.path,disp)
-                self._updatedList.append(entry)
 
             # Otherwise act directly
             else:
                 d   = {}
                 addPathToDict(d,var.path,disp)
                 yml = dictToYaml(d,default_flow_style=False)
-                lst = [entry]
-
-                self._updateVarListeners(yml,lst)
                 self._sendYamlFrame(yml)
 
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -158,7 +158,7 @@ class BaseVariable(pr.Node):
         Add a listener Variable or function to call when variable changes. 
         If listener is a Variable then Variable.updated() will be used as the function
         This is usefull when chaining variables together. (adc conversions, etc)
-        The variable, value and display string will be passed as an arg: func(var,value,disp)
+        The variable, value and display string will be passed as an arg: func(path,value,disp)
         """
         if isinstance(listener, BaseVariable):
             self.__listeners.append(listener.updated)
@@ -182,7 +182,7 @@ class BaseVariable(pr.Node):
         return self.get(read=False)
 
     @Pyro4.expose
-    def updated(self, var=None, value=None, disp=None):
+    def updated(self, path=None, value=None, disp=None):
         """Variable has been updated. Inform listeners."""
 
         if len(self.__listeners) == 0 and self._update is False:
@@ -193,13 +193,13 @@ class BaseVariable(pr.Node):
 
         for func in self.__listeners:
             if hasattr(func,'varListener'):
-                func.varListener(self,value,disp)
+                func.varListener(self.path,value,disp)
             else:
-                func(self,value,disp)
+                func(self.path,value,disp)
 
         # Root variable update log
         if self._update is True and self._root is not None:
-            self._root._varUpdated(self,value,disp)
+            self._root._varUpdated(self.path,value,disp)
 
     @Pyro4.expose
     def genDisp(self, value):
@@ -254,7 +254,6 @@ class BaseVariable(pr.Node):
         # Called by parent Device after _buildBlocks()
         if self._default is not None:
             self.setDisp(self._default, write=False)
-
 
     def _updatePollInterval(self):
         if self._pollInterval > 0 and self.root._pollQueue is not None:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -158,7 +158,7 @@ class BaseVariable(pr.Node):
         Add a listener Variable or function to call when variable changes. 
         If listener is a Variable then Variable.updated() will be used as the function
         This is usefull when chaining variables together. (adc conversions, etc)
-        The variable and value will be passed as an arg: func(var,value,disp)
+        The variable, value and display string will be passed as an arg: func(var,value,disp)
         """
         if isinstance(listener, BaseVariable):
             self.__listeners.append(listener.updated)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -185,6 +185,9 @@ class BaseVariable(pr.Node):
     def updated(self, var=None, value=None, disp=None):
         """Variable has been updated. Inform listeners."""
 
+        if len(self.__listeners) == 0 and self._update is False:
+            return
+
         value = self.value()
         disp  = self.valueDisp()
 

--- a/python/pyrogue/epics.py
+++ b/python/pyrogue/epics.py
@@ -223,10 +223,10 @@ class EpicsCaServer(object):
                 pass
 
     # Variable was updated
-    def _variableUpdated(self,var,value,disp):
+    def _variableUpdated(self,path,value,disp):
         if self._driver is None: return
 
-        d = self._pvMap[var.path]
+        d = self._pvMap[path]
 
         if d['type'] == 'enum':
             val = d['enums'].index(disp)

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -133,26 +133,28 @@ class DataLink(QObject):
         pass
 
     @Pyro4.expose
-    def varListener(self,var,value,disp):
+    def varListener(self,path,value,disp):
 
         if self.block: return
 
-        if var.name == 'dataFile':
+        name = path.split('.')[-1]
+
+        if name == 'dataFile':
             self.emit(SIGNAL("updateDataFile"),disp)
 
-        elif var.name == 'open':
+        elif name == 'open':
             self.emit(SIGNAL("updateOpenState"),self.openState.findText(disp))
 
-        elif var.name == 'bufferSize':
+        elif name == 'bufferSize':
             self.emit(SIGNAL("updateBufferSize"),disp)
 
-        elif var.name == 'maxFileSize':
+        elif name == 'maxFileSize':
             self.emit(SIGNAL("updateMaxSize"),disp)
 
-        elif var.name == 'fileSize':
+        elif name == 'fileSize':
             self.emit(SIGNAL("updateFileSize"),disp)
 
-        elif var.name == 'frameCount':
+        elif name == 'frameCount':
             self.emit(SIGNAL("updateFrameCount"),disp)
 
     def dataFileEdited(self):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -92,7 +92,7 @@ class VariableLink(QObject):
             self._tree.resizeColumnToContents(i)
 
     @Pyro4.expose
-    def varListener(self, var, value, disp):
+    def varListener(self, path, value, disp):
         #print('{} varListener ( {} {} )'.format(self.variable, type(value), value))
         with self._lock:
             if self._widget is None or self._inEdit is True:

--- a/python/pyrogue/mysql.py
+++ b/python/pyrogue/mysql.py
@@ -194,7 +194,7 @@ class MysqlGw(object):
         self._varSer[variable.path] = 0
         variable.addListener(self._updateVariables)
 
-    def _updateVariables (self, var, value, disp):
+    def _updateVariables (self, path, value, disp):
         with self._dbLock:
             if self._db is None:
                 #self._log.error("Not connected to Mysql server " + self._host)
@@ -202,8 +202,8 @@ class MysqlGw(object):
 
             try:
                 cursor = self._db.cursor(MySQLdb.cursors.DictCursor)
-                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(num['disp']))
-                sql += "server_ser = (server_ser + 1) where name='{}'".format(num['path'])
+                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(disp))
+                sql += "server_ser = (server_ser + 1) where name='{}'".format(path)
                 cursor.execute(sql)
                 self._db.commit()
             except:

--- a/python/pyrogue/mysql.py
+++ b/python/pyrogue/mysql.py
@@ -107,7 +107,6 @@ class MysqlGw(object):
                     self._addVariable(v)
             self._db.commit()
             self._delOldEntries()
-            self._root.addVarListener(self._updateVariables)
 
     def start(self):
         self._runEn = True
@@ -193,19 +192,19 @@ class MysqlGw(object):
 
         cursor.execute(sql)
         self._varSer[variable.path] = 0
+        variable.addListener(self._updateVariables)
 
-    def _updateVariables (self, yml, lst):
-        if self._db is None:
-            #self._log.error("Not connected to Mysql server " + self._host)
-            return
-
+    def _updateVariables (self, var, value, disp):
         with self._dbLock:
+            if self._db is None:
+                #self._log.error("Not connected to Mysql server " + self._host)
+                return
+
             try:
                 cursor = self._db.cursor(MySQLdb.cursors.DictCursor)
-                for num in lst:
-                    sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(num['disp']))
-                    sql += "server_ser = (server_ser + 1) where name='{}'".format(num['path'])
-                    cursor.execute(sql)
+                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(num['disp']))
+                sql += "server_ser = (server_ser + 1) where name='{}'".format(num['path'])
+                cursor.execute(sql)
                 self._db.commit()
             except:
                 self._log.error("Error executing sql.")


### PR DESCRIPTION
While working on ESROGUE-151 (pyro gui performance) I found some items which are hurting our performance when propagating variable updates. I am proposing a few changes which may impact existing code. 

1. The varUpdate callback from the variable changes format from:
   func(var,value,disp)
to
  func(path,value,disp)

The path string is passed instead of the variable object. Passing an object has overhead with pyro (also creates infinite loops) and most receivers just need the path. The local name or object can be obtained through additional local calls. i.e. self.root.getNode(path)

2. The root level variable update callback changes from:
   func(xml, list)
to
   func(path,value,disp)

Basically it becomes exactly the same as the variable level callback. The only different now is that root level call back receivers get all variable changes, where going right to the variable allows a receiver to register for targeted callbacks. As far as I can tell my Rogue internals are the only code which was using the root level callbacks.

I also separated the xml stream generation from the callbacks. Now the callbacks are immediate, while the xml generate can be blocked during reads or writes. This reduced the number of objects that I was storing and generating.

I also removed some unnecessary locks after reading up on python collection thread safety.

Let me know if you know of code that is using the passed var object in the variable update listener or code which was using the root level variable callback.

