### PR TITLE
Deprecate class method function command decorators

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -159,6 +159,8 @@ class Device(pr.Node,rim.Hub):
             args = getattr(cmd, 'PyrogueCommandArgs')
             if 'name' not in args:
                 args['name'] = cmd.__name__
+
+            print("Adding command {} using depcreated decorator. Please use __init__ decorators instead!".format(args['name']))
             self.add(pr.LocalCommand(function=cmd, **args))
 
     @Pyro4.expose

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -95,6 +95,32 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalVariable(name='ForceWrite', value=False, mode='RW', hidden=True,
             description='Configuration Flag To Control Write All Block'))
 
+        # Commands
+        self.add(pr.LocalCommand(name='WriteAll', function=self._write, 
+                                 description='Write all values to the hardware'))
+
+        self.add(pr.LocalCommand(name="ReadAll", function=self._read,
+                                 description='Read all values from the hardware'))
+
+        self.add(pr.LocalCommand(name='WriteConfig', value='', function=self._writeConfig,
+                                 description='Write configuration to passed filename in YAML format'))
+
+        self.add(pr.LocalCommand(name='ReadConfig', value='', function=self._readConfig,
+                                 description='Read configuration from passed filename in YAML format'))
+
+        self.add(pr.LocalCommand(name='SoftReset', function=self._softReset,
+                                 description='Generate a soft reset to each device in the tree'))
+
+        self.add(pr.LocalCommand(name='HardReset', function=self._hardReset,
+                                 description='Generate a hard reset to each device in the tree'))
+
+        self.add(pr.LocalCommand(name='CountReset', function=self._countReset,
+                                 description='Generate a count reset to each device in the tree'))
+
+        self.add(pr.LocalCommand(name='ClearLog', function=self._clearLog,
+                                 description='Clear the message log cntained in the SystemLog variable'))
+
+
     def start(self, initRead=False, initWrite=False, pollEn=True, pyroGroup=None, pyroHost=None, pyroNs=None):
         """Setup the tree. Start the polling thread."""
 
@@ -321,7 +347,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._sendYamlFrame(yml)
                 self._updatedDict = None
 
-    @pr.command(order=7, name='WriteAll', description='Write all values to the hardware')
     def _write(self):
         """Write all blocks"""
         self._log.info("Start root write")
@@ -335,7 +360,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._log.exception(e)
         self._log.info("Done root write")
 
-    @pr.command(order=6, name="ReadAll", description='Read all values from the hardware')
     def _read(self):
         """Read all blocks"""
         self._log.info("Start root read")
@@ -349,7 +373,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._doneUpdatedVars()
         self._log.info("Done root read")
 
-    @pr.command(order=0, name='WriteConfig', value='', description='Write configuration to passed filename in YAML format')
     def _writeConfig(self,arg):
         """Write YAML configuration to a file. Called from command"""
         try:
@@ -358,7 +381,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         except Exception as e:
             self._log.exception(e)
 
-    @pr.command(order=1, name='ReadConfig', value='', description='Read configuration from passed filename in YAML format')
     def _readConfig(self,arg):
         """Read YAML configuration from a file. Called from command"""
         try:
@@ -367,23 +389,19 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         except Exception as e:
             self._log.exception(e)
 
-    @pr.command(order=3, name='SoftReset', description='Generate a soft reset to each device in the tree')
     def _softReset(self):
         """Generate a soft reset on all devices"""
         self.callRecursive('softReset', nodeTypes=[pr.Device])
 
-    @pr.command(order=2, name='HardReset', description='Generate a hard reset to each device in the tree')
     def _hardReset(self):
         """Generate a hard reset on all devices"""
         self.callRecursive('hardReset', nodeTypes=[pr.Device])        
         self._clearLog()
 
-    @pr.command(order=4, name='CountReset', description='Generate a count reset to each device in the tree')
     def _countReset(self):
         """Generate a count reset on all devices"""
         self.callRecursive('countReset', nodeTypes=[pr.Device])        
 
-    @pr.command(order=5, name='ClearLog', description='Clear the message log cntained in the SystemLog variable')
     def _clearLog(self):
         """Clear the system log"""
         with self._sysLogLock:


### PR DESCRIPTION
Adding @pyrogue.Command decorators on class methods will no longer be supported in a future release. This PR adds a deprecation message and modified the Root class to no longer use this decorator. 

Using decorators on functions within the Device's __init__ method is the preferred way to create Commands attached to Device functions.