### PR TITLE
Add big-endian integer and floating-point Models

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -335,9 +335,9 @@ class Device(pr.Node,rim.Hub):
             if isinstance(data, bytearray):
                 ldata = data
             elif isinstance(data, collections.Iterable):
-                ldata = b''.join(base.mask(base.toBytes(word, wordBitSize), wordBitSize) for word in data)
+                ldata = b''.join(base.toBytes(word, wordBitSize) for word in data)
             else:
-                ldata = base.mask(base.toBytes(data, wordBitSize), wordBitSize)
+                ldata = base.toBytes(data, wordBitSize)
 
         else:
             if data is not None:
@@ -375,9 +375,9 @@ class Device(pr.Node,rim.Hub):
 
                 if self._getError() == 0:
                     if numWords == 1:
-                        return base.fromBytes(base.mask(ldata, wordBitSize),wordBitSize)
+                        return base.fromBytes(ldata, wordBitSize)
                     else:
-                        return [base.fromBytes(base.mask(ldata[i:i+stride], wordBitSize),wordBitSize) for i in range(0, len(ldata), stride)]
+                        return [base.fromBytes(ldata[i:i+stride], wordBitSize) for i in range(0, len(ldata), stride)]
                 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -25,36 +25,11 @@ def wordCount(bits, wordSize):
 def byteCount(bits):
     return wordCount(bits, 8)
 
-# class ModelMeta(type):
-#     def __init__(cls, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         cls.cache = {}
 
-#     def __call__(cls, *args, **kwargs):
-#         key = str(args) + str(kwargs)
-#         if key not in cls.cache:
-#             inst = super().__call__(*args, **kwargs)
-#             cls.cache[key] = inst
-#         return cls.cache[key]
-
-# # Python magic so that only one instance of each Model 
-# # with a specific set of args is ever created
-# class Model(metaclass=ModelMeta):
-#     pass
 class Model(object):
 
-#     @staticmethod
-#     def getMask(bitSize):
-#         # For now all models are little endian so we can get away with this
-#         i = (2**bitSize-1)
-#         return i.to_bytes(byteCount(bitSize), 'little', signed=False)
-
-    @classmethod
-    def mask(cls, ba, bitSize):
-        #m = cls.getMask(bitSize)
-        #for i in range(len(ba)):
-            #ba[i] = ba[i] & m[i]
-        return ba
+    defaultdisp = '{:#x}'
+    pytype = int
 
 @Pyro4.expose   
 class UInt(Model):

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -69,7 +69,7 @@ class Int(UInt):
     defaultdisp = '{:d}'
     signed = True
 
-    @clasmethod
+    @classmethod
     def toBytes(cls, value, bitSize):
         if (value < 0) and (bitSize < (byteCount(bitSize) * 8)):
             newValue = value & (2**(bitSize)-1) # Strip upper bits
@@ -175,7 +175,7 @@ class Float(Model):
 
     @classmethod
     def check(cls,value,bitSize):
-        return (type(val) == cls.pytype) and (bitSize = cls.size)
+        return (type(val) == cls.pytype) and (bitSize == cls.size)
 
     @classmethod
     def toBytes(cls, value, bitSize):


### PR DESCRIPTION
**This PR is an alternative to https://github.com/slaclab/rogue/pull/190. Here we would just add big-endian support but not fixed-point support.**

This PR adds the following new Models:
 * UIntBE - Unsigned big-endian integer
 * IntBe - Signed big-endian integer
 * Float - Existed before but is now explicitly 32-bits
 * Double - An 64-bit float (little-endian)
 * FloatBE - A big-endian Float
 * DoubleBE - a big-endian Double

It also removes Model.mask(), which wasn't doing anything.

This hasn't been tested yet.