### PR TITLE
Proposal For stream interface FIFO module

### DIFF
--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -1,0 +1,78 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title         : SLAC Register Protocol (SRP) Fifo
+ * ----------------------------------------------------------------------------
+ * File          : Fifo.h
+ * Author        : Ryan Herbst <rherbst@slac.stanford.edu>
+ * Created       : 02/02/2018
+ *-----------------------------------------------------------------------------
+ * Description :
+ *    AXI Stream FIFO
+ *-----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+    * https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ *-----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_STREAM_FIFO_H__
+#define __ROGUE_INTERFACES_STREAM_FIFO_H__
+#include <stdint.h>
+#include <boost/thread.hpp>
+#include <rogue/interfaces/stream/Master.h>
+#include <rogue/interfaces/stream/Slave.h>
+#include <rogue/Logging.h>
+
+namespace rogue {
+   namespace interfaces {
+      namespace stream {
+
+         //!  AXI Stream FIFO
+         class Fifo : public rogue::interfaces::stream::Master,
+                      public rogue::interfaces::stream::Slave {
+
+               rogue::Logging * log_;
+
+               // Configurations
+               uint32_t trimSize_;
+               uint32_t maxDepth_;
+
+               // Queue
+               rogue::Queue<boost::shared_ptr<rogue::interfaces::stream::Frame>> queue_;
+
+               // Transmission thread
+               boost::thread* thread_;
+
+               //! Thread background
+               void runThread();
+
+            public:
+
+               //! Class creation
+               static boost::shared_ptr<rogue::interfaces::stream::Fifo> 
+                  create(uint32_t maxDepth, uint32_t trimSize);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Creator
+               Fifo(uint32_t maxDepth, uint32_t trimSize);
+
+               //! Deconstructor
+               ~Fifo();
+
+               //! Accept a frame from master
+               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
+
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::Fifo> FifoPtr;
+      }
+   }
+}
+#endif
+

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -78,6 +78,9 @@ namespace rogue {
                //! Append frame to end. Passed frame is emptied.
                void appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
+               //! Copy count bytes frame, starting at offset in local frame
+               uint32_t copyFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint32_t offset, uint32_t count);
+
                //! Get buffer count
                uint32_t getCount();
 

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -1,0 +1,98 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title         : SLAC Register Protocol (SRP) Fifo
+ * ----------------------------------------------------------------------------
+ * File          : Fifo.cpp
+ * Author        : Ryan Herbst <rherbst@slac.stanford.edu>
+ * Created       : 02/02/2018
+ *-----------------------------------------------------------------------------
+ * Description :
+ *    AXI Stream FIFO
+ *-----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+    * https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ *-----------------------------------------------------------------------------
+**/
+#include <stdint.h>
+#include <boost/thread.hpp>
+#include <boost/make_shared.hpp>
+#include <rogue/interfaces/stream/Master.h>
+#include <rogue/interfaces/stream/Slave.h>
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/interfaces/stream/Fifo.h>
+#include <rogue/Logging.h>
+#include <sys/syscall.h>
+
+namespace bp = boost::python;
+namespace ris = rogue::interfaces::stream;
+
+//! Class creation
+ris::FifoPtr ris::Fifo::create(uint32_t maxDepth, uint32_t trimSize) {
+   ris::FifoPtr p = boost::make_shared<ris::Fifo>(maxDepth,trimSize);
+   return(p);
+}
+
+//! Setup class in python
+void ris::Fifo::setup_python() {
+   bp::class_<ris::Fifo, ris::FifoPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Fifo",bp::init<uint32_t,uint32_t>())
+      .def("create", &ris::Fifo::create)
+      .staticmethod("create")
+   ;
+}
+
+//! Creator with version constant
+ris::Fifo::Fifo(uint32_t maxDepth, uint32_t trimSize ) : ris::Master(), ris::Slave() { 
+   maxDepth_ = maxDepth;
+   trimSize_ = trimSize;
+
+   queue_.setThold(maxDepth);
+
+   log_ = new rogue::Logging("Fifo");
+
+   // Start read thread
+   thread_ = new boost::thread(boost::bind(&ris::Fifo::runThread, this));
+}
+
+//! Deconstructor
+ris::Fifo::~Fifo() {}
+
+//! Accept a frame from master
+void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
+   uint32_t       size;
+   ris::BufferPtr buff;
+   ris::FramePtr  nFrame;
+
+   // FIFO is full, drop frame
+   if ( queue_.busy()  ) return;
+
+   // Get size, adjust if trim is enabled
+   size = frame->getPayload();
+   if ( trimSize_ != 0 && trimSize_ < size ) size = trimSize_;
+
+   // Request a new frame to hold the data
+   nFrame = reqFrame(size,true,0);
+
+   // Copy the frame
+   nFrame->copyFrame(frame,0,size);
+
+   // Append to buffer
+   queue_.push(nFrame);
+}
+
+//! Thread background
+void ris::Fifo::runThread() {
+   log_->info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+
+   try {
+      while(1) {
+         sendFrame(queue_.pop());
+      }
+   } catch (boost::thread_interrupted&) { }
+}
+

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -58,6 +58,34 @@ void ris::Frame::appendFrame(ris::FramePtr frame) {
    for (x=0; x < frame->getCount(); x++) buffers_.push_back(frame->getBuffer(x));
 }
 
