### PR TITLE
Remove max buffer size from frame request API

### DIFF
--- a/include/rogue/hardware/data/DataCard.h
+++ b/include/rogue/hardware/data/DataCard.h
@@ -100,12 +100,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                /* 

--- a/include/rogue/hardware/pgp/PgpCard.h
+++ b/include/rogue/hardware/pgp/PgpCard.h
@@ -124,12 +124,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                /* 

--- a/include/rogue/hardware/rce/AxiStream.h
+++ b/include/rogue/hardware/rce/AxiStream.h
@@ -93,12 +93,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBufferSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -76,12 +76,8 @@ namespace rogue {
                /*
                 * An allocate command will be issued to the primary slave set with setSlave()
                 * Pass size and flag indicating if zero copy buffers are allowed
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  reqFrame ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize);
+               boost::shared_ptr<rogue::interfaces::stream::Frame> reqFrame ( uint32_t size, bool zeroCopyEn);
 
                //! Push frame to all slaves
                void sendFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/interfaces/stream/Pool.h
+++ b/include/rogue/interfaces/stream/Pool.h
@@ -78,11 +78,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. 
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               virtual boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               virtual boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn );
 
                //! Return a buffer
                /*

--- a/include/rogue/protocols/packetizer/Application.h
+++ b/include/rogue/protocols/packetizer/Application.h
@@ -75,12 +75,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -81,8 +81,7 @@ namespace rogue {
                ~Controller();
 
                //! Transport frame allocation request
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  reqFrame ( uint32_t size, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> reqFrame ( uint32_t size);
 
                //! Frame received at transport interface
                void transportRx( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/packetizer/Transport.h
+++ b/include/rogue/protocols/packetizer/Transport.h
@@ -65,12 +65,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/rssi/Application.h
+++ b/include/rogue/protocols/rssi/Application.h
@@ -65,12 +65,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -133,8 +133,7 @@ namespace rogue {
                ~Controller();
 
                //! Transport frame allocation request
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  reqFrame ( uint32_t size, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> reqFrame ( uint32_t size );
 
                //! Frame received at transport interface
                void transportRx( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/rssi/Transport.h
+++ b/include/rogue/protocols/rssi/Transport.h
@@ -68,12 +68,8 @@ namespace rogue {
                /*
                 * Pass total size required.
                 * Pass flag indicating if zero copy buffers are acceptable
-                * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
-                * returned but the total buffer count must assume each buffer is of size maxBuffSize
-                * If maxBuffSize = 0, slave will freely determine the buffer size.
                 */
-               boost::shared_ptr<rogue::interfaces::stream::Frame>
-                  acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+               boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/utilities/StreamUnZip.h
+++ b/include/rogue/utilities/StreamUnZip.h
@@ -47,8 +47,7 @@ namespace rogue {
             void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
 
             //! Accept a new frame request
-            boost::shared_ptr<rogue::interfaces::stream::Frame>
-               acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+            boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn );
       };
 
       // Convienence

--- a/include/rogue/utilities/StreamZip.h
+++ b/include/rogue/utilities/StreamZip.h
@@ -47,8 +47,7 @@ namespace rogue {
             void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
 
             //! Accept a new frame request
-            boost::shared_ptr<rogue::interfaces::stream::Frame>
-               acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize );
+            boost::shared_ptr<rogue::interfaces::stream::Frame> acceptReq ( uint32_t size, bool zeroCopyEn );
       };
 
       // Convienence

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -294,7 +294,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """
         Generate a frame containing the passed string.
         """
-        frame = self._reqFrame(len(yml),True,0)
+        frame = self._reqFrame(len(yml),True)
         b = bytearray(yml,'utf-8')
         frame.write(b,0)
         self._sendFrame(frame)

