### PR TITLE
Allow Hub.doTransaction() to be overridden in Python

### DIFF
--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -68,8 +68,7 @@ namespace rogue {
                uint64_t doAddress();
 
                //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
-
+               virtual void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
          };
          
          //! Memory Hub class, wrapper to enable pyton overload of virtual methods
@@ -80,17 +79,13 @@ namespace rogue {
             public:
 
                //! Constructor
-              HubWrap(uint64_t offset);
-
-
-               //! Post a transaction. Master will call this method with the access attributes.
-               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                  uint64_t address, uint32_t size, uint32_t type);
+               HubWrap(uint64_t offset);
 
                //! Post a transaction. Master will call this method with the access attributes.
-               void defDoTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
-                                     uint64_t address, uint32_t size, uint32_t type);
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
 
+               //! Post a transaction. Master will call this method with the access attributes.
+               void defDoTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
          };
          
          // Convienence

--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -72,9 +72,31 @@ namespace rogue {
                                   uint64_t address, uint32_t size, uint32_t type);
 
          };
+         
+         //! Memory Hub class, wrapper to enable pyton overload of virtual methods
+         class HubWrap : 
+            public rogue::interfaces::memory::Hub, 
+            public boost::python::wrapper<rogue::interfaces::memory::Hub> {
 
+            public:
+
+               //! Constructor
+              HubWrap(uint64_t offset);
+
+
+               //! Post a transaction. Master will call this method with the access attributes.
+               void doTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
+                                  uint64_t address, uint32_t size, uint32_t type);
+
+               //! Post a transaction. Master will call this method with the access attributes.
+               void defDoTransaction(uint32_t id, boost::shared_ptr<rogue::interfaces::memory::Master> master,
+                                     uint64_t address, uint32_t size, uint32_t type);
+
+         };
+         
          // Convienence
          typedef boost::shared_ptr<rogue::interfaces::memory::Hub> HubPtr;
+         typedef boost::shared_ptr<rogue::interfaces::memory::HubWrap> HubWrapPtr;
 
       }
    }

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -400,7 +400,7 @@ class Device(pr.Node,rim.Hub):
         pr.Node._rootAttached(self, parent, root)
 
         self._maxTxnSize = self._reqMaxAccess()
-        self._minTxnSize = self._reqMinAccess()        
+        self._minTxnSize = self._doMinAccess()
 
         for key,value in self._nodes.items():
             value._rootAttached(self,root)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -414,7 +414,7 @@ class Device(pr.Node,rim.Hub):
     def _rootAttached(self, parent, root):
         pr.Node._rootAttached(self, parent, root)
 
-        self._maxTxnSize = self._reqMaxAccess()
+        self._maxTxnSize = self._doMaxAccess()
         self._minTxnSize = self._doMinAccess()
 
         for key,value in self._nodes.items():

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -86,36 +86,30 @@ void rim::Hub::setup_python() {
    ;
 
    bp::implicitly_convertible<rim::HubPtr, rim::MasterPtr>();
-   
 }
-
 
 //! Constructor
 rim::HubWrap::HubWrap(uint64_t offset) : rim::Hub(offset) {}
 
-
-
 //! Post a transaction. Master will call this method with the access attributes.
-void rim::HubWrap::doTransaction(uint32_t id, rim::MasterPtr master,
-                                   uint64_t address, uint32_t size, uint32_t type) {
+void rim::HubWrap::doTransaction(rim::TransactionPtr transaction) {
    {
       rogue::ScopedGil gil;
 
       if (boost::python::override pb = this->get_override("_doTransaction")) {
          try {
-            pb(id,master,address,size,type);
+            pb(transaction);
             return;
          } catch (...) {
             PyErr_Print();
          }
       }
    }
-   rim::Hub::doTransaction(id,master,address,size,type);
+   rim::Hub::doTransaction(transaction);
 }
 
 //! Post a transaction. Master will call this method with the access attributes.
-void rim::HubWrap::defDoTransaction(uint32_t id, rim::MasterPtr master,
-                                      uint64_t address, uint32_t size, uint32_t type) {
-   rim::Hub::doTransaction(id, master, address, size, type);
+void rim::HubWrap::defDoTransaction(rim::TransactionPtr transaction) {
+   rim::Hub::doTransaction(transaction);
 }
 

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -78,8 +78,6 @@ void rim::Hub::doTransaction(rim::TransactionPtr tran) {
 void rim::Hub::setup_python() {
 
    bp::class_<rim::HubWrap, rim::HubWrapPtr, bp::bases<rim::Master,rim::Slave>, boost::noncopyable>("Hub",bp::init<uint64_t>())
-      .def("create", &rim::Hub::create)
-      .staticmethod("create")
        .def("_getAddress",    &rim::Hub::doAddress)
        .def("_getOffset",     &rim::Hub::getOffset)
        .def("_doTransaction", &rim::Hub::doTransaction, &rim::HubWrap::defDoTransaction)


### PR DESCRIPTION
A pyrogue Device can now override `_doTransaction()` to perform a limited amount of address manipulation.