### PR TITLE
Add locking token for transactions and frame receivers

### DIFF
--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -23,7 +23,6 @@
 #define __ROGUE_INTERFACES_MEMORY_MASTER_H__
 #include <stdint.h>
 #include <vector>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <rogue/Logging.h>
@@ -36,7 +35,7 @@ namespace rogue {
          class Transaction;
 
          //! Master container
-         class Master : public boost::enable_shared_from_this<rogue::interfaces::memory::Master> {
+         class Master {
             friend class Transaction;
 
             private:
@@ -55,9 +54,6 @@ namespace rogue {
 
                //! Mutex
                boost::mutex mastMtx_;
-
-               //! Conditional
-               boost::condition_variable cond_;
 
                //! Error status
                uint32_t error_;
@@ -117,9 +113,6 @@ namespace rogue {
 
                //! Internal transaction
                uint32_t intTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
-
-               //! Transaction is done, called from transaction record
-               void doneTransaction(uint32_t id);
 
             public:
 

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -109,7 +109,7 @@ namespace rogue {
                ~Transaction();
 
                //! Get lock
-               static boost::shared_ptr<rogue::interfaces::memory::TransactionLock> lock();
+               boost::shared_ptr<rogue::interfaces::memory::TransactionLock> lock();
 
                //! Get expired flag
                bool expired();

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -49,10 +49,10 @@ namespace rogue {
                //! Class instance lock
                static boost::mutex classMtx_;
 
-            protected:
+               //! Conditional
+               boost::condition_variable cond_;
 
-               //! Associated master
-               boost::weak_ptr<rogue::interfaces::memory::Master> master_;
+            protected:
 
                //! Transaction start time
                struct timeval endTime_;
@@ -87,23 +87,19 @@ namespace rogue {
                //! Done state
                bool done_;
 
-               //! Reset the transaction
-               void reset();
-
                //! Transaction lock
                boost::mutex lock_;
 
             public:
 
                //! Create a transaction container
-               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create (
-                  boost::shared_ptr<rogue::interfaces::memory::Master> master);
+               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create ();
 
                //! Setup class in python
                static void setup_python();
 
                //! Constructor
-               Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
+               Transaction();
 
                //! Destructor
                ~Transaction();
@@ -128,6 +124,9 @@ namespace rogue {
 
                //! Complete transaction with passed error
                void done(uint32_t error);
+
+               //! Wait for the transaction to complete
+               uint32_t wait();
 
                //! start iterator, caller must lock around access
                rogue::interfaces::memory::Transaction::iterator begin();

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -19,6 +19,7 @@
 **/
 #ifndef __ROGUE_INTERFACES_MEMORY_TRANSACTION_H__
 #define __ROGUE_INTERFACES_MEMORY_TRANSACTION_H__
+#include <boost/enable_shared_from_this.hpp>
 #include <stdint.h>
 #include <vector>
 #include <boost/python.hpp>
@@ -28,11 +29,13 @@ namespace rogue {
    namespace interfaces {
       namespace memory {
 
+         class TransactionLock;
          class Master;
          class Hub;
 
          //! Transaction
-         class Transaction {
+         class Transaction : public boost::enable_shared_from_this<rogue::interfaces::memory::Transaction> {
+            friend class TransactionLock;
             friend class Master;
             friend class Hub;
 
@@ -87,6 +90,9 @@ namespace rogue {
                //! Reset the transaction
                void reset();
 
+               //! Transaction lock
+               boost::mutex lock_;
+
             public:
 
                //! Create a transaction container
@@ -99,11 +105,11 @@ namespace rogue {
                //! Constructor
                Transaction(boost::shared_ptr<rogue::interfaces::memory::Master> master);
 
-               //! Transaction lock which must be held when using iterator
-               boost::mutex lock;
-
                //! Destructor
                ~Transaction();
+
+               //! Get lock
+               static boost::shared_ptr<rogue::interfaces::memory::TransactionLock> lock();
 
                //! Get expired flag
                bool expired();

--- a/include/rogue/interfaces/memory/TransactionLock.h
+++ b/include/rogue/interfaces/memory/TransactionLock.h
@@ -1,0 +1,69 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Transaction Lock
+ * ----------------------------------------------------------------------------
+ * File       : TransactionLock.h
+ * Created    : 2018-03-16
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Transaction lock
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_MEMORY_TRANSACTION_LOCK_H__
+#define __ROGUE_INTERFACES_MEMORY_TRANSACTION_LOCK_H__
+#include <stdint.h>
+#include <boost/python.hpp>
+#include <boost/thread.hpp>
+
+namespace rogue {
+   namespace interfaces {
+      namespace memory {
+
+         class Transaction;
+
+         //! Transaction
+         class TransactionLock {
+
+               boost::shared_ptr<rogue::interfaces::memory::Transaction> tran_;
+               bool locked_ = false;
+
+            public:
+
+               //! Create a transaction container
+               static boost::shared_ptr<rogue::interfaces::memory::TransactionLock> create (
+                  boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
+
+               //! Constructor
+               TransactionLock(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Destructor
+               ~TransactionLock();
+
+               //! lock
+               void lock();
+
+               //! lock
+               void unlock();
+
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::memory::TransactionLock> TransactionLockPtr;
+
+      }
+   }
+}
+
+#endif
+

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -106,7 +106,7 @@ namespace rogue {
                ~Frame();
 
                //! Get lock
-               static boost::shared_ptr<rogue::interfaces::stream::FrameLock> lock();
+               boost::shared_ptr<rogue::interfaces::stream::FrameLock> lock();
 
                //! Add a buffer to end of frame, return interator to inserted buffer
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -26,6 +26,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_H__
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/thread.hpp>
 #include <stdint.h>
 #include <vector>
 
@@ -36,6 +37,7 @@ namespace rogue {
 
          class Buffer;
          class FrameIterator;
+         class FrameLock;
 
          //! Frame container
          /*
@@ -49,6 +51,7 @@ namespace rogue {
          class Frame : public boost::enable_shared_from_this<rogue::interfaces::stream::Frame> {
 
                friend class Buffer;
+               friend class FrameLock;
 
                //! Interface specific flags
                uint32_t flags_;
@@ -76,6 +79,9 @@ namespace rogue {
                //! Set size values dirty
                void setSizeDirty();
 
+               //! Frame lock
+               boost::mutex lock_;
+
             public:
 
                //! Itererator for buffer list
@@ -98,6 +104,9 @@ namespace rogue {
 
                //! Destroy a frame.
                ~Frame();
+
+               //! Get lock
+               static boost::shared_ptr<rogue::interfaces::stream::FrameLock> lock();
 
                //! Add a buffer to end of frame, return interator to inserted buffer
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -122,6 +122,9 @@ namespace rogue {
                //! Buffer end iterator
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator endBuffer();
 
+               //! Clear the list
+               void clear();
+
                //! Buffers list is empty
                bool isEmpty();
 

--- a/include/rogue/interfaces/stream/FrameLock.h
+++ b/include/rogue/interfaces/stream/FrameLock.h
@@ -1,0 +1,69 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Frame Lock
+ * ----------------------------------------------------------------------------
+ * File       : FrameLock.h
+ * Created    : 2018-03-16
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Frame lock
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_MEMORY_FRAME_LOCK_H__
+#define __ROGUE_INTERFACES_MEMORY_FRAME_LOCK_H__
+#include <stdint.h>
+#include <boost/python.hpp>
+#include <boost/thread.hpp>
+
+namespace rogue {
+   namespace interfaces {
+      namespace stream {
+
+         class Frame;
+
+         //! Frame
+         class FrameLock {
+
+               boost::shared_ptr<rogue::interfaces::stream::Frame> frame_;
+               bool locked_ = false;
+
+            public:
+
+               //! Create a frame container
+               static boost::shared_ptr<rogue::interfaces::stream::FrameLock> create (
+                  boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
+
+               //! Constructor
+               FrameLock(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Destructor
+               ~FrameLock();
+
+               //! lock
+               void lock();
+
+               //! lock
+               void unlock();
+
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::FrameLock> FrameLockPtr;
+
+      }
+   }
+}
+
+#endif
+

--- a/include/rogue/protocols/rssi/Header.h
+++ b/include/rogue/protocols/rssi/Header.h
@@ -32,19 +32,19 @@ namespace rogue {
          class Header {
 
                //! Set 16-bit uint value
-               inline void setUInt16 ( uint8_t byte, uint16_t value);
+               inline void setUInt16 ( uint8_t *data, uint8_t byte, uint16_t value);
 
                //! Get 16-bit uint value
-               inline uint16_t getUInt16 ( uint8_t byte );
+               inline uint16_t getUInt16 ( uint8_t *data, uint8_t byte );
 
                //! Set 32-bit uint value
-               inline void setUInt32 ( uint8_t byte, uint32_t value);
+               inline void setUInt32 ( uint8_t *data, uint8_t byte, uint32_t value);
 
                //! Get 32-bit uint value
-               inline uint32_t getUInt32 ( uint8_t byte );
+               inline uint32_t getUInt32 ( uint8_t *data, uint8_t byte );
 
                //! compute checksum
-               uint16_t compSum (uint8_t size);
+               uint16_t compSum (uint8_t *data, uint8_t size);
 
             public:
 
@@ -56,9 +56,6 @@ namespace rogue {
    
                //! Frame pointer
                boost::shared_ptr<rogue::interfaces::stream::Frame> frame_;
-
-               //! Raw data
-               uint8_t * data_;
 
                //! Time last transmitted
                struct timeval time_;

--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -52,8 +52,8 @@ namespace rogue {
             //! Min size
             uint32_t   minSize_;
 
-            //! RX Count
-            boost::mutex rxMtx_;
+            //! Lock
+            boost::mutex pMtx_;
 
             //! rx sequence tracking
             uint32_t   rxSeq_;
@@ -66,9 +66,6 @@ namespace rogue {
 
             //! Rx bytes
             uint32_t   rxBytes_;
-
-            //! TX Mutex
-            boost::mutex txMtx_;
 
             //! tx sequence tracking
             uint32_t   txSeq_;

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -80,6 +80,7 @@ class StreamSim(rogue.interfaces.stream.Master,
     def _acceptFrame(self,frame):
         """ Forward frame to simulation """
 
+        flock = frame.lock();
         flags = frame.getFlags()
         fuser = flags & 0xFF
         luser = (flags >> 8) & 0xFF

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -17,6 +17,7 @@
 #include <rogue/hardware/axi/AxiMemMap.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
@@ -70,7 +71,7 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
    ret = 0;
 
    rogue::GilRelease noGil;
-   boost::unique_lock<boost::mutex> lock(tran->lock);
+   rim::TransactionLockPtr lock = tran->lock();
    it = tran->begin();
 
    while ( (ret == 0) && (count != tran->size()) ) {
@@ -85,7 +86,6 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it += dataSize;
    }
-   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
    tran->done((ret==0)?0:1);

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -168,9 +168,11 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         fuser;
    uint32_t         luser;
    uint32_t         cont;
+   bool             emptyFrame;
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr lock = frame->lock();
+   emptyFrame = false;
 
    // Get Flags
    flags = frame->getFlags();
@@ -204,6 +206,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
+         emptyFrame = true;
 
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
@@ -250,6 +253,8 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
          while ( res == 0 );
       }
    }
+
+   if ( emptyFrame ) frame->clear();
 }
 
 //! Return a buffer

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/hardware/axi/AxiStreamDma.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -169,6 +170,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         cont;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    // Get Flags
    flags = frame->getFlags();

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -171,9 +171,11 @@ void rhd::DataCard::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         fuser;
    uint32_t         luser;
    uint32_t         cont;
+   bool             emptyFrame;
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr lock = frame->lock();
+   emptyFrame = false;
 
    // Get Flags
    flags = frame->getFlags();
@@ -207,6 +209,7 @@ void rhd::DataCard::acceptFrame ( ris::FramePtr frame ) {
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
+         emptyFrame = true;
 
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
@@ -253,6 +256,8 @@ void rhd::DataCard::acceptFrame ( ris::FramePtr frame ) {
          while ( res == 0 );
       }
    }
+
+   if ( emptyFrame ) frame->clear();
 }
 
 //! Return a buffer

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/hardware/data/DataCard.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -172,6 +173,7 @@ void rhd::DataCard::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         cont;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    // Get Flags
    flags = frame->getFlags();

--- a/src/rogue/hardware/data/DataMap.cpp
+++ b/src/rogue/hardware/data/DataMap.cpp
@@ -20,6 +20,7 @@
 #include <rogue/hardware/data/DataMap.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
@@ -76,7 +77,7 @@ void rhd::DataMap::doTransaction(rim::TransactionPtr tran) {
    ret = 0;
 
    rogue::GilRelease noGil;
-   boost::unique_lock<boost::mutex> lock(tran->lock);
+   rim::TransactionLockPtr lock = tran->lock();
    it = tran->begin();
 
    while ( (ret == 0) && (count != tran->size()) ) {
@@ -91,7 +92,6 @@ void rhd::DataMap::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it += dataSize;
    }
-   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
    tran->done((ret==0)?0:1);

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -218,9 +218,11 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
    struct timeval   tout;
    uint32_t         meta;
    uint32_t         cont;
+   bool             emptyFrame;
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr lock = frame->lock();
+   emptyFrame = false;
 
    // Go through each (*it)er in the frame
    ris::Frame::BufferIterator it;
@@ -236,6 +238,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
+         emptyFrame = true;
 
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
@@ -280,6 +283,8 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
          while ( res == 0 );
       }
    }
+
+   if ( emptyFrame ) frame->clear();
 }
 
 //! Return a buffer

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -26,6 +26,7 @@
 #include <rogue/hardware/pgp/EvrStatus.h>
 #include <rogue/hardware/pgp/EvrControl.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -219,6 +220,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         cont;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    // Go through each (*it)er in the frame
    ris::Frame::BufferIterator it;

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -173,9 +173,11 @@ void rhr::AxiStream::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         fuser;
    uint32_t         luser;
    uint32_t         cont;
+   bool             emptyFrame;
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr lock = frame->lock();
+   emptyFrame = false;
 
    // Get Flags
    flags = frame->getFlags();
@@ -209,6 +211,7 @@ void rhr::AxiStream::acceptFrame ( ris::FramePtr frame ) {
 
       // Meta is zero copy as indicated by bit 31
       if ( (meta & 0x80000000) != 0 ) {
+         emptyFrame = true;
 
          // Buffer is not already stale as indicates by bit 30
          if ( (meta & 0x40000000) == 0 ) {
@@ -255,6 +258,7 @@ void rhr::AxiStream::acceptFrame ( ris::FramePtr frame ) {
          while ( res == 0 );
       }
    }
+   if ( emptyFrame ) frame->clear();
 }
 
 //! Return a buffer

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -21,6 +21,7 @@
 **/
 #include <rogue/hardware/rce/AxiStream.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -174,6 +175,7 @@ void rhr::AxiStream::acceptFrame ( ris::FramePtr frame ) {
    uint32_t         cont;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    // Get Flags
    flags = frame->getFlags();

--- a/src/rogue/hardware/rce/MapMemory.cpp
+++ b/src/rogue/hardware/rce/MapMemory.cpp
@@ -21,6 +21,8 @@
 **/
 #include <rogue/hardware/rce/MapMemory.h>
 #include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
@@ -118,7 +120,7 @@ void rhr::MapMemory::doTransaction(rim::TransactionPtr tran) {
    count = 0;
 
    rogue::GilRelease noGil;
-   boost::unique_lock<boost::mutex> lock(tran->lock);
+   rim::TransactionLockPtr lock = tran->lock();
    it = tran->begin();
 
    if ((ptr = findSpace(tran->address(),tran->size())) == NULL) {
@@ -137,7 +139,6 @@ void rhr::MapMemory::doTransaction(rim::TransactionPtr tran) {
       count += dataSize;
       it    += dataSize;
    }
-   lock.unlock(); // Done with iterator
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
    tran->done(0);

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -125,7 +125,7 @@ void rim::Master::setTimeout(uint64_t timeout) {
 
 //! Post a transaction, called locally, forwarded to slave
 uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type) {
-   rim::TransactionPtr tran = rim::Transaction::create(shared_from_this());
+   rim::TransactionPtr tran = rim::Transaction::create();
 
    tran->iter_    = (uint8_t *)data;
    tran->size_    = size;
@@ -137,7 +137,7 @@ uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data
 
 //! Post a transaction, called locally, forwarded to slave, python version
 uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type) {
-   rim::TransactionPtr tran = rim::Transaction::create(shared_from_this());
+   rim::TransactionPtr tran = rim::Transaction::create();
 
    if ( PyObject_GetBuffer(p.ptr(),&(tran->pyBuf_),PyBUF_SIMPLE) < 0 )
       throw(rogue::GeneralError("Master::reqTransactionPy","Python Buffer Error"));
@@ -169,74 +169,38 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
       slave = slave_;
 
       gettimeofday(&(tran->startTime_),NULL);
-
+      timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
       tranMap_[tran->id_] = tran;
    }
 
    log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
-
    slave->doTransaction(tran);
-
-   // Update time after transaction is started
-   gettimeofday(&currTime,NULL);
-   timeradd(&currTime,&sumTime_,&(tran->endTime_));
    return(tran->id_);
-}
-
-//! Transaction complete,
-void rim::Master::doneTransaction(uint32_t id) {
-   log_->debug("Done transaction id=%i",id);
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lock(mastMtx_);
-   cond_.notify_all();
 }
 
 // Wait for transaction. Timeout in seconds
 void rim::Master::waitTransaction(uint32_t id) {
-   struct timeval currTime;
-
    TransactionMap::iterator it;
+   rim::TransactionPtr tran = NULL;
+   uint32_t error;
 
    rogue::GilRelease noGil;
-   boost::unique_lock<boost::mutex> lock(mastMtx_);
+   while (1) {
 
-   // Init iterator
-   if ( id != 0 ) it = tranMap_.find(id);
-   else it = tranMap_.begin();
+      {  // Lock the vector
+         boost::unique_lock<boost::mutex> lock(mastMtx_);
+         if ( id != 0 ) it = tranMap_.find(id);
+         else it = tranMap_.begin();
 
-   while ( it != tranMap_.end() ){
-
-      // Transaction is done
-      if ( it->second->done_ ) {
-         if ( it->second->error_ != 0 ) error_ = it->second->error_;
-         it->second->reset();
-         tranMap_.erase(it);
-      }
-      
-      // Transaction is still pending. wait for timeout or completion
-      else {
-
-         // Timeout?
-         gettimeofday(&currTime,NULL);
-         if ( it->second->endTime_.tv_sec  != 0 && 
-              it->second->endTime_.tv_usec != 0 && 
-              timercmp(&currTime,&(it->second->endTime_),>) ) {
-
-            log_->info("Transaction timeout id=%i start =%i:%i end=%i:%i curr=%i:%i",
-                  it->first, it->second->startTime_.tv_sec, it->second->startTime_.tv_usec,
-                  it->second->endTime_.tv_sec,it->second->endTime_.tv_usec,
-                  currTime.tv_sec,currTime.tv_usec);
-
-            error_ = rim::TimeoutError;
-            it->second->reset();
+         if ( it != tranMap_.end() ) {
+            tran = it->second;
             tranMap_.erase(it);
          }
-         else cond_.timed_wait(lock,boost::posix_time::microseconds(1000));
+         else break;
       }
 
-      // Refresh iterator
-      if ( id != 0 ) it = tranMap_.find(id);
-      else it = tranMap_.begin();
+      // Outside of lock
+      if ( (error = tran->wait()) != 0 ) error_ = error;
    }
 }
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -86,7 +86,7 @@ rim::Transaction::~Transaction() { }
 
 //! Get lock
 rim::TransactionLockPtr rim::Transaction::lock() {
-   //return(rim::TransactionLock::create(shared_from_this()));
+   return(rim::TransactionLock::create(shared_from_this()));
 }
 
 //! Reset the transaction
@@ -143,10 +143,6 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
    uint8_t *  data;
 
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lg(lock_);
-   noGil.acquire();
-
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
       throw(rogue::GeneralError("Transaction::writePy","Python Buffer Error In Frame"));
 
@@ -166,10 +162,6 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
 void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
    uint8_t *  data;
-
-   rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lg(lock_);
-   noGil.acquire();
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 
       throw(rogue::GeneralError("Transaction::readPy","Python Buffer Error In Frame"));

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -20,6 +20,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
@@ -83,10 +84,15 @@ rim::Transaction::Transaction(rim::MasterPtr master) {
 //! Destroy object
 rim::Transaction::~Transaction() { }
 
+//! Get lock
+rim::TransactionLockPtr rim::Transaction::lock() {
+   //return(rim::TransactionLock::create(shared_from_this()));
+}
+
 //! Reset the transaction
 void rim::Transaction::reset() {
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lg(lock);
+   boost::lock_guard<boost::mutex> lg(lock_);
 
    iter_ = NULL;
    if ( pyValid_ ) {
@@ -138,7 +144,7 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
    uint8_t *  data;
 
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lg(lock);
+   boost::lock_guard<boost::mutex> lg(lock_);
    noGil.acquire();
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
@@ -162,7 +168,7 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    uint8_t *  data;
 
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lg(lock);
+   boost::lock_guard<boost::mutex> lg(lock_);
    noGil.acquire();
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -45,6 +45,7 @@ rim::TransactionPtr rim::Transaction::create (rim::MasterPtr master) {
 
 void rim::Transaction::setup_python() {
    bp::class_<rim::Transaction, rim::TransactionPtr, boost::noncopyable>("Transaction",bp::no_init)
+      .def("lock",    &rim::Transaction::lock)
       .def("id",      &rim::Transaction::id)
       .def("address", &rim::Transaction::address)
       .def("size",    &rim::Transaction::size)

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/GilRelease.h>
 
 namespace rim = rogue::interfaces::memory;
 namespace bp  = boost::python;
@@ -31,6 +32,7 @@ rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr tran) 
 
 //! Constructor
 rim::TransactionLock::TransactionLock(rim::TransactionPtr tran) {
+   rogue::GilRelease noGil;
    tran_ = tran;
    tran_->lock_.lock();
    locked_ = true;
@@ -53,6 +55,7 @@ rim::TransactionLock::~TransactionLock() {
 //! lock
 void rim::TransactionLock::lock() {
    if ( ! locked_ ) {
+      rogue::GilRelease noGil;
       tran_->lock_.lock();
       locked_ = true;
    }

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -53,16 +53,16 @@ rim::TransactionLock::~TransactionLock() {
 //! lock
 void rim::TransactionLock::lock() {
    if ( ! locked_ ) {
-      tran_->lock_.unlock();
-      locked_ = false;
+      tran_->lock_.lock();
+      locked_ = true;
    }
 }
 
 //! lock
 void rim::TransactionLock::unlock() {
    if ( locked_ ) {
-      tran_->lock_.lock();
-      locked_ = true;
+      tran_->lock_.unlock();
+      locked_ = false;
    }
 }
 

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -17,27 +17,27 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <rogue/interfaces/stream/TransactionLock.h>
-#include <rogue/interfaces/stream/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
+#include <rogue/interfaces/memory/Transaction.h>
 
 namespace rim = rogue::interfaces::memory;
 namespace bp  = boost::python;
 
 //! Create a container
 rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr tran) {
-   rim::TransactionLockPtr tranLock = boost::make_shared<rim::TransactionLock>();
+   rim::TransactionLockPtr tranLock = boost::make_shared<rim::TransactionLock>(tran);
    return(tranLock);
 }
 
 //! Constructor
-rim:TransactionLock::TransactionLock(rim::TransactionPtr tran) {
+rim::TransactionLock::TransactionLock(rim::TransactionPtr tran) {
    tran_ = tran;
    tran_->lock_.lock();
    locked_ = true;
 }
 
 //! Setup class in python
-static void rim::TransactionLock::setup_python() {
+void rim::TransactionLock::setup_python() {
 
    bp::class_<rim::TransactionLock, rim::TransactionLockPtr, boost::noncopyable>("TransactionLock",bp::no_init)
       .def("lock",      &rim::TransactionLock::lock)
@@ -46,7 +46,7 @@ static void rim::TransactionLock::setup_python() {
 }
 
 //! Destructor
-rim::TransactionLock::~Transaction() {
+rim::TransactionLock::~TransactionLock() {
    if ( locked_ ) tran_->lock_.unlock();
 }
 

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -23,15 +23,16 @@
 namespace rim = rogue::interfaces::memory;
 namespace bp  = boost::python;
 
-//! Create a frame container
-rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr frame) {
-   rim::TransactionLockPtr frameLock = boost::make_shared<rim::TransactionLock>();
-   return(frameLock);
+//! Create a container
+rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr tran) {
+   rim::TransactionLockPtr tranLock = boost::make_shared<rim::TransactionLock>();
+   return(tranLock);
 }
 
 //! Constructor
-rim:TransactionLock::TransactionLock(rim::TransactionPtr frame) {
-   frame->lock_.lock();
+rim:TransactionLock::TransactionLock(rim::TransactionPtr tran) {
+   tran_ = tran;
+   tran_->lock_.lock();
    locked_ = true;
 }
 
@@ -46,13 +47,13 @@ static void rim::TransactionLock::setup_python() {
 
 //! Destructor
 rim::TransactionLock::~Transaction() {
-   if ( locked_ ) frame->lock_.unlock();
+   if ( locked_ ) tran_->lock_.unlock();
 }
 
 //! lock
 void rim::TransactionLock::lock() {
    if ( ! locked_ ) {
-      frame->lock_.unlock();
+      tran_->lock_.unlock();
       locked_ = false;
    }
 }
@@ -60,8 +61,9 @@ void rim::TransactionLock::lock() {
 //! lock
 void rim::TransactionLock::unlock() {
    if ( locked_ ) {
-      frame->lock_.lock();
+      tran_->lock_.lock();
       locked_ = true;
    }
 }
+
 

--- a/src/rogue/interfaces/memory/TransactionLock.pp
+++ b/src/rogue/interfaces/memory/TransactionLock.pp
@@ -1,0 +1,67 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Transaction Lock
+ * ----------------------------------------------------------------------------
+ * File       : TransactionLock.cpp
+ * Created    : 2018-03-16
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Transaction lock
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/TransactionLock.h>
+#include <rogue/interfaces/stream/Transaction.h>
+
+namespace rim = rogue::interfaces::memory;
+namespace bp  = boost::python;
+
+//! Create a frame container
+rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr frame) {
+   rim::TransactionLockPtr frameLock = boost::make_shared<rim::TransactionLock>();
+   return(frameLock);
+}
+
+//! Constructor
+rim:TransactionLock::TransactionLock(rim::TransactionPtr frame) {
+   frame->lock_.lock();
+   locked_ = true;
+}
+
+//! Setup class in python
+static void rim::TransactionLock::setup_python() {
+
+   bp::class_<rim::TransactionLock, rim::TransactionLockPtr, boost::noncopyable>("TransactionLock",bp::no_init)
+      .def("lock",      &rim::TransactionLock::lock)
+      .def("unlock",    &rim::TransactionLock::unlock)
+   ;
+}
+
+//! Destructor
+rim::TransactionLock::~Transaction() {
+   if ( locked_ ) frame->lock_.unlock();
+}
+
+//! lock
+void rim::TransactionLock::lock() {
+   if ( ! locked_ ) {
+      frame->lock_.unlock();
+      locked_ = false;
+   }
+}
+
+//! lock
+void rim::TransactionLock::unlock() {
+   if ( locked_ ) {
+      frame->lock_.lock();
+      locked_ = true;
+   }
+}
+

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/memory/Hub.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -59,6 +60,7 @@ void rim::setup_module() {
    rim::Slave::setup_python(); 
    rim::Hub::setup_python(); 
    rim::Transaction::setup_python(); 
+   rim::TransactionLock::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -24,10 +24,12 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/Logging.h>
+#include <rogue/GilRelease.h>
 #include <sys/syscall.h>
 
 namespace bp = boost::python;

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -69,6 +69,9 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    // FIFO is full, drop frame
    if ( queue_.busy()  ) return;
 
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
+
    // Get size, adjust if trim is enabled
    size = frame->getPayload();
    if ( trimSize_ != 0 && trimSize_ < size ) size = trimSize_;

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -86,6 +86,11 @@ ris::Frame::BufferIterator ris::Frame::endBuffer() {
    return(buffers_.end());
 }
 
+//! Clear the list
+void ris::Frame::clear() {
+   buffers_.clear();
+}
+
 //! Buffer list is empty
 bool ris::Frame::isEmpty() {
    return(buffers_.empty());

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -19,6 +19,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
@@ -45,6 +46,11 @@ ris::Frame::Frame() {
 
 //! Destroy a frame.
 ris::Frame::~Frame() { }
+
+//! Get lock
+ris::FrameLockPtr ris::Frame::lock() {
+   //return(ris::FrameLock::create(shared_from_this()));
+}
 
 //! Add a buffer to end of frame
 ris::Frame::BufferIterator ris::Frame::appendBuffer(ris::BufferPtr buff) {

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -89,6 +89,8 @@ ris::Frame::BufferIterator ris::Frame::endBuffer() {
 //! Clear the list
 void ris::Frame::clear() {
    buffers_.clear();
+   size_    = 0;
+   payload_ = 0;
 }
 
 //! Buffer list is empty

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -49,7 +49,7 @@ ris::Frame::~Frame() { }
 
 //! Get lock
 ris::FrameLockPtr ris::Frame::lock() {
-   //return(ris::FrameLock::create(shared_from_this()));
+   return(ris::FrameLock::create(shared_from_this()));
 }
 
 //! Add a buffer to end of frame

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -321,6 +321,7 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
 void ris::Frame::setup_python() {
 
    bp::class_<ris::Frame, ris::FramePtr, boost::noncopyable>("Frame",bp::no_init)
+      .def("lock",         &ris::Frame::lock)
       .def("getSize",      &ris::Frame::getSize)
       .def("getAvailable", &ris::Frame::getAvailable)
       .def("getPayload",   &ris::Frame::getPayload)

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -53,16 +53,16 @@ ris::FrameLock::~FrameLock() {
 //! lock
 void ris::FrameLock::lock() {
    if ( ! locked_ ) {
-      frame_->lock_.unlock();
-      locked_ = false;
+      frame_->lock_.lock();
+      locked_ = true;
    }
 }
 
 //! lock
 void ris::FrameLock::unlock() {
    if ( locked_ ) {
-      frame_->lock_.lock();
-      locked_ = true;
+      frame_->lock_.unlock();
+      locked_ = false;
    }
 }
 

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -1,0 +1,68 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Frame Lock
+ * ----------------------------------------------------------------------------
+ * File       : FrameLock.cpp
+ * Created    : 2018-03-16
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Frame lock
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/FrameLock.h>
+#include <rogue/interfaces/stream/Frame.h>
+
+namespace ris = rogue::interfaces::stream;
+namespace bp  = boost::python;
+
+//! Create a frame container
+ris::FrameLockPtr ris::FrameLock::create (ris::FramePtr frame) {
+   ris::FrameLockPtr frameLock = boost::make_shared<ris::FrameLock>(frame);
+   return(frameLock);
+}
+
+//! Constructor
+ris::FrameLock::FrameLock(ris::FramePtr frame) {
+   frame_ = frame;
+   frame_->lock_.lock();
+   locked_ = true;
+}
+
+//! Setup class in python
+void ris::FrameLock::setup_python() {
+
+   bp::class_<ris::FrameLock, ris::FrameLockPtr, boost::noncopyable>("FrameLock",bp::no_init)
+      .def("lock",      &ris::FrameLock::lock)
+      .def("unlock",    &ris::FrameLock::unlock)
+   ;
+}
+
+//! Destructor
+ris::FrameLock::~FrameLock() {
+   if ( locked_ ) frame_->lock_.unlock();
+}
+
+//! lock
+void ris::FrameLock::lock() {
+   if ( ! locked_ ) {
+      frame_->lock_.unlock();
+      locked_ = false;
+   }
+}
+
+//! lock
+void ris::FrameLock::unlock() {
+   if ( locked_ ) {
+      frame_->lock_.lock();
+      locked_ = true;
+   }
+}
+

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -40,9 +40,7 @@ ris::Master::Master() {
 }
 
 //! Destructor
-ris::Master::~Master() {
-   slaves_.clear();
-}
+ris::Master::~Master() { }
 
 //! Set primary slave, used for buffer request forwarding
 void ris::Master::setSlave ( boost::shared_ptr<interfaces::stream::Slave> slave ) {

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -63,6 +64,9 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
 
    uint32_t count;
    uint8_t  val;
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    frameCount_++;
    frameBytes_ += frame->getPayload();

--- a/src/rogue/interfaces/stream/module.cpp
+++ b/src/rogue/interfaces/stream/module.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/interfaces/stream/module.h>
@@ -46,6 +47,7 @@ void ris::setup_module() {
 
    ris::Buffer::setup_python();
    ris::Frame::setup_python();
+   ris::FrameLock::setup_python();
    ris::FrameIterator::setup_python();
    ris::Master::setup_python();
    ris::Slave::setup_python();

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -21,6 +21,7 @@
 #include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
@@ -111,6 +112,9 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    uint32_t size_;
    uint32_t i;
 
+   rogue::GilRelease noGil();
+   ris::FrameLockPtr fLock = frame->lock();
+
    fSize = frame->getPayload();
    iter = frame->begin();
 
@@ -126,7 +130,7 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    // Limit size
    if ( size_ > max_ ) size_ = max_;
 
-   rogue::GilRelease noGil;
+   rogue::GilRelease noGil();
    boost::lock_guard<boost::mutex> lock(rpe::Value::mtx_);
 
    // Release old data

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -19,6 +19,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/protocols/packetizer/Controller.h>
 #include <rogue/protocols/packetizer/Transport.h>

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -18,6 +18,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/protocols/packetizer/ControllerV1.h>
 #include <rogue/protocols/packetizer/Transport.h>
@@ -62,7 +63,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
       log_->warning("Empty frame received At Transport");
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = *(frame->beginBuffer());
@@ -169,7 +170,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    if ( frame->getError() ) return;
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
    boost::lock_guard<boost::mutex> lock(appMtx_);
 
    // Wait while queue is busy

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -124,6 +124,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    }
 
    tranFrame_[0]->appendBuffer(buff);
+   frame->clear(); // Empty old frame
 
    // Last of transfer
    if ( tmpEof ) {
@@ -168,6 +169,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    if ( frame->getError() ) return;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
    boost::lock_guard<boost::mutex> lock(appMtx_);
 
    // Wait while queue is busy
@@ -218,5 +220,6 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       segment++;
    }
    appIndex_++;
+   frame->clear(); // Empty old frame
 }
 

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -62,6 +62,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
       log_->warning("Empty frame received At Transport");
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = *(frame->beginBuffer());

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -73,6 +73,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    }
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = *(frame->beginBuffer());
@@ -170,6 +171,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    }
 
    tranFrame_[tmpDest]->appendBuffer(buff);
+   frame->clear(); // Empty old frame
 
    // Last of transfer
    if ( tmpEof ) {
@@ -224,6 +226,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    if ( frame->getError() ) return;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
    boost::lock_guard<boost::mutex> lock(appMtx_);
 
    // Wait while queue is busy
@@ -308,4 +311,5 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       tranQueue_.push(tFrame);
    }
    appIndex_++;
+   frame->clear(); // Empty old frame
 }

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -18,6 +18,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/protocols/packetizer/ControllerV2.h>
 #include <rogue/protocols/packetizer/Transport.h>
@@ -73,7 +74,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
    }
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
    boost::lock_guard<boost::mutex> lock(tranMtx_);
 
    buff = *(frame->beginBuffer());
@@ -226,7 +227,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    if ( frame->getError() ) return;
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
    boost::lock_guard<boost::mutex> lock(appMtx_);
 
    // Wait while queue is busy

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -20,6 +20,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/protocols/rssi/Header.h>
 #include <rogue/protocols/rssi/Controller.h>
@@ -144,7 +145,7 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
 
    if ( frame->isEmpty() || ! head->verify() ) {
       log_->info("Dumping frame state=%i server=%i",state_,server_);
@@ -205,7 +206,7 @@ ris::FramePtr rpr::Controller::applicationTx() {
       stCond_.notify_all();
 
       frame = head->getFrame();
-      ris::FrameLockPtr lock = frame->lock();
+      ris::FrameLockPtr flock = frame->lock();
       (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
    }
    return(frame);
@@ -219,7 +220,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
    gettimeofday(&startTime,NULL);
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = frame->lock();
+   ris::FrameLockPtr flock = frame->lock();
 
    if ( frame->isEmpty() ) {
       log_->info("Dumping empty application frame");

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -176,7 +176,6 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
       if ( state_ == StOpen || state_ == StWaitSyn ) {
          lastSeqRx_ = head->sequence;
          nextSeqRx_ = lastSeqRx_ + 1;
-
          stQueue_.push(head);
       }
    }

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -233,6 +233,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
    // Map to RSSI 
    rpr::HeaderPtr head = rpr::Header::create(frame);
    head->ack = true;
+   flock->unlock();
 
    // Connection is closed
    if ( state_ != StOpen ) return;
@@ -298,8 +299,9 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool retr
    }
  
    rogue::GilRelease noGil;
-   ris::FrameLockPtr lock = head->getFrame()->lock();
+   ris::FrameLockPtr flock = head->getFrame()->lock();
    head->update();
+   flock->unlock();
 
    // Track last tx time
    gettimeofday(&txTime_,NULL);
@@ -310,7 +312,6 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool retr
          head->acknowledge,head->sequence,retranCount_);
 
    // Send frame
-   lock->unlock();
    tran_->sendFrame(head->getFrame());
 }
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -143,6 +143,9 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 void rpr::Controller::transportRx( ris::FramePtr frame ) {
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
+
    if ( frame->isEmpty() || ! head->verify() ) {
       log_->info("Dumping frame state=%i server=%i",state_,server_);
       dropCount_++;
@@ -162,7 +165,6 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
    // Reset
    if ( head->rst ) {
       if ( state_ == StOpen || state_ == StWaitSyn ) {
-         rogue::GilRelease noGil;
          stQueue_.push(head);
       }
    }
@@ -174,7 +176,6 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
          lastSeqRx_ = head->sequence;
          nextSeqRx_ = lastSeqRx_ + 1;
 
-         rogue::GilRelease noGil;
          stQueue_.push(head);
       }
    }
@@ -187,7 +188,6 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
       stCond_.notify_all();
 
       if ( !head->nul ) {
-         rogue::GilRelease noGil;
          appQueue_.push(head);
       }
    }
@@ -205,6 +205,7 @@ ris::FramePtr rpr::Controller::applicationTx() {
       stCond_.notify_all();
 
       frame = head->getFrame();
+      ris::FrameLockPtr lock = frame->lock();
       (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
    }
    return(frame);
@@ -216,6 +217,9 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
    struct timeval startTime;
 
    gettimeofday(&startTime,NULL);
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
 
    if ( frame->isEmpty() ) {
       log_->info("Dumping empty application frame");
@@ -231,8 +235,6 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
 
    // Connection is closed
    if ( state_ != StOpen ) return;
-
-   rogue::GilRelease noGil;
 
    // Wait while busy either by flow control or buffer starvation
    while ( txListCount_ >= remMaxBuffers_ ) {
@@ -293,6 +295,9 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool retr
       lastAckTx_ = lastSeqRx_;
       head->busy = false;
    }
+ 
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = head->getFrame()->lock();
    head->update();
 
    // Track last tx time
@@ -304,6 +309,7 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool retr
          head->acknowledge,head->sequence,retranCount_);
 
    // Send frame
+   lock->unlock();
    tran_->sendFrame(head->getFrame());
 }
 

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -126,7 +126,7 @@ bool rpr::Header::verify() {
 
    size = (syn)?SynSize:HeaderSize;
 
-   if ( (data[1] != size) || (buff->getPayload() < size) || (getUInt16(data,size-2) != compSum(size))) return false;
+   if ( (data[1] != size) || (buff->getPayload() < size) || (getUInt16(data,size-2) != compSum(data,size))) return false;
 
    sequence    = data[2];
    acknowledge = data[3];
@@ -193,7 +193,7 @@ void rpr::Header::update() {
       data[18] = connectionId;
    }
 
-   setUInt16(data,size-2,compSum(size));
+   setUInt16(data,size-2,compSum(data,size));
    gettimeofday(&time_,NULL);
    count_++;
 }
@@ -216,6 +216,9 @@ void rpr::Header::rstTime() {
 //! Dump message
 std::string rpr::Header::dump() {
    uint32_t   x;
+
+   ris::BufferPtr buff = *(frame_->beginBuffer());
+   uint8_t * data = buff->begin();
 
    std::stringstream ret("");
 

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -32,32 +32,32 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 
 //! Set 16-bit uint value
-void rpr::Header::setUInt16 ( uint8_t byte, uint16_t value) {
-   *((uint16_t *)(&(data_[byte]))) = htons(value);
+void rpr::Header::setUInt16 ( uint8_t *data, uint8_t byte, uint16_t value) {
+   *((uint16_t *)(&(data[byte]))) = htons(value);
 }
 
 //! Get 16-bit uint value
-uint16_t rpr::Header::getUInt16 ( uint8_t byte ) {
-   return(ntohs(*((uint16_t *)(&(data_[byte])))));
+uint16_t rpr::Header::getUInt16 ( uint8_t *data, uint8_t byte ) {
+   return(ntohs(*((uint16_t *)(&(data[byte])))));
 }
 
 //! Set 32-bit uint value
-void rpr::Header::setUInt32 ( uint8_t byte, uint32_t value) {
-   *((uint32_t *)(&(data_[byte]))) = htonl(value);
+void rpr::Header::setUInt32 ( uint8_t *data, uint8_t byte, uint32_t value) {
+   *((uint32_t *)(&(data[byte]))) = htonl(value);
 }
 
 //! Get 32-bit uint value
-uint32_t rpr::Header::getUInt32 ( uint8_t byte ) {
-   return(ntohl(*((uint32_t *)(&(data_[byte])))));
+uint32_t rpr::Header::getUInt32 ( uint8_t *data, uint8_t byte ) {
+   return(ntohl(*((uint32_t *)(&(data[byte])))));
 }
 
 //! compute checksum
-uint16_t rpr::Header::compSum (uint8_t size) {
+uint16_t rpr::Header::compSum (uint8_t *data, uint8_t size) {
    uint8_t  x;
    uint32_t sum;
 
    sum = 0;
-   for (x=0; x < size-2; x = x+2) sum += getUInt16(x);
+   for (x=0; x < size-2; x = x+2) sum += getUInt16(data,x);
 
    sum = (sum % 0x10000) + (sum / 0x10000);
    sum = sum ^ 0xFFFF;
@@ -79,7 +79,6 @@ rpr::Header::Header(ris::FramePtr frame) {
    if ( frame->isEmpty() ) 
       throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
-   data_  = (*(frame->beginBuffer()))->begin();
    count_ = 0;
 
    syn = false;
@@ -115,36 +114,37 @@ bool rpr::Header::verify() {
    uint8_t size;
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
+   uint8_t * data = buff->begin();
 
    if ( buff->getPayload() < HeaderSize ) return(false);
   
-   syn  = data_[0] & 0x80;
-   ack  = data_[0] & 0x40;
-   rst  = data_[0] & 0x10;
-   nul  = data_[0] & 0x08;
-   busy = data_[0] & 0x01;
+   syn  = data[0] & 0x80;
+   ack  = data[0] & 0x40;
+   rst  = data[0] & 0x10;
+   nul  = data[0] & 0x08;
+   busy = data[0] & 0x01;
 
    size = (syn)?SynSize:HeaderSize;
 
-   if ( (data_[1] != size) || (buff->getPayload() < size) || (getUInt16(size-2) != compSum(size))) return false;
+   if ( (data[1] != size) || (buff->getPayload() < size) || (getUInt16(data,size-2) != compSum(size))) return false;
 
-   sequence    = data_[2];
-   acknowledge = data_[3];
+   sequence    = data[2];
+   acknowledge = data[3];
 
    if ( ! syn ) return true;
 
-   version = data_[4] >> 4;
-   chk  = data_[4] & 0x04;
+   version = data[4] >> 4;
+   chk  = data[4] & 0x04;
 
-   maxOutstandingSegments = data_[5];
-   maxSegmentSize = getUInt16(6);
-   retransmissionTimeout = getUInt16(8);
-   cumulativeAckTimeout = getUInt16(10);
-   nullTimeout = getUInt16(12);
-   maxRetransmissions = data_[14];
-   maxCumulativeAck = data_[15];
-   timeoutUnit = data_[17];
-   connectionId = data_[18];
+   maxOutstandingSegments = data[5];
+   maxSegmentSize = getUInt16(data,6);
+   retransmissionTimeout = getUInt16(data,8);
+   cumulativeAckTimeout = getUInt16(data,10);
+   nullTimeout = getUInt16(data,12);
+   maxRetransmissions = data[14];
+   maxCumulativeAck = data[15];
+   timeoutUnit = data[17];
+   connectionId = data[18];
 
    return(true);
 }
@@ -154,6 +154,7 @@ void rpr::Header::update() {
    uint8_t size;
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
+   uint8_t * data = buff->begin();
 
    size = (syn)?SynSize:HeaderSize;
 
@@ -162,37 +163,37 @@ void rpr::Header::update() {
 
    buff->minPayload(size);
 
-   memset(data_,0,size);
-   data_[1] = size;
+   memset(data,0,size);
+   data[1] = size;
 
-   if ( ack  ) data_[0] |= 0x40;
-   if ( rst  ) data_[0] |= 0x10;
-   if ( nul  ) data_[0] |= 0x08;
-   if ( busy ) data_[0] |= 0x01;
+   if ( ack  ) data[0] |= 0x40;
+   if ( rst  ) data[0] |= 0x10;
+   if ( nul  ) data[0] |= 0x08;
+   if ( busy ) data[0] |= 0x01;
 
-   data_[2] = sequence;
-   data_[3] = acknowledge;
+   data[2] = sequence;
+   data[3] = acknowledge;
 
    if ( syn ) {
-      data_[0] |= 0x80;
-      data_[4] |= 0x08;
-      data_[4] |= (version << 4);
-      if ( chk ) data_[4] |= 0x04;
+      data[0] |= 0x80;
+      data[4] |= 0x08;
+      data[4] |= (version << 4);
+      if ( chk ) data[4] |= 0x04;
 
-      data_[5] = maxOutstandingSegments;
+      data[5] = maxOutstandingSegments;
 
-      setUInt16(6,maxSegmentSize);
-      setUInt16(8,retransmissionTimeout);
-      setUInt16(10,cumulativeAckTimeout);
-      setUInt16(12,nullTimeout);
+      setUInt16(data,6,maxSegmentSize);
+      setUInt16(data,8,retransmissionTimeout);
+      setUInt16(data,10,cumulativeAckTimeout);
+      setUInt16(data,12,nullTimeout);
 
-      data_[14] = maxRetransmissions;
-      data_[15] = maxCumulativeAck;
-      data_[17] = timeoutUnit;
-      data_[18] = connectionId;
+      data[14] = maxRetransmissions;
+      data[15] = maxCumulativeAck;
+      data[17] = timeoutUnit;
+      data[18] = connectionId;
    }
 
-   setUInt16(size-2,compSum(size));
+   setUInt16(data,size-2,compSum(size));
    gettimeofday(&time_,NULL);
    count_++;
 }
@@ -222,9 +223,9 @@ std::string rpr::Header::dump() {
    ret << "     Raw Size : " << std::dec << (*(frame_->beginBuffer()))->getSize() << std::endl;
    ret << "   Raw Header : ";
 
-   for (x=0; x < data_[1]; x++) {
-      ret << "0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)data_[x] << " ";
-      if ( (x % 8) == 7 && (x+1) != data_[1]) ret << std::endl << "                ";
+   for (x=0; x < data[1]; x++) {
+      ret << "0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)data[x] << " ";
+      if ( (x % 8) == 7 && (x+1) != data[1]) ret << std::endl << "                ";
    }
    ret << std::endl;
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Constants.h>
@@ -159,6 +160,9 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    bool     doWrite;
    uint32_t fSize;
 
+   rogue::GilRelease noGil();
+   ris::FrameLockPtr fLock = frame->lock();
+
    // Check frame size
    if ( (fSize = frame->getPayload()) < 16 ) {
       log_->info("Got undersize frame size = %i",fSize);
@@ -183,7 +187,6 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Setup transaction iterator
-   rogue::GilRelease noGil;
    rim::TransactionLockPtr lock = tran->lock();
 
    // Transaction expired

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Constants.h>
@@ -137,7 +138,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    frame->setPayload(frameSize);
 
    // Setup iterators
-   rogue::GilRelease noGil;
+   rogue::GilRelease noGil();
    rim::TransactionLockPtr lock = tran->lock();
    fIter = frame->begin();
    tIter = tran->begin();
@@ -170,6 +171,9 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    bool     doWrite;
    uint32_t fSize;
 
+   rogue::GilRelease noGil();
+   ris::FrameLockPtr frLock = frame->lock();
+
    // Check frame size
    if ( (fSize = frame->getPayload()) < HeadLen ) {
       log_->info("Got undersize frame size = %i",fSize);
@@ -194,7 +198,6 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Setup transaction iterator
-   rogue::GilRelease noGil;
    rim::TransactionLockPtr lock = tran->lock();
 
    // Transaction expired

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -215,7 +215,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    if ( (fSize != expFrameLen) ||
         (header[4]+1) != tran->size() ) {
       delTransaction(id);
-      log_->debug("Size mismatch id=0x%08x",id);
+      log_->warning("Size mismatch id=0x%08x",id);
       return;
    }
 
@@ -223,7 +223,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    if ( ((header[0] & 0xFFFFC3FF) != expHeader[0]) ||
          (header[1] != expHeader[1]) || (header[2] != expHeader[2]) ||
          (header[3] != expHeader[3]) || (header[4] != expHeader[4]) ) {
-     log_->debug("Bad header for %i",id);
+     log_->warning("Bad header for %i",id);
      return;
    }
 
@@ -236,7 +236,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
       if ( tail[0] & 0xFF) tran->done(rim::AxiFail | (tail[0] & 0xFF));
       else if ( tail[0] & 0x100 ) tran->done(rim::AxiTimeout);
       else tran->done(tail[0]);
-      log_->debug("Error detect id=0x%08x",id);
+      log_->warning("Error detect id=0x%08x",id);
       return;
    }
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -21,6 +21,7 @@
 #include <rogue/protocols/udp/Core.h>
 #include <rogue/protocols/udp/Client.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -107,6 +108,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
    msg.msg_flags      = 0;
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Go through each buffer in the frame

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -108,7 +108,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
    msg.msg_flags      = 0;
 
    rogue::GilRelease noGil;
-   //ris::FrameLockPtr frLock = frame->lock();
+   ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Go through each buffer in the frame

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -108,7 +108,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
    msg.msg_flags      = 0;
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr frLock = frame->lock();
+   //ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Go through each buffer in the frame

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -20,6 +20,7 @@
 #include <rogue/protocols/udp/Core.h>
 #include <rogue/protocols/udp/Server.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
@@ -103,6 +104,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
    struct iovec     msg_iov[1];
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Setup message header

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -104,7 +104,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
    struct iovec     msg_iov[1];
 
    rogue::GilRelease noGil;
-   //ris::FrameLockPtr frLock = frame->lock();
+   ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Setup message header

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -104,7 +104,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
    struct iovec     msg_iov[1];
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr frLock = frame->lock();
+   //ris::FrameLockPtr frLock = frame->lock();
    boost::lock_guard<boost::mutex> lock(udpMtx_);
 
    // Setup message header

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -85,8 +85,7 @@ void ru::Prbs::setWidth(uint32_t width) {
       throw(rogue::GeneralError("Prbs::setWidth","Invalid width."));
 
    rogue::GilRelease noGil;
-   boost::lock_guard<boost::mutex> lockR(rxMtx_);
-   boost::lock_guard<boost::mutex> lockT(txMtx_);
+   boost::lock_guard<boost::mutex> lockT(pMtx_);
 
    width_     = width;
    byteWidth_ = width / 8;
@@ -97,8 +96,7 @@ void ru::Prbs::setWidth(uint32_t width) {
 void ru::Prbs::setTaps(uint32_t tapCnt, uint8_t * taps) {
    uint32_t i;
 
-   boost::lock_guard<boost::mutex> lockR(rxMtx_);
-   boost::lock_guard<boost::mutex> lockT(txMtx_);
+   boost::lock_guard<boost::mutex> lockT(pMtx_);
 
    free(taps_);
    tapCnt_ = tapCnt;
@@ -198,19 +196,14 @@ void ru::Prbs::checkPayload(bool state) {
 //! Reset counters
 // Counters should really be locked!
 void ru::Prbs::resetCount() {
-
-   txMtx_.lock();
+   pMtx_.lock();
    txErrCount_ = 0;
    txCount_    = 0;
    txBytes_    = 0;
-   txMtx_.unlock();
-
-   rxMtx_.lock();
    rxErrCount_ = 0;
    rxCount_    = 0;
    rxBytes_    = 0;
-   rxMtx_.unlock();
-
+   pMtx_.unlock();
 }
 
 //! Generate a data frame
@@ -225,19 +218,13 @@ void ru::Prbs::genFrame (uint32_t size) {
    if ((( size % byteWidth_ ) != 0) || size < minSize_ ) 
       throw rogue::GeneralError("Prbs::genFrame","Invalid frame size");
 
-   boost::unique_lock<boost::mutex> lock(txMtx_,boost::defer_lock);
-
-   rogue::GilRelease noGil;
-   lock.lock();
-   noGil.acquire(); // Not sure we need this
-
    // Setup size
    memset(frSize,0,16);
    frSize[0] = (size / byteWidth_) - 1;
 
    // Setup sequence
    memset(frSeq,0,16);
-   frSeq[0] = txSeq_++;
+   frSeq[0] = txSeq_;
 
    // Get frame
    fr = reqFrame(size,true);
@@ -262,10 +249,13 @@ void ru::Prbs::genFrame (uint32_t size) {
    }
    fr->setPayload(size);
 
+   sendFrame(fr);
+
    // Update counters
+   boost::lock_guard<boost::mutex> lock(pMtx_);
+   txSeq_++;
    txCount_++;
    txBytes_ += size;
-   sendFrame(fr);
 }
 
 //! Accept a frame from master
@@ -280,12 +270,9 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    uint32_t      pos;
    uint8_t       compData[16];
 
-   boost::unique_lock<boost::mutex> lock(rxMtx_,boost::defer_lock);
-
    rogue::GilRelease noGil;
    ris::FrameLockPtr fLock = frame->lock();
-   lock.lock();
-   noGil.acquire(); // Not sure we need this
+   boost::lock_guard<boost::mutex> lock(pMtx_);
 
    size = frame->getPayload();
    frIter = frame->beginRead();

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/utilities/Prbs.h>
@@ -281,6 +282,7 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    boost::unique_lock<boost::mutex> lock(rxMtx_,boost::defer_lock);
 
    rogue::GilRelease noGil;
+   ris::FrameLockPtr fLock = frame->lock();
    lock.lock();
    noGil.acquire(); // Not sure we need this
 

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -21,9 +21,11 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/utilities/StreamUnZip.h>
 #include <rogue/GeneralError.h>
+#include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
 #include <bzlib.h>
 
@@ -48,7 +50,10 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
    ris::Frame::BufferIterator rBuff;
    ris::Frame::BufferIterator wBuff;
    int32_t ret;
-   
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
+
    // First request a new frame of the same size
    ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true);
 

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -21,9 +21,11 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/utilities/StreamZip.h>
 #include <rogue/GeneralError.h>
+#include <rogue/GilRelease.h>
 #include <boost/make_shared.hpp>
 #include <bzlib.h>
 
@@ -49,7 +51,10 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    ris::Frame::BufferIterator wBuff;
    bool done;
    int32_t ret;
-   
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr lock = frame->lock();
+
    // First request a new frame of the same size
    ris::FramePtr newFrame = this->reqFrame(frame->getPayload(),true);
 


### PR DESCRIPTION
I have created two classes, FrameLock and TransactionLock which are used to lock Frame data and Transaction data respectively. The transaction lock was always required, but in a less convenient form, and adding a Frame data lock allows us to make less assumptions on how Frame data is processed and stored, opening up the possibility of frame data queues.

The lock can be gained in a c++ process:
````
ris::FrameLockPtr flock = frame->lock()
rim::TransactionLockPtr tlock = transaction->lock()
````
or in python:
````
flock = frame.lock()
tlock = transaction.lock()
````
The lock will be removed when the lock container goes out of scope. Both lock classes have an unlock and lock method for turning the lock off and on as needed. Both transaction and frame locking is done properly in internal classes now.