### PR TITLE
Allow additional args in functions called by varFuncHelper

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -706,7 +706,7 @@ def varFuncHelper(func,pargs,log,path):
                     inspect.getfullargspec(func).kwonlyargs 
 
             # Build overlapping arg list
-            args = {k:pargs[k] for k in fargs if k is not 'self'}
+            args = {k:pargs[k] for k in fargs if k is not 'self' and k in pargs}
 
         # handle c++ functions, no args supported for now
         except:


### PR DESCRIPTION
This change allows called functions to have additional arguments as long as they have default values.

This allows the functions to avoid the "for-each closure trap", as described here:
https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result

