### PR TITLE
Set flags in outbound frame for packetizer

### DIFF
--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -119,16 +119,17 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
       if ( tmpEof ) flags += tmpLuser << 8;
       flags += tmpId   << 16;
       flags += tmpDest << 24;
-      frame->setFlags(flags);
+      tranFrame_[0]->setFlags(flags);
    }
 
    tranFrame_[0]->appendBuffer(buff);
+   frame->clear();
 
    // Last of transfer
    if ( tmpEof ) {
-      flags = frame->getFlags() & 0xFFFF00FF;
+      flags = tranFrame_[0]->getFlags() & 0xFFFF00FF;
       flags += tmpLuser << 8;
-      frame->setFlags(flags);
+      tranFrame_[0]->setFlags(flags);
 
       tranCount_[0] = 0;
       if ( app_[tranDest_] ) {
@@ -217,5 +218,6 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       segment++;
    }
    appIndex_++;
+   frame->clear();
 }
 

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -123,7 +123,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    }
 
    tranFrame_[0]->appendBuffer(buff);
-   frame->clear();
+   //frame->clear();
 
    // Last of transfer
    if ( tmpEof ) {
@@ -218,6 +218,6 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       segment++;
    }
    appIndex_++;
-   frame->clear();
+   //frame->clear();
 }
 

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -170,13 +170,13 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    }
 
    tranFrame_[tmpDest]->appendBuffer(buff);
-   frame->clear();
+   //frame->clear();
 
    // Last of transfer
    if ( tmpEof ) {
       flags = tranFrame_[tmpDest]->getFlags() & 0xFFFF00FF;
       flags |= uint32_t(tmpLuser) << 8;
-      tranFram_[tmpDest]->setFlags(flags);
+      tranFrame_[tmpDest]->setFlags(flags);
 
       transSof_[tmpDest]  = true;
       tranCount_[tmpDest] = 0;
@@ -309,6 +309,6 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       tranQueue_.push(tFrame);
    }
    appIndex_++;
-   frame->clear();
+   //frame->clear();
 }
 

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -166,16 +166,17 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
       if ( tmpEof ) flags |= uint32_t(tmpLuser) << 8;
       flags += tmpId   << 16;
       flags += tmpDest << 24;
-      frame->setFlags(flags);
+      tranFrame_[tmpDest]->setFlags(flags);
    }
 
    tranFrame_[tmpDest]->appendBuffer(buff);
+   frame->clear();
 
    // Last of transfer
    if ( tmpEof ) {
-      flags = frame->getFlags() & 0xFFFF00FF;
+      flags = tranFrame_[tmpDest]->getFlags() & 0xFFFF00FF;
       flags |= uint32_t(tmpLuser) << 8;
-      frame->setFlags(flags);
+      tranFram_[tmpDest]->setFlags(flags);
 
       transSof_[tmpDest]  = true;
       tranCount_[tmpDest] = 0;
@@ -308,4 +309,6 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       tranQueue_.push(tFrame);
    }
    appIndex_++;
+   frame->clear();
 }
+


### PR DESCRIPTION
When doing another update I noticed that the flags were being modified in the inbound frame instead of the outbound frame.