+//! Copy count bytes frame, starting at offset in local frame
+uint32_t ris::Frame::copyFrame(ris::FramePtr frame, uint32_t offset, uint32_t count) {
+   uint32_t x;
+   uint32_t off;
+   uint32_t rem;
+   uint32_t bsize;
+
+   ris::BufferPtr buff;
+
+   off = offset;
+   rem = count;
+
+   // Process incoming frame buffer by buffer
+   for (x=0; x < frame->getCount(); x++ ) {
+      buff = frame->getBuffer(x);
+      bsize = buff->getPayload();
+
+      if (bsize > rem) bsize = rem;
+
+      this->write ( buff->getPayloadData(), off, bsize );
+      off += bsize;
+      rem -= bsize;
+
+      if ( rem == 0 ) break;
+   }
+   return(count);
+}
+
 //! Get buffer count
 uint32_t ris::Frame::getCount() {
    return(buffers_.size());
@@ -383,6 +411,7 @@ void ris::Frame::setup_python() {
    bp::class_<ris::Frame, ris::FramePtr, boost::noncopyable>("Frame",bp::no_init)
       .def("getAvailable", &ris::Frame::getAvailable)
       .def("getPayload",   &ris::Frame::getPayload)
+      .def("copyframe",    &ris::Frame::copyFrame)
       .def("read",         &ris::Frame::readPy)
       .def("write",        &ris::Frame::writePy)
       .def("setError",     &ris::Frame::setError)

--- a/src/rogue/interfaces/stream/module.cpp
+++ b/src/rogue/interfaces/stream/module.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/interfaces/stream/module.h>
 #include <boost/python.hpp>
 
@@ -47,6 +48,7 @@ void ris::setup_module() {
    ris::Master::setup_python();
    ris::Slave::setup_python();
    ris::Pool::setup_python();
+   ris::Fifo::setup_python();
 
 }
 


### PR DESCRIPTION

This module will accept a pyrogue stream (as a slave), create a copy of the frame and insert it into a FIFO.  On the master side, a thread will then read form the FIFO and act as a stream master.

A configuration parameter sets the max number of entries for the FIFO. Once the FIFO has hit this threshold frames will drop. If set to zero, no dropping will occur.

Another parameter is the trim size. If set to non-zero the frame copy will only include the specified number of bytes. This is useful when only the first portion of the frame will be looked at.

We can use this FIFO to pass data to a pyqt display without disrupting the main data path. We may also be able to use this when interfacing to epics.

Please suggest any other features or comment on the current interfaces.