### PR TITLE
Add proper iterator for stream interface and add transaction class for memory interface

### DIFF
--- a/include/rogue/hardware/axi/AxiMemMap.h
+++ b/include/rogue/hardware/axi/AxiMemMap.h
@@ -17,6 +17,7 @@
 #ifndef __ROGUE_HARDWARE_AXI_MEM_MAP_H__
 #define __ROGUE_HARDWARE_AXI_MEM_MAP_H__
 #include <rogue/interfaces/memory/Slave.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
@@ -50,8 +51,7 @@ namespace rogue {
                ~AxiMemMap();
 
                //! Post a transaction
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
          };
 
          // Convienence

--- a/include/rogue/hardware/data/DataMap.h
+++ b/include/rogue/hardware/data/DataMap.h
@@ -53,8 +53,7 @@ namespace rogue {
                ~DataMap();
 
                //! Post a transaction
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
          };
 
          // Convienence

--- a/include/rogue/hardware/rce/MapMemory.h
+++ b/include/rogue/hardware/rce/MapMemory.h
@@ -22,6 +22,7 @@
 #ifndef __ROGUE_HARDWARE_RCE_MAP_MEMORY_H__
 #define __ROGUE_HARDWARE_RCE_MAP_MEMORY_H__
 #include <rogue/interfaces/memory/Slave.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
@@ -75,8 +76,7 @@ namespace rogue {
                void addMap(uint32_t address, uint32_t size);
 
                //! Post a transaction
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
          };
 
          // Convienence