--- a/python/pyrogue/simulation.py
+++ b/python/pyrogue/simulation.py
@@ -116,7 +116,7 @@ class StreamSim(rogue.interfaces.stream.Master,
             luser = bytearray(r[1])[0]
             data  = bytearray(r[2])
 
-            frame = self._reqFrame(len(data),True,0)
+            frame = self._reqFrame(len(data),True)
 
             if ( self._ssi and (luser & 0x1)): frame.setError(1)
 

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -92,7 +92,7 @@ void rhd::DataCard::dmaAck() {
 }
 
 //! Generate a buffer. Called from master
-ris::FramePtr rhd::DataCard::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize) {
+ris::FramePtr rhd::DataCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
@@ -102,12 +102,12 @@ ris::FramePtr rhd::DataCard::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_
    uint32_t         buffSize;
 
    //! Adjust allocation size
-   if ( (maxBuffSize > bSize_) || (maxBuffSize == 0)) buffSize = bSize_;
-   else buffSize = maxBuffSize;
+   if ( size > bSize_) buffSize = bSize_;
+   else buffSize = size;
 
    // Zero copy is disabled. Allocate from memory.
    if ( zeroCopyEn == false || rawBuff_ == NULL ) {
-      frame = ris::Pool::acceptReq(size,false,buffSize);
+      frame = ris::Pool::acceptReq(size,false);
    }
 
    // Allocate zero copy buffers from driver

--- a/src/rogue/hardware/exo/Tem.cpp
+++ b/src/rogue/hardware/exo/Tem.cpp
@@ -158,7 +158,7 @@ void rhe::Tem::runThread() {
          if ( select(fd_+1,&fds,NULL,NULL,&tout) > 0 ) {
 
             // Allocate frame
-            frame = acceptReq(1024*1024*2,false,0);
+            frame = acceptReq(1024*1024*2,false);
             buff = frame->getBuffer(0);
 
             // Attempt read, lane and vc not needed since only one lane/vc is open

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -149,7 +149,7 @@ void rhp::PgpCard::sendOpCode(uint8_t code) {
 }
 
 //! Generate a buffer. Called from master
-ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
+ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
@@ -159,12 +159,12 @@ ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t
    uint32_t         buffSize;
 
    //! Adjust allocation size
-   if ( (maxBuffSize > bSize_) || (maxBuffSize == 0)) buffSize = bSize_;
-   else buffSize = maxBuffSize;
+   if ( size > bSize_) buffSize = bSize_;
+   else buffSize = size;
 
    // Zero copy is disabled. Allocate from memory.
    if ( zeroCopyEn_ == false || zeroCopyEn == false || rawBuff_ == NULL ) {
-      frame = ris::Pool::acceptReq(size,false,buffSize);
+      frame = ris::Pool::acceptReq(size,false);
    }
 
    // Allocate zero copy buffers from driver

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -94,7 +94,7 @@ void rhr::AxiStream::dmaAck() {
 }
 
 //! Generate a buffer. Called from master
-ris::FramePtr rhr::AxiStream::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize) {
+ris::FramePtr rhr::AxiStream::acceptReq ( uint32_t size, bool zeroCopyEn) {
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
@@ -104,12 +104,12 @@ ris::FramePtr rhr::AxiStream::acceptReq ( uint32_t size, bool zeroCopyEn, uint32
    uint32_t         buffSize;
 
    //! Adjust allocation size
-   if ( (maxBuffSize > bSize_) || (maxBuffSize == 0)) buffSize = bSize_;
-   else buffSize = maxBuffSize;
+   if ( size > bSize_ ) buffSize = bSize_;
+   else buffSize = size;
 
    // Zero copy is disabled. Allocate from memory.
    if ( zeroCopyEn == false || rawBuff_ == NULL ) {
-      frame = ris::Pool::acceptReq(size,false,buffSize);
+      frame = ris::Pool::acceptReq(size,false);
    }
 
    // Allocate zero copy buffers from driver

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -76,7 +76,7 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    if ( trimSize_ != 0 && trimSize_ < size ) size = trimSize_;
 
    // Request a new frame to hold the data
-   nFrame = reqFrame(size,true,0);
+   nFrame = reqFrame(size,true);
 
    // Copy the frame
    nFrame->copyFrame(frame,0,size);

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -62,13 +62,13 @@ void ris::Master::addSlave ( ris::SlavePtr slave ) {
 }
 
 //! Request frame from primary slave
-ris::FramePtr ris::Master::reqFrame ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
+ris::FramePtr ris::Master::reqFrame ( uint32_t size, bool zeroCopyEn ) {
    ris::SlavePtr slave;
 
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(slaveMtx_);
    slave = primary_;
-   return(slave->acceptReq(size,zeroCopyEn,maxBuffSize));
+   return(slave->acceptReq(size,zeroCopyEn));
 }
 
 //! Push frame to slaves

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -58,20 +58,15 @@ uint32_t ris::Pool::getAllocCount() {
  * Pass total size required.
  * Pass flag indicating if zero copy buffers are acceptable
  */
-ris::FramePtr ris::Pool::acceptReq (uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
+ris::FramePtr ris::Pool::acceptReq (uint32_t size, bool zeroCopyEn) {
    ris::FramePtr ret;
-   uint32_t bSize;
    uint32_t frSize;
 
    ret  = ris::Frame::create();
    frSize = 0;
 
-   // Determine buffer size
-   if ( maxBuffSize == 0 ) bSize = size;
-   else bSize = maxBuffSize;
-
-   while ( frSize < size ) ret->appendBuffer(allocBuffer(bSize,&frSize));
-
+   // Buffers may be smaller than frame
+   while ( frSize < size ) ret->appendBuffer(allocBuffer(size,&frSize));
    return(ret);
 }
 

--- a/src/rogue/protocols/packetizer/Application.cpp
+++ b/src/rogue/protocols/packetizer/Application.cpp
@@ -67,8 +67,8 @@ void rpp::Application::setController( rpp::ControllerPtr cntl ) {
 }
 
 //! Generate a Frame. Called from master
-ris::FramePtr rpp::Application::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
-   return(cntl_->reqFrame(size,maxBuffSize));
+ris::FramePtr rpp::Application::acceptReq ( uint32_t size, bool zeroCopyEn) {
+   return(cntl_->reqFrame(size));
 }
 
 //! Accept a frame from master

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -63,7 +63,7 @@ rpp::Controller::Controller ( uint32_t segmentSize, rpp::TransportPtr tran, rpp:
 rpp::Controller::~Controller() { }
 
 //! Transport frame allocation request
-ris::FramePtr rpp::Controller::reqFrame ( uint32_t size, uint32_t maxBuffSize ) {
+ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {
    ris::FramePtr  lFrame;
    ris::FramePtr  rFrame;
    ris::BufferPtr buff;
@@ -73,7 +73,7 @@ ris::FramePtr rpp::Controller::reqFrame ( uint32_t size, uint32_t maxBuffSize ) 
 
    // Request individual frames upstream with buffer = segmentSize_
    while ( lFrame->getAvailable() < size ) {
-      rFrame = tran_->reqFrame (segmentSize_, false, segmentSize_);
+      rFrame = tran_->reqFrame (segmentSize_, false);
       buff = rFrame->getBuffer(0);
   
       // Buffer should support our header/tail plus at least one payload byte 

--- a/src/rogue/protocols/packetizer/Transport.cpp
+++ b/src/rogue/protocols/packetizer/Transport.cpp
@@ -70,11 +70,8 @@ void rpp::Transport::setController( rpp::ControllerPtr cntl ) {
 /*
  * Pass total size required.
  * Pass flag indicating if zero copy buffers are acceptable
- * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
- * returned but the total buffer count must assume each buffer is of size maxBuffSize
- * If maxBuffSize = 0, slave will freely determine the buffer size.
  */
-ris::FramePtr rpp::Transport::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
+ris::FramePtr rpp::Transport::acceptReq ( uint32_t size, bool zeroCopyEn) {
    throw(rogue::GeneralError("Transport::acceptReq","Invalid frame request."));
 }
 

--- a/src/rogue/protocols/rssi/Application.cpp
+++ b/src/rogue/protocols/rssi/Application.cpp
@@ -67,8 +67,8 @@ void rpr::Application::setController( rpr::ControllerPtr cntl ) {
 }
 
 //! Generate a Frame. Called from master
-ris::FramePtr rpr::Application::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
-   return(cntl_->reqFrame(size,maxBuffSize));
+ris::FramePtr rpr::Application::acceptReq ( uint32_t size, bool zeroCopyEn ) {
+   return(cntl_->reqFrame(size));
 }
 
 //! Accept a frame from master

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -104,7 +104,7 @@ void rpr::Controller::stop() {
 }
 
 //! Transport frame allocation request
-ris::FramePtr rpr::Controller::reqFrame ( uint32_t size, uint32_t maxBuffSize ) {
+ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
    ris::FramePtr  frame;
    ris::BufferPtr buffer;
    uint32_t       nSize;
@@ -117,7 +117,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size, uint32_t maxBuffSize ) 
    if ( nSize > segmentSize_  ) nSize = segmentSize_;
 
    // Forward frame request to transport slave
-   frame = tran_->reqFrame (nSize, false, nSize);
+   frame = tran_->reqFrame (nSize, false);
    buffer = frame->getBuffer(0);
 
    // Make sure there is enough room in first buffer for our header
@@ -394,7 +394,7 @@ uint32_t rpr::Controller::stateClosedWait () {
    else if ( timePassed(&stTime_,TryPeriod) ) {
 
       // Allocate frame
-      head = rpr::Header::create(tran_->reqFrame(rpr::Header::SynSize,false,rpr::Header::SynSize));
+      head = rpr::Header::create(tran_->reqFrame(rpr::Header::SynSize,false));
 
       // Set frame
       head->syn = true;
@@ -427,7 +427,7 @@ uint32_t rpr::Controller::stateSendSeqAck () {
    uint32_t x;
 
    // Allocate frame
-   rpr::HeaderPtr ack = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false,rpr::Header::HeaderSize));
+   rpr::HeaderPtr ack = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));
 
    // Setup frame
    ack->ack = true;
@@ -477,7 +477,7 @@ uint32_t rpr::Controller::stateOpen () {
    if ( ( doNull || ackPend >= maxCumAck_ || 
         ((ackPend > 0 || appQueue_.busy()) && timePassed(&locTime,cumAckTout_)) ) ) {
 
-      head = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false,rpr::Header::HeaderSize));
+      head = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));
       head->ack = true;
       head->nul = doNull;
 
@@ -542,7 +542,7 @@ uint32_t rpr::Controller::stateError () {
    rpr::HeaderPtr rst;
    uint32_t x;
 
-   rst = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false,rpr::Header::HeaderSize));
+   rst = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));
    rst->rst = true;
 
    boost::unique_lock<boost::mutex> lock(txMtx_);

--- a/src/rogue/protocols/rssi/Transport.cpp
+++ b/src/rogue/protocols/rssi/Transport.cpp
@@ -68,11 +68,8 @@ void rpr::Transport::setController( rpr::ControllerPtr cntl ) {
 /*
  * Pass total size required.
  * Pass flag indicating if zero copy buffers are acceptable
- * maxBuffSize indicates the largest acceptable buffer size. A larger buffer can be
- * returned but the total buffer count must assume each buffer is of size maxBuffSize
- * If maxBuffSize = 0, slave will freely determine the buffer size.
  */
-ris::FramePtr rpr::Transport::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
+ris::FramePtr rpr::Transport::acceptReq ( uint32_t size, bool zeroCopyEn ) {
    throw(rogue::GeneralError("Transport::acceptReq","Invalid frame request."));
 }
 

--- a/src/rogue/protocols/srp/Cmd.cpp
+++ b/src/rogue/protocols/srp/Cmd.cpp
@@ -64,7 +64,7 @@ void rps::Cmd::sendCmd(uint8_t opCode, uint32_t context) {
    frameSize = 16;
 
    // Request frame
-   frame = reqFrame(frameSize, true, 0);
+   frame = reqFrame(frameSize, true);
 
    // First 32-bit value is context
    temp = context;

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -86,7 +86,7 @@ void rps::SrpV0::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t addr
       frameSize = 16;
 
    // Request frame
-   frame = reqFrame(frameSize,true,0);
+   frame = reqFrame(frameSize,true);
 
    // First 32-bit value is context
    temp = id;

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -82,7 +82,7 @@ void rps::SrpV3::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t addr
    else frameSize = 20;
 
    // Request frame
-   frame = reqFrame(frameSize,true,0);
+   frame = reqFrame(frameSize,true);
 
    // Bits 7:0 of first 32-bit word are version
    temp = 0x03;

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -158,7 +158,7 @@ void rpu::Client::runThread() {
    log.info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
 
    // Preallocate frame
-   frame = ris::Pool::acceptReq(maxSize_,false,maxSize_);
+   frame = ris::Pool::acceptReq(maxSize_,false);
 
    try {
 
@@ -173,7 +173,7 @@ void rpu::Client::runThread() {
 
             // Push frame and get a new empty frame
             sendFrame(frame);
-            frame = ris::Pool::acceptReq(maxSize_,false,maxSize_);
+            frame = ris::Pool::acceptReq(maxSize_,false);
          }
          else {
 

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -252,7 +252,7 @@ void ru::Prbs::genFrame (uint32_t size) {
    if ( width_ == 16 ) txSeq_ &= 0xFFFF;
 
    // Get frame
-   fr = reqFrame(size,true,0);
+   fr = reqFrame(size,true);
 
    // Frame allocation failed
    if ( fr->getAvailable() < size ) {

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -52,7 +52,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
    int32_t ret;
    
    // First request a new frame of the same size
-   ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true,0);
+   ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true);
 
    // Setup compression
    bz_stream strm;
@@ -91,7 +91,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
 
       // Increase the frame size if we run out of room
       if ( ! newFrame->nextWrite(writeIter) ) {
-         ris::FramePtr tmpFrame = this->reqFrame(frame->getPayload(),true,0);
+         ris::FramePtr tmpFrame = this->reqFrame(frame->getPayload(),true);
          newFrame->appendFrame(tmpFrame);
          writeIter = newFrame->startWrite(strm.total_out_lo32,frame->getPayload());
       }
@@ -107,8 +107,8 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
 }
 
 //! Accept a new frame request. Forward request.
-ris::FramePtr ru::StreamUnZip::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
-   return(this->reqFrame(size,zeroCopyEn,maxBuffSize));
+ris::FramePtr ru::StreamUnZip::acceptReq ( uint32_t size, bool zeroCopyEn ) {
+   return(this->reqFrame(size,zeroCopyEn));
 }
 
 void ru::StreamUnZip::setup_python() {

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -52,7 +52,7 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    int32_t ret;
    
    // First request a new frame of the same size
-   ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true,0);
+   ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true);
 
    // Setup compression
    bz_stream strm;
@@ -102,8 +102,8 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
 }
 
 //! Accept a new frame request. Forward request.
-ris::FramePtr ru::StreamZip::acceptReq ( uint32_t size, bool zeroCopyEn, uint32_t maxBuffSize ) {
-   return(this->reqFrame(size,zeroCopyEn,maxBuffSize));
+ris::FramePtr ru::StreamZip::acceptReq ( uint32_t size, bool zeroCopyEn ) {
+   return(this->reqFrame(size,zeroCopyEn));
 }
 
 void ru::StreamZip::setup_python() {

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -168,7 +168,7 @@ void ruf::StreamReader::runThread() {
             }
 
             // Request frame
-            frame = reqFrame(size,true,0);
+            frame = reqFrame(size,true);
             frame->setFlags(flags);
 
             // Populate frame


### PR DESCRIPTION
This will break some frame transmitters, but not many exist in python right now.

Turns out including the maxBufferSize field is unnecessary. If a module needs a smaller buffers it should request smaller frames downstream and recombine the buffers into an upstream frame. The interface is confusing as is.

I ended up doing this in the packetizer and it makes more sense.
