### PR TITLE
Add list variable support in EPICS & LocalVariable

### DIFF
--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -46,6 +46,7 @@ namespace rogue {
                uint32_t    max_;
                uint32_t    size_;
                uint32_t    fSize_;
+               bool        array_;
 
                std::vector<std::string> enums_;
                rogue::protocols::epicsV3::Pv * pv_;
@@ -133,6 +134,7 @@ namespace rogue {
                gddAppFuncTableStatus readUnits(gdd &value);
 
                gddAppFuncTableStatus readEnums(gdd &value);
+
          };
 
          // Convienence

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -20,6 +20,7 @@ import math
 import textwrap
 import pyrogue as pr
 import inspect
+import copy
 
 
 class MemoryError(Exception):
@@ -72,7 +73,6 @@ class BaseBlock(object):
 
         # Setup logging
         self._log = pr.logInit(self,name)
-
 
     def __repr__(self):
         return repr(self.name)
@@ -164,7 +164,7 @@ class LocalBlock(BaseBlock):
     def set(self, value):
         with self._lock:
             changed = self._value != value
-            self._value = value
+            self._value = copy.copy(value)
 
             # If a setFunction exists, call it (Used by local variables)
             if self._localSet is not None:
@@ -183,7 +183,7 @@ class LocalBlock(BaseBlock):
 
                 self._value = pr.varFuncHelper(self._localGet,pargs, self._log, self._variable.path)
 
-        return self._value
+        return copy.copy(self._value)
 
     def updated(self):
         self._variable.updated()

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -73,7 +73,10 @@ class BaseVariable(pr.Node):
 
         # Determine typeStr from value type
         if value is not None:
-            self._typeStr = value.__class__.__name__
+            if isinstance(value, list):
+                self._typeStr = f'List[{value[0].__class__.__name__}]'
+            else:
+                self._typeStr = value.__class__.__name__
         else:
             self._typeStr = 'Unknown'
 
@@ -501,13 +504,19 @@ class LocalVariable(BaseVariable):
         
     @Pyro4.expose
     def set(self, value, write=True):
+        print("Here1 {}".format(value))
         try:
+            print("Here2")
             self._block.set(value)
+            print("Here3")
 
         except Exception as e:
+            print("Here4")
             self._log.exception(e)
 
+        print("Here5")
         if write: self.updated()
+        print("Here6")
 
     def __set__(self, value):
         self.set(value, write=False)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -504,19 +504,13 @@ class LocalVariable(BaseVariable):
         
     @Pyro4.expose
     def set(self, value, write=True):
-        print("Here1 {}".format(value))
         try:
-            print("Here2")
             self._block.set(value)
-            print("Here3")
 
         except Exception as e:
-            print("Here4")
             self._log.exception(e)
 
-        print("Here5")
         if write: self.updated()
-        print("Here6")
 
     def __set__(self, value):
         self.set(value, write=False)

--- a/python/pyrogue/protocols/epics.py
+++ b/python/pyrogue/protocols/epics.py
@@ -49,12 +49,12 @@ class EpicsCaServer(object):
 
     def createSlave(self, name, maxSize, type):
         slave = rogue.protocols.epicsV3.Slave(self._base + ':' + name,maxSize,type)
-        self.addValue(slave)
+        self._srv.addValue(slave)
         return slave
 
     def createMaster(self, name, maxSize, type):
         mast = rogue.protocols.epicsV3.Master(self._base + ':' + name,maxSize,type)
-        self.addValue(mast)
+        self._srv.addValue(mast)
         return mast
 
     def stop(self):

--- a/src/rogue/protocols/epicsV3/Command.cpp
+++ b/src/rogue/protocols/epicsV3/Command.cpp
@@ -23,7 +23,6 @@
 #include <rogue/protocols/epicsV3/Pv.h>
 #include <rogue/protocols/epicsV3/Server.h>
 #include <rogue/GeneralError.h>
-#include <rogue/ScopedGil.h>
 #include <boost/make_shared.hpp>
 #include <boost/make_shared.hpp>
 

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -117,48 +117,56 @@ void rpe::Master::valueSet() {
       aitUint8 * pF = new aitUint8[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumUint16 ) {
       aitUint16 * pF = new aitUint16[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumUint32 ) {
       aitUint32 * pF = new aitUint32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt8 ) {
       aitInt8 * pF = new aitInt8[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt16 ) {
       aitInt16 * pF = new aitInt16[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt32 ) {
       aitInt32 * pF = new aitInt32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumFloat32 ) {
       aitFloat32 * pF = new aitFloat32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumFloat64 ) {
       aitFloat64 * pF = new aitFloat64[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      delete [] pF;
    }
 
    // Should this be pushed to a queue for a worker thread to call slaves?

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -22,8 +22,6 @@
 #include <rogue/protocols/epicsV3/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GeneralError.h>
-#include <rogue/ScopedGil.h>
-#include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
 #include <boost/make_shared.hpp>
 
@@ -117,56 +115,48 @@ void rpe::Master::valueSet() {
       aitUint8 * pF = new aitUint8[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumUint16 ) {
       aitUint16 * pF = new aitUint16[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumUint32 ) {
       aitUint32 * pF = new aitUint32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt8 ) {
       aitInt8 * pF = new aitInt8[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt16 ) {
       aitInt16 * pF = new aitInt16[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumInt32 ) {
       aitInt32 * pF = new aitInt32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumFloat32 ) {
       aitFloat32 * pF = new aitFloat32[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    else if ( epicsType_ == aitEnumFloat64 ) {
       aitFloat64 * pF = new aitFloat64[size_];
       pValue_->getRef(pF);
       for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
-      delete [] pF;
    }
 
    // Should this be pushed to a queue for a worker thread to call slaves?

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -22,7 +22,6 @@
 #include <rogue/protocols/epicsV3/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GeneralError.h>
-#include <rogue/ScopedGil.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
 #include <boost/make_shared.hpp>
@@ -185,6 +184,7 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
       for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
       pValue_->putRef(pF, new rpe::Destructor<aitFloat64 *>);
    }
+
    updated();
 }
 

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -142,10 +142,6 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
       log_->info("Detected string for %s typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumString;
       pValue_ = new gddScalar(gddAppType_value, epicsType_);
-      //pValue_->setBound(0,0,400);
-      //max_   = 400;
-      //size_  = 400;
-      array_ = false;
    }
 
    // Vector
@@ -161,7 +157,6 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    else {
       log_->info("Create scalar GDD for %s epicsType_=%i",epicsName_.c_str(),epicsType_);
       pValue_ = new gddScalar(gddAppType_value, epicsType_);
-      array_  = false;
    }
 }
 

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -280,7 +280,7 @@ aitEnum rpe::Value::bestExternalType() {
 }
 
 unsigned rpe::Value::maxDimension() {
-   return 1;
+   return (array_)?1:0;
 }
 
 aitIndex rpe::Value::maxBound(unsigned dimension) {

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -32,7 +32,7 @@ namespace bp  = boost::python;
 
 //! Setup class in python
 void rpe::Value::setup_python() {
-   bp::class_<rpe::Value, rpe::ValuePtr, boost::noncopyable >("Value",bp::init<std::string>())
+   bp::class_<rpe::Value, rpe::ValuePtr, boost::noncopyable >("Value",bp::no_init)
       .def("epicsName", &rpe::Value::epicsName)
    ;
 }
@@ -42,6 +42,14 @@ rpe::Value::Value (std::string epicsName) {
    epicsName_ = epicsName;
    pv_        = NULL;
    pValue_    = NULL;
+
+   precision_ = 0;
+   typeStr_   = "";
+   size_      = 1;
+   max_       = 1;
+   fSize_     = 1;
+   array_     = false;
+   epicsType_ = aitEnumInvalid;
 
    units_         = "";
    precision_     = 0;
@@ -71,22 +79,10 @@ rpe::Value::Value (std::string epicsName) {
    funcTable_.installReadFunc("controlLow",       &rpe::Value::readLowCtrl);
    funcTable_.installReadFunc("units",            &rpe::Value::readUnits);
    funcTable_.installReadFunc("enums",            &rpe::Value::readEnums);
-
-   // Default, type
-   this->initGdd("UInt32",false,0);
- 
-   // Default value 
-   pValue_->putConvert((uint32_t) 0);
 }
 
 void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    uint32_t bitSize;
-
-   precision_ = 0;
-   typeStr_   = typeStr;
-   size_      = 1;
-   max_       = 1;
-   fSize_     = 1;
 
    log_->info("Init GDD for %s typeStr=%s, isEnum=%i, count=%i",
          epicsName_.c_str(),typeStr.c_str(),isEnum,count);
@@ -141,26 +137,31 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
       fSize_ = 8;
    }
 
-   // String type for all others
-   else {
+   // Unknown type maps to string
+   if ( epicsType_ == aitEnumInvalid ) {
       log_->info("Detected string for %s typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumString;
+      pValue_ = new gddScalar(gddAppType_value, epicsType_);
       pValue_->setBound(0,0,400);
       max_   = 400;
       size_  = 400;
+      array_ = false;
    }
 
    // Vector
-   if ( count != 0 ) {
+   else if ( count != 0 ) {
       log_->info("Create vector GDD for %s epicsType_=%i, size=%i",epicsName_.c_str(),epicsType_,count);
       pValue_ = new gddAtomic (gddAppType_value, epicsType_, 1u, count);
-      size_ = count;
+      size_   = count;
+      max_    = count;
+      array_  = true;
    }
 
    // Scalar
    else {
       log_->info("Create scalar GDD for %s epicsType_=%i",epicsName_.c_str(),epicsType_);
       pValue_ = new gddScalar(gddAppType_value, epicsType_);
+      array_  = false;
    }
 }
 
@@ -236,7 +237,7 @@ caStatus rpe::Value::write(const gdd &value) {
    boost::lock_guard<boost::mutex> lock(mtx_);
 
    // Array
-   if ( value.isAtomic()) {
+   if ( array_ && value.isAtomic()) {
 
       // Bound checking
       if ( value.dimension() != 1 ) return S_casApp_badDimension;
@@ -254,7 +255,9 @@ caStatus rpe::Value::write(const gdd &value) {
    }
 
    // Scalar
-   else if ( value.isScalar() ) pValue_->put(&value);
+   else if ( (!array_) && value.isScalar() ) {
+      pValue_->put(&value);
+   }
 
    // Unsupported type
    else return S_casApp_outOfBounds;


### PR DESCRIPTION
List types are now supported for LocalVariables. The LocalBlock set and get use the copy function to avoid locking issues at the expense of extra copies.

Sets from the rogue side show up as the proper length for monitored PVs (camonitor) but the max size will always be returned for caget. I am not sure how to solve this yet.

Puts to rogue will always show up as the correct size in rogue.

Long string support is not in place with this version.