--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -68,8 +68,7 @@ namespace rogue {
                uint64_t doAddress();
 
                //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
 
          };
 

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -33,6 +33,7 @@ namespace rogue {
       namespace memory {
 
          class Slave;
+         class Transaction;
 
          //! Master container
          class Master : public boost::enable_shared_from_this<rogue::interfaces::memory::Master> {
@@ -57,6 +58,9 @@ namespace rogue {
 
                //! Conditional
                boost::condition_variable cond_;
+
+               //! Error status
+               uint32_t error_;
 
                //! Log
                rogue::LoggingPtr log_;
@@ -112,7 +116,7 @@ namespace rogue {
             protected:
 
                //! Internal transaction
-               uint32_t intTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> > tran);
+               uint32_t intTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
 
                //! Transaction is done, called from transaction record
                void doneTransaction(uint32_t id);

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -79,9 +79,6 @@ namespace rogue {
                //! Destroy object
                virtual ~Master();
 
-               //! Get Transaction with index
-               boost::shared_ptr<rogue::interfaces::memory::Transaction> getTransaction(uint32_t index);
-
                //! Set slave
                void setSlave ( boost::shared_ptr<rogue::interfaces::memory::Slave> slave );
 

--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -3,9 +3,7 @@
  * Title      : Memory Slave
  * ----------------------------------------------------------------------------
  * File       : Slave.h
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2016-09-20
- * Last update: 2016-09-20
  * ----------------------------------------------------------------------------
  * Description:
  * Memory slave interface.
@@ -31,24 +29,25 @@ namespace rogue {
       namespace memory {
 
          class Master;
+         class Transaction;
 
          //! Slave container
          class Slave {
 
-               //! Slave map
-               std::map<uint32_t, boost::shared_ptr<rogue::interfaces::memory::Master> > masterMap_;
+               //! Alias for map
+               typedef std::map<uint32_t, boost::weak_ptr<rogue::interfaces::memory::Transaction> > TransactionMap;
 
-               //! Slave map lock
-               boost::mutex mtx_;
+               //! Transaction map
+               TransactionMap tranMap_;
+
+               //! Slave lock
+               boost::mutex slaveMtx_;
 
                //! Min access
                uint32_t min_;
 
                //! Max access
                uint32_t max_;
-               
-               //! Enable local response
-               bool enLocDone_;
 
             public:
 
@@ -64,20 +63,14 @@ namespace rogue {
                //! Destroy object
                virtual ~Slave();
 
-               //! Register a master.
-               void addMaster(uint32_t index, boost::shared_ptr<rogue::interfaces::memory::Master> master);
+               //! Register a transaction
+               void addTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
 
-               //! Get master device with index
-               boost::shared_ptr<rogue::interfaces::memory::Master> getMaster(uint32_t index);
+               //! Get Transaction with index
+               boost::shared_ptr<rogue::interfaces::memory::Transaction> getTransaction(uint32_t index);
 
-               //! Return true if master is valid
-               bool validMaster(uint32_t index);
-
-               //! Remove master from the list
-               void delMaster(uint32_t index);
-
-               //! Enable local response
-               void enLocDone(bool enable);
+               //! Remove transaction from the list, also cleanup stale transactions
+               void delTransaction(uint32_t index);
 
                //! Return min access size to requesting master
                virtual uint32_t doMinAccess();
@@ -89,9 +82,7 @@ namespace rogue {
                virtual uint64_t doAddress();
 
                //! Post a transaction. Master will call this method with the access attributes.
-               virtual void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                          uint64_t address, uint32_t size, uint32_t type);
-
+               virtual void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
          };
 
          //! Memory slave class, wrapper to enable pyton overload of virtual methods
@@ -122,13 +113,11 @@ namespace rogue {
                //! Return offset
                uint64_t defDoAddress();
 
-               //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                  uint64_t address, uint32_t size, uint32_t type);
+               //! Post a transaction. Master will call this method.
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
 
-               //! Post a transaction. Master will call this method with the access attributes.
-               void defDoTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                     uint64_t address, uint32_t size, uint32_t type);
+               //! Post a transaction. Master will call this method.
+               void defDoTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
 
          };
 

--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -72,6 +72,12 @@ namespace rogue {
                //! Remove transaction from the list, also cleanup stale transactions
                void delTransaction(uint32_t index);
 
+               //! Get min size from slave
+               uint32_t min();
+
+               //! Get min size from slave
+               uint32_t max();
+
                //! Return min access size to requesting master
                virtual uint32_t doMinAccess();
 

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -1,0 +1,134 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Transaction
+ * ----------------------------------------------------------------------------
+ * File       : Transaction.h
+ * Created    : 2019-03-08
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Transaction
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_MEMORY_MASTER_H__
+#define __ROGUE_INTERFACES_MEMORY_MASTER_H__
+#include <stdint.h>
+#include <vector>
+#include <boost/python.hpp>
+#include <boost/thread.hpp>
+
+namespace rogue {
+   namespace interfaces {
+      namespace memory {
+
+         class Master;
+
+         //! Transaction
+         class Transaction {
+            friend rogue::interfaces::memory::Master;
+   
+            private:
+
+               //! Class instance counter
+               static uint32_t classIdx_;
+
+               //! Class instance lock
+               static boost::mutex classMtx_;
+
+            protected:
+
+               //! Create a transaction container
+               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create (
+                  boost::shared_ptr<rogue::interfaces::memory::Master> master);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Constructor
+               Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
+
+               //! Associated master
+               rogue::interfaces::memory::Master master_;
+
+               //! Transaction start time
+               struct timeval endTime_;
+
+               //! Transaction start time
+               struct timeval startTime_;
+
+               //! Transaction python buffer
+               Py_buffer pyBuf_;
+
+               //! Python buffer is valid
+               bool pyValid_;
+
+               //! Transaction data
+               uint8_t * data_;
+
+               //! Transaction address
+               uint64_t address_;
+
+               //! Transaction size
+               uint32_t size_;
+
+               //! Transaction type
+               uint32_t type_;
+
+               //! Transaction error
+               uint32_t error_;
+
+               //! Transaction id
+               uint32_t id_;
+
+            public:
+
+               //! Transaction lock
+               boost::mutex lock;
+
+               //! Destructor
+               ~Transaction();
+
+               //! Get id
+               uint32_t id();
+
+               //! Get address
+               uint32_t address();
+
+               //! Get size
+               uint32_t size();
+
+               //! Get type
+               uint32_t type();
+
+               //! Complete transaction with passed error
+               void complete(uint32_t error);
+
+               //! start iterator, caller must lock around access
+               rogue::interfaces::memory::Transaction::iterator begin();
+
+               //! end iterator, caller must lock around access
+               rogue::interfaces::memory::Transaction::iterator end();
+
+               //! Write data from python
+               void writePy ( boost::python::object p, uint32_t offset );
+
+               //! Read data from python
+               void readPy ( boost::python::object p, uint32_t offset );
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::memory::Transaction> TransactionPtr;
+
+      }
+   }
+}
+
+#endif
+

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -17,8 +17,8 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#ifndef __ROGUE_INTERFACES_MEMORY_MASTER_H__
-#define __ROGUE_INTERFACES_MEMORY_MASTER_H__
+#ifndef __ROGUE_INTERFACES_MEMORY_TRANSACTION_H__
+#define __ROGUE_INTERFACES_MEMORY_TRANSACTION_H__
 #include <stdint.h>
 #include <vector>
 #include <boost/python.hpp>
@@ -29,11 +29,15 @@ namespace rogue {
       namespace memory {
 
          class Master;
+         class Hub;
 
          //! Transaction
          class Transaction {
             friend rogue::interfaces::memory::Master;
-   
+            friend rogue::interfaces::memory::Hub;
+
+            public: 
+               typedef uint8_t * iterator;
             private:
 
                //! Class instance counter
@@ -44,18 +48,8 @@ namespace rogue {
 
             protected:
 
-               //! Create a transaction container
-               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create (
-                  boost::shared_ptr<rogue::interfaces::memory::Master> master);
-
-               //! Setup class in python
-               static void setup_python();
-
-               //! Constructor
-               Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
-
                //! Associated master
-               rogue::interfaces::memory::Master master_;
+               boost::shared_ptr<rogue::interfaces::memory::Master> master_;
 
                //! Transaction start time
                struct timeval endTime_;
@@ -69,8 +63,8 @@ namespace rogue {
                //! Python buffer is valid
                bool pyValid_;
 
-               //! Transaction data
-               uint8_t * data_;
+               //! Iterator (mapped to uint8_t * for now)
+               iterator iter_;
 
                //! Transaction address
                uint64_t address_;
@@ -88,6 +82,16 @@ namespace rogue {
                uint32_t id_;
 
             public:
+
+               //! Create a transaction container
+               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create (
+                  boost::shared_ptr<rogue::interfaces::memory::Master> master);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Constructor
+               Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
 
                //! Transaction lock
                boost::mutex lock;
@@ -108,7 +112,7 @@ namespace rogue {
                uint32_t type();
 
                //! Complete transaction with passed error
-               void complete(uint32_t error);
+               void done(uint32_t error);
 
                //! start iterator, caller must lock around access
                rogue::interfaces::memory::Transaction::iterator begin();

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -103,7 +103,7 @@ namespace rogue {
                uint32_t id();
 
                //! Get address
-               uint32_t address();
+               uint64_t address();
 
                //! Get size
                uint32_t size();

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -93,7 +93,7 @@ namespace rogue {
                //! Constructor
                Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
 
-               //! Transaction lock
+               //! Transaction lock which must be held when using iterator
                boost::mutex lock;
 
                //! Destructor
@@ -111,7 +111,7 @@ namespace rogue {
                //! Get type
                uint32_t type();
 
-               //! Complete transaction with passed error
+               //! Complete transaction with passed error, Release lock before calling.
                void done(uint32_t error);
 
                //! start iterator, caller must lock around access

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -99,6 +99,9 @@ namespace rogue {
                //! Destructor
                ~Transaction();
 
+               //! Get expired flag
+               bool expired();
+
                //! Get id
                uint32_t id();
 
@@ -120,11 +123,11 @@ namespace rogue {
                //! end iterator, caller must lock around access
                rogue::interfaces::memory::Transaction::iterator end();
 
-               //! Write data from python
-               void writePy ( boost::python::object p, uint32_t offset );
+               //! Get transaction data from python
+               void getData ( boost::python::object p, uint32_t offset );
 
-               //! Read data from python
-               void readPy ( boost::python::object p, uint32_t offset );
+               //! Set transaction data from python
+               void setData ( boost::python::object p, uint32_t offset );
          };
 
          // Convienence

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -74,6 +74,7 @@ namespace rogue {
 
             public:
 
+               //! Iterator for data
                typedef uint8_t * iterator;
 
                //! Class creation

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -33,6 +33,7 @@ namespace rogue {
       namespace stream {
 
          class Pool;
+         class Frame;
 
          //! Frame buffer
          /*
@@ -43,7 +44,10 @@ namespace rogue {
          class Buffer {
 
                //! Pointer to entity which allocated this buffer
-               boost::shared_ptr<rogue::interfaces::stream::Pool> source_; 
+               boost::shared_ptr<rogue::interfaces::stream::Pool> source_;
+
+               //! Pointer to frame containing this buffer
+               boost::shared_ptr<rogue::interfaces::stream::Frame> frame_;
 
                //! Pointer to raw data buffer. Raw pointer is used here!
                uint8_t *  data_;
@@ -71,6 +75,9 @@ namespace rogue {
 
                //! Error state
                uint32_t   error_;
+
+            protected:
+
 
             public:
 
@@ -100,6 +107,9 @@ namespace rogue {
                 * Owner return buffer method is called
                 */
                ~Buffer();
+
+               //! Set ownder frame
+               void setFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
                //! Get meta data, used by pool
                uint32_t getMeta();

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -163,6 +163,12 @@ namespace rogue {
                /* Set payload size (not including header) */
                void setPayload(uint32_t size);
 
+               /* 
+                * Set min payload size (not including header)
+                * Payload size is updated only if size > current size
+                */
+               void minPayload(uint32_t size);
+
                //! Adjust payload size
                void adjustPayload(int32_t value);
 

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -160,13 +160,8 @@ namespace rogue {
                 */
                uint32_t getPayload();
 
-               /*
-                * Set payload size (not including header)
-                * If shink flag is true, the size will be
-                * descreased if size is less than the current
-                * payload size.
-                */
-               void setPayload(uint32_t size, bool shrink);
+               /* Set payload size (not including header) */
+               void setPayload(uint32_t size);
 
                //! Adjust payload size
                void adjustPayload(int32_t value);

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -74,6 +74,8 @@ namespace rogue {
 
             public:
 
+               typedef uint8_t * iterator;
+
                //! Class creation
                /*
                 * Pass owner, raw data buffer, and meta data
@@ -98,15 +100,6 @@ namespace rogue {
                 */
                ~Buffer();
 
-                //! Get raw data pointer
-               uint8_t * getRawData();
-
-               /* 
-                * Get data pointer
-                * Returns base + header size
-                */
-               uint8_t * getPayloadData();
-
                //! Get meta data, used by pool
                uint32_t getMeta();
 
@@ -124,6 +117,24 @@ namespace rogue {
 
                //! Clear the tail reservation
                void zeroTail();
+
+               /* 
+                * Get data pointer (begin iterator)
+                * Returns base + header size
+                */
+               uint8_t * begin();
+
+               /*
+                * Get end data pointer (end iterator)
+                * This is the end of raw data buffer
+                */
+               uint8_t * end();
+
+               /*
+                * Get end payload pointer (end iterator)
+                * This is the end of payload data
+                */
+               uint8_t * endPayload();
 
                /*
                 * Get size of buffer that can hold

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -148,8 +148,13 @@ namespace rogue {
                 */
                uint32_t getPayload();
 
-               //! Set payload size (not including header)
-               void setPayload(uint32_t size);
+               /*
+                * Set payload size (not including header)
+                * If shink flag is true, the size will be
+                * descreased if size is less than the current
+                * payload size.
+                */
+               void setPayload(uint32_t size, bool shrink);
 
                //! Adjust payload size
                void adjustPayload(int32_t value);

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -75,11 +75,11 @@ namespace rogue {
                //! Add a buffer to end of frame
                void appendBuffer(boost::shared_ptr<rogue::interfaces::stream::Buffer> buff);
 
-               //! Append frame to end. Passed frame is emptied.
+               //! Append passed frame buffers to end of frame.
                void appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
-               //! Copy count bytes frame, starting at offset in local frame
-               uint32_t copyFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint32_t offset, uint32_t count);
+               //! Copy count bytes frame, to local frame, pass zero to copy all
+               uint32_t copyFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint32_t count);
 
                //! Get buffer count
                uint32_t getCount();
@@ -90,11 +90,45 @@ namespace rogue {
                //! Get buffer at index
                boost::shared_ptr<rogue::interfaces::stream::Buffer> getBuffer(uint32_t index);
 
-               //! Get total available capacity (not including header space)
+               /*
+                * Get size of buffers that can hold
+                * payload data. This function 
+                * returns the full buffer size minus
+                * the head and tail reservation.
+                */
+               uint32_t getSize();
+
+               /*
+                * Get available size for payload
+                * This is the space remaining for payload
+                * minus the space reserved for the tail
+                */
                uint32_t getAvailable();
 
-               //! Get total real payload size (not including header space)
+               /*
+                * Get real payload size without header
+                * This is the count of real data in the 
+                * packet, minus the portion reserved for
+                * the head.
+                */
                uint32_t getPayload();
+
+               /*
+                * Set payload size (not including header)
+                * If shink flag is true, the size will be
+                * descreased if size is less than the current
+                * payload size.
+                */
+               void setPayload(uint32_t size, bool shrink);
+
+               //! Adjust payload size
+               void adjustPayload(int32_t value);
+
+               //! Set the buffer as full (minus tail reservation)
+               void setPayloadFull();
+
+               //! Set the buffer as empty (minus header reservation)
+               void setPayloadEmpty();
 
                //! Get flags
                uint32_t getFlags();
@@ -107,6 +141,25 @@ namespace rogue {
 
                //! Set error state
                void setError(uint32_t error);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
                //! Read count bytes from frame payload, starting from offset.
                /* 
@@ -134,6 +187,19 @@ namespace rogue {
                 */
                void writePy ( boost::python::object p, uint32_t offset );
 
+
+
+
+
+
+
+
+
+
+
+
+
+
                //! Start an iterative write
                /*
                 * Pass offset and total size
@@ -147,6 +213,12 @@ namespace rogue {
                //! Continue an iterative write
                bool nextWrite(boost::shared_ptr<rogue::interfaces::stream::FrameIterator> iter);
 
+
+
+
+
+
+
                //! Start an iterative read
                /*
                 * Pass offset and total size
@@ -159,6 +231,16 @@ namespace rogue {
 
                //! Continue an iterative read
                bool nextRead(boost::shared_ptr<rogue::interfaces::stream::FrameIterator> iter);
+
+
+
+
+
+
+
+
+
+
 
          };
 

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -48,6 +48,8 @@ namespace rogue {
          */
          class Frame : public boost::enable_shared_from_this<rogue::interfaces::stream::Frame> {
 
+               friend Buffer;
+
                //! Interface specific flags
                uint32_t flags_;
 
@@ -56,6 +58,23 @@ namespace rogue {
 
                //! List of buffers which hold real data
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> > buffers_;
+
+               //! Total size of buffers
+               uint32_t size_;
+
+               //! Total payload size
+               uint32_t payload_;
+
+               //! Update buffer size counts
+               void updateSizes();
+
+               //! Size values dirty flage
+               bool sizeDirty_;
+
+            protected:
+
+               //! Set size values dirty
+               void setSizeDirty();
 
             public:
 

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -44,6 +44,7 @@ namespace rogue {
           * payload. Calls to write and read take into account the header offset.
           * It is assumed only one thread will interact with a buffer. Buffers 
           * are not thread safe.
+          * TODO: Consider tracking size and payload in frame 
          */
          class Frame : public boost::enable_shared_from_this<rogue::interfaces::stream::Frame> {
 
@@ -116,11 +117,17 @@ namespace rogue {
 
                /*
                 * Set payload size (not including header)
-                * If shink flag is true, the size will be
-                * descreased if size is less than the current
-                * payload size.
+                * If passed size is less then current, 
+                * the frame payload size will be descreased.
                 */
-               void setPayload(uint32_t size, bool shrink);
+               void setPayload(uint32_t size);
+
+               /*
+                * Set the min payload size (not including header)
+                * If the current payload size is greater, the
+                * payload size will be unchanged.
+                */
+               void minPayload(uint32_t size);
 
                //! Adjust payload size
                void adjustPayload(int32_t value);
@@ -152,14 +159,8 @@ namespace rogue {
                //! Get end of payload iterator
                rogue::interfaces::stream::FrameIterator endPayload();
 
-               //! Read count bytes from frame payload, starting from offset.
-               uint32_t read  ( void *p, uint32_t offset, uint32_t count );
-
                //! Read count bytes from frame payload, starting from offset. Python version.
                void readPy ( boost::python::object p, uint32_t offset );
-
-               //! Write count bytes to frame payload, starting at offset
-               uint32_t write ( void *p, uint32_t offset, uint32_t count );
 
                //! Write count bytes to frame payload, starting at offset. Python Version
                void writePy ( boost::python::object p, uint32_t offset );

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -80,11 +80,13 @@ namespace rogue {
                //! Destroy a frame.
                ~Frame();
 
-               //! Add a buffer to end of frame
-               void appendBuffer(boost::shared_ptr<rogue::interfaces::stream::Buffer> buff);
+               //! Add a buffer to end of frame, return interator to inserted buffer
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator
+                  appendBuffer(boost::shared_ptr<rogue::interfaces::stream::Buffer> buff);
 
-               //! Append passed frame buffers to end of frame.
-               void appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
+               //! Append passed frame buffers to end of frame, return interator to inserted buffer
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator
+                  appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
                //! Buffer begin iterator
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator beginBuffer();

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -142,154 +142,63 @@ namespace rogue {
                //! Set error state
                void setError(uint32_t error);
 
+               //! Get start of buffer iterator
+               rogue::interfaces::stream::FrameIterator begin();
 
+               //! Get end of buffer iterator
+               rogue::interfaces::stream::FrameIterator end();
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+               //! Get end of payload iterator
+               rogue::interfaces::stream::FrameIterator end_payload();
 
                //! Read count bytes from frame payload, starting from offset.
-               /* 
-                * Frame reads can be from random offsets
-                */
                uint32_t read  ( void *p, uint32_t offset, uint32_t count );
 
                //! Read count bytes from frame payload, starting from offset. Python version.
-               /* 
-                * Frame reads can be from random offsets
-                */
                void readPy ( boost::python::object p, uint32_t offset );
 
                //! Write count bytes to frame payload, starting at offset
-               /* 
-                * Frame writes can be at random offsets. Payload size will
-                * be set to highest write offset.
-                */
                uint32_t write ( void *p, uint32_t offset, uint32_t count );
 
                //! Write count bytes to frame payload, starting at offset. Python Version
-               /* 
-                * Frame writes can be at random offsets. Payload size will
-                * be set to highest write offset.
-                */
                void writePy ( boost::python::object p, uint32_t offset );
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-               //! Start an iterative write
-               /*
-                * Pass offset and total size
-                * Returns iterator object.
-                * Use data and size fields in object to control transaction
-                * Call writeNext to following data update.
-                */
-               boost::shared_ptr<rogue::interfaces::stream::FrameIterator> 
-                   startWrite(uint32_t offset, uint32_t size);
-
-               //! Continue an iterative write
-               bool nextWrite(boost::shared_ptr<rogue::interfaces::stream::FrameIterator> iter);
-
-
-
-
-
-
-
-               //! Start an iterative read
-               /*
-                * Pass offset and total size
-                * Returns iterator object.
-                * Use data and size fields in object to control transaction
-                * Call readNext to following data update.
-                */
-                boost::shared_ptr<rogue::interfaces::stream::FrameIterator> 
-                   startRead(uint32_t offset, uint32_t size);
-
-               //! Continue an iterative read
-               bool nextRead(boost::shared_ptr<rogue::interfaces::stream::FrameIterator> iter);
-
-
-
-
-
-
-
-
-
-
-
          };
 
          //! Frame iterator
-         /*
-          * Tracks accesses within a frame while iterating.
-          * data is pointer to raw buffer to act on
-          * size is the transaction size allowed for pointer
-          */
-         class FrameIterator {
+         class FrameIterator : public iterator<forward_iterator_tag, uint8_t> {
             friend class rogue::interfaces::stream::Frame;
+
             protected:
 
-               //! Buffer index
+               //! Current Frame position
+               bool framePos_;
+
+               //! Current buffer position
+               uint32_t buffPos_;
+
+               //! Current buffer index
                uint32_t index_;
 
-               //! Remaining bytes in transaction
-               uint32_t remaining_;
-
-               //! Buffer pointer
+               //! Current buffer payload
                uint8_t * data_;
 
-               //! Buffer offset
-               uint32_t offset_;
-
-               //! Size of pointer
-               uint32_t size_;
-
-               //! Amount completed in transaction
-               uint32_t completed_;
-
-               //! Transaction total
-               uint32_t total_;
+               //! Createtor
+               FrameIterator(uint32_t offset);
 
             public:
 
-               //! Get pointer
-               uint8_t * data() { return(data_); }
+               //! De-reference
+               uint8_t * operator*();
 
-               //! Get size
-               uint32_t size() { return(size_); }
+               //! Increment
+               const rogue::interfaces::stream::FrameIterator & operator++();
 
-               //! Transaction total
-               uint32_t total() {return(total_);}
+               //! Not Equal
+               bool operator!=(rogue::interfaces::stream::FrameIterator & other);
 
-               //! Update the amount accessed
-               void completed(uint32_t value) {
-                  if ( value < size_ ) completed_ = value;
-               }
+               //! Get current buffer
+
+
          };
 
          // Convienence

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -92,6 +92,9 @@ namespace rogue {
                //! Buffer end iterator
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator endBuffer();
 
+               //! Buffers list is empty
+               bool isEmpty();
+
                /*
                 * Get size of buffers that can hold
                 * payload data. This function 

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -57,6 +57,12 @@ namespace rogue {
 
             public:
 
+               //! Itererator for buffer list
+               typedef std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator BufferIterator;
+
+               //! Itererator for data
+               typedef rogue::interfaces::stream::FrameIterator iterator;
+
                //! Setup class in python
                static void setup_python();
 
@@ -78,14 +84,17 @@ namespace rogue {
                //! Append passed frame buffers to end of frame.
                void appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
-               //! Copy count bytes frame, to local frame, pass zero to copy all
-               uint32_t copyFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint32_t count);
+               //! Remove buffers from frame
+               void clear();
 
                //! Get buffer count
                uint32_t getCount();
 
-               //! Remove buffers from frame
-               void clear();
+               //! Buffer begin iterator
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator beginBuffer();
+
+               //! Buffer end iterator
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator endBuffer();
 
                //! Get buffer at index
                boost::shared_ptr<rogue::interfaces::stream::Buffer> getBuffer(uint32_t index);
@@ -142,14 +151,14 @@ namespace rogue {
                //! Set error state
                void setError(uint32_t error);
 
-               //! Get start of buffer iterator
+               //! Get start of data iterator
                rogue::interfaces::stream::FrameIterator begin();
 
-               //! Get end of buffer iterator
+               //! Get end of data iterator
                rogue::interfaces::stream::FrameIterator end();
 
                //! Get end of payload iterator
-               rogue::interfaces::stream::FrameIterator end_payload();
+               rogue::interfaces::stream::FrameIterator endPayload();
 
                //! Read count bytes from frame payload, starting from offset.
                uint32_t read  ( void *p, uint32_t offset, uint32_t count );
@@ -170,9 +179,6 @@ namespace rogue {
 
             protected:
 
-               //! Current Frame position
-               bool framePos_;
-
                //! Current buffer position
                uint32_t buffPos_;
 
@@ -183,7 +189,7 @@ namespace rogue {
                uint8_t * data_;
 
                //! Createtor
-               FrameIterator(uint32_t offset);
+               FrameIterator(boost::shared_ptr<rogue::interface::stream::Frame> frame, uint32_t offset);
 
             public:
 
@@ -195,10 +201,6 @@ namespace rogue {
 
                //! Not Equal
                bool operator!=(rogue::interfaces::stream::FrameIterator & other);
-
-               //! Get current buffer
-
-
          };
 
          // Convienence

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -25,6 +25,7 @@
 **/
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_H__
+#include <boost/enable_shared_from_this.hpp>
 #include <stdint.h>
 #include <vector>
 
@@ -44,7 +45,7 @@ namespace rogue {
           * It is assumed only one thread will interact with a buffer. Buffers 
           * are not thread safe.
          */
-         class Frame {
+         class Frame : public boost::enable_shared_from_this<rogue::interfaces::stream::Frame> {
 
                //! Interface specific flags
                uint32_t flags_;
@@ -58,7 +59,7 @@ namespace rogue {
             public:
 
                //! Itererator for buffer list
-               typedef std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator BufferIterator;
+               typedef std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator BufferIterator;
 
                //! Itererator for data
                typedef rogue::interfaces::stream::FrameIterator iterator;
@@ -91,13 +92,10 @@ namespace rogue {
                uint32_t getCount();
 
                //! Buffer begin iterator
-               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator beginBuffer();
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator beginBuffer();
 
                //! Buffer end iterator
-               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer>::iterator endBuffer();
-
-               //! Get buffer at index
-               boost::shared_ptr<rogue::interfaces::stream::Buffer> getBuffer(uint32_t index);
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator endBuffer();
 
                /*
                 * Get size of buffers that can hold
@@ -173,40 +171,8 @@ namespace rogue {
                void writePy ( boost::python::object p, uint32_t offset );
          };
 
-         //! Frame iterator
-         class FrameIterator : public iterator<forward_iterator_tag, uint8_t> {
-            friend class rogue::interfaces::stream::Frame;
-
-            protected:
-
-               //! Current buffer position
-               uint32_t buffPos_;
-
-               //! Current buffer index
-               uint32_t index_;
-
-               //! Current buffer payload
-               uint8_t * data_;
-
-               //! Createtor
-               FrameIterator(boost::shared_ptr<rogue::interface::stream::Frame> frame, uint32_t offset);
-
-            public:
-
-               //! De-reference
-               uint8_t * operator*();
-
-               //! Increment
-               const rogue::interfaces::stream::FrameIterator & operator++();
-
-               //! Not Equal
-               bool operator!=(rogue::interfaces::stream::FrameIterator & other);
-         };
-
          // Convienence
          typedef boost::shared_ptr<rogue::interfaces::stream::Frame> FramePtr;
-         typedef boost::shared_ptr<rogue::interfaces::stream::FrameIterator> FrameIteratorPtr;
-
       }
    }
 }

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -85,12 +85,6 @@ namespace rogue {
                //! Append passed frame buffers to end of frame.
                void appendFrame(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
-               //! Remove buffers from frame
-               void clear();
-
-               //! Get buffer count
-               uint32_t getCount();
-
                //! Buffer begin iterator
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator beginBuffer();
 

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -63,7 +63,7 @@ namespace rogue {
                      const rogue::interfaces::stream::FrameIterator &rhs);
 
                //! De-reference
-               uint8_t operator *() const;
+               uint8_t & operator *() const;
 
                //! Pointer
                uint8_t * operator ->() const;
@@ -121,13 +121,13 @@ namespace rogue {
          // Helper function to copy values to a frame iterator
          // Frame iterator is incremented appropriately
          inline void toFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * src) {
-            //iter = std::copy((uint8_t*)src, ((uint8_t*)src)+size, iter);
+            iter = std::copy((uint8_t*)src, ((uint8_t*)src)+size, iter);
          }
 
          // Helper function to copy values from a frame iterator
          // Frame iterator is incremented appropriately
          inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
-            //std::copy(iter,iter+size,(uint8_t*)dst);
+            std::copy(iter,iter+size,(uint8_t*)dst);
             iter += size;
          }
       }

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -117,6 +117,19 @@ namespace rogue {
                rogue::interfaces::stream::FrameIterator & operator -=(const int32_t &sub);
 
          };
+
+         // Helper function to copy values to a frame iterator
+         // Frame iterator is incremented appropriately
+         inline void toFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * src) {
+            //iter = std::copy((uint8_t*)src, ((uint8_t*)src)+size, iter);
+         }
+
+         // Helper function to copy values from a frame iterator
+         // Frame iterator is incremented appropriately
+         inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
+            //std::copy(iter,iter+size,(uint8_t*)dst);
+            iter += size;
+         }
       }
    }
 }

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -46,11 +46,14 @@ namespace rogue {
                //! Current buffer position
                uint32_t buffPos_;
 
-               //! Createtor
+               //! Creator
                FrameIterator(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, 
                              uint32_t offset, bool end);
 
             public:
+
+               //! Creator
+               FrameIterator();
 
                //! Setup class in python
                static void setup_python();

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -1,0 +1,122 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Stream frame iterator
+ * ----------------------------------------------------------------------------
+ * File       : FrameIterator.h
+ * Created    : 2018-03-06
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Stream frame iterator
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_STREAM_FRAME_ITERATOR_H__
+#define __ROGUE_INTERFACES_STREAM_FRAME_ITERATOR_H__
+#include <stdint.h>
+#include <vector>
+
+#include <boost/python.hpp>
+namespace rogue {
+   namespace interfaces {
+      namespace stream {
+
+         //! Frame iterator
+         class FrameIterator : public std::iterator<std::random_access_iterator_tag, uint8_t> {
+            friend class rogue::interfaces::stream::Frame;
+
+               //! End flag
+               bool end_;
+
+               //! Frame position
+               uint32_t framePos_;
+
+               //! Associated frame
+               boost::shared_ptr<rogue::interfaces::stream::Frame> frame_;
+
+               //! current buffer
+               std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator curr_;
+
+               //! Current buffer position
+               uint32_t buffPos_;
+
+               //! Createtor
+               FrameIterator(boost::shared_ptr<rogue::interfaces::stream::Frame> frame, 
+                             uint32_t offset, bool end);
+
+            public:
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Copy assignment
+               const rogue::interfaces::stream::FrameIterator operator =(
+                     const rogue::interfaces::stream::FrameIterator &rhs);
+
+               //! De-reference
+               uint8_t operator *() const;
+
+               //! Pointer
+               uint8_t * operator ->() const;
+
+               //! De-reference by index
+               uint8_t operator [](const uint32_t &offset) const;
+
+               //! Increment
+               const rogue::interfaces::stream::FrameIterator & operator ++();
+
+               //! Post Increment
+               rogue::interfaces::stream::FrameIterator operator ++(int);
+
+               //! Decrement
+               const rogue::interfaces::stream::FrameIterator & operator --();
+
+               //! Post Decrement
+               rogue::interfaces::stream::FrameIterator operator --(int);
+
+               //! Not Equal
+               bool operator !=(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! Equal
+               bool operator ==(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! Less than
+               bool operator <(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! greater than
+               bool operator >(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! Less than equal
+               bool operator <=(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! greater than equal
+               bool operator >=(const rogue::interfaces::stream::FrameIterator & other) const;
+
+               //! Increment by value
+               rogue::interfaces::stream::FrameIterator operator +(const int32_t &add) const;
+
+               //! Descrment by value
+               rogue::interfaces::stream::FrameIterator operator -(const int32_t &sub) const;
+
+               //! Sub incrementers
+               int32_t operator -(const rogue::interfaces::stream::FrameIterator &other) const;
+
+               //! Increment by value
+               rogue::interfaces::stream::FrameIterator & operator +=(const int32_t &add);
+
+               //! Descrment by value
+               rogue::interfaces::stream::FrameIterator & operator -=(const int32_t &sub);
+
+         };
+      }
+   }
+}
+
+#endif
+

--- a/include/rogue/protocols/srp/SrpV0.h
+++ b/include/rogue/protocols/srp/SrpV0.h
@@ -58,8 +58,7 @@ namespace rogue {
                ~SrpV0();
 
                //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/srp/SrpV0.h
+++ b/include/rogue/protocols/srp/SrpV0.h
@@ -43,6 +43,16 @@ namespace rogue {
 
                rogue::LoggingPtr log_;
 
+               static const uint32_t WrHeadLen  = 8;
+               static const uint32_t RdHeadLen  = 12;
+               static const uint32_t MaxHeadLen = 12;
+               static const uint32_t RxHeadLen  = 8;
+               static const uint32_t TailLen    = 4;
+
+               // Setup header, return write flag
+               bool setupHeader(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran, 
+                                uint32_t *header, uint32_t &headerLen, uint32_t &frameLen, bool tx);
+
             public:
 
                //! Class creation

--- a/include/rogue/protocols/srp/SrpV3.h
+++ b/include/rogue/protocols/srp/SrpV3.h
@@ -44,6 +44,13 @@ namespace rogue {
 
                rogue::LoggingPtr log_;
 
+               static const uint32_t HeadLen = 20;
+               static const uint32_t TailLen = 4;
+
+               // Setup header, return write flag
+               bool setupHeader(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran, 
+                                uint32_t *header, uint32_t &frameLen, bool tx);
+
             public:
 
                //! Class creation
@@ -59,8 +66,7 @@ namespace rogue {
                ~SrpV3();
 
                //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                  uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
 
                //! Accept a frame from master
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -416,6 +416,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             # Otherwise act directly
             else:
                 d   = {}
+
+                # The following three lines are causing major slowdowns
                 addPathToDict(d,path,disp)
                 yml = dictToYaml(d,default_flow_style=False)
                 self._sendYamlFrame(yml)

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -137,7 +137,6 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         self._data = {}
 
     def _checkRange(self, address, size):
-
         return 0
 
     def _doMaxAccess(self):
@@ -146,13 +145,16 @@ class MemEmulate(rogue.interfaces.memory.Slave):
     def _doMinAccess(self):
         return(self._minWidth)
 
-    def _doTransaction(self,tid,master,address,size,type):
+    def _doTransaction(self,transaction):
+        address = transaction.address()
+        size    = transaction.size()
+        type    = transaction.type()
 
         if (address % self._minWidth) != 0:
-            master._doneTransaction(tid,rogue.interfaces.memory.AddressError)
+            transaction.done(rogue.interfaces.memory.AddressError)
             return
         elif size > self._maxSize:
-            master._doneTransaction(tid,rogue.interfaces.memory.SizeError)
+            transaction.done(rogue.interfaces.memory.SizeError)
             return
 
         for i in range (0, size):
@@ -162,17 +164,17 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         ba = bytearray(size)
 
         if type == rogue.interfaces.memory.Write or type == rogue.interfaces.memory.Post:
-            master._getTransactionData(tid,0,ba)
+            transaction.getData(ba,0)
 
             for i in range(0, size):
                 self._data[address+i] = ba[i]
 
-            master._doneTransaction(tid,0)
+            transaction.done(0)
 
         else:
             for i in range(0, size):
                 ba[i] = self._data[address+i]
 
-            master._setTransactionData(tid,0,ba)
-            master._doneTransaction(tid,0)
+            transaction.setData(ba,0)
+            transaction.done(0)
 

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -16,6 +16,7 @@
 **/
 #include <rogue/hardware/axi/AxiMemMap.h>
 #include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
 #include <stdio.h>
@@ -49,32 +50,37 @@ rha::AxiMemMap::~AxiMemMap() {
 }
 
 //! Post a transaction
-void rha::AxiMemMap::doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                uint64_t address, uint32_t size, uint32_t type) {
+void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
+   rim::Transaction::iterator it;
+
    uint32_t count;
    uint32_t data;
+   uint32_t dataSize;
    int32_t  ret;
+
+   dataSize = sizeof(uint32_t);
+
+   if ( (tran->size() % dataSize) != 0 ) tran->done(rim::SizeError);
 
    count = 0;
    ret = 0;
+   it = tran->begin();
 
-   while ( (ret == 0 ) && (count < size) ) {
-      if (type == rim::Write || type == rim::Post) {
-         master->getTransactionData(id,&data,count,4);
-         ret = dmaWriteRegister(fd_,address+count,data);
+   while ( (ret == 0) && (count != tran->size()) ) {
+      if (tran->type() == rim::Write || tran->type() == rim::Post) {
+         std::copy(it,it+dataSize,&data);
+         ret = dmaWriteRegister(fd_,tran->address()+count,data);
       }
       else {
-         ret = dmaReadRegister(fd_,address+count,&data);
-         master->setTransactionData(id,&data,count,4);
+         ret = dmaReadRegister(fd_,tran->address()+count,&data);
+         std::copy(&data,&data+dataSize,it);
       }
-      count += 4;
+      count += dataSize;
+      it += dataSize;
    }
 
-   if ( ret != 0 ) 
-      throw rogue::GeneralError::create("AxiMemMap::doTransaction","Error accessing register space. Check driver permissions");
-
-   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",id,address,size,type,data);
-   master->doneTransaction(id,(ret==0)?0:1);
+   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
+   tran->done((ret==0)?0:1);
 }
 
 void rha::AxiMemMap::setup_python () {

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -18,7 +18,9 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GeneralError.h>
+#include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
+#include <boost/thread.hpp>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -57,29 +59,35 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
    uint32_t data;
    uint32_t dataSize;
    int32_t  ret;
+   uint8_t * ptr;
 
    dataSize = sizeof(uint32_t);
+   ptr = (uint8_t *)(&data);
 
    if ( (tran->size() % dataSize) != 0 ) tran->done(rim::SizeError);
 
    count = 0;
    ret = 0;
+
+   rogue::GilRelease noGil;
+   boost::unique_lock<boost::mutex> lock(tran->lock);
    it = tran->begin();
 
    while ( (ret == 0) && (count != tran->size()) ) {
       if (tran->type() == rim::Write || tran->type() == rim::Post) {
-         std::copy(it,it+dataSize,&data);
+         std::copy(it,it+dataSize,ptr);
          ret = dmaWriteRegister(fd_,tran->address()+count,data);
       }
       else {
          ret = dmaReadRegister(fd_,tran->address()+count,&data);
-         std::copy(&data,&data+dataSize,it);
+         std::copy(ptr,ptr+dataSize,it);
       }
       count += dataSize;
       it += dataSize;
    }
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
+   lock.unlock();
    tran->done((ret==0)?0:1);
 }
 

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -85,9 +85,9 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it += dataSize;
    }
+   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
-   lock.unlock();
    tran->done((ret==0)?0:1);
 }
 

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -240,7 +240,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
             }
             else {
                // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->getPayloadData(), buff->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
+               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
                   throw(rogue::GeneralError("AxiStreamDma::acceptFrame","AXIS Write Call Failed!!!!"));
                }
             }
@@ -316,7 +316,7 @@ void rha::AxiStreamDma::runThread() {
                buff = allocBuffer(bSize_,NULL);
 
                // Attempt read, dest is not needed since only one lane/vc is open
-               res = dmaRead(fd_, buff->getPayloadData(), buff->getAvailable(), &rxFlags, &rxError, NULL);
+               res = dmaRead(fd_, buff->begin(), buff->getAvailable(), &rxFlags, &rxError, NULL);
                fuser = axisGetFuser(rxFlags);
                luser = axisGetLuser(rxFlags);
                cont  = axisGetCont(rxFlags);

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -340,8 +340,7 @@ void rha::AxiStreamDma::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res,true);
-               frame->appendBuffer(buff);
+               buff->setPayload(res);
                flags = frame->getFlags();
                error = frame->getError();
 
@@ -349,7 +348,7 @@ void rha::AxiStreamDma::runThread() {
                error |= rxError;
 
                // First buffer of frame
-               if ( frame->getCount() == 1 ) flags |= (fuser & 0xFF);
+               if ( frame->isEmpty() ) flags |= (fuser & 0xFF);
 
                // Last buffer of frame
                if ( cont == 0 ) {
@@ -359,6 +358,7 @@ void rha::AxiStreamDma::runThread() {
 
                frame->setError(error);
                frame->setFlags(flags);
+               frame->appendBuffer(buff);
                buff.reset();
 
                // If continue flag is not set, push frame and get a new empty frame

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -159,12 +159,10 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
 
 //! Accept a frame from master
 void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
-   ris::BufferPtr buff;
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
    uint32_t         meta;
-   uint32_t         x;
    uint32_t         flags;
    uint32_t         fuser;
    uint32_t         luser;
@@ -175,32 +173,32 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
    // Get Flags
    flags = frame->getFlags();
 
-   // Go through each buffer in the frame
-   for (x=0; x < frame->getCount(); x++) {
-      buff = frame->getBuffer(x);
-      buff->zeroHeader();
+   // Go through each (*it)er in the frame
+   ris::Frame::BufferIterator it;
+   for (it = frame->beginBuffer(); it != frame->endBuffer(); ++it) {
+      (*it)->zeroHeader();
 
-      // First buff
-      if ( x == 0 ) {
+      // First buffer
+      if ( it == frame->beginBuffer() ) {
          fuser = flags & 0xFF;
          if ( enSsi_ ) fuser |= 0x2;
       }
       else fuser = 0;
 
-      // Last buffer
-      if ( x == (frame->getCount() - 1) ) {
+      // Last Buffer
+      if ( it == (frame->endBuffer()-1) ) {
          cont = 0;
          luser = (flags >> 8) & 0xFF;
       }
 
-      // Continue flag is set if this is not the last buffer
+      // Continue flag is set if this is not the last (*it)er
       else {
          cont = 1;
          luser = 0;
       }
 
-      // Get buffer meta field
-      meta = buff->getMeta();
+      // Get (*it)er meta field
+      meta = (*it)->getMeta();
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
@@ -208,22 +206,22 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
 
-            // Write by passing buffer index to driver
-            if ( dmaWriteIndex(fd_, meta & 0x3FFFFFFF, buff->getPayload(), axisSetFlags(fuser, luser, cont), dest_) <= 0 ) {
+            // Write by passing (*it)er index to driver
+            if ( dmaWriteIndex(fd_, meta & 0x3FFFFFFF, (*it)->getPayload(), axisSetFlags(fuser, luser, cont), dest_) <= 0 ) {
                throw(rogue::GeneralError("AxiStreamDma::acceptFrame","AXIS Write Call Failed"));
             }
 
-            // Mark buffer as stale
+            // Mark (*it)er as stale
             meta |= 0x40000000;
-            buff->setMeta(meta);
+            (*it)->setMeta(meta);
          }
       }
 
-      // Write to pgp with buffer copy in driver
+      // Write to pgp with (*it)er copy in driver
       else {
 
          // Keep trying since select call can fire 
-         // but write fails because we did not win the buffer lock
+         // but write fails because we did not win the (*it)er lock
          do {
 
             // Setup fds for select call
@@ -239,8 +237,8 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
                res = 0;
             }
             else {
-               // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
+               // Write with (*it)er copy
+               if ( (res = dmaWrite(fd_, (*it)->begin(), (*it)->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
                   throw(rogue::GeneralError("AxiStreamDma::acceptFrame","AXIS Write Call Failed!!!!"));
                }
             }
@@ -342,7 +340,7 @@ void rha::AxiStreamDma::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res);
+               buff->setPayload(res,true);
                frame->appendBuffer(buff);
                flags = frame->getFlags();
                error = frame->getError();

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -243,7 +243,7 @@ void rhd::DataCard::acceptFrame ( ris::FramePtr frame ) {
             }
             else {
                // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->getPayloadData(), buff->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
+               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), axisSetFlags(fuser, luser,0), dest_)) < 0 ) {
                   throw(rogue::GeneralError("DataCard::acceptFrame","AXIS Write Call Failed!!!!"));
                }
             }
@@ -319,7 +319,7 @@ void rhd::DataCard::runThread() {
                buff = allocBuffer(bSize_,NULL);
 
                // Attempt read, dest is not needed since only one lane/vc is open
-               res = dmaRead(fd_, buff->getPayloadData(), buff->getAvailable(), &rxFlags, &rxError, NULL);
+               res = dmaRead(fd_, buff->begin(), buff->getAvailable(), &rxFlags, &rxError, NULL);
                fuser = axisGetFuser(rxFlags);
                luser = axisGetLuser(rxFlags);
                cont  = axisGetCont(rxFlags);

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -343,8 +343,7 @@ void rhd::DataCard::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res,true);
-               frame->appendBuffer(buff);
+               buff->setPayload(res);
                flags = frame->getFlags();
                error = frame->getError();
 
@@ -352,7 +351,7 @@ void rhd::DataCard::runThread() {
                error |= rxError;
 
                // First buffer of frame
-               if ( frame->getCount() == 1 ) flags |= (fuser & 0xFF);
+               if ( frame->isEmpty() ) flags |= (fuser & 0xFF);
 
                // Last buffer of frame
                if ( cont == 0 ) {
@@ -362,6 +361,7 @@ void rhd::DataCard::runThread() {
 
                frame->setError(error);
                frame->setFlags(flags);
+               frame->appendBuffer(buff);
                buff.reset();
 
                // If continue flag is not set, push frame and get a new empty frame

--- a/src/rogue/hardware/data/DataMap.cpp
+++ b/src/rogue/hardware/data/DataMap.cpp
@@ -91,9 +91,9 @@ void rhd::DataMap::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it += dataSize;
    }
+   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
-   lock.unlock();
    tran->done((ret==0)?0:1);
 }
 

--- a/src/rogue/hardware/data/DataMap.cpp
+++ b/src/rogue/hardware/data/DataMap.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/hardware/data/DataMap.h>
 #include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
 #include <stdio.h>
@@ -55,29 +56,37 @@ rhd::DataMap::~DataMap() {
 }
 
 //! Post a transaction
-void rhd::DataMap::doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                   uint64_t address, uint32_t size, uint32_t type) {
+void rhd::DataMap::doTransaction(rim::TransactionPtr tran) {
+   rim::Transaction::iterator it;
+
    uint32_t count;
    uint32_t data;
+   uint32_t dataSize;
    int32_t  ret;
+
+   dataSize = sizeof(uint32_t);
+
+   if ( (tran->size() % dataSize) != 0 ) tran->done(rim::SizeError);
 
    count = 0;
    ret = 0;
+   it = tran->begin();
 
-   while ( (ret == 0 ) && (count < size) ) {
-      if (type == rim::Write || type == rim::Post) {
-         master->getTransactionData(id,&data,count,4);
-         ret = dmaWriteRegister(fd_,address+count,data);
+   while ( (ret == 0) && (count != tran->size()) ) {
+      if (tran->type() == rim::Write || tran->type() == rim::Post) {
+         std::copy(it,it+dataSize,&data);
+         ret = dmaWriteRegister(fd_,tran->address()+count,data);
       }
       else {
-         ret = dmaReadRegister(fd_,address+count,&data);
-         master->setTransactionData(id,&data,count,4);
+         ret = dmaReadRegister(fd_,tran->address()+count,&data);
+         std::copy(&data,&data+dataSize,it);
       }
-      count += 4;
+      count += dataSize;
+      it += dataSize;
    }
 
-   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",id,address,size,type,data);
-   master->doneTransaction(id,(ret==0)?0:1);
+   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
+   tran->done((ret==0)?0:1);
 }
 
 void rhd::DataMap::setup_python () {

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -354,7 +354,7 @@ void rhp::PgpCard::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res,true);
+               buff->setPayload(res);
                frame->setError(error | frame->getError());
                frame->appendBuffer(buff);
                buff.reset();

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -271,7 +271,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
             }
             else {
                // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->getPayloadData(), buff->getPayload(), pgpSetFlags(cont), pgpSetDest(lane_, vc_)) < 0 ) )
+               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), pgpSetFlags(cont), pgpSetDest(lane_, vc_)) < 0 ) )
                   throw(rogue::GeneralError("PgpCard::acceptFrame","PGP Write Call Failed"));
             } 
          }
@@ -338,7 +338,7 @@ void rhp::PgpCard::runThread() {
                buff = allocBuffer(bSize_,NULL);
 
                // Attempt read, lane and vc not needed since only one lane/vc is open
-               res = dmaRead(fd_, buff->getPayloadData(), buff->getAvailable(), &flags, &error, NULL);
+               res = dmaRead(fd_, buff->begin(), buff->getAvailable(), &flags, &error, NULL);
                cont = pgpGetCont(flags);
             }
 

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -212,27 +212,25 @@ ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
 
 //! Accept a frame from master
 void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
-   ris::BufferPtr buff;
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
    uint32_t         meta;
-   uint32_t         x;
    uint32_t         cont;
 
    rogue::GilRelease noGil;
 
-   // Go through each buffer in the frame
-   for (x=0; x < frame->getCount(); x++) {
-      buff = frame->getBuffer(x);
-      buff->zeroHeader();
+   // Go through each (*it)er in the frame
+   ris::Frame::BufferIterator it;
+   for (it = frame->beginBuffer(); it != frame->endBuffer(); ++it) {
+      (*it)->zeroHeader();
 
-      // Continue flag is set if this is not the last buffer
-      if ( x == (frame->getCount() - 1) ) cont = 0;
+      // Continue flag is set if this is not the last (*it)er
+      if ( it == (frame->endBuffer()-1) ) cont = 0;
       else cont = 1;
 
-      // Get buffer meta field
-      meta = buff->getMeta();
+      // Get (*it)er meta field
+      meta = (*it)->getMeta();
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
@@ -240,21 +238,21 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
 
-            // Write by passing buffer index to driver
-            if ( dmaWriteIndex(fd_, meta & 0x3FFFFFFF, buff->getPayload(), pgpSetFlags(cont),pgpSetDest(lane_, vc_)) <= 0 )
+            // Write by passing (*it)er index to driver
+            if ( dmaWriteIndex(fd_, meta & 0x3FFFFFFF, (*it)->getPayload(), pgpSetFlags(cont),pgpSetDest(lane_, vc_)) <= 0 )
                throw(rogue::GeneralError("PgpCard::acceptFrame","PGP Write Call Failed"));
 
-            // Mark buffer as stale
+            // Mark (*it)er as stale
             meta |= 0x40000000;
-            buff->setMeta(meta);
+            (*it)->setMeta(meta);
          }
       }
 
-      // Write to pgp with buffer copy in driver
+      // Write to pgp with (*it)er copy in driver
       else {
 
          // Keep trying since select call can fire 
-         // but write fails because we did not win the buffer lock
+         // but write fails because we did not win the (*it)er lock
          do {
 
             // Setup fds for select call
@@ -270,8 +268,8 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
                res = 0;
             }
             else {
-               // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), pgpSetFlags(cont), pgpSetDest(lane_, vc_)) < 0 ) )
+               // Write with (*it)er copy
+               if ( (res = dmaWrite(fd_, (*it)->begin(), (*it)->getPayload(), pgpSetFlags(cont), pgpSetDest(lane_, vc_)) < 0 ) )
                   throw(rogue::GeneralError("PgpCard::acceptFrame","PGP Write Call Failed"));
             } 
          }
@@ -356,7 +354,7 @@ void rhp::PgpCard::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res);
+               buff->setPayload(res,true);
                frame->setError(error | frame->getError());
                frame->appendBuffer(buff);
                buff.reset();

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -245,7 +245,7 @@ void rhr::AxiStream::acceptFrame ( ris::FramePtr frame ) {
             }
             else {
                // Write with buffer copy
-               if ( (res = dmaWrite(fd_, buff->getPayloadData(), buff->getPayload(), axisSetFlags(fuser, luser,cont), dest_)) < 0 ) {
+               if ( (res = dmaWrite(fd_, buff->begin(), buff->getPayload(), axisSetFlags(fuser, luser,cont), dest_)) < 0 ) {
                   throw(rogue::GeneralError("AxiStream::acceptFrame","AXIS Write Call Failed"));
                }
             }
@@ -321,7 +321,7 @@ void rhr::AxiStream::runThread() {
                buff = allocBuffer(bSize_,NULL);
 
                // Attempt read, dest is not needed since only one lane/vc is open
-               res = dmaRead(fd_, buff->getPayloadData(), buff->getAvailable(), &rxFlags, &rxError, NULL);
+               res = dmaRead(fd_, buff->begin(), buff->getAvailable(), &rxFlags, &rxError, NULL);
                fuser = axisGetFuser(rxFlags);
                luser = axisGetLuser(rxFlags);
                cont  = axisGetCont(rxFlags);

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -345,8 +345,7 @@ void rhr::AxiStream::runThread() {
 
             // Read was successfull
             if ( res > 0 ) {
-               buff->setPayload(res,true);
-               frame->appendBuffer(buff);
+               buff->setPayload(res);
                flags = frame->getFlags();
                error = frame->getError();
 
@@ -354,7 +353,7 @@ void rhr::AxiStream::runThread() {
                error |= rxError;
 
                // First buffer of frame
-               if ( frame->getCount() == 1 ) flags |= (fuser & 0xFF);
+               if ( frame->isEmpty() ) flags |= (fuser & 0xFF);
 
                // Last buffer of frame
                if ( cont == 0 ) {
@@ -364,6 +363,7 @@ void rhr::AxiStream::runThread() {
 
                frame->setError(error);
                frame->setFlags(flags);
+               frame->appendBuffer(buff);
                buff.reset();
 
                // If continue flag is not set, push frame and get a new empty frame

--- a/src/rogue/hardware/rce/MapMemory.cpp
+++ b/src/rogue/hardware/rce/MapMemory.cpp
@@ -137,9 +137,9 @@ void rhr::MapMemory::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it    += dataSize;
    }
+   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
-   lock.unlock();
    tran->done(0);
 }
 

--- a/src/rogue/hardware/rce/MapMemory.cpp
+++ b/src/rogue/hardware/rce/MapMemory.cpp
@@ -101,27 +101,40 @@ uint8_t * rhr::MapMemory::findSpace (uint32_t base, uint32_t size) {
 }
 
 //! Post a transaction
-void rhr::MapMemory::doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master, 
-                                   uint64_t address, uint32_t size, uint32_t type) {
-   uint8_t * ptr;
+void rhr::MapMemory::doTransaction(rim::TransactionPtr tran) {
+   rim::Transaction::iterator it;
+
    uint32_t count;
+   uint32_t data;
+   uint32_t dataSize;
+   uint8_t * ptr;
 
-   if ((ptr = findSpace(address,size)) == NULL) {
-      master->doneTransaction(id,rim::AddressError);
+   dataSize = sizeof(uint32_t);
+
+   if ( (tran->size() % dataSize) != 0 ) tran->done(rim::SizeError);
+
+   count = 0;
+   it = tran->begin();
+
+   if ((ptr = findSpace(tran->address(),tran->size())) == NULL) {
+      tran->done(rim::AddressError);
+      return;
    }
-   else {
-      count = 0;
 
-      while ( count < size ) {
-         if (type == rim::Write || type == rim::Post) 
-            master->getTransactionData(id,ptr+count,count,4);
-         else 
-            master->setTransactionData(id,ptr+count,count,4);
-         count += 4;
+   while (count != tran->size()) {
+      if (tran->type() == rim::Write || tran->type() == rim::Post) {
+         std::copy(it,it+dataSize,ptr);
       }
-
-      master->doneTransaction(id,0);
+      else {
+         std::copy(ptr,ptr+count+dataSize,it);
+      }
+      ptr   += dataSize;
+      count += dataSize;
+      it    += dataSize;
    }
+
+   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
+   tran->done(0);
 }
 
 void rhr::MapMemory::setup_python () {

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -22,6 +22,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/memory/Hub.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
 #include <boost/python.hpp>
@@ -64,15 +65,13 @@ uint64_t rim::Hub::doAddress() {
 }
 
 //! Post a transaction. Master will call this method with the access attributes.
-void rim::Hub::doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                             uint64_t address, uint32_t size, uint32_t type) {
-   uint64_t outAddress;
+void rim::Hub::doTransaction(rim::TransactionPtr tran) {
 
    // Adjust address
-   outAddress = offset_ | address;
+   tran->address_ |= offset_;
 
    // Forward transaction
-   getSlave()->doTransaction(id,master,outAddress,size,type);
+   getSlave()->doTransaction(tran);
 }
 
 void rim::Hub::setup_python() {

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -3,9 +3,7 @@
  * Title      : Memory Master
  * ----------------------------------------------------------------------------
  * File       : Master.cpp
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2016-09-20
- * Last update: 2016-09-20
  * ----------------------------------------------------------------------------
  * Description:
  * Memory master interface.
@@ -30,21 +28,34 @@
 namespace rim = rogue::interfaces::memory;
 namespace bp  = boost::python;
 
-// Init class counter
-uint32_t rim::Master::classIdx_ = 0;
-
-//! Class instance lock
-boost::mutex rim::Master::classIdxMtx_;
-
 //! Create a master container
 rim::MasterPtr rim::Master::create () {
    rim::MasterPtr m = boost::make_shared<rim::Master>();
    return(m);
 }
 
+void rim::Master::setup_python() {
+   bp::class_<rim::Master, rim::MasterPtr, boost::noncopyable>("Master",bp::init<>())
+      .def("_getTransaction",     &rim::Master::getTransaction)
+      .def("_setSlave",           &rim::Master::setSlave)
+      .def("_getSlave",           &rim::Master::getSlave)
+      .def("_reqMinAccess",       &rim::Master::reqMinAccess)
+      .def("_reqMaxAccess",       &rim::Master::reqMaxAccess)
+      .def("_reqAddress",         &rim::Master::reqAddress)
+      .def("_getError",           &rim::Master::getError)
+      .def("_setError",           &rim::Master::setError)
+      .def("_setTimeout",         &rim::Master::setTimeout)
+      .def("_reqTransaction",     &rim::Master::reqTransactionPy)
+      .def("_endTransaction",     &rim::Master::endTransaction)
+      .def("_waitTransaction",    &rim::Master::waitTransaction)
+   ;
+
+   bp::register_ptr_to_python< boost::shared_ptr<rim::Master> >();
+   bp::implicitly_convertible<rim::MasterWrapPtr, rim::MasterPtr>();
+}
+
 //! Create object
 rim::Master::Master() {
-   slave_   = rim::Slave::create(4,4);
    error_   = 0;
 
    sumTime_.tv_sec  = 1;
@@ -56,30 +67,26 @@ rim::Master::Master() {
 //! Destroy object
 rim::Master::~Master() { }
 
-//! Generate a transaction id, not python safe
-uint32_t rim::Master::genId() {
-   uint32_t nid;
+//! Get transaction with index
+rim::TransactionPtr rim::Master::getTransaction(uint32_t index) {
+   rim::TransactionPtr ret;
+   TransactionMap::iterator it;
 
-   classIdxMtx_.lock();
-   if ( classIdx_ == 0 ) classIdx_ = 1;
-   nid = classIdx_;
-   classIdx_++;
-   classIdxMtx_.unlock();
-
-   return(nid);
-}
-
-//! Get transaaction count
-uint32_t rim::Master::tranCount() {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   return(tran_.size());
+   boost::lock_guard<boost::mutex> lock(slaveMtx_);
+
+   it = tranMap_.find(index);
+
+   if ( ( it = tranMap_.find(index)) != tranMap_.end() ) 
+      return it->second;
+   else
+      return NULL;
 }
 
 //! Set slave
 void rim::Master::setSlave ( rim::SlavePtr slave ) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
+   boost::lock_guard<boost::mutex> lock(mastMtx_);
    slave_ = slave;
 }
 
@@ -111,15 +118,14 @@ uint32_t rim::Master::getError() {
 //! Rst error
 void rim::Master::setError(uint32_t error) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-
+   boost::lock_guard<boost::mutex> lock(mastMtx_);
    error_ = error;
 }
 
 //! Set timeout
 void rim::Master::setTimeout(uint64_t timeout) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
+   boost::lock_guard<boost::mutex> lock(mastMtx_);
 
    if (timeout == 0 ) {
       sumTime_.tv_sec  = 1;
@@ -130,255 +136,157 @@ void rim::Master::setTimeout(uint64_t timeout) {
    }
 }
 
-uint32_t rim::Master::intTransaction(uint64_t address, rim::MasterTransaction *tran, uint32_t type) {
-   std::map<uint32_t, rim::MasterTransaction>::iterator it;
+uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
+   TransactionMap::iterator it;
    struct timeval currTime;
    rim::SlavePtr slave;
-   uint32_t id;
 
    {
       rogue::GilRelease noGil;
-      boost::lock_guard<boost::mutex> lock(mtx_);
+      boost::lock_guard<boost::mutex> lock(mastMtx_);
       slave = slave_;
-      id    = genId();
 
-      tran->endTime.tv_sec = 0;
-      tran->endTime.tv_usec = 0;
+      gettimeofday(&(tran->startTime_),NULL);
 
-      gettimeofday(&(tran->startTime),NULL);
-
-      tran_[id] = *tran;
+      tranMap_[tran->id_] = tran;
    }
 
-   log_->debug("Request transaction type=%i id=%i",type,id);
+   log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
 
-   slave->doTransaction(id,shared_from_this(),address,tran->tSize,type);
+   slave->doTransaction(tran);
 
    // Update time after transaction is started, but not if transaction has already completed
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
+   boost::lock_guard<boost::mutex> lock(mastMtx_);
 
-   it = tran_.find(id);
-   if ( it != tran_.end() ) {
+   it = tranMap_.find(id);
+   if ( it != tranMap_.end() ) {
       gettimeofday(&currTime,NULL);
-      timeradd(&currTime,&sumTime_,&(tran->endTime));
-      tran_[id] = *tran;
+      timeradd(&currTime,&sumTime_,&(tran->endTime_));
    }
-   return(id);
+   return(tran->id_);
 }
 
 //! Post a transaction, called locally, forwarded to slave
 uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type) {
-   rim::MasterTransaction tran;
+   rim::TransactionPtr tran = rim::Transaction::create(shared_from_this());
 
-   memset(&(tran.pyBuf),0,sizeof(Py_buffer));
+   tran->data_    = (uint8_t *)data;
+   tran->size_    = size;
+   tran->address_ = address;
+   tran->type_    = type;
 
-   tran.pyValid = false;
-   tran.tData   = (uint8_t *)data;
-   tran.tSize   = size;
-
-   return(intTransaction(address,&tran,type));
+   return(intTransaction(tran));
 }
 
 //! Post a transaction, called locally, forwarded to slave, python version
 uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type) {
-   rim::MasterTransaction tran;
+   rim::TransactionPtr tran = rim::Transaction::create();
 
-   if ( PyObject_GetBuffer(p.ptr(),&(tran.pyBuf),PyBUF_SIMPLE) < 0 )
+   if ( PyObject_GetBuffer(p.ptr(),&(tran->pyBuf_),PyBUF_SIMPLE) < 0 )
       throw(rogue::GeneralError("Master::reqTransactionPy","Python Buffer Error"));
 
-   if ( size == 0 ) tran.tSize = tran.pyBuf.len;
-   else tran.tSize = size;
+   if ( size == 0 ) tran->size_ = tran->pyBuf_.len;
+   else tran->size_ = size;
 
-   if ( (tran.tSize + offset) > tran.pyBuf.len ) {
-      PyBuffer_Release(&(tran.pyBuf));
-      throw(rogue::GeneralError::boundary("Master::reqTransactionPy",(tran.tSize+offset),tran.pyBuf.len));
+   if ( (tran->size_ + offset) > tran->pyBuf_.len ) {
+      PyBuffer_Release(&(tran->pyBuf_));
+      throw(rogue::GeneralError::boundary("Master::reqTransactionPy",(tran->size_+offset),tran->pyBuf_.len));
    }
 
-   tran.pyValid = true;
-   tran.tData   = ((uint8_t *)tran.pyBuf.buf) + offset;
+   tran->pyValid_ = true;
+   tran->data_    = ((uint8_t *)tran->pyBuf_.buf) + offset;
+   tran->type_    = type;
+   tran->address_ = address;
 
-   return(intTransaction(address,&tran,type));
+   return(intTransaction(tran));
 }
 
-//! Reset transaction data, not python safe, needs lock
-void rim::Master::rstTransaction(uint32_t id, uint32_t error, bool notify) {
-   std::map<uint32_t, rim::MasterTransaction>::iterator it;
+//! Transaction complete,
+void rim::Master::doneTransaction(uint32_t id) {
+   TransactionMap::iterator it;
 
-   it = tran_.find(id);
-   if ( it == tran_.end() ) {
-      log_->info("Reset transaction failed to find transaction id=%i",id);
-      return;
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lock(mtx_);
+
+   if ( (it = tranMap_->find(id)) == tranMap_.end() ) {
+      log_->info("Done transaction failed to find transaction id=%i",id);
+   } else {
+      log_->debug("Done transaction id=%i",id);
+      rstTransaction(it,true);
    }
-
-   log_->debug("Resetting transaction id=%i",id);
-
-   if ( it->second.pyValid ) {
-      rogue::ScopedGil gil;
-      PyBuffer_Release(&(it->second.pyBuf));
-   }
-
-   tran_.erase(it);
-
-   if ( error != 0 ) error_ = error;
-   if ( notify ) cond_.notify_all();
 }
 
 //! End current transaction, ensures data pointer is not update and de-allocates python buffer
 void rim::Master::endTransaction(uint32_t id) {
+   TransactionMap::iterator it;
+
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(mtx_);
 
    log_->debug("End transaction id=%i",id);
 
    if ( id == 0 ) {
-      std::map<uint32_t, rim::MasterTransaction>::iterator it;
-      for ( it=tran_.begin(); it != tran_.end(); it++ ) rstTransaction(it->first,0,false);
-   } else rstTransaction(id,0,false);
-}
+      for ( it=tranMap_.begin(); it != tranMap_.end(); ++it ) rstTransaction(it,false);
+   } 
+   else {
 
-//! Transaction complete, set by slave, error passed
-void rim::Master::doneTransaction(uint32_t id, uint32_t error) { 
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   log_->debug("Done transaction id=%i",id);
-   rstTransaction(id,error,true);
-}
-
-//! Set to master from slave, called by slave
-void rim::Master::setTransactionData(uint32_t id, void *data, uint32_t offset, uint32_t size) { 
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-
-   std::map<uint32_t, rim::MasterTransaction>::iterator it;
-
-   it = tran_.find(id);
-   if ( it == tran_.end() ) {
-      log_->info("Set transaction data failed to find transaction id=%i",id);
-      return;
-   }
-
-   if ( (offset + size) > it->second.tSize ) return;
-
-   log_->debug("Set transaction data id=%i",id);
-   memcpy(it->second.tData + offset, data, size);
-}
-
-//! Set to master from slave, called by slave to push data into master. Python Version.
-void rim::Master::setTransactionDataPy(uint32_t id, uint32_t offset, boost::python::object p) {
-   Py_buffer pb;
-
-   if ( PyObject_GetBuffer(p.ptr(),&pb,PyBUF_SIMPLE) < 0 )
-      throw(rogue::GeneralError("Master::setTransactionDataPy","Python Buffer Error"));
-   
-   setTransactionData(id, pb.buf, offset, pb.len);
-   PyBuffer_Release(&pb);
-}
-
-//! Get from master to slave, called by slave
-void rim::Master::getTransactionData(uint32_t id, void *data, uint32_t offset, uint32_t size) { 
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-
-   std::map<uint32_t, rim::MasterTransaction>::iterator it;
-
-   it = tran_.find(id);
-   if ( it == tran_.end() ) {
-      log_->info("Get transaction data failed to find transaction id=%i",id);
-      return;
-   }
-
-   if ( (offset + size) > it->second.tSize ) return;
-
-   log_->debug("Get transaction data id=%i",id);
-   memcpy(data,it->second.tData + offset, size);
-}
-
-//! Get from master to slave, called by slave to pull data from mater. Python Version.
-void rim::Master::getTransactionDataPy(uint32_t id, uint32_t offset, boost::python::object p) {
-   Py_buffer pb;
-
-   if ( PyObject_GetBuffer(p.ptr(),&pb,PyBUF_SIMPLE) < 0 )
-      throw(rogue::GeneralError("Master::getTransactionDataPy","Python Buffer Error"));
-   
-   getTransactionData(id, pb.buf, offset, pb.len);
-   PyBuffer_Release(&pb);
-}
-
-void rim::Master::setup_python() {
-   bp::class_<rim::MasterWrap, rim::MasterWrapPtr, boost::noncopyable>("Master",bp::init<>())
-      .def("_setSlave",           &rim::Master::setSlave)
-      .def("_getSlave",           &rim::Master::getSlave)
-      .def("_tranCount",          &rim::Master::tranCount)
-      .def("_reqMinAccess",       &rim::Master::reqMinAccess)
-      .def("_reqMaxAccess",       &rim::Master::reqMaxAccess)
-      .def("_reqAddress",         &rim::Master::reqAddress)
-      .def("_getError",           &rim::Master::getError)
-      .def("_setError",           &rim::Master::setError)
-      .def("_setTimeout",         &rim::Master::setTimeout)
-      .def("_reqTransaction",     &rim::Master::reqTransactionPy)
-      .def("_endTransaction",     &rim::Master::endTransaction)
-      .def("_doneTransaction",    &rim::Master::doneTransaction, &rim::MasterWrap::defDoneTransaction)
-      .def("_setTransactionData", &rim::Master::setTransactionDataPy)
-      .def("_getTransactionData", &rim::Master::getTransactionDataPy)
-      .def("_waitTransaction",    &rim::Master::waitTransaction)
-   ;
-
-   bp::register_ptr_to_python< boost::shared_ptr<rim::Master> >();
-   bp::implicitly_convertible<rim::MasterWrapPtr, rim::MasterPtr>();
-}
-
-//! Transaction complete, called by slave when transaction is complete, error passed
-void rim::MasterWrap::doneTransaction(uint32_t id, uint32_t error) {
-   bool found = false;
-   {
-      rogue::ScopedGil gil;
-
-      if (boost::python::override pb = this->get_override("_doneTransaction")) {
-         try {
-            pb(id,error);
-         } catch (...) {
-            PyErr_Print();
-         }
-         found = true;
+      if ( (it = tranMap_->find(tran->id_)) == tranMap_.end() ) {
+         log_->info("Done transaction failed to find transaction id=%i",tran->id_);
       }
+      else rstTransaction(it,true);
    }
-   if ( !found ) rim::Master::doneTransaction(id,error);
-}
-
-//! Transaction complete, called by slave when transaction is complete, error passed
-void rim::MasterWrap::defDoneTransaction(uint32_t id, uint32_t error) {
-   rim::Master::doneTransaction(id,error);
 }
 
 // Wait for transaction. Timeout in seconds
 void rim::Master::waitTransaction(uint32_t id) {
    struct timeval currTime;
 
-   std::map<uint32_t, rim::MasterTransaction>::iterator it;
+   TransactionMap::iterator it;
 
    rogue::GilRelease noGil;
    boost::unique_lock<boost::mutex> lock(mtx_);
 
    // No id means wait for all
-   if ( id == 0 ) it = tran_.begin();
-   else it = tran_.find(id);
+   if ( id == 0 ) it = tranMap_.begin();
+   else it = tranMap_.find(id);
 
    while (it != tran_.end()) {
 
       // Timeout?
       gettimeofday(&currTime,NULL);
-      if ( it->second.endTime.tv_sec != 0 && it->second.endTime.tv_usec != 0 && timercmp(&currTime,&(it->second.endTime),>) ) {
-         log_->info("Transaction timeout id=%i start =%i:%i end=%i:%i curr=%i:%i",it->first,
-               it->second.startTime.tv_sec, it->second.startTime.tv_usec,
-               it->second.endTime.tv_sec,it->second.endTime.tv_usec,
+      if ( it->second->endTime_.tv_sec  != 0 && 
+           it->second->endTime_.tv_usec != 0 && 
+           timercmp(&currTime,&(it->second->endTime_),>) ) {
+
+         log_->info("Transaction timeout id=%i start =%i:%i end=%i:%i curr=%i:%i",
+               it->first, it->second->startTime_.tv_sec, it->second->startTime_.tv_usec,
+               it->second->endTime_.tv_sec,it->second->endTime_.tv_usec,
                currTime.tv_sec,currTime.tv_usec);
-         rstTransaction(it->first,rim::TimeoutError,false);
+
+         it->second->error_ = rim::TimeoutError;
+         rstTransaction(it,false);
       }
       else cond_.timed_wait(lock,boost::posix_time::microseconds(1000));
 
       if ( id == 0 ) it = tran_.begin();
-      else it = tran_.find(id);
+      else break;
    }
+}
+
+//! Reset transaction data, not python safe, needs lock
+void rim::Master::rstTransaction(TransactionMap::iterator it, bool notify) {
+
+   log_->debug("Resetting transaction id=%i",it->second->id_);
+
+   if ( it->second->pyValid_ ) {
+      rogue::ScopedGil gil;
+      PyBuffer_Release(&(it->second->pyBuf_));
+   }
+
+   if ( it->second->error_ != 0 ) error_ = error;
+
+   tranMap_.erase(it);
+   if ( notify ) cond_.notify_all();
 }
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -222,7 +222,7 @@ void rim::Master::rstTransaction(TransactionMap::iterator it, bool notify) {
    log_->debug("Resetting transaction id=%i",it->second->id_);
 
    // Lock the transaction
-   boost::lock_guard<boost::mutex> lock(it->lock);
+   boost::lock_guard<boost::mutex> lock(it->second->lock);
 
    it->second->iter_ = NULL;
    if ( it->second->pyValid_ ) {

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -37,7 +37,6 @@ rim::MasterPtr rim::Master::create () {
 
 void rim::Master::setup_python() {
    bp::class_<rim::Master, rim::MasterPtr, boost::noncopyable>("Master",bp::init<>())
-      .def("_getTransaction",     &rim::Master::getTransaction)
       .def("_setSlave",           &rim::Master::setSlave)
       .def("_getSlave",           &rim::Master::getSlave)
       .def("_reqMinAccess",       &rim::Master::reqMinAccess)
@@ -65,22 +64,6 @@ rim::Master::Master() {
 
 //! Destroy object
 rim::Master::~Master() { }
-
-//! Get transaction with index
-rim::TransactionPtr rim::Master::getTransaction(uint32_t index) {
-   rim::TransactionPtr ret;
-   TransactionMap::iterator it;
-
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mastMtx_);
-
-   it = tranMap_.find(index);
-
-   if ( ( it = tranMap_.find(index)) != tranMap_.end() ) 
-      return it->second;
-   else
-      return NULL;
-}
 
 //! Set slave
 void rim::Master::setSlave ( rim::SlavePtr slave ) {

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -55,6 +55,7 @@ void rim::Master::setup_python() {
 //! Create object
 rim::Master::Master() {
    error_   = 0;
+   slave_   = rim::Slave::create(4,4);
 
    sumTime_.tv_sec  = 1;
    sumTime_.tv_usec = 0;

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -220,6 +220,7 @@ void rim::Master::rstTransaction(TransactionMap::iterator it, bool notify) {
 
    log_->debug("Resetting transaction id=%i",it->second->id_);
 
+   it->second->iter_ = NULL;
    if ( it->second->pyValid_ ) {
       rogue::ScopedGil gil;
       PyBuffer_Release(&(it->second->pyBuf_));

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -55,7 +55,7 @@ void rim::Master::setup_python() {
 //! Create object
 rim::Master::Master() {
    error_   = 0;
-   slave_   = rim::Slave::create(4,4);
+   slave_   = rim::Slave::create(4,4); // Empty placeholder
 
    sumTime_.tv_sec  = 1;
    sumTime_.tv_usec = 0;
@@ -216,10 +216,13 @@ void rim::Master::doneTransaction(uint32_t id) {
    }
 }
 
-//! Reset transaction data, not python safe, needs lock
+//! Reset transaction data, not python safe, needs lock on master
 void rim::Master::rstTransaction(TransactionMap::iterator it, bool notify) {
 
    log_->debug("Resetting transaction id=%i",it->second->id_);
+
+   // Lock the transaction
+   boost::lock_guard<boost::mutex> lock(it->lock);
 
    it->second->iter_ = NULL;
    if ( it->second->pyValid_ ) {

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -83,14 +83,24 @@ void rim::Slave::delTransaction(uint32_t index) {
    }
 }
 
+//! Get min size from slave
+uint32_t rim::Slave::min() {
+   return min_;
+}
+
+//! Get min size from slave
+uint32_t rim::Slave::max() {
+   return max_;
+}
+
 //! Return min access size to requesting master
 uint32_t rim::Slave::doMinAccess() {
-   return(min_);
+   return(min());
 }
 
 //! Return max access size to requesting master
 uint32_t rim::Slave::doMaxAccess() {
-   return(max_);
+   return(max());
 }
 
 //! Return offset

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -3,9 +3,7 @@
  * Title      : Memory Slave
  * ----------------------------------------------------------------------------
  * File       : Slave.cpp
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2016-09-20
- * Last update: 2016-09-20
  * ----------------------------------------------------------------------------
  * Description:
  * Memory slave interface.
@@ -40,48 +38,49 @@ rim::SlavePtr rim::Slave::create (uint32_t min, uint32_t max) {
 rim::Slave::Slave(uint32_t min, uint32_t max) { 
    min_ = min;
    max_ = max;
-   enLocDone_ = false;
 } 
 
 //! Destroy object
 rim::Slave::~Slave() { }
 
-//! Enable local response
-void rim::Slave::enLocDone(bool enable) {
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   enLocDone_ = enable;
-}
-
 //! Register a master.
-void rim::Slave::addMaster(uint32_t id, rim::MasterPtr master) {
+void rim::Slave::addTransaction(uint32_t id, rim::TransactionPtr transaction) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   masterMap_[id] = master;
+   boost::lock_guard<boost::mutex> lock(slaveMtx_);
+   transactionMap_[id] = transaction; // Weak pointer copy
 }
 
-//! Get master device with index, called by sub classes
-rim::MasterPtr rim::Slave::getMaster(uint32_t index) {
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
+//! Get transaction with index, called by sub classes
+rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
+   rim::TransactionPtr ret;
+   TransactionMap::iterator it;
 
-   if ( masterMap_.find(index) != masterMap_.end() ) return(masterMap_[index]);
-   else throw(rogue::GeneralError("Slave::getMaster","Memory Master Not Linked To Slave"));
-}
-
-//! Return true if master is valid
-bool rim::Slave::validMaster(uint32_t index) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   if ( masterMap_.find(index) != masterMap_.end() ) return(true);
-   else return(false);
+   boost::lock_guard<boost::mutex> lock(slaveMtx_);
+
+   it = tranMap_.find(index);
+
+   if ( ( it = tranMap_.find(index)) != tranMap_.end() ) {
+
+      // Expired pointer
+      if ( (it->second.expired() ) tranMap_.erase(it);
+      else ret = it->second;
+   } 
+   return ret;
 }
 
 //! Remove master from the list
 void rim::Slave::delMaster(uint32_t index) {
+   TransactionMap::iterator it;
+
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mtx_);
-   if ( masterMap_.find(index) != masterMap_.end() ) masterMap_.erase(index);
+   boost::lock_guard<boost::mutex> lock(slaveMtx_);
+
+   for (it = tranMap_.begin(); it != tranMap_.end(); ++it) {
+
+      // Weak pointer or matching index
+      if ( it->second.expired() || it->first == index ) tranMap_.erase(it);
+   }
 }
 
 //! Return min access size to requesting master
@@ -100,22 +99,19 @@ uint64_t rim::Slave::doAddress() {
 }
 
 //! Post a transaction
-void rim::Slave::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t address, uint32_t size, uint32_t type) {
-   if ( enLocDone_ ) master->doneTransaction(id,0);
-   else master->doneTransaction(id,rim::Unsupported);
+void rim::Slave::doTransaction(rim::TransactionPtr transaction) {
+   transaction->complete(rim::Unsupported);
 }
 
 void rim::Slave::setup_python() {
    bp::class_<rim::SlaveWrap, rim::SlaveWrapPtr, boost::noncopyable>("Slave",bp::init<uint32_t,uint32_t>())
-      .def("_addMaster",     &rim::Slave::addMaster)
-      .def("_getMaster",     &rim::Slave::getMaster)
-      .def("_validMaster",   &rim::Slave::validMaster)
-      .def("_delMaster",     &rim::Slave::delMaster)
-      .def("enLocDone",      &rim::Slave::enLocDone)
-      .def("_doMinAccess",   &rim::Slave::doMinAccess,   &rim::SlaveWrap::defDoMinAccess)
-      .def("_doMaxAccess",   &rim::Slave::doMaxAccess,   &rim::SlaveWrap::defDoMaxAccess)
-      .def("_doAddress",     &rim::Slave::doAddress,     &rim::SlaveWrap::defDoAddress)
-      .def("_doTransaction", &rim::Slave::doTransaction, &rim::SlaveWrap::defDoTransaction)
+      .def("_addTransaction", &rim::Slave::addTransaction)
+      .def("_getTransaction", &rim::Slave::getTransaction)
+      .def("_delTransaction", &rim::Slave::delTransaction)
+      .def("_doMinAccess",    &rim::Slave::doMinAccess,   &rim::SlaveWrap::defDoMinAccess)
+      .def("_doMaxAccess",    &rim::Slave::doMaxAccess,   &rim::SlaveWrap::defDoMaxAccess)
+      .def("_doAddress",      &rim::Slave::doAddress,     &rim::SlaveWrap::defDoAddress)
+      .def("_doTransaction",  &rim::Slave::doTransaction, &rim::SlaveWrap::defDoTransaction)
    ;
 }
 
@@ -186,26 +182,24 @@ uint64_t rim::SlaveWrap::defDoAddress() {
 }
 
 //! Post a transaction. Master will call this method with the access attributes.
-void rim::SlaveWrap::doTransaction(uint32_t id, rim::MasterPtr master,
-                                   uint64_t address, uint32_t size, uint32_t type) {
+void rim::SlaveWrap::doTransaction(rim::TransactionPtr transaction) {
    {
       rogue::ScopedGil gil;
 
       if (boost::python::override pb = this->get_override("_doTransaction")) {
          try {
-            pb(id,master,address,size,type);
+            pb(transaction);
             return;
          } catch (...) {
             PyErr_Print();
          }
       }
    }
-   rim::Slave::doTransaction(id,master,address,size,type);
+   rim::Slave::doTransaction(transaction);
 }
 
 //! Post a transaction. Master will call this method with the access attributes.
-void rim::SlaveWrap::defDoTransaction(uint32_t id, rim::MasterPtr master,
-                                      uint64_t address, uint32_t size, uint32_t type) {
+void rim::SlaveWrap::defDoTransaction(rim::TransactionPtr transaction) {
    rim::Slave::doTransaction(id, master, address, size, type);
 }
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -49,8 +49,8 @@ void rim::Transaction::setup_python() {
       .def("size",    &rim::Transaction::size)
       .def("type",    &rim::Transaction::type)
       .def("done",    &rim::Transaction::done)
-      .def("write",   &rim::Transaction::writePy)
-      .def("read",    &rim::Transaction::readPy)
+      .def("setData", &rim::Transaction::setData)
+      .def("getData", &rim::Transaction::getData)
    ;
 }
 
@@ -80,6 +80,9 @@ rim::Transaction::Transaction(rim::MasterPtr master) {
 
 //! Destroy object
 rim::Transaction::~Transaction() { }
+
+//! Get expired state
+bool rim::Transaction::expired() { return (iter_ == NULL); }
 
 //! Get id
 uint32_t rim::Transaction::id() { return id_; }
@@ -115,8 +118,8 @@ rim::Transaction::iterator rim::Transaction::end() {
    return iter_ + size_;
 }
 
-//! Write data from python
-void rim::Transaction::writePy ( boost::python::object p, uint32_t offset ) {
+//! Set transaction data from python
+void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
    uint8_t *  data;
 
@@ -139,8 +142,8 @@ void rim::Transaction::writePy ( boost::python::object p, uint32_t offset ) {
    PyBuffer_Release(&pyBuf);
 }
 
-//! Read data from python
-void rim::Transaction::readPy ( boost::python::object p, uint32_t offset ) {
+//! Get transaction data from python
+void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
    uint8_t *  data;
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -1,0 +1,148 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Transaction
+ * ----------------------------------------------------------------------------
+ * File       : Transaction.cpp
+ * Author     : Ryan Herbst, rherbst@slac.stanford.edu
+ * Created    : 2016-09-20
+ * Last update: 2016-09-20
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory master interface.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/Master.h>
+#include <rogue/interfaces/memory/Constants.h>
+#include <rogue/GeneralError.h>
+#include <boost/make_shared.hpp>
+#include <rogue/GilRelease.h>
+#include <rogue/ScopedGil.h>
+
+namespace rim = rogue::interfaces::memory;
+namespace bp  = boost::python;
+
+// Init class counter
+uint32_t rim::Transaction::classIdx_ = 0;
+
+//! Class instance lock
+boost::mutex rim::Transaction::classMtx_;
+
+//! Create a master container
+rim::TransactionPtr rim::Transaction::create (rim::MasterPtr master) {
+   rim::TransactionPtr m = boost::make_shared<rim::Transaction>(master);
+   return(m);
+}
+
+//! Create object
+rim::Transaction::Transaction(rim::MasterPtr master) {
+   master_ = master;
+
+   endTime_.tv_sec    = 0;
+   endTime_.tv_usec   = 0;
+   startTime_.tv_sec  = 0;
+   startTime_.tv_usec = 0;
+
+   memset(pyBuf_),0,sizeof(Py_buffer);
+   pyValid_ = false;
+
+   data_    = NULL;
+   address_ = 0;
+   size_    = 0;
+   type_    = 0;
+   error_   = 0;
+
+   classMtx_.lock();
+   if ( classIdx_ == 0 ) classIdx_ = 1;
+   id_ = classIdx_;
+   classIdx_++;
+   classMtx_.unlock();
+} 
+
+//! Destroy object
+rim::Transaction::~Transaction() { }
+
+//! Get id
+uint32_t rim::Transaction::id() { return id_; }
+
+//! Get address
+uint32_t rim::Transaction::address(); { return address_; }
+
+//! Get size
+uint32_t rim::Transaction::size() { return size_; }
+
+//! Get type
+uint32_t rim::Transaction::type() { return type_; }
+
+//! Complete transaction with passed error
+void rim::Transaction::complete(uint32_t error) {
+   {
+      rogue::GilRelease noGil;
+      boost::lock_guard<boost::mutex> lg(lock);
+      error_ = error;
+   }
+   master_->doneTransaction(id_);
+}
+
+//! start iterator, caller must lock around access
+rim::Transaction::iterator rim::Transaction::begin() {
+   return data_;
+}
+
+//! end iterator, caller must lock around access
+rim::Transaction::iterator rim::Transaction::end() {
+   return data_ + size_;
+}
+
+//! Write data from python
+void rim::Transaction::writePy ( boost::python::object p, uint32_t offset ) {
+   Py_buffer  pyBuf;
+
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lg(lock);
+   noGil.acquire();
+
+   if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
+      throw(rogue::GeneralError("Transaction::writePy","Python Buffer Error In Frame"));
+
+   uint32_t count = pyBuf.len;
+
+   if ( (offset + count) > size_ ) {
+      PyBuffer_Release(&pyBuf);
+      throw(rogue::GeneralError::boundary("Frame::write",offset+count,size));
+   }
+
+   std::copy(pyBuf.buf,pyBuf.buf+count,data_+offset);
+   PyBuffer_Release(&pyBuf);
+}
+
+//! Read data from python
+void rim::Transaction::readPy ( boost::python::object p, uint32_t offset ) {
+   Py_buffer  pyBuf;
+
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lg(lock);
+   noGil.acquire();
+
+   if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 
+      throw(rogue::GeneralError("Transaction::readPy","Python Buffer Error In Frame"));
+
+   uint32_t count = pyBuf.len;
+
+   if ( (offset + count) > size_ ) 
+      PyBuffer_Release(&pyBuf);
+      throw(rogue::GeneralError::boundary("Frame::readPy",offset+count,size));
+   }
+
+   std::copy(data_+offset,data_+offset+count,pyBuf.buf);
+   PyBuffer_Release(&pyBuf);
+}
+

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -43,7 +43,7 @@ rim::TransactionPtr rim::Transaction::create (rim::MasterPtr master) {
 }
 
 void rim::Transaction::setup_python() {
-   bp::class_<rim::Transaction, rim::TransactionPtr, boost::noncopyable>("Master",bp::no_init)
+   bp::class_<rim::Transaction, rim::TransactionPtr, boost::noncopyable>("Transaction",bp::no_init)
       .def("id",      &rim::Transaction::id)
       .def("address", &rim::Transaction::address)
       .def("size",    &rim::Transaction::size)

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/interfaces/memory/Hub.h>
 #include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -57,6 +58,7 @@ void rim::setup_module() {
    rim::Master::setup_python(); 
    rim::Slave::setup_python(); 
    rim::Hub::setup_python(); 
+   rim::Transaction::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -171,7 +171,11 @@ uint32_t ris::Buffer::getPayload() {
 }
 
 //! Set payload size (not including header)
-void ris::Buffer::setPayload(uint32_t size) {
+void ris::Buffer::setPayload(uint32_t size, bool shrink) {
+
+   // Shrink is disabled and size is less than current payload
+   if ( ( !shrink ) && ( size < getPayload() ) ) return;
+
    if ( size > (rawSize_ - (headRoom_ + tailRoom_) ) ) 
       throw(rogue::GeneralError::boundary("Buffer::setPayload",
             size, (rawSize_ - (headRoom_ + tailRoom_))));
@@ -185,7 +189,7 @@ void ris::Buffer::adjustPayload(int32_t value) {
       throw(rogue::GeneralError::boundary("Buffer::adjustPayload",
             abs(value), (getPayload())));
 
-   setPayload(getPayload() + value);
+   setPayload(getPayload() + value, true);
 }
 
 //! Set the buffer as full (minus tail reservation)

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -196,7 +196,7 @@ void ris::Buffer::adjustPayload(int32_t value) {
       throw(rogue::GeneralError::boundary("Buffer::adjustPayload",
             abs(value), (getPayload())));
 
-   setPayload(getPayload() + value, true);
+   setPayload(getPayload() + value);
 }
 
 //! Set the buffer as full (minus tail reservation)

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -99,13 +99,13 @@ void ris::Buffer::adjustHeader(int32_t value) {
    // Payload can never be less than headeroom
    if ( payload_ < headRoom_ ) payload_ = headRoom_;
 
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 //! Clear the header reservation
 void ris::Buffer::zeroHeader() {
    headRoom_ = 0;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 //! Adjust tail by passed value
@@ -122,13 +122,13 @@ void ris::Buffer::adjustTail(int32_t value) {
 
    // Make adjustment
    tailRoom_ += value;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 //! Clear the tail reservation
 void ris::Buffer::zeroTail() {
    tailRoom_ = 0;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 /* 
@@ -199,7 +199,7 @@ void ris::Buffer::setPayload(uint32_t size) {
             size, (rawSize_ - (headRoom_ + tailRoom_))));
 
    payload_ = size + headRoom_;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 /* 
@@ -220,12 +220,12 @@ void ris::Buffer::adjustPayload(int32_t value) {
 //! Set the buffer as full (minus tail reservation)
 void ris::Buffer::setPayloadFull() {
    payload_ = rawSize_ - tailRoom_;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 
 //! Set the buffer as empty (minus header reservation)
 void ris::Buffer::setPayloadEmpty() {
    payload_ = headRoom_;
-   if ( frame_ ) frame_->setSizeDirty();
+   if ( frame_ != NULL ) frame_->setSizeDirty();
 }
 

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -190,6 +190,14 @@ void ris::Buffer::setPayload(uint32_t size) {
    payload_ = size + headRoom_;
 }
 
+/* 
+ * Set min payload size (not including header)
+ * Payload size is updated only if size > current size
+*/
+void ris::Buffer::minPayload(uint32_t size) {
+   if ( size > getPayload() ) setPayload(size);
+}
+
 //! Adjust payload size
 void ris::Buffer::adjustPayload(int32_t value) {
    if ( value < 0 && (uint32_t)abs(value) > getPayload())

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -65,19 +65,6 @@ ris::Buffer::~Buffer() {
    source_->retBuffer(data_,meta_,allocSize_);
 }
 
-//! Get raw data pointer
-uint8_t * ris::Buffer::getRawData() {
-   return(data_);
-}
-
-/* 
- * Get data pointer
- * Returns base + header size
- */
-uint8_t * ris::Buffer::getPayloadData() {
-   return(data_ + headRoom_);
-}
-
 //! Get meta data, used by pool 
 uint32_t ris::Buffer::getMeta() {
    return(meta_);
@@ -131,6 +118,30 @@ void ris::Buffer::adjustTail(int32_t value) {
 //! Clear the tail reservation
 void ris::Buffer::zeroTail() {
    tailRoom_ = 0;
+}
+
+/* 
+ * Get data pointer (begin iterator)
+ * Returns base + header size
+ */
+uint8_t * ris::Buffer::begin() {
+   return(data_ + headRoom_);
+}
+
+/*
+ * Get end data pointer (end iterator)
+ * This is the end of raw data buffer
+ */
+uint8_t * ris::Buffer::end() {
+   return(data_ + rawSize_);
+}
+
+/*
+ * Get end payload pointer (end iterator)
+ * This is the end of payload data
+ */
+uint8_t * ris::Buffer::endPayload() {
+   return(data_ + payload_);
 }
 
 /*

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -182,11 +182,7 @@ uint32_t ris::Buffer::getPayload() {
 }
 
 //! Set payload size (not including header)
-void ris::Buffer::setPayload(uint32_t size, bool shrink) {
-
-   // Shrink is disabled and size is less than current payload
-   if ( ( !shrink ) && ( size < getPayload() ) ) return;
-
+void ris::Buffer::setPayload(uint32_t size) {
    if ( size > (rawSize_ - (headRoom_ + tailRoom_) ) ) 
       throw(rogue::GeneralError::boundary("Buffer::setPayload",
             size, (rawSize_ - (headRoom_ + tailRoom_))));

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/Logging.h>
@@ -76,7 +77,8 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    nFrame = reqFrame(size,true);
 
    // Copy the frame
-   nFrame->copyFrame(frame,0,size);
+   //std::copy(frame->begin(), frame->begin()+size, nFrame->begin());
+   nFrame->setPayload(size,true);
 
    // Append to buffer
    queue_.push(nFrame);

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -77,7 +77,7 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    nFrame = reqFrame(size,true);
 
    // Copy the frame
-   //std::copy(frame->begin(), frame->begin()+size, nFrame->begin());
+   std::copy(frame->begin(), frame->begin()+size, nFrame->begin());
    nFrame->setPayload(size);
 
    // Append to buffer

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -78,7 +78,7 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
 
    // Copy the frame
    //std::copy(frame->begin(), frame->begin()+size, nFrame->begin());
-   nFrame->setPayload(size,true);
+   nFrame->setPayload(size);
 
    // Append to buffer
    queue_.push(nFrame);

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -52,6 +52,7 @@ ris::Frame::~Frame() {
 ris::Frame::BufferIterator ris::Frame::appendBuffer(ris::BufferPtr buff) {
    uint32_t oSize = buffers_.size();
 
+   buff->setFrame(shared_from_this());
    buffers_.push_back(buff);
    updateSizes();
    return(buffers_.begin()+oSize);
@@ -61,9 +62,10 @@ ris::Frame::BufferIterator ris::Frame::appendBuffer(ris::BufferPtr buff) {
 ris::Frame::BufferIterator ris::Frame::appendFrame(ris::FramePtr frame) {
    uint32_t oSize = buffers_.size();
 
-   std::back_insert_iterator< std::vector<BufferPtr> > backIt(buffers_);
-
-   std::copy(frame->beginBuffer(), frame->endBuffer(), backIt);
+   for (ris::Frame::BufferIterator it = frame->beginBuffer(); it != frame->endBuffer(); ++it) {
+      (*it)->setFrame(shared_from_this());
+      buffers_.push_back(*it);
+   }
    frame->buffers_.clear();
    updateSizes();
    return(buffers_.begin()+oSize);

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -274,7 +274,7 @@ void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    ris::Frame::iterator end = ris::Frame::iterator(shared_from_this(),offset+count,false);
 
    data = (uint8_t *)pyBuf.buf;
-   //std::copy(beg,end,data);
+   std::copy(beg,end,data);
    PyBuffer_Release(&pyBuf);
 }
 
@@ -297,7 +297,7 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
    ris::Frame::iterator beg = ris::Frame::iterator(shared_from_this(),offset,false);
 
    data = (uint8_t *)pyBuf.buf;
-   //std::copy(data,data+count,beg);
+   std::copy(data,data+count,beg);
 
    minPayload(offset+count);
    PyBuffer_Release(&pyBuf);

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -67,6 +67,11 @@ ris::Frame::BufferIterator ris::Frame::endBuffer() {
    return(buffers_.end());
 }
 
+//! Buffer list is empty
+bool ris::Frame::isEmpty() {
+   return(buffers_.empty());
+}
+
 /*
  * Get size of buffers that can hold
  * payload data. This function 
@@ -250,7 +255,8 @@ ris::Frame::iterator ris::Frame::endPayload() {
 
 //! Read up to count bytes from frame, starting from offset. Python version.
 void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
-   Py_buffer  pyBuf;
+   Py_buffer pyBuf;
+   uint8_t * data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 
       throw(rogue::GeneralError("Frame::readPy","Python Buffer Error In Frame"));
@@ -266,13 +272,15 @@ void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    ris::Frame::iterator beg = ris::Frame::iterator(shared_from_this(),offset,false);
    ris::Frame::iterator end = ris::Frame::iterator(shared_from_this(),offset+count,false);
 
-   std::copy(beg,end,pyBuf.buf);
+   data = (uint8_t *)pyBuf.buf;
+   //std::copy(beg,end,data);
    PyBuffer_Release(&pyBuf);
 }
 
 //! Write python buffer to frame, starting at offset. Python Version
 void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
-   Py_buffer  pyBuf;
+   Py_buffer pyBuf;
+   uint8_t * data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
       throw(rogue::GeneralError("Frame::writePy","Python Buffer Error In Frame"));
@@ -287,7 +295,8 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
 
    ris::Frame::iterator beg = ris::Frame::iterator(shared_from_this(),offset,false);
 
-   std::copy(pyBuf.buf,pyBuf.buf+count,beg);
+   data = (uint8_t *)pyBuf.buf;
+   //std::copy(data,data+count,beg);
 
    minPayload(offset+count);
    PyBuffer_Release(&pyBuf);

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -55,6 +55,7 @@ void ris::Frame::appendFrame(ris::FramePtr frame) {
    std::back_insert_iterator< std::vector<BufferPtr> > backIt(buffers_);
 
    std::copy(frame->beginBuffer(), frame->endBuffer(), backIt);
+   frame->buffers_.clear();
 }
 
 //! Buffer begin iterator

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -57,16 +57,6 @@ void ris::Frame::appendFrame(ris::FramePtr frame) {
    std::copy(frame->beginBuffer(), frame->endBuffer(), backIt);
 }
 
-//! Remove buffers from frame
-void ris::Frame::clear() {
-   buffers_.clear();
-}
-
-//! Get buffer count
-uint32_t ris::Frame::getCount() {
-   return(buffers_.size());
-}
-
 //! Buffer begin iterator
 ris::Frame::BufferIterator ris::Frame::beginBuffer() {
    return(buffers_.begin());

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -46,16 +46,22 @@ ris::Frame::~Frame() {
 }
 
 //! Add a buffer to end of frame
-void ris::Frame::appendBuffer(ris::BufferPtr buff) {
+ris::Frame::BufferIterator ris::Frame::appendBuffer(ris::BufferPtr buff) {
+   uint32_t oSize = buffers_.size();
+
    buffers_.push_back(buff);
+   return(buffers_.begin()+oSize);
 }
 
 //! Append passed frame buffers to end of frame.
-void ris::Frame::appendFrame(ris::FramePtr frame) {
+ris::Frame::BufferIterator ris::Frame::appendFrame(ris::FramePtr frame) {
+   uint32_t oSize = buffers_.size();
+
    std::back_insert_iterator< std::vector<BufferPtr> > backIt(buffers_);
 
    std::copy(frame->beginBuffer(), frame->endBuffer(), backIt);
    frame->buffers_.clear();
+   return(buffers_.begin()+oSize);
 }
 
 //! Buffer begin iterator

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -44,9 +44,7 @@ ris::Frame::Frame() {
 }
 
 //! Destroy a frame.
-ris::Frame::~Frame() {
-   buffers_.clear();
-}
+ris::Frame::~Frame() { }
 
 //! Add a buffer to end of frame
 ris::Frame::BufferIterator ris::Frame::appendBuffer(ris::BufferPtr buff) {
@@ -67,6 +65,7 @@ ris::Frame::BufferIterator ris::Frame::appendFrame(ris::FramePtr frame) {
       buffers_.push_back(*it);
    }
    frame->buffers_.clear();
+   frame->updateSizes();
    updateSizes();
    return(buffers_.begin()+oSize);
 }

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -65,7 +65,7 @@ const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator 
 }
 
 //! De-reference
-uint8_t ris::FrameIterator::operator *() const {
+uint8_t & ris::FrameIterator::operator *() const {
    if ( frame_ == NULL ) return 0;
    else if ( end_ ) return 0;
    else return *((*curr_)->begin());

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -33,7 +33,7 @@ ris::FrameIterator::FrameIterator(ris::FramePtr frame, uint32_t offset, bool end
    frame_    = frame;
    curr_     = frame_->endBuffer();
    buffPos_  = 0;
-   framePos_ = 0;
+   framePos_ = frame_->getSize();
 
    if ( ! end ) {
       buffPos_  = offset;
@@ -170,7 +170,7 @@ ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
 ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
    if ( sub < 0 ) return(*this + sub);
 
-   if ( sub < framePos_ ) 
+   if ( (uint32_t)sub > framePos_ ) 
       throw rogue::GeneralError("FrameIterator::-","Iterator underflow!");
 
    ris::FrameIterator ret(frame_, framePos_ - sub, ((framePos_ - sub) == frame_->getSize()));

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -1,0 +1,198 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Stream iterator container
+ * ----------------------------------------------------------------------------
+ * File       : FrameIterator.h
+ * Created    : 2018-03-06
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Stream frame iterator
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/GeneralError.h>
+#include <boost/python.hpp>
+
+namespace ris = rogue::interfaces::stream;
+namespace bp  = boost::python;
+
+ris::FrameIterator::FrameIterator(ris::FramePtr frame, uint32_t offset, bool end) {
+   ris::Frame::BufferIterator it;
+  
+   end_      = end; 
+   frame_    = frame;
+   curr_     = frame->endBuffer();
+   buffPos_  = 0;
+   framePos_ = 0;
+
+   if ( ! end ) {
+      buffPos_  = offset;
+      framePos_ = offset;
+
+      for ( it=frame_->beginBuffer(); it != frame->endBuffer(); ++it ) {
+         curr_ = it;
+
+         if ( (*it)->getSize() > buffPos_ ) break;
+         else buffPos_ -= (*it)->getSize();
+      }
+   }
+}
+
+//! Copy assignment
+const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator &rhs) {
+   this->end_      = rhs.end_;
+   this->frame_    = rhs.frame_;
+   this->curr_     = rhs.curr_;
+   this->buffPos_  = rhs.buffPos_;
+   this->framePos_ = rhs.framePos_;
+   return *this;
+}
+
+//! De-reference
+uint8_t ris::FrameIterator::operator *() const {
+   if ( end_ ) return 0;
+   else return *((*curr_)->begin());
+}
+
+//! Pointer
+uint8_t * ris::FrameIterator::operator ->() const {
+   if ( end_ ) return NULL;
+   else return (*curr_)->begin();
+}
+
+//! De-reference by index
+uint8_t ris::FrameIterator::operator [](const uint32_t &offset) const {
+   if ((offset + framePos_) >= frame_->getSize()) 
+      throw rogue::GeneralError("FrameIterator::[]","Ran past end of frame!");
+
+   ris::FrameIterator ret(frame_, (framePos_ + offset),false);
+   return *ret;
+}
+
+//! Increment
+const ris::FrameIterator & ris::FrameIterator::operator ++() {
+   if ( end_ ) throw rogue::GeneralError("FrameIterator::++","Ran past end of frame!");
+   ++framePos_;
+
+   if ( ++buffPos_ == (*curr_)->getSize() ) {
+      buffPos_ = 0;
+      if ( ++curr_ == frame_->endBuffer() ) end_ = true;
+   }
+   return *this;
+}
+
+//! post Increment
+ris::FrameIterator ris::FrameIterator::operator ++(int) {
+   ris::FrameIterator ret(*this);
+   ++(*this);
+   return ret;
+}
+
+//! Decrement
+const ris::FrameIterator & ris::FrameIterator::operator --() {
+   if ( framePos_ == 0 ) throw rogue::GeneralError("FrameIterator::++","Ran past start of frame!");
+   --framePos_;
+
+   if ( end_ || buffPos_ == 0 ) {
+      curr_--;
+      end_ = false;
+      buffPos_ = (*curr_)->getSize()-1;
+   }
+   else --buffPos_;
+   return *this;
+}
+
+//! post Decrement
+ris::FrameIterator ris::FrameIterator::operator --(int) {
+   ris::FrameIterator ret(*this);
+   --(*this);
+   return ret;
+}
+
+//! Not Equal
+bool ris::FrameIterator::operator !=(const ris::FrameIterator & other) const {
+   return(other.framePos_ != framePos_ || other.frame_ != frame_);
+}
+
+//! Equal
+bool ris::FrameIterator::operator ==(const ris::FrameIterator & other) const {
+   return(other.framePos_ == framePos_ && other.frame_ == frame_);
+}
+
+//! Less than
+bool ris::FrameIterator::operator <(const ris::FrameIterator & other) const {
+   return ( framePos_ < other.framePos_ );
+}
+
+//! greater than
+bool ris::FrameIterator::operator >(const ris::FrameIterator & other) const {
+   return ( framePos_ > other.framePos_ );
+}
+
+//! Less than equal
+bool ris::FrameIterator::operator <=(const ris::FrameIterator & other) const {
+   return ( framePos_ <= other.framePos_ );
+}
+
+//! greater than equal
+bool ris::FrameIterator::operator >=(const ris::FrameIterator & other) const {
+   return ( framePos_ >= other.framePos_ );
+}
+
+//! Increment by value, this can be done better
+ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
+   ris::FrameIterator ret(*this);
+   int32_t loc = add;
+
+   if ( loc > 0 ) while ( --loc >= 0 ) ++ret;
+   else if ( loc < 0 ) while ( ++loc >= 0 ) --ret;
+
+   return ret;
+}
+
+//! Descrment by value, this can be done better
+ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
+   ris::FrameIterator ret(*this);
+   int32_t loc = sub;
+
+   if ( loc > 0 ) while ( --loc >= 0 ) --ret;
+   else if ( loc < 0 ) while ( ++loc >= 0 ) ++ret;
+
+   return ret;
+}
+
+//! Sub incrementers
+int32_t ris::FrameIterator::operator -(const ris::FrameIterator &other) const {
+   return(framePos_ - other.framePos_);
+}
+
+//! Increment by value, this can be done better
+ris::FrameIterator & ris::FrameIterator::operator +=(const int32_t &add) {
+   int32_t loc = add;
+   if ( loc > 0 ) while ( --loc >= 0 ) ++(*this);
+   else if ( loc < 0 ) while ( ++loc >= 0 ) --(*this);
+
+   return *this;
+}
+
+//! Descrment by value, this can be done better
+ris::FrameIterator & ris::FrameIterator::operator -=(const int32_t &sub) {
+   int32_t loc = sub;
+   if ( loc > 0 ) while ( --loc >= 0 ) --(*this);
+   else if ( loc < 0 ) while ( ++loc >= 0 ) ++(*this);
+
+   return *this;
+}
+
+void ris::FrameIterator::setup_python() { }
+

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -49,7 +49,7 @@ ris::FrameIterator::FrameIterator(ris::FramePtr frame, uint32_t offset, bool end
 }
 
 ris::FrameIterator::FrameIterator() {
-   end_      = false;
+   end_      = true;
    buffPos_  = 0;
    framePos_ = 0;
 }
@@ -66,22 +66,22 @@ const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator 
 
 //! De-reference
 uint8_t & ris::FrameIterator::operator *() const {
-   if ( frame_ == NULL ) return 0;
-   else if ( end_ ) return 0;
-   else return *((*curr_)->begin());
+   if ( end_ )
+      throw rogue::GeneralError("FrameIterator::*","Ran past end of frame!");
+
+   else return *((*curr_)->begin() + buffPos_);
 }
 
 //! Pointer
 uint8_t * ris::FrameIterator::operator ->() const {
-   if ( (frame_ == NULL) || end_ ) return NULL;
-   else return (*curr_)->begin();
+   if ( end_ )
+      throw rogue::GeneralError("FrameIterator::->","Ran past end of frame!");
+
+   else return ((*curr_)->begin() + buffPos_);
 }
 
 //! De-reference by index
 uint8_t ris::FrameIterator::operator [](const uint32_t &offset) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::[]","Empty iterator");
-
    if ((offset + framePos_) >= frame_->getSize()) 
       throw rogue::GeneralError("FrameIterator::[]","Ran past end of frame!");
 
@@ -91,9 +91,6 @@ uint8_t ris::FrameIterator::operator [](const uint32_t &offset) const {
 
 //! Increment
 const ris::FrameIterator & ris::FrameIterator::operator ++() {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::++","Empty iterator");
-
    if ( end_ ) throw rogue::GeneralError("FrameIterator::++","Ran past end of frame!");
    ++framePos_;
 
@@ -113,9 +110,6 @@ ris::FrameIterator ris::FrameIterator::operator ++(int) {
 
 //! Decrement
 const ris::FrameIterator & ris::FrameIterator::operator --() {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::--","Empty iterator");
-
    if ( framePos_ == 0 ) throw rogue::GeneralError("FrameIterator::++","Ran past start of frame!");
    --framePos_;
 
@@ -137,57 +131,36 @@ ris::FrameIterator ris::FrameIterator::operator --(int) {
 
 //! Not Equal
 bool ris::FrameIterator::operator !=(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::!=","Empty iterator");
-
    return(other.framePos_ != framePos_ || other.frame_ != frame_);
 }
 
 //! Equal
 bool ris::FrameIterator::operator ==(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::==","Empty iterator");
-
    return(other.framePos_ == framePos_ && other.frame_ == frame_);
 }
 
 //! Less than
 bool ris::FrameIterator::operator <(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::<","Empty iterator");
-
    return ( framePos_ < other.framePos_ );
 }
 
 //! greater than
 bool ris::FrameIterator::operator >(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::>","Empty iterator");
-
    return ( framePos_ > other.framePos_ );
 }
 
 //! Less than equal
 bool ris::FrameIterator::operator <=(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::<=","Empty iterator");
-
    return ( framePos_ <= other.framePos_ );
 }
 
 //! greater than equal
 bool ris::FrameIterator::operator >=(const ris::FrameIterator & other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::>=","Empty iterator");
-
    return ( framePos_ >= other.framePos_ );
 }
 
 //! Increment by value, this can be done better
 ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::+","Empty iterator");
-
    ris::FrameIterator ret(*this);
    int32_t loc = add;
 
@@ -199,9 +172,6 @@ ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
 
 //! Descrment by value, this can be done better
 ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::-","Empty iterator");
-
    ris::FrameIterator ret(*this);
    int32_t loc = sub;
 
@@ -213,17 +183,11 @@ ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
 
 //! Sub incrementers
 int32_t ris::FrameIterator::operator -(const ris::FrameIterator &other) const {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::-","Empty iterator");
-
    return(framePos_ - other.framePos_);
 }
 
 //! Increment by value, this can be done better
 ris::FrameIterator & ris::FrameIterator::operator +=(const int32_t &add) {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::+=","Empty iterator");
-
    int32_t loc = add;
    if ( loc > 0 ) while ( --loc >= 0 ) ++(*this);
    else if ( loc < 0 ) while ( ++loc >= 0 ) --(*this);
@@ -233,9 +197,6 @@ ris::FrameIterator & ris::FrameIterator::operator +=(const int32_t &add) {
 
 //! Descrment by value, this can be done better
 ris::FrameIterator & ris::FrameIterator::operator -=(const int32_t &sub) {
-   if ( frame_ == NULL ) 
-      throw rogue::GeneralError("FrameIterator::-=","Empty iterator");
-
    int32_t loc = sub;
    if ( loc > 0 ) while ( --loc >= 0 ) --(*this);
    else if ( loc < 0 ) while ( ++loc >= 0 ) ++(*this);

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -48,6 +48,12 @@ ris::FrameIterator::FrameIterator(ris::FramePtr frame, uint32_t offset, bool end
    }
 }
 
+ris::FrameIterator::FrameIterator() {
+   end_      = false;
+   buffPos_  = 0;
+   framePos_ = 0;
+}
+
 //! Copy assignment
 const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator &rhs) {
    this->end_      = rhs.end_;
@@ -60,18 +66,22 @@ const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator 
 
 //! De-reference
 uint8_t ris::FrameIterator::operator *() const {
-   if ( end_ ) return 0;
+   if ( frame_ == NULL ) return 0;
+   else if ( end_ ) return 0;
    else return *((*curr_)->begin());
 }
 
 //! Pointer
 uint8_t * ris::FrameIterator::operator ->() const {
-   if ( end_ ) return NULL;
+   if ( (frame_ == NULL) || end_ ) return NULL;
    else return (*curr_)->begin();
 }
 
 //! De-reference by index
 uint8_t ris::FrameIterator::operator [](const uint32_t &offset) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::[]","Empty iterator");
+
    if ((offset + framePos_) >= frame_->getSize()) 
       throw rogue::GeneralError("FrameIterator::[]","Ran past end of frame!");
 
@@ -81,6 +91,9 @@ uint8_t ris::FrameIterator::operator [](const uint32_t &offset) const {
 
 //! Increment
 const ris::FrameIterator & ris::FrameIterator::operator ++() {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::++","Empty iterator");
+
    if ( end_ ) throw rogue::GeneralError("FrameIterator::++","Ran past end of frame!");
    ++framePos_;
 
@@ -100,6 +113,9 @@ ris::FrameIterator ris::FrameIterator::operator ++(int) {
 
 //! Decrement
 const ris::FrameIterator & ris::FrameIterator::operator --() {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::--","Empty iterator");
+
    if ( framePos_ == 0 ) throw rogue::GeneralError("FrameIterator::++","Ran past start of frame!");
    --framePos_;
 
@@ -121,36 +137,57 @@ ris::FrameIterator ris::FrameIterator::operator --(int) {
 
 //! Not Equal
 bool ris::FrameIterator::operator !=(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::!=","Empty iterator");
+
    return(other.framePos_ != framePos_ || other.frame_ != frame_);
 }
 
 //! Equal
 bool ris::FrameIterator::operator ==(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::==","Empty iterator");
+
    return(other.framePos_ == framePos_ && other.frame_ == frame_);
 }
 
 //! Less than
 bool ris::FrameIterator::operator <(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::<","Empty iterator");
+
    return ( framePos_ < other.framePos_ );
 }
 
 //! greater than
 bool ris::FrameIterator::operator >(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::>","Empty iterator");
+
    return ( framePos_ > other.framePos_ );
 }
 
 //! Less than equal
 bool ris::FrameIterator::operator <=(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::<=","Empty iterator");
+
    return ( framePos_ <= other.framePos_ );
 }
 
 //! greater than equal
 bool ris::FrameIterator::operator >=(const ris::FrameIterator & other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::>=","Empty iterator");
+
    return ( framePos_ >= other.framePos_ );
 }
 
 //! Increment by value, this can be done better
 ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::+","Empty iterator");
+
    ris::FrameIterator ret(*this);
    int32_t loc = add;
 
@@ -162,6 +199,9 @@ ris::FrameIterator ris::FrameIterator::operator +(const int32_t &add) const {
 
 //! Descrment by value, this can be done better
 ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::-","Empty iterator");
+
    ris::FrameIterator ret(*this);
    int32_t loc = sub;
 
@@ -173,11 +213,17 @@ ris::FrameIterator ris::FrameIterator::operator -(const int32_t &sub) const {
 
 //! Sub incrementers
 int32_t ris::FrameIterator::operator -(const ris::FrameIterator &other) const {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::-","Empty iterator");
+
    return(framePos_ - other.framePos_);
 }
 
 //! Increment by value, this can be done better
 ris::FrameIterator & ris::FrameIterator::operator +=(const int32_t &add) {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::+=","Empty iterator");
+
    int32_t loc = add;
    if ( loc > 0 ) while ( --loc >= 0 ) ++(*this);
    else if ( loc < 0 ) while ( ++loc >= 0 ) --(*this);
@@ -187,6 +233,9 @@ ris::FrameIterator & ris::FrameIterator::operator +=(const int32_t &add) {
 
 //! Descrment by value, this can be done better
 ris::FrameIterator & ris::FrameIterator::operator -=(const int32_t &sub) {
+   if ( frame_ == NULL ) 
+      throw rogue::GeneralError("FrameIterator::-=","Empty iterator");
+
    int32_t loc = sub;
    if ( loc > 0 ) while ( --loc >= 0 ) --(*this);
    else if ( loc < 0 ) while ( ++loc >= 0 ) ++(*this);

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -35,7 +35,9 @@ ris::MasterPtr ris::Master::create () {
 }
 
 //! Creator
-ris::Master::Master() { }
+ris::Master::Master() { 
+   primary_ = ris::Slave::create();
+}
 
 //! Destructor
 ris::Master::~Master() {

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -3,9 +3,7 @@
  * Title      : Stream interface master
  * ----------------------------------------------------------------------------
  * File       : Master.h
- * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2016-09-16
- * Last update: 2016-09-16
  * ----------------------------------------------------------------------------
  * Description:
  * Stream interface master
@@ -37,9 +35,7 @@ ris::MasterPtr ris::Master::create () {
 }
 
 //! Creator
-ris::Master::Master() {
-   primary_ = ris::Slave::create();
-}
+ris::Master::Master() { }
 
 //! Destructor
 ris::Master::~Master() {
@@ -49,8 +45,6 @@ ris::Master::~Master() {
 //! Set primary slave, used for buffer request forwarding
 void ris::Master::setSlave ( boost::shared_ptr<interfaces::stream::Slave> slave ) {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(slaveMtx_);
-   slaves_.push_back(slave);
    primary_ = slave;
 }
 
@@ -63,28 +57,33 @@ void ris::Master::addSlave ( ris::SlavePtr slave ) {
 
 //! Request frame from primary slave
 ris::FramePtr ris::Master::reqFrame ( uint32_t size, bool zeroCopyEn ) {
-   ris::SlavePtr slave;
-
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(slaveMtx_);
-   slave = primary_;
-   return(slave->acceptReq(size,zeroCopyEn));
+
+   if ( primary_ == NULL ) return NULL;
+
+   return(primary_->acceptReq(size,zeroCopyEn));
 }
 
 //! Push frame to slaves
 void ris::Master::sendFrame ( FramePtr frame) {
-   uint32_t x;
-
    std::vector<ris::SlavePtr> slaves;
+   std::vector<ris::SlavePtr> primary;
+   std::vector<ris::SlavePtr>::iterator it;
 
    {
       rogue::GilRelease noGil;
       boost::lock_guard<boost::mutex> lock(slaveMtx_);
       slaves = slaves_;
+      primary = primary_;
    }
 
-   for (x=0; x < slaves_.size(); x++) 
-      slaves[x]->acceptFrame(frame);
+   if ( primary_ != NULL ) {
+      for (it = slaves_.begin(); it != slaves_.end(); ++it) 
+         (*it)->acceptFrame(frame);
+
+      primary_->acceptFrame(frame);
+   }
 }
 
 void ris::Master::setup_python() {

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -68,8 +68,8 @@ ris::FramePtr ris::Master::reqFrame ( uint32_t size, bool zeroCopyEn ) {
 //! Push frame to slaves
 void ris::Master::sendFrame ( FramePtr frame) {
    std::vector<ris::SlavePtr> slaves;
-   std::vector<ris::SlavePtr> primary;
    std::vector<ris::SlavePtr>::iterator it;
+   ris::SlavePtr primary;
 
    {
       rogue::GilRelease noGil;

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
@@ -58,7 +59,9 @@ void ris::Slave::setDebug(uint32_t debug, std::string name) {
 
 //! Accept a frame from master
 void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
-   uint32_t x;
+   ris::Frame::iterator it;
+
+   uint32_t count;
    uint8_t  val;
 
    frameCount_++;
@@ -70,11 +73,13 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
       log_->log(100,"Got Size=%i, Data:",frame->getPayload());
       sprintf(buffer,"     ");
 
-      for (x=0; (x < debug_ && x < frame->getPayload()); x++) {
-         frame->read(&val,x,1);
+      count = 0;
+      for (it = frame->begin(); (count < debug_) && (it != frame->end()); ++it) {
+         count++;
+         val = *it;
 
          snprintf(buffer + strlen(buffer),1000-strlen(buffer)," 0x%.2x",val);
-         if (( (x+1) % 8 ) == 0) {
+         if (( (count+1) % 8 ) == 0) {
             log_->log(100,buffer);
             sprintf(buffer,"     ");
          }

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -70,7 +70,7 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
    if ( debug_ > 0 ) {
       char buffer[1000];
 
-      log_->log(100,"Got Size=%i, Data:",frame->getPayload());
+      log_->critical("Got Size=%i, Data:",frame->getPayload());
       sprintf(buffer,"     ");
 
       count = 0;
@@ -80,7 +80,7 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
 
          snprintf(buffer + strlen(buffer),1000-strlen(buffer)," 0x%.2x",val);
          if (( (count+1) % 8 ) == 0) {
-            log_->log(100,buffer);
+            log_->critical(buffer);
             sprintf(buffer,"     ");
          }
       }

--- a/src/rogue/interfaces/stream/module.cpp
+++ b/src/rogue/interfaces/stream/module.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/interfaces/stream/module.h>
 #include <boost/python.hpp>
@@ -45,6 +46,7 @@ void ris::setup_module() {
 
    ris::Buffer::setup_python();
    ris::Frame::setup_python();
+   ris::FrameIterator::setup_python();
    ris::Master::setup_python();
    ris::Slave::setup_python();
    ris::Pool::setup_python();

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
 #include <boost/make_shared.hpp>
@@ -102,64 +103,65 @@ void rpe::Master::valueGet() { }
 
 void rpe::Master::valueSet() {
    ris::FramePtr frame;
+   ris::Frame::iterator iter;
    uint32_t txSize;
-   uint32_t pos;
    uint32_t i;
 
    txSize = size_ * fSize_;
    frame = reqFrame(txSize, true);
-   pos = 0;
+   iter = frame->begin();
 
    // Create vector of appropriate type
    if ( epicsType_ == aitEnumUint8 ) {
       aitUint8 * pF = new aitUint8[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumUint16 ) {
       aitUint16 * pF = new aitUint16[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumUint32 ) {
       aitUint32 * pF = new aitUint32[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumInt8 ) {
       aitInt8 * pF = new aitInt8[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumInt16 ) {
       aitInt16 * pF = new aitInt16[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumInt32 ) {
       aitInt32 * pF = new aitInt32[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumFloat32 ) {
       aitFloat32 * pF = new aitFloat32[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    else if ( epicsType_ == aitEnumFloat64 ) {
       aitFloat64 * pF = new aitFloat64[size_];
       pValue_->getRef(pF);
-      for ( i = 0; i < size_; i++ ) pos += frame->write(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) toFrame(iter,fSize_,&(pF[i]));
    }
 
    // Should this be pushed to a queue for a worker thread to call slaves?
+   frame->setPayload(txSize);
    sendFrame(frame);
 }
 

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
@@ -104,22 +105,23 @@ void rpe::Slave::valueGet() { }
 void rpe::Slave::valueSet() { }
 
 void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
+   ris::Frame::iterator iter;
    struct timespec t;
-   uint32_t tSize;
+   uint32_t fSize;
    uint32_t size_;
-   uint32_t pos;
    uint32_t i;
 
-   tSize = frame->getPayload();
+   fSize = frame->getPayload();
+   iter = frame->begin();
 
    // First check to see if frame is valid
-   if ( (tSize % fSize_) != 0 ) {
-      rpe::Value::log_->error("Invalid frame size (%i) from epics: %s\n",tSize,epicsName_.c_str());
+   if ( (fSize % fSize_) != 0 ) {
+      rpe::Value::log_->error("Invalid frame size (%i) from epics: %s\n",fSize,epicsName_.c_str());
       return;
    }
 
    // Compute element count
-   size_ = tSize / fSize_;
+   size_ = fSize / fSize_;
 
    // Limit size
    if ( size_ > max_ ) size_ = max_;
@@ -130,7 +132,6 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    // Release old data
    pValue_->unreference();
    pValue_ = new gddAtomic (gddAppType_value, epicsType_, 1u, size_);
-   pos = 0;
 
    // Set timestamp
    clock_gettime(CLOCK_REALTIME,&t);
@@ -139,49 +140,49 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    // Create vector of appropriate type
    if ( epicsType_ == aitEnumUint8 ) {
       aitUint8 * pF = new aitUint8[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitUint8 *>);
    }
 
    else if ( epicsType_ == aitEnumUint16 ) {
       aitUint16 * pF = new aitUint16[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitUint16 *>);
    }
 
    else if ( epicsType_ == aitEnumUint32 ) {
       aitUint32 * pF = new aitUint32[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitUint32 *>);
    }
 
    else if ( epicsType_ == aitEnumInt8 ) {
       aitInt8 * pF = new aitInt8[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitInt8 *>);
    }
 
    else if ( epicsType_ == aitEnumInt16 ) {
       aitInt16 * pF = new aitInt16[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitInt16 *>);
    }
 
    else if ( epicsType_ == aitEnumInt32 ) {
       aitInt32 * pF = new aitInt32[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitInt32 *>);
    }
 
    else if ( epicsType_ == aitEnumFloat32 ) {
       aitFloat32 * pF = new aitFloat32[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitFloat32 *>);
    }
 
    else if ( epicsType_ == aitEnumFloat64 ) {
       aitFloat64 * pF = new aitFloat64[size_];
-      for ( i = 0; i < size_; i++ ) pos += frame->read(&(pF[i]), pos, fSize_);
+      for (i=0; i < size_; ++i) fromFrame(iter,fSize_,&(pF[i]));
       pValue_->putRef(pF, new rpe::Destructor<aitFloat64 *>);
    }
 

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -87,7 +87,7 @@ ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {
 
       // Take only the first buffer. This will break a cascaded packetizer
       // system. We need to fix this!
-      buff = rFrame->getBuffer(0);
+      buff = *(rFrame->beginBuffer());
   
       // Buffer should support our header/tail plus at least one payload byte 
       if ( buff->getAvailable() < (headSize_ + tailSize_ + 1) )

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -59,7 +59,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    uint8_t * data;
 
    if ( frame->isEmpty() == 0 ) 
-      throw(rogue::GeneralError("packetizer::ControllerV1::transportRx","Frame must not be empty"));
+      log_->warning("Empty frame received");
 
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(tranMtx_);

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -65,7 +65,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = frame->getBuffer(0);
-   data = buff->getPayloadData();
+   data = buff->begin();
 
    // Drop invalid data
    if ( frame->getError() || (buff->getPayload() < 9) || ((data[0] & 0xF) != 0) ) {
@@ -195,7 +195,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       buff->adjustPayload(1);
 
       size = buff->getPayload();
-      data = buff->getPayloadData();
+      data = buff->begin();
 
       data[0] = ((appIndex_ % 16) << 4);
       data[1] = (appIndex_ / 16) & 0xFF;

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -64,7 +64,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
-   buff = frame->getBuffer(0);
+   buff = *(frame->beginBuffer());
    data = buff->begin();
 
    // Drop invalid data
@@ -141,9 +141,9 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
 
 //! Frame received at application interface
 void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
-   ris::BufferPtr buff;
+   ris::Frame::BufferIterator it;
+   uint32_t segment;
    uint8_t * data;
-   uint32_t x;
    uint32_t size;
    uint8_t  fUser;
    uint8_t  lUser;
@@ -183,26 +183,26 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    lUser = (frame->getFlags() >> 8) & 0xFF;
    tId   = (frame->getFlags() >> 16) & 0xFF;
 
-   for (x=0; x < frame->getCount(); x++ ) {
+   segment = 0;
+   for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) {
       ris::FramePtr tFrame = ris::Frame::create();
-      buff = frame->getBuffer(x);
 
       // Adjust header and tail, before setting new size
-      buff->adjustHeader(-8);
-      buff->adjustTail(-1);
+      (*it)->adjustHeader(-8);
+      (*it)->adjustTail(-1);
       
       // Make payload one byte longer
-      buff->adjustPayload(1);
+      (*it)->adjustPayload(1);
 
-      size = buff->getPayload();
-      data = buff->begin();
+      size = (*it)->getPayload();
+      data = (*it)->begin();
 
       data[0] = ((appIndex_ % 16) << 4);
       data[1] = (appIndex_ / 16) & 0xFF;
 
-      data[2] = x % 256;
-      data[3] = (x % 0xFFFF) / 256;
-      data[4] = x / 0xFFFF;
+      data[2] = segment % 256;
+      data[3] = (segment % 0xFFFF) / 256;
+      data[4] = segment / 0xFFFF;
 
       data[5] = tDest;
       data[6] = tId;
@@ -210,10 +210,11 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
 
       data[size-1] = lUser & 0x7F;
 
-      if ( x == (frame->getCount()-1) ) data[size-1] |= 0x80;
+      if ( it == (frame->endBuffer()-1) ) data[size-1] |= 0x80;
 
-      tFrame->appendBuffer(buff);
+      tFrame->appendBuffer(*it);
       tranQueue_.push(tFrame);
+      segment++;
    }
    appIndex_++;
 }

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -58,8 +58,8 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    uint32_t  flags;
    uint8_t * data;
 
-   if ( frame->isEmpty() == 0 ) 
-      log_->warning("Empty frame received");
+   if ( frame->isEmpty() ) 
+      log_->warning("Empty frame received At Transport");
 
    rogue::GilRelease noGil;
    boost::lock_guard<boost::mutex> lock(tranMtx_);
@@ -161,8 +161,8 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    }
    else gettimeofday(&endTime,NULL);
 
-   if ( frame->isEmpty() == 0 ) 
-      throw(rogue::GeneralError("packetizer::ControllerV1::applicationRx","Frame must not be empty"));
+   if ( frame->isEmpty() ) 
+      log_->warning("Empty frame received at application");
 
    if ( frame->getError() ) return;
 

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -58,7 +58,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    uint32_t  flags;
    uint8_t * data;
 
-   if ( frame->getCount() == 0 ) 
+   if ( frame->isEmpty() == 0 ) 
       throw(rogue::GeneralError("packetizer::ControllerV1::transportRx","Frame must not be empty"));
 
    rogue::GilRelease noGil;
@@ -161,7 +161,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    }
    else gettimeofday(&endTime,NULL);
 
-   if ( frame->getCount() == 0 ) 
+   if ( frame->isEmpty() == 0 ) 
       throw(rogue::GeneralError("packetizer::ControllerV1::applicationRx","Frame must not be empty"));
 
    if ( frame->getError() ) return;

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -67,7 +67,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    uint32_t  tmpCrc;
    uint8_t * data;
 
-   if ( frame->isEmpty() == 0 ) {
+   if ( frame->isEmpty() ) {
       log_->warning("Bad incoming transportRx frame, size=0");
       return;
    }
@@ -216,8 +216,10 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    }
    else gettimeofday(&endTime,NULL);
 
-   if ( frame->isEmpty() == 0 ) 
-      throw(rogue::GeneralError("packetizer::ControllerV2::applicationRx","Frame must not be empty"));
+   if ( frame->isEmpty() ) {
+      log_->warning("Bad incoming applicationRx frame, size=0");
+      return;
+   }
 
    if ( frame->getError() ) return;
 

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -257,7 +257,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       (*it)->adjustPayload(8);
 
       // Get data pointer and new size
-      data = (*it)->getPayloadData();
+      data = (*it)->begin();
       size = (*it)->getPayload();
 
       // Header word 0

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -67,7 +67,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    uint32_t  tmpCrc;
    uint8_t * data;
 
-   if ( frame->getCount() == 0 ) {
+   if ( frame->isEmpty() == 0 ) {
       log_->warning("Bad incoming transportRx frame, size=0");
       return;
    }
@@ -216,7 +216,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    }
    else gettimeofday(&endTime,NULL);
 
-   if ( frame->getCount() == 0 ) 
+   if ( frame->isEmpty() == 0 ) 
       throw(rogue::GeneralError("packetizer::ControllerV2::applicationRx","Frame must not be empty"));
 
    if ( frame->getError() ) return;
@@ -255,7 +255,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
 
       // Add tail to payload, set new size
       size += 8;
-      (*it)->setPayload(size,true);
+      (*it)->setPayload(size);
 
       // Get data pointer
       data = (*it)->begin();

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -76,7 +76,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = frame->getBuffer(0);
-   data = buff->getPayloadData();
+   data = buff->begin();
    size = buff->getPayload();
 
    // Drop invalid data
@@ -258,7 +258,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       buff->setPayload(size);
 
       // Get data pointer
-      data = buff->getPayloadData();
+      data = buff->begin();
       size = buff->getPayload();
 
       // Header word 0

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -131,12 +131,9 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
    // Update buffer to include our header space.
    buffer->adjustHeader(rpr::Header::HeaderSize);
 
-   // Trim multi buffer frames, RSSI can not work on payloads
-   // with multiple buffers.
-   if ( frame->getCount() > 1 ) {
-      frame = ris::Frame::create();
-      frame->appendBuffer(buffer);
-   }
+   // Recreate frame to ensure outbound only has a single buffer
+   frame = ris::Frame::create();
+   frame->appendBuffer(buffer);
 
    // Return frame
    return(frame);
@@ -146,7 +143,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 void rpr::Controller::transportRx( ris::FramePtr frame ) {
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
-   if ( frame->getCount() == 0 || ! head->verify() ) {
+   if ( frame->isEmpty() == 0 || ! head->verify() ) {
       log_->info("Dumping frame state=%i server=%i",state_,server_);
       dropCount_++;
       return;
@@ -216,7 +213,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
 
    gettimeofday(&startTime,NULL);
 
-   if ( frame->getCount() == 0 ) 
+   if ( frame->isEmpty() == 0 ) 
       throw(rogue::GeneralError("rss::Controller::applicationRx","Frame must not be empty"));
 
    // Adjust header in first buffer

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -120,7 +120,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 
    // Forward frame request to transport slave
    frame = tran_->reqFrame (nSize, false);
-   buffer = frame->getBuffer(0);
+   buffer = *(frame->beginBuffer());
 
    // Make sure there is enough room the buffer for our header
    if ( buffer->getAvailable() < rpr::Header::HeaderSize )
@@ -204,7 +204,7 @@ ris::FramePtr rpr::Controller::applicationTx() {
       stCond_.notify_all();
 
       frame = head->getFrame();
-      frame->getBuffer(0)->adjustHeader(rpr::Header::HeaderSize);
+      (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
    }
    return(frame);
 }
@@ -220,7 +220,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
       throw(rogue::GeneralError("rss::Controller::applicationRx","Frame must not be empty"));
 
    // Adjust header in first buffer
-   frame->getBuffer(0)->adjustHeader(-rpr::Header::HeaderSize);
+   (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
 
    // Map to RSSI 
    rpr::HeaderPtr head = rpr::Header::create(frame);

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -143,7 +143,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 void rpr::Controller::transportRx( ris::FramePtr frame ) {
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
-   if ( frame->isEmpty() == 0 || ! head->verify() ) {
+   if ( frame->isEmpty() || ! head->verify() ) {
       log_->info("Dumping frame state=%i server=%i",state_,server_);
       dropCount_++;
       return;
@@ -213,11 +213,13 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
 
    gettimeofday(&startTime,NULL);
 
-   if ( frame->isEmpty() == 0 ) 
-      throw(rogue::GeneralError("rss::Controller::applicationRx","Frame must not be empty"));
+   if ( frame->isEmpty() ) {
+      log_->info("Dumping empty application frame");
+      return;
+   }
 
    // Adjust header in first buffer
-   (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
+   (*(frame->beginBuffer()))->adjustHeader(-rpr::Header::HeaderSize);
 
    // Map to RSSI 
    rpr::HeaderPtr head = rpr::Header::create(frame);

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -76,7 +76,7 @@ void rpr::Header::setup_python() {
 
 //! Creator
 rpr::Header::Header(ris::FramePtr frame) {
-   if ( frame->getCount() == 0 ) 
+   if ( frame->isEmpty() == 0 ) 
       throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
    data_  = (*(frame->beginBuffer()))->begin();
@@ -160,7 +160,7 @@ void rpr::Header::update() {
    if ( buff->getSize() < size )
       throw(rogue::GeneralError::boundary("Header::update",size,buff->getSize()));
 
-   if ( buff->getPayload() == 0 ) buff->setPayload(size,true);
+   if ( buff->getPayload() == 0 ) buff->setPayload(size);
 
    memset(data_,0,size);
    data_[1] = size;

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -76,7 +76,7 @@ void rpr::Header::setup_python() {
 
 //! Creator
 rpr::Header::Header(ris::FramePtr frame) {
-   if ( frame->isEmpty() == 0 ) 
+   if ( frame->isEmpty() ) 
       throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
    data_  = (*(frame->beginBuffer()))->begin();
@@ -160,7 +160,7 @@ void rpr::Header::update() {
    if ( buff->getSize() < size )
       throw(rogue::GeneralError::boundary("Header::update",size,buff->getSize()));
 
-   if ( buff->getPayload() == 0 ) buff->setPayload(size);
+   buff->minPayload(size);
 
    memset(data_,0,size);
    data_[1] = size;

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -79,7 +79,7 @@ rpr::Header::Header(ris::FramePtr frame) {
    if ( frame->getCount() == 0 ) 
       throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
-   data_  = frame->getBuffer(0)->begin();
+   data_  = (*(frame->beginBuffer()))->begin();
    count_ = 0;
 
    syn = false;
@@ -114,7 +114,9 @@ ris::FramePtr rpr::Header::getFrame() {
 bool rpr::Header::verify() {
    uint8_t size;
 
-   if ( frame_->getBuffer(0)->getPayload() < HeaderSize ) return(false);
+   ris::BufferPtr buff = *(frame_->beginBuffer());
+
+   if ( buff->getPayload() < HeaderSize ) return(false);
   
    syn  = data_[0] & 0x80;
    ack  = data_[0] & 0x40;
@@ -124,9 +126,7 @@ bool rpr::Header::verify() {
 
    size = (syn)?SynSize:HeaderSize;
 
-   if ( (data_[1] != size) ||
-        (frame_->getBuffer(0)->getPayload() < size) ||
-        (getUInt16(size-2) != compSum(size))) return false;
+   if ( (data_[1] != size) || (buff->getPayload() < size) || (getUInt16(size-2) != compSum(size))) return false;
 
    sequence    = data_[2];
    acknowledge = data_[3];
@@ -153,13 +153,14 @@ bool rpr::Header::verify() {
 void rpr::Header::update() {
    uint8_t size;
 
+   ris::BufferPtr buff = *(frame_->beginBuffer());
+
    size = (syn)?SynSize:HeaderSize;
 
-   if ( frame_->getBuffer(0)->getSize() < size )
-      throw(rogue::GeneralError::boundary("Header::update",size,frame_->getBuffer(0)->getSize()));
+   if ( buff->getSize() < size )
+      throw(rogue::GeneralError::boundary("Header::update",size,buff->getSize()));
 
-   if ( frame_->getBuffer(0)->getPayload() == 0 )
-      frame_->getBuffer(0)->setPayload(size);
+   if ( buff->getPayload() == 0 ) buff->setPayload(size,true);
 
    memset(data_,0,size);
    data_[1] = size;
@@ -217,8 +218,8 @@ std::string rpr::Header::dump() {
 
    std::stringstream ret("");
 
-   ret << "   Total Size : " << std::dec << frame_->getBuffer(0)->getPayload() << std::endl;
-   ret << "     Raw Size : " << std::dec << frame_->getBuffer(0)->getSize() << std::endl;
+   ret << "   Total Size : " << std::dec << (*(frame_->beginBuffer()))->getPayload() << std::endl;
+   ret << "     Raw Size : " << std::dec << (*(frame_->beginBuffer()))->getSize() << std::endl;
    ret << "   Raw Header : ";
 
    for (x=0; x < data_[1]; x++) {

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -79,7 +79,7 @@ rpr::Header::Header(ris::FramePtr frame) {
    if ( frame->getCount() == 0 ) 
       throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
-   data_  = frame->getBuffer(0)->getPayloadData();
+   data_  = frame->getBuffer(0)->begin();
    count_ = 0;
 
    syn = false;

--- a/src/rogue/protocols/srp/Cmd.cpp
+++ b/src/rogue/protocols/srp/Cmd.cpp
@@ -69,7 +69,7 @@ void rps::Cmd::sendCmd(uint8_t opCode, uint32_t context) {
    it = frame->begin();
 
    // Copy frame
-   //std::copy(it,it+sizeof(txData),frame);
+   ris::toFrame(it,sizeof(txData),txData);
    sendFrame(frame);
 }
 

--- a/src/rogue/protocols/srp/Cmd.cpp
+++ b/src/rogue/protocols/srp/Cmd.cpp
@@ -24,6 +24,7 @@
 #include <boost/make_shared.hpp>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/protocols/srp/Cmd.h>
 
 namespace bp = boost::python;
@@ -53,32 +54,22 @@ rps::Cmd::~Cmd() {}
 
 //! Post a transaction
 void rps::Cmd::sendCmd(uint8_t opCode, uint32_t context) {
-   ris::FramePtr  frame;
-   uint32_t  frameSize;
-   uint32_t  temp;
-   uint32_t  cnt;
+   ris::Frame::iterator it;
+   ris::FramePtr frame;
+   uint32_t txData[4];
 
-   // Always 4x 32-bit words
-   frameSize = 16;
+   // Build frame
+   txData[0] = context;
+   txData[1] = opCode;
+   txData[2] = 0;
+   txData[3] = 0;
 
    // Request frame
-   frame = reqFrame(frameSize, true);
+   frame = reqFrame(sizeof(txData), true);
+   it = frame->begin();
 
-   // First 32-bit value is context
-   temp = context;
-   cnt  = frame->write(&(temp), 0, 4);
-   
-   // Second 32-bit value is opcode
-   temp = opCode;
-   cnt  += frame->write(&(temp), cnt, 4);
-
-   // Last two fields are zero
-   temp = 0;
-   cnt += frame->write(&temp, cnt, 4);
-   cnt += frame->write(&temp, cnt, 4);   
-
+   // Copy frame
+   //std::copy(it,it+sizeof(txData),frame);
    sendFrame(frame);
 }
-
-
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -182,6 +182,13 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    // Setup transaction iterator
    rogue::GilRelease noGil;
    boost::unique_lock<boost::mutex> lock(tran->lock);
+
+   // Transaction expired
+   if ( tran->expired() ) {
+      log_->debug("Transaction expired. Id=%i",id);
+      delTransaction(tran->id());
+      return;
+   }
    tIter = tran->begin();
 
    // Setup header and frame size

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -127,7 +127,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
 
    // Write data
    if ( doWrite ) {
-      //std::copy(tIter,tIter+tran->size(),fIter);
+      std::copy(tIter,tIter+tran->size(),fIter);
       fIter += tran->size();
    }
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -124,13 +124,9 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
 
    // Write header
    ris::toFrame(fIter,headerLen,header); 
-   fIter += headerLen;
 
    // Write data
-   if ( doWrite ) {
-      std::copy(tIter,tIter+tran->size(),fIter);
-      fIter += tran->size();
-   }
+   if ( doWrite ) std::copy(tIter,tIter+tran->size(),fIter);
 
    // Last field is zero
    tail[0] = 0;

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -144,7 +144,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    ris::toFrame(fIter,HeadLen,header);
 
    // Write data
-   // if ( doWrite ) std::copy(tIter,tIter+tran->size(),fIter);
+   if ( doWrite ) std::copy(tIter,tIter+tran->size(),fIter);
 
    lock.unlock();
    if ( tran->type() == rim::Post ) tran->done(0);

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -25,10 +25,13 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/protocols/srp/SrpV3.h>
 #include <rogue/Logging.h>
+#include <rogue/GilRelease.h>
 
 namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
@@ -60,140 +63,175 @@ rps::SrpV3::SrpV3() : ris::Master(), ris::Slave(), rim::Slave(4,4096) {
 //! Deconstructor
 rps::SrpV3::~SrpV3() {}
 
-//! Post a transaction
-void rps::SrpV3::doTransaction(uint32_t id, rim::MasterPtr master, uint64_t address, uint32_t size, uint32_t type) {
-   ris::FrameIteratorPtr iter;
-   ris::FramePtr  frame;
-   uint32_t  frameSize;
-   uint32_t  temp;
-   uint32_t  cnt;
-
-   // Size error
-   if ((size % 4) != 0 || size < 4) {
-      master->doneTransaction(id,rim::SizeError);
-      return;
-   }
-
-   // Compute transmit frame size
-   if (type == rim::Write || type == rim::Post) frameSize = (size + 20); // 5 x 32 bits for header
-   else frameSize = 20;
-
-   // Request frame
-   frame = reqFrame(frameSize,true);
+//! Setup header, return frame size
+bool rps::SrpV3::setupHeader(rim::TransactionPtr tran, uint32_t *header, uint32_t &frameLen, bool tx) {
+   bool doWrite = true;
 
    // Bits 7:0 of first 32-bit word are version
-   temp = 0x03;
+   header[0] = 0x03;
 
    // Bits 9:8: 0x0 = read, 0x1 = write, 0x2 = posted write
-   switch ( type ) {
-      case rim::Write : temp |= 0x100; break;
-      case rim::Post  : temp |= 0x200; break;
-      default: break; // Read or verify
+   switch ( tran->type() ) {
+      case rim::Write : header[0] |= 0x100; break;
+      case rim::Post  : header[0] |= 0x200; break;
+      default: doWrite = false; break; // Read or verify
    }
    
    // Bits 13:10 not used in gen frame
    // Bit 14 = ignore mem resp
    // Bit 23:15 = Unused
    // Bit 31:24 = timeout count
-   temp |= 0x0A000000;
-   cnt = frame->write(&(temp),0,4);
+   header[0] |= 0x0A000000;
 
    // Header word 1, transaction ID
-   temp = id;
-   cnt += frame->write(&(temp),cnt,4);
+   header[1] = tran->id();
 
    // Header word 2, lower address
-   temp = address & 0xFFFFFFFF;
-   cnt += frame->write(&(temp),cnt,4);
+   header[2] = tran->address() & 0xFFFFFFFF;
 
    // Header word 3, upper address
-   temp = (address >> 32) & 0xFFFFFFFF;
-   cnt += frame->write(&(temp),cnt,4);
+   header[3] = (tran->address() >> 32) & 0xFFFFFFFF;
 
    // Header word 4, request size
-   temp = size-1;
-   cnt += frame->write(&(temp),cnt,4);
+   header[4] = tran->size()-1;
 
-   // Write data
-   if ( type == rim::Write || type == rim::Post ) {
-      iter = frame->startWrite(cnt,size);
+   // Determine frame length
+   frameLen = HeadLen;
 
-      do {
-         master->getTransactionData(id,iter->data(),iter->total(),iter->size());
-      } while (frame->nextWrite(iter));
-      cnt += size;
+   // Transmit with write data
+   if ( tx && doWrite ) frameLen += tran->size();
+
+   // Receive frames
+   else if ( ! tx ) frameLen += tran->size() + TailLen;
+
+   return doWrite;
+}
+
+//! Post a transaction
+void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
+   ris::Frame::iterator fIter;
+   rim::Transaction::iterator tIter;
+   ris::FramePtr  frame;
+   uint32_t frameSize;
+   uint32_t header[HeadLen];
+   bool doWrite;
+
+   // Size error
+   if ((tran->address() % min()) != 0 ) {
+      tran->done(rim::AddressError);
+      return;
    }
 
-   if ( type == rim::Post ) master->doneTransaction(id,0);
-   else addMaster(id,master);
+   // Size error
+   if ((tran->size() % min()) != 0 || tran->size() < min() || tran->size() > max()) {
+      tran->done(rim::SizeError);
+      return;
+   }
 
-   log_->debug("Send frame for id=0x%08x, addr 0x%08x. Size=%i, type=%i",id,address,size,type);
+   // Compute header and frame size
+   doWrite = setupHeader(tran,header,frameSize,true);
+
+   // Request frame
+   frame = reqFrame(frameSize,true);
+
+   // Setup iterators
+   rogue::GilRelease noGil;
+   boost::unique_lock<boost::mutex> lock(tran->lock);
+   fIter = frame->begin();
+   tIter = tran->begin();
+
+   // Write header
+   ris::toFrame(fIter,HeadLen,header);
+
+   // Write data
+   // if ( doWrite ) std::copy(tIter,tIter+tran->size(),fIter);
+
+   lock.unlock();
+   if ( tran->type() == rim::Post ) tran->done(0);
+   else addTransaction(tran);
+
+   log_->debug("Send frame for id=0x%08x, addr 0x%08x. Size=%i, type=%i",tran->id(),tran->address(),tran->size(),tran->type());
    sendFrame(frame);
 }
 
 //! Accept a frame from master
 void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
-   ris::FrameIteratorPtr iter;
-   rim::MasterPtr m;
-   uint32_t  id;
-   uint32_t  cnt;
-   uint32_t  temp;
-   uint32_t  size;
+   ris::Frame::iterator fIter;
+   rim::Transaction::iterator tIter;
+   rim::TransactionPtr tran;
+   uint32_t header[HeadLen];
+   uint32_t expHeader[HeadLen];
+   uint32_t expFrameLen;
+   uint32_t tail[TailLen];
+   uint32_t id;
+   bool     doWrite;
+   uint32_t fSize;
 
    // Check frame size
-   if ( frame->getPayload() < 20 ) {
-     log_->debug("Recv invalid frame size %i", frame->getPayload());
-     return; // Invalid frame, drop it
+   if ( (fSize = frame->getPayload()) < sizeof(header) ) {
+      log_->info("Got undersize frame size = %i",fSize);
+      return; // Invalid frame, drop it
    }
 
-   // Extract id from frame
-   frame->read(&id,4,4);
+   // Setup iterators
+   rogue::GilRelease noGil;
+   boost::unique_lock<boost::mutex> lock(tran->lock);
+   fIter = frame->begin();
+   tIter = tran->begin();
 
+   // Get the header
+   ris::fromFrame(fIter,HeadLen,header);
+
+   // Extract the id
+   id = header[1];
    log_->debug("Recv frame for id=0x%08x",id);
 
-   // Find master
-   if ( ! validMaster(id) ) {
-      log_->debug("Bad master for id=0x%08x",id);
-      return; // Bad id or post, drop frame
+   // Find Transaction
+   if ( (tran = getTransaction(id)) == NULL ) {
+     log_->debug("Invalid ID frame for id=0x%08x",id);
+     return; // Bad id or post, drop frame
    }
-   else m = getMaster(id);
+
+   // Setup expect header and length
+   doWrite = setupHeader(tran,expHeader,expFrameLen,false);
 
    // Verify frame size, drop frame
-   frame->read(&size,16,4);
-   size += 1;
-   if ( size != (frame->getPayload()-24) ) {
-      delMaster(id);
+   if ( (fSize != expFrameLen) ||
+        (header[4]+1) != tran->size() ) {
+      delTransaction(id);
       log_->debug("Size mismatch id=0x%08x",id);
       return;
    }
 
-   // Read tail error value, complete if error is set
-   frame->read(&temp,frame->getPayload()-4,4);
-   if ( temp != 0 ) {
-      delMaster(id);
+   // Check header
+   if ( ((header[0] & 0xFFFFC3FF) != expHeader[0]) ||
+         (header[1] != expHeader[1]) || (header[2] != expHeader[2]) ||
+         (header[3] != expHeader[3]) || (header[4] != expHeader[4]) ) {
+     log_->debug("Bad header for %i",id);
+     return;
+   }
 
-      if ( temp & 0xFF) m->doneTransaction(id,rim::AxiFail | (temp & 0xFF));
-      else if ( temp & 0x100 ) m->doneTransaction(id,rim::AxiTimeout);
-      else m->doneTransaction(id,temp);
+   // Read tail error value, complete if error is set
+   fIter = frame->endPayload()-TailLen;
+   ris::fromFrame(fIter,TailLen,tail);
+   if ( tail[0] != 0 ) {
+      delTransaction(tran->id());
+
+      if ( tail[0] & 0xFF) tran->done(rim::AxiFail | (tail[0] & 0xFF));
+      else if ( tail[0] & 0x100 ) tran->done(rim::AxiTimeout);
+      else tran->done(tail[0]);
       log_->debug("Error detect id=0x%08x",id);
       return;
    }
 
    // Copy data if read
-   // Bits 9:8: 0x0 = read, 0x1 = write, 0x2 = posted write
-   frame->read(&temp,0,4);
-   if ( (temp & 0x300) == 0 ) {
-      cnt = 20;
-
-      iter = frame->startRead(cnt,size);
-
-      do {
-         m->setTransactionData(id,iter->data(),iter->total(),iter->size());
-      } while (frame->nextRead(iter));
-      cnt += size;
+   if ( ! doWrite ) {
+      fIter = frame->begin() + HeadLen;
+      std::copy(fIter,fIter+tran->size(),tIter);
    }
 
-   delMaster(id);
-   m->doneTransaction(id,0);
+   delTransaction(tran->id());
+   lock.unlock();
+   tran->done(0);
 }
 

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -197,6 +197,13 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    // Setup transaction iterator
    rogue::GilRelease noGil;
    boost::unique_lock<boost::mutex> lock(tran->lock);
+
+   // Transaction expired
+   if ( tran->expired() ) {
+      log_->debug("Transaction expired. Id=%i",id);
+      delTransaction(tran->id());
+      return;
+   }
    tIter = tran->begin();
 
    // Setup expect header and length

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -118,7 +118,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
       if ( buff->getPayload() == 0 ) break;
 
       // Setup IOVs
-      msg_iov[0].iov_base = buff->getPayloadData();
+      msg_iov[0].iov_base = buff->begin();
       msg_iov[0].iov_len  = buff->getPayload();
 
       // Keep trying since select call can fire 
@@ -165,7 +165,7 @@ void rpu::Client::runThread() {
 
          // Attempt receive
          buff = frame->getBuffer(0);
-         res = ::read(fd_, buff->getPayloadData(), maxSize_);
+         res = ::read(fd_, buff->begin(), maxSize_);
 
          if ( res > 0 ) {
             buff->setPayload(res);

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -89,7 +89,7 @@ rpu::Client::~Client() {
 
 //! Accept a frame from master
 void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
-   ris::BufferPtr   buff;
+   ris::Frame::BufferIterator it;
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
@@ -110,16 +110,15 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Go through each buffer in the frame
-   for (x=0; x < frame->getCount(); x++) {
-      buff = frame->getBuffer(x);
-      if ( buff->getPayload() == 0 ) break;
+   for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) {
+      if ( (*it)->getPayload() == 0 ) break;
 
       // Setup IOVs
-      msg_iov[0].iov_base = buff->begin();
-      msg_iov[0].iov_len  = buff->getPayload();
+      msg_iov[0].iov_base = (*it)->begin();
+      msg_iov[0].iov_len  = (*it)->getPayload();
 
       // Keep trying since select call can fire 
-      // but write fails because we did not win the buffer lock
+      // but write fails because we did not win the (*it)er lock
       do {
 
          // Setup fds for select call
@@ -162,7 +161,7 @@ void rpu::Client::runThread() {
       while(1) {
 
          // Attempt receive
-         buff = frame->getBuffer(0);
+         buff = *(frame->beginBuffer());
          avail = buff->getAvailable();
          res = recvfrom(fd_, buff->begin(), avail, MSG_TRUNC, NULL, 0);
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -164,7 +164,7 @@ void rpu::Client::runThread() {
          // Attempt receive
          buff = frame->getBuffer(0);
          avail = buff->getAvailable();
-         res = recvfrom(fd_, buff->getPayloadData(), avail, MSG_TRUNC, NULL, 0);
+         res = recvfrom(fd_, buff->begin(), avail, MSG_TRUNC, NULL, 0);
 
          if ( res > 0 ) {
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -124,7 +124,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
       if ( buff->getPayload() == 0 ) break;
 
       // Setup IOVs
-      msg_iov[0].iov_base = buff->getPayloadData();
+      msg_iov[0].iov_base = buff->begin();
       msg_iov[0].iov_len  = buff->getPayload();
 
       // Keep trying since select call can fire 
@@ -173,7 +173,7 @@ void rpu::Server::runThread() {
 
          // Attempt receive
          buff = frame->getBuffer(0);
-         res = recvfrom(fd_, buff->getPayloadData(), maxSize_, 0 , (struct sockaddr *)&tmpAddr, &tmpLen);
+         res = recvfrom(fd_, buff->begin(), maxSize_, 0 , (struct sockaddr *)&tmpAddr, &tmpLen);
 
          if ( res > 0 ) {
             buff->setPayload(res);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -171,7 +171,7 @@ void rpu::Server::runThread() {
          // Attempt receive
          buff = frame->getBuffer(0);
          avail = buff->getAvailable();
-         res = recvfrom(fd_, buff->getPayloadData(), avail, MSG_TRUNC, (struct sockaddr *)&tmpAddr, &tmpLen);
+         res = recvfrom(fd_, buff->begin(), avail, MSG_TRUNC, (struct sockaddr *)&tmpAddr, &tmpLen);
 
          if ( res > 0 ) {
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -94,7 +94,7 @@ uint32_t rpu::Server::getPort() {
 
 //! Accept a frame from master
 void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
-   ris::BufferPtr   buff;
+   ris::Frame::BufferIterator it;
    int32_t          res;
    fd_set           fds;
    struct timeval   tout;
@@ -115,13 +115,12 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
    msg.msg_flags      = 0;
 
    // Go through each buffer in the frame
-   for (x=0; x < frame->getCount(); x++) {
-      buff = frame->getBuffer(x);
-      if ( buff->getPayload() == 0 ) break;
+   for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) {
+      if ( (*it)->getPayload() == 0 ) break;
 
       // Setup IOVs
-      msg_iov[0].iov_base = buff->begin();
-      msg_iov[0].iov_len  = buff->getPayload();
+      msg_iov[0].iov_base = (*it)->begin();
+      msg_iov[0].iov_len  = (*it)->getPayload();
 
       // Keep trying since select call can fire 
       // but write fails because we did not win the buffer lock
@@ -169,7 +168,7 @@ void rpu::Server::runThread() {
       while(1) {
 
          // Attempt receive
-         buff = frame->getBuffer(0);
+         buff = *(frame->beginBuffer());
          avail = buff->getAvailable();
          res = recvfrom(fd_, buff->begin(), avail, MSG_TRUNC, (struct sockaddr *)&tmpAddr, &tmpLen);
 

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -251,6 +251,8 @@ void ru::Prbs::genFrame (uint32_t size) {
    // Update counters
    txCount_++;
    txBytes_ += size;
+   fr->setPayload(size);
+
    sendFrame(fr);
 }
 

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/utilities/Prbs.h>
 #include <boost/make_shared.hpp>
@@ -122,40 +123,6 @@ void ru::Prbs::runThread() {
    } catch (boost::thread_interrupted&) {}
 }
 
-//! Read data with the appropriate width and set passed 32-bit integer pointer
-uint32_t ru::Prbs::readSingle ( ris::FramePtr frame, uint32_t offset, uint32_t * value ) {
-   uint32_t data32;
-   uint16_t data16;
-   uint32_t ret;
-
-   if ( width_ == 16 ) {
-      ret = frame->read(&data16,offset,2);
-      *value = data16;
-   }
-   else {
-      ret = frame->read(&data32,offset,4);
-      *value = data32;
-   }
-   return(ret);
-}
-
-//! Write data with the appropriate width
-uint32_t ru::Prbs::writeSingle ( ris::FramePtr frame, uint32_t offset, uint32_t value ) {
-   uint32_t data32;
-   uint16_t data16;
-   uint32_t ret;
-
-   if ( width_ == 16 ) {
-      data16 = value & 0xFFFF;
-      ret = frame->write(&data16,offset,2);
-   }
-   else {
-      data32 = value;
-      ret = frame->write(&data32,offset,4);
-   }
-   return(ret);
-}
-
 //! Auto run data generation
 void ru::Prbs::enable(uint32_t size) {
 
@@ -234,6 +201,7 @@ void ru::Prbs::resetCount() {
 
 //! Generate a data frame
 void ru::Prbs::genFrame (uint32_t size) {
+   ris::Frame::iterator iter;
    uint32_t      cnt;
    uint32_t      frSize;
    uint32_t      value;
@@ -256,6 +224,7 @@ void ru::Prbs::genFrame (uint32_t size) {
 
    // Get frame
    fr = reqFrame(size,true);
+   iter = fr->begin();
 
    // Frame allocation failed
    if ( fr->getAvailable() < size ) {
@@ -264,16 +233,19 @@ void ru::Prbs::genFrame (uint32_t size) {
    }
 
    // First word is sequence
-   cnt = writeSingle(fr,0,value);
+   ris::toFrame(iter,byteWidth_,&value);
+   cnt = byteWidth_;
 
    // Second word is size
    frSize = (size - byteWidth_) / byteWidth_;
-   cnt += writeSingle(fr,cnt,frSize);
+   ris::toFrame(iter,byteWidth_,&frSize);
+   cnt += byteWidth_;
 
    // Generate payload
    while ( cnt < size ) {
       value = flfsr(value);
-      cnt += writeSingle(fr,cnt,value);
+      ris::toFrame(iter,byteWidth_,&value);
+      cnt += byteWidth_;
    }
 
    // Update counters
@@ -284,6 +256,7 @@ void ru::Prbs::genFrame (uint32_t size) {
 
 //! Accept a frame from master
 void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
+   ris::Frame::iterator iter;
    uint32_t   frSize;
    uint32_t   frSeq;
    uint32_t   curSeq;
@@ -300,6 +273,7 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    noGil.acquire();
 
    size = frame->getPayload();
+   iter = frame->begin();
 
    // Verify size
    if ((( size % byteWidth_ ) != 0) || size < minSize_ ) {
@@ -309,7 +283,8 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Get sequence value
-   cnt = readSingle(frame,0,&frSeq);
+   ris::fromFrame(iter,byteWidth_,&frSeq);
+   cnt = byteWidth_;
 
    // Update sequence
    curSeq = rxSeq_;
@@ -317,17 +292,13 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    if ( width_ == 16 ) rxSeq_ &= 0xFFFF;
 
    // Get size
-   cnt += readSingle(frame,cnt,&frSize);
+   ris::fromFrame(iter,byteWidth_,&frSize);
+   cnt += byteWidth_;
    frSize = (frSize * byteWidth_) + byteWidth_;
 
    // Check size
    if ( frSize != size ) {
       rxLog_->warning("Bad size. exp=%i, got=%i, count=%i",frSize,size,rxCount_);
-
-      for ( x=0; x < 8; x++ ) {
-         frame->read(&gotValue,x*4,4);
-         rxLog_->warning("Data: %i = 0x%.8x",x,gotValue);
-      }
       rxErrCount_++;
       return;
    }
@@ -347,7 +318,8 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
       while ( cnt < size ) {
          expValue = flfsr(expValue);
 
-         cnt += readSingle(frame,cnt,&gotValue);
+         ris::fromFrame(iter,byteWidth_,&gotValue);
+         cnt += byteWidth_;
 
          if (expValue != gotValue) {
             rxLog_->warning("Bad value at index %i. exp=0x%x, got=0x, count=%i%x",
@@ -380,7 +352,6 @@ void ru::Prbs::setup_python() {
 
    bp::implicitly_convertible<ru::PrbsPtr, ris::SlavePtr>();
    bp::implicitly_convertible<ru::PrbsPtr, ris::MasterPtr>();
-
 }
 
 

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -45,10 +45,8 @@ ru::StreamUnZip::~StreamUnZip() { }
 
 //! Accept a frame from master
 void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
-   ris::FrameIteratorPtr readIter;
-   ris::FrameIteratorPtr writeIter;
-   uint32_t writeCnt = 0;
-   uint32_t readCnt  = 0;
+   ris::Frame::BufferIterator rBuff;
+   ris::Frame::BufferIterator wBuff;
    int32_t ret;
    
    // First request a new frame of the same size
@@ -63,40 +61,44 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
    if ( (ret = BZ2_bzDecompressInit(&strm,0,0)) != BZ_OK ) 
       throw(rogue::GeneralError::ret("StreamUnZip::acceptFrame","Error initializing decompressor",ret));
 
-   // Use the frame iterator in this case to avoid a copy to local memory
-   readIter  = frame->startRead(0,frame->getPayload());
-   writeIter = newFrame->startWrite(0,frame->getPayload());
+   // Setup decompression pointers
+   rBuff = frame->beginBuffer();
+   strm.next_in  = (char *)(*rBuff)->begin();
+   strm.avail_in = (*rBuff)->getPayload();
+
+   wBuff = newFrame->beginBuffer();
+   strm.next_out  = (char *)(*wBuff)->begin();
+   strm.avail_out = (*wBuff)->getAvailable();
 
    // Use the iterators to move data
    do {
-
-      // Init counters
-      readCnt  = strm.total_in_lo32;
-      writeCnt = strm.total_out_lo32;
-
-      // Setup decompression pointers
-      strm.next_in  = (char *)readIter->data();
-      strm.avail_in = readIter->size();
-
-      strm.next_out  = (char *)writeIter->data();
-      strm.avail_out = writeIter->size();
 
       ret = BZ2_bzDecompress(&strm);
 
       if ( (ret != BZ_STREAM_END) && (ret != BZ_OK) ) 
          throw(rogue::GeneralError::ret("StreamUnZip::acceptFrame","Decompression runtime error",ret));
 
-      readIter->completed(strm.total_in_lo32-readCnt);
-      writeIter->completed(strm.total_out_lo32-writeCnt);
-
-      // Increase the frame size if we run out of room
-      if ( ! newFrame->nextWrite(writeIter) ) {
-         ris::FramePtr tmpFrame = this->reqFrame(frame->getPayload(),true);
-         newFrame->appendFrame(tmpFrame);
-         writeIter = newFrame->startWrite(strm.total_out_lo32,frame->getPayload());
+      // Update read buffer if neccessary
+      if ( strm.avail_in == 0 ) {
+         ++rBuff;
+         strm.next_in  = (char *)(*rBuff)->begin();
+         strm.avail_in = (*rBuff)->getPayload();
       }
-      frame->nextRead(readIter);
 
+      // Update write buffer if neccessary
+      if ( strm.avail_out == 0 ) {
+         (*wBuff)->setPayloadFull();
+
+         // We ran out of room, double the frame size, should not happen
+         if ( (wBuff+1) == newFrame->endBuffer() ) {
+            ris::FramePtr tmpFrame = this->reqFrame(frame->getPayload(),true);
+            newFrame->appendFrame(tmpFrame);
+         }
+         ++wBuff; // Will this work?
+
+         strm.next_out  = (char *)(*wBuff)->begin();
+         strm.avail_out = (*wBuff)->getAvailable();
+      }
    } while ( ret != BZ_STREAM_END );
 
    BZ2_bzDecompressEnd(&strm);

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -45,10 +45,9 @@ ru::StreamZip::~StreamZip() { }
 
 //! Accept a frame from master
 void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
-   ris::FrameIteratorPtr readIter;
-   ris::FrameIteratorPtr writeIter;
-   uint32_t writeCnt = 0;
-   uint32_t readCnt  = 0;
+   ris::Frame::BufferIterator rBuff;
+   ris::Frame::BufferIterator wBuff;
+   bool done;
    int32_t ret;
    
    // First request a new frame of the same size
@@ -63,35 +62,45 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    if ( (ret = BZ2_bzCompressInit(&strm,1,0,30)) != BZ_OK ) 
       throw(rogue::GeneralError::ret("StreamZip::acceptFrame","Error initializing compressor",ret));
 
-   // Use the frame iterator in this case to avoid a copy to local memory
-   readIter  = frame->startRead(0,frame->getPayload());
-   writeIter = newFrame->startWrite(0,frame->getPayload());
+   // Setup decompression pointers
+   rBuff = frame->beginBuffer();
+   strm.next_in  = (char *)(*rBuff)->begin();
+   strm.avail_in = (*rBuff)->getPayload();
+
+   wBuff = newFrame->beginBuffer();
+   strm.next_out  = (char *)(*wBuff)->begin();
+   strm.avail_out = (*wBuff)->getAvailable();
 
    // Use the iterators to move data
+   done = false;
    do {
 
-      // Init counters
-      readCnt  = strm.total_in_lo32;
-      writeCnt = strm.total_out_lo32;
-
-      // Setup compression pointers
-      strm.next_in  = (char *)readIter->data();
-      strm.avail_in = readIter->size();
-
-      strm.next_out  = (char *)writeIter->data();
-      strm.avail_out = writeIter->size();
-
-      if ( (ret = BZ2_bzCompress(&strm,(readIter->size()>0)?BZ_RUN:BZ_FINISH)) == BZ_SEQUENCE_ERROR )
+      if ( (ret = BZ2_bzCompress(&strm,(done)?BZ_FINISH:BZ_RUN)) == BZ_SEQUENCE_ERROR )
          throw(rogue::GeneralError::ret("StreamZip::acceptFrame","Compression runtime error",ret));
 
-      readIter->completed(strm.total_in_lo32-readCnt);
-      writeIter->completed(strm.total_out_lo32-writeCnt);
+      // Update read buffer if neccessary
+      if ( strm.avail_in == 0 ) {
+         if ( ++rBuff != frame->endBuffer()) {
+            strm.next_in  = (char *)(*rBuff)->begin();
+            strm.avail_in = (*rBuff)->getPayload();
+         }
+         else done = true;
+      }
 
-      if ( ! newFrame->nextWrite(writeIter) ) 
-         throw(rogue::GeneralError("StreamZip::acceptFrame","Unexpected overflow in outbound frame"));
+      // Update write buffer if neccessary
+      if ( strm.avail_out == 0 ) {
+         (*wBuff)->setPayloadFull();
 
-      frame->nextRead(readIter);
+         // We ran out of room, double the frame size, should not happen
+         if ( (wBuff+1) == newFrame->endBuffer() ) {
+            ris::FramePtr tmpFrame = this->reqFrame(frame->getPayload(),true);
+            newFrame->appendFrame(tmpFrame);
+         }
+         ++wBuff; // Will this work?
 
+         strm.next_out  = (char *)(*wBuff)->begin();
+         strm.avail_out = (*wBuff)->getAvailable();
+      }
    } while (ret != BZ_STREAM_END);
 
    BZ2_bzCompressEnd(&strm);

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -170,8 +170,8 @@ void ruf::StreamReader::runThread() {
             }
 
             // Skip next step if frame is empty
+            if ( size <= 4 ) continue;
             size -= 4;
-            if ( size == 0 ) continue;
 
             // Request frame
             frame = reqFrame(size,true);

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -21,6 +21,8 @@
 **/
 #include <rogue/utilities/fileio/StreamReader.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
@@ -141,12 +143,14 @@ void ruf::StreamReader::runThread() {
    int32_t  ret;
    uint32_t size;
    uint32_t flags;
-   bool err;
+   uint32_t bSize;
+   bool     err;
    ris::FramePtr frame;
-   ris::FrameIteratorPtr iter;
+   ris::Frame::BufferIterator it;
+   char * bData;
    Logging log("streamReader");
 
-   err = false;
+   ret = 0;
    try {
       do {
 
@@ -168,17 +172,24 @@ void ruf::StreamReader::runThread() {
             // Request frame
             frame = reqFrame(size,true);
             frame->setFlags(flags);
+            it = frame->beginBuffer();
 
-            // Populate frame
-            iter = frame->startWrite(0,size-4);
-            do {
-               if ( (ret = read(fd_,iter->data(),iter->size())) != (int32_t)iter->size()) {
-                  log.warning("Short read. Ret = %i Req = %i after %i bytes",ret,iter->size(),iter->total());
+            while ( (err == false) && (size > 0) ) {
+               bSize = size;
+
+               // Adjust to buffer size, if neccessary
+               if ( bSize > (*it)->getSize() ) bSize = (*it)->getSize();
+
+               if ( (ret = read(fd_,(*it)->begin(),bSize)) != bSize) {
+                  log.warning("Short read. Ret = %i Req = %i after %i bytes",ret,bSize,frame->getPayload());
                   ::close(fd_);
                   fd_ = -1;
                   frame->setError(0x1);
+                  err = true;
                }
-            } while (frame->nextWrite(iter));
+               else (*it)->setPayload(bSize);
+               size -= bSize;
+            }
             sendFrame(frame);
             boost::this_thread::interruption_point();
          }

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -169,6 +169,10 @@ void ruf::StreamReader::runThread() {
                break;
             }
 
+            // Skip next step if frame is empty
+            size -= 4;
+            if ( size == 0 ) continue;
+
             // Request frame
             frame = reqFrame(size,true);
             frame->setFlags(flags);
@@ -187,7 +191,10 @@ void ruf::StreamReader::runThread() {
                   frame->setError(0x1);
                   err = true;
                }
-               else (*it)->setPayload(bSize);
+               else {
+                  (*it)->setPayload(bSize);
+                  if ( (*it)->getAvailable() == 0 ) ++it; // Next buffer
+               }
                size -= bSize;
             }
             sendFrame(frame);

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -188,6 +188,8 @@ void ruf::StreamWriter::writeFile ( uint8_t channel, boost::shared_ptr<rogue::in
    uint32_t value;
    uint32_t size;
 
+   if ( frame->getPayload() == 0 ) return;
+
    rogue::GilRelease noGil;
    boost::unique_lock<boost::mutex> lock(mtx_);
 

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -35,6 +35,7 @@
 #include <rogue/utilities/fileio/StreamWriter.h>
 #include <rogue/utilities/fileio/StreamWriterChannel.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <stdint.h>
 #include <boost/thread.hpp>
@@ -183,7 +184,7 @@ void ruf::StreamWriter::waitFrameCount(uint32_t count) {
 
 //! Write data to file. Called from StreamWriterChannel
 void ruf::StreamWriter::writeFile ( uint8_t channel, boost::shared_ptr<rogue::interfaces::stream::Frame> frame) {
-   ris::FrameIteratorPtr iter;
+   ris::Frame::BufferIterator it;
    uint32_t value;
    uint32_t size;
 
@@ -204,10 +205,9 @@ void ruf::StreamWriter::writeFile ( uint8_t channel, boost::shared_ptr<rogue::in
       value |= (channel << 24);
       intWrite(&value,4);
 
-      iter = frame->startRead(0,size-4);
-      do {
-         intWrite(iter->data(),iter->size());
-      } while (frame->nextRead(iter));
+      // Write buffers
+      for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) 
+         intWrite((*it)->begin(),(*it)->getPayload());
 
       // Update counters
       frameCount_ ++;


### PR DESCRIPTION
### Stream Iterator

This first change in this pull request modifies the Frame/Buffer interface to use proper iterators. The existing `frame->getCount()` and `frame->getBuffer()` are now replaced with `frame->beginBuffer()` and `frame->endBuffer()` iterators. The previous iterator model for frames (`startRead`, `startWrite`, `nextRead`, `nextWrite`) have been removed in favor of a proper frame iterator in the form of `frame->begin()` and `frame->end()`.

The buffer interface to data is now also consistent with the iterator model allowing the user to access buffer bytes in the following ways:
```c++
// for payload data space
for (Buffer::iterator it = buffer->begin(); it != buffer->endPayload(); ++it)  
```
```c++
// for all frame data space
for (Buffer::iterator it = buffer->begin(); it != buffer->end(); ++it) 
```

Users can choose to iterate directly through the entire frame byte array in the following ways:
```c++
// for frame payload data space
for (Frame::iterator it = frame->begin(); it != frame->endPayload(); ++it)  
```
```c++
// for all frame data space
for (Frame::iterator it = frame->begin(); it != frame->end(); ++it) 
```
Alternatively a user can iterate over buffers and treat the buffer data as large blocks:
```c++
for(Frame::BufferIterator it = frame->beginBuffer(); it != frame->endBuffer(); ++it)
   write(socket, (*it)->begin(), (*it)->endPayload()-(*it)->begin());  
```
Both the frame and buffer have cleaner methods to get and adjust frame lengths. The python interface to frame data does not change.

### Memory Transaction Class
The second change is a major modification to the memory interface. A new class type `Transaction` is created to contain the transaction information as well as provide the interface to moving data and completing the transaction. This new class is passed between the master and slave to initiate a memory transaction. The slave then operates on this transaction object to get and put data and complete the transaction. Right now this transaction wraps a `char *` iterator, but in the future more complex iterators will be added as needed by more complicated memory transaction masters. 

Both python and c++ memory slave code requires updates to work with this new model. Python memory slaves have a cleaner interface now when interfacing with the `Transaction` object. 



