### PR TITLE
Generate address space overlap warnings

### DIFF
--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -58,6 +58,9 @@ namespace rogue {
                //! Get offset
                uint64_t getOffset();
 
+               //! Return ID to requesting master
+               uint32_t doSlaveId();
+
                //! Return min access size to requesting master
                uint32_t doMinAccess();
 

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -85,6 +85,9 @@ namespace rogue {
                //! Get slave
                boost::shared_ptr<rogue::interfaces::memory::Slave> getSlave();
 
+               //! Query the slave ID
+               uint32_t reqSlaveId();
+
                //! Query the minimum access size in bytes for interface
                uint32_t reqMinAccess();
 

--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -34,6 +34,15 @@ namespace rogue {
          //! Slave container
          class Slave {
 
+               //! Class instance counter
+               static uint32_t classIdx_;
+
+               //! Class instance lock
+               static boost::mutex classMtx_;
+
+               //! Unique slave ID
+               uint32_t id_;
+
                //! Alias for map
                typedef std::map<uint32_t, boost::weak_ptr<rogue::interfaces::memory::Transaction> > TransactionMap;
 
@@ -77,6 +86,12 @@ namespace rogue {
 
                //! Get min size from slave
                uint32_t max();
+
+               //! Get ID
+               uint32_t id();
+
+               //! Return ID to requesting master
+               virtual uint32_t doSlaveId();
 
                //! Return min access size to requesting master
                virtual uint32_t doMinAccess();

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -437,7 +437,8 @@ class RemoteBlock(BaseBlock, rim.Master):
             for x in range(0, len(var.bitOffset)):
                 for y in range(0, var.bitSize[x]):
                     if getBitFromBytes(self._varMask,var.bitOffset[x]+y):
-                        self._log.critical(f"Detected bit overlap for variable {var.name} in block {self.name} at offset {self.offset:#02x}")
+                        msg = f"Detected bit overlap for variable {var.name}"
+                        raise MemoryError(name=self.name, address=self.address, msg=msg)
                     setBitToBytes(self._varMask,var.bitOffset[x]+y,1)
 
             # Update verify mask

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -176,6 +176,11 @@ class Device(pr.Node,rim.Hub):
     def size(self):
         return self._size
 
+    @Pyro4.expose
+    @property
+    def memId(self):
+        return self._reqSlaveId()
+
     def add(self,node):
         # Call node add
         pr.Node.add(self,node)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -171,6 +171,11 @@ class Device(pr.Node,rim.Hub):
     def offset(self):
         return self._getOffset()
 
+    @Pyro4.expose
+    @property
+    def size(self):
+        return self._size
+
     def add(self,node):
         # Call node add
         pr.Node.add(self,node)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -414,7 +414,7 @@ class Device(pr.Node,rim.Hub):
                 
                 # Variable overlaps the range of the previous variable
                 if (remVars[i].offset != remVars[i-1].offset) and (remVars[i].offset <= (remVars[i-1].offset + remVars[i-1].varBytes - 1)):
-                    self._log.warning("Overlap detected cur offset={} prev offset={} prev bytes={}".format(remVars[i].offset,remVars[i-1].offset,remVars[i-1].varBytes))
+                    self._log.info("Overlap detected cur offset={} prev offset={} prev bytes={}".format(remVars[i].offset,remVars[i-1].offset,remVars[i-1].varBytes))
                     remVars[i]._shiftOffsetDown(remVars[i].offset - remVars[i-1].offset, blkSize)
                     done = False
                     break

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -178,7 +178,7 @@ class Device(pr.Node,rim.Hub):
 
     @Pyro4.expose
     @property
-    def memId(self):
+    def memBaseId(self):
         return self._reqSlaveId()
 
     def add(self,node):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -411,10 +411,12 @@ class Device(pr.Node,rim.Hub):
 
             # Look for overlaps and adjust offset
             for i in range(1,len(remVars)):
-                
+
                 # Variable overlaps the range of the previous variable
-                if (remVars[i].offset != remVars[i-1].offset) and (remVars[i].offset <= (remVars[i-1].offset + remVars[i-1].varBytes - 1)):
-                    self._log.info("Overlap detected cur offset={} prev offset={} prev bytes={}".format(remVars[i].offset,remVars[i-1].offset,remVars[i-1].varBytes))
+                if (remVars[i].offset != remVars[i-1].offset) and \
+                   (remVars[i].offset <= (remVars[i-1].offset + remVars[i-1].varBytes - 1)):
+                    self._log.info("Overlap detected cur offset={} prev offset={} prev bytes={}".format(
+                        remVars[i].offset,remVars[i-1].offset,remVars[i-1].varBytes))
                     remVars[i]._shiftOffsetDown(remVars[i].offset - remVars[i-1].offset, blkSize)
                     done = False
                     break

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -220,6 +220,20 @@ class Node(object):
 
     @Pyro4.expose
     @property
+    def deviceList(self):
+        """
+        Get a recursive list of devices
+        """
+        lst = []
+        for key,value in self._nodes.items():
+            if isinstance(value,pr.Device):
+                lst.append(value)
+            else:
+                lst.extend(value.deviceList)
+        return lst
+
+    @Pyro4.expose
+    @property
     def commands(self):
         """
         Return an OrderedDict of the Commands that are children of this Node

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -115,7 +115,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         tmpDevs.sort(key=lambda x: (x.memBaseId, x.address, x.size))
 
         for i in range(1,len(tmpDevs)):
-            if (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and \
+            if (tmpDevs[i].size != 0) and (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and \
                 (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
                 raise pr.NodeError("Device {} at address={} overlaps {} at address={} with size={}".format(
                     tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -112,10 +112,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Look for device overlaps
         tmpDevs = self.deviceList
-        tmpDevs.sort(key=lambda x: (x.memId, x.address, x.size))
+        tmpDevs.sort(key=lambda x: (x.memBaseId, x.address, x.size))
 
         for i in range(1,len(tmpDevs)):
-            if (tmpDevs[i].memId == tmpDevs[i-1].memId) and (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
+            if (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
                 self._log.critical("Device {} at address={} overlaps {} at address={} with size={}".format(
                     tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -114,13 +114,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         tmpDevs = self.deviceList
         tmpDevs.sort(key=lambda x: (x.memId, x.address, x.size))
 
-        for i in range(0,len(tmpDevs)):
-            print("Device {} at address={} with size={}".format(tmpDevs[i].name,tmpDevs[i].address,tmpDevs[i].size))
-
         for i in range(1,len(tmpDevs)):
             if (tmpDevs[i].memId == tmpDevs[i-1].memId) and (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
-                self._log.critical("Device overlap {} at address={} overlaps {} at address={} with size={}".format(
-                    tmpDevs[i].name,tmpDevs[i].address,tmpDevs[i-1].name,tmpDevs[i-1].address,tmpDevs[i-1].size))
+                self._log.critical("Device {} at address={} overlaps {} at address={} with size={}".format(
+                    tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
 
         # Get list of deprecated nodes
         lst = self._getDepWarn()

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -110,6 +110,18 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         for key,value in self._nodes.items():
             value._rootAttached(self,self)
 
+        # Look for device overlaps
+        tmpDevs = self.deviceList
+        tmpDevs.sort(key=lambda x: (x.memId, x.address, x.size))
+
+        for i in range(0,len(tmpDevs)):
+            print("Device {} at address={} with size={}".format(tmpDevs[i].name,tmpDevs[i].address,tmpDevs[i].size))
+
+        for i in range(1,len(tmpDevs)):
+            if (tmpDevs[i].memId == tmpDevs[i-1].memId) and (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
+                self._log.critical("Device overlap {} at address={} overlaps {} at address={} with size={}".format(
+                    tmpDevs[i].name,tmpDevs[i].address,tmpDevs[i-1].name,tmpDevs[i-1].address,tmpDevs[i-1].size))
+
         # Get list of deprecated nodes
         lst = self._getDepWarn()
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -115,8 +115,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         tmpDevs.sort(key=lambda x: (x.memBaseId, x.address, x.size))
 
         for i in range(1,len(tmpDevs)):
-            if (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
-                self._log.critical("Device {} at address={} overlaps {} at address={} with size={}".format(
+            if (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and \
+                (tmpDevs[i].address <= (tmpDevs[i-1].address + tmpDevs[i-1].size)):
+                raise pr.NodeError("Device {} at address={} overlaps {} at address={} with size={}".format(
                     tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
 
         # Get list of deprecated nodes

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -50,6 +50,11 @@ uint64_t rim::Hub::getOffset() {
    return offset_;
 }
 
+//! Return id to requesting master
+uint32_t rim::Hub::doSlaveId() {
+   return(reqSlaveId());
+}
+
 //! Return min access size to requesting master
 uint32_t rim::Hub::doMinAccess() {
    return(reqMinAccess());

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -39,6 +39,7 @@ void rim::Master::setup_python() {
    bp::class_<rim::Master, rim::MasterPtr, boost::noncopyable>("Master",bp::init<>())
       .def("_setSlave",           &rim::Master::setSlave)
       .def("_getSlave",           &rim::Master::getSlave)
+      .def("_reqSlaveId",         &rim::Master::reqSlaveId)
       .def("_reqMinAccess",       &rim::Master::reqMinAccess)
       .def("_reqMaxAccess",       &rim::Master::reqMaxAccess)
       .def("_reqAddress",         &rim::Master::reqAddress)
@@ -75,6 +76,11 @@ void rim::Master::setSlave ( rim::SlavePtr slave ) {
 //! Get slave
 rim::SlavePtr rim::Master::getSlave () {
    return(slave_);
+}
+
+//! Query the slave id
+uint32_t rim::Master::reqSlaveId() {
+   return(slave_->doSlaveId());
 }
 
 //! Query the minimum access size in bytes for interface

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -29,6 +29,12 @@
 namespace rim = rogue::interfaces::memory;
 namespace bp = boost::python;
 
+// Init class counter
+uint32_t rim::Slave::classIdx_ = 0;
+
+//! Class instance lock
+boost::mutex rim::Slave::classMtx_;
+
 //! Create a slave container
 rim::SlavePtr rim::Slave::create (uint32_t min, uint32_t max) {
    rim::SlavePtr s = boost::make_shared<rim::Slave>(min,max);
@@ -39,6 +45,12 @@ rim::SlavePtr rim::Slave::create (uint32_t min, uint32_t max) {
 rim::Slave::Slave(uint32_t min, uint32_t max) { 
    min_ = min;
    max_ = max;
+
+   classMtx_.lock();
+   if ( classIdx_ == 0 ) classIdx_ = 1;
+   id_ = classIdx_;
+   classIdx_++;
+   classMtx_.unlock();
 } 
 
 //! Destroy object
@@ -91,6 +103,16 @@ uint32_t rim::Slave::min() {
 //! Get min size from slave
 uint32_t rim::Slave::max() {
    return max_;
+}
+
+//! Get id from slave
+uint32_t rim::Slave::id() {
+   return id_;
+}
+
+//! Return id to requesting master
+uint32_t rim::Slave::doSlaveId() {
+   return(id());
 }
 
 //! Return min access size to requesting master


### PR DESCRIPTION
This pull request adds two features. 

The first looks for overlapping variables within a block. This is done by doing a bit by bit check as variables are added to the block. A critical log message is generated when an overlap is detected.

The second feature looks for overlapping device address spaces.  In order for this feature to work properly I added a unique ID to each memory interface slave. The device will query the memBase chain to find the ID of the memory interface it is connected to. This allows the pyrogue root to avoid mislabeling overlaps between devices connected to different memory interfaces. If any devices overlap and are connected to the same memory interface, a critical log message is generated.