### PR TITLE
Enable bit sizes larger than 32 as strings, fix epics string handling

### DIFF
--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -47,6 +47,7 @@ namespace rogue {
                uint32_t    size_;
                uint32_t    fSize_;
                bool        array_;
+               bool        isString_;
 
                std::vector<std::string> enums_;
                rogue::protocols::epicsV3::Pv * pv_;

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -93,21 +93,23 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
       log_->info("Detected enum for %s typeStr=%s", epicsName_.c_str(),typeStr.c_str());
    }
 
-   // Unsigned Int types, 64-bits treated as string
-   else if ( typeStr != "UInt64" && (sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1) ) {
+   // Unsigned Int types, > 32-bits treated as string
+   else if ( sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8; } 
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; } 
-      else { fSize_ = 4; epicsType_ = aitEnumUint32; } 
+      else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; } 
+      else { epicsType_ = aitEnumString; } 
 
       log_->info("Detected Rogue Uint with size %i for %s typeStr=%s",
             bitSize, epicsName_.c_str(),typeStr.c_str());
   }
 
-   // Signed Int types, 64-bits treated as string
-   else if ( typeStr != "Int64" && (sscanf(typeStr.c_str(),"Int%i",&bitSize) == 1) ) {
+   // Signed Int types, > 32-bits treated as string
+   else if ( sscanf(typeStr.c_str(),"Int%i",&bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; } 
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; } 
-      else { fSize_ = 4; epicsType_ = aitEnumInt32; } 
+      else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; } 
+      else { epicsType_ = aitEnumString; }
 
       log_->info("Detected Rogue Int with size %i for %s typeStr=%s",
             bitSize, epicsName_.c_str(),typeStr.c_str());


### PR DESCRIPTION
This pulls request includes:
* All values greater than 32bit should be treated as string, not only 64bit values (The GitHash for example is 160bit long and it was not treated correctly before).
* Also, as EPICS string PV are limited to 40 chars, I propose to use array of char instead. On the client side, the user must convert the array of char to a string. `caget` and `caput` utilities have the `-S` option for this purpose. Before this change, long string (like the buildstamp) or long numbers (as the githash on hex representation) were truncated to 40 chars. With this modification the values are read correctly, for example:
```
[jvasquez@tid-pc93099 ~]$ caget -S jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:GitHash
jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:GitHash 0xb8669ccf9c72e481e6c81870111ffc5206c7640
[jvasquez@tid-pc93099 ~]$ caget -S jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:BuildStamp
jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:BuildStamp CryoDetCmbHcdBpEth: Vivado v2016.4, rdsrv223 (x86_64), Built Thu Nov 30 15:51:15 PST 2017 by mdewart
```
It  also works for reading/wrtting string:

```
[jvasquez@tid-pc93099 ~]$ caget -S jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString
jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString Local variable with a string
[jvasquez@tid-pc93099 ~]$ caput -S jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString "New string set from EPICS"
Old : jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString Local variable with a string
New : jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString New string set from EPICS
[jvasquez@tid-pc93099 ~]$ caget -S jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString
jesus_test:AMCc:FpgaTopLevel:AmcCarrierCore:AxiVersion:LocalString New string set from EPICS
```
