### PR TITLE
using HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "drivers"]
 	path = drivers
-	url = git@github.com:slaclab/aes-stream-drivers.git
+	url = https://github.com/slaclab/aes-stream-drivers
 	branch = master


### PR DESCRIPTION
Since slaclab/aes-stream-drivers is public (not private) and I have mixed submodule repos (github, gitlab, etc), I think it makes sense to use the HTTPS link to the slaclab/aes-stream-drivers submodule.  