### PR TITLE
Add __version__ attribute with the module version number

### DIFF
--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -55,6 +55,8 @@ namespace rogue {
          static uint32_t getMinor ();
          static uint32_t getMaint ();
          static uint32_t getDevel ();
+
+         static std::string pythonVersion();
    };
 }
 

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -129,4 +129,5 @@ def genBaseList(cls):
     return ret
 
 # Add __version__ attribute with the module version number
-__version__ = rogue.Version.current()
+__version__ = rogue.Version.pythonVersion()
+

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -128,3 +128,5 @@ def genBaseList(cls):
 
     return ret
 
+# Add __version__ attribute with the module version number
+__version__ = rogue.Version.current()

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -96,6 +96,18 @@ uint32_t rogue::Version::getDevel() {
    return _devel;
 }
 
+std::string rogue::Version::pythonVersion() {
+   init();
+   std::stringstream ret;
+
+   ret << std::dec << _major;
+   ret << "." << std::dec << _minor;
+   ret << "." << std::dec << _maint;
+
+   if ( _devel > 0 ) ret << ".dev" << std::dec << _devel;
+   return ret.str();
+}
+
 void rogue::Version::setup_python() {
    bp::class_<rogue::Version, boost::noncopyable>("Version",bp::no_init)
       .def("current", &rogue::Version::current)
@@ -114,6 +126,8 @@ void rogue::Version::setup_python() {
       .staticmethod("maint")
       .def("devel", &rogue::Version::getDevel)
       .staticmethod("devel")
+      .def("pythonVersion", &rogue::Version::pythonVersion)
+      .staticmethod("pythonVersion")
    ;
 
 }


### PR DESCRIPTION
Add the `__version__` attribute with the version number. When importing `pyrogue`the module one can call `pyrogue.__version__` and importing other modules conditionally. An example is the EPICS module which is different in the current release and the after the pre-release branch will be merge.