### PR TITLE
Update logging message and address minor issues found when debugging.

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -362,6 +362,7 @@ class Device(pr.Node,rim.Hub):
                 self._waitTransaction(0)
 
                 if self._getError() == 0: return
+                self._log.warning("Retrying raw write transaction")
 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
@@ -378,6 +379,7 @@ class Device(pr.Node,rim.Hub):
                         return base.fromBytes(base.mask(ldata, wordBitSize),wordBitSize)
                     else:
                         return [base.fromBytes(base.mask(ldata[i:i+stride], wordBitSize),wordBitSize) for i in range(0, len(ldata), stride)]
+                self._log.warning("Retrying raw read transaction")
                 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -167,14 +167,19 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
       rogue::GilRelease noGil;
       boost::lock_guard<boost::mutex> lock(mastMtx_);
       slave = slave_;
-
-      gettimeofday(&(tran->startTime_),NULL);
-      timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
       tranMap_[tran->id_] = tran;
    }
 
+   // Initial time update
+   gettimeofday(&(tran->startTime_),NULL);
+   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
+
    log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
    slave->doTransaction(tran);
+
+   // Refresh timer after transaction start
+   gettimeofday(&(tran->startTime_),NULL);
+   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
    return(tran->id_);
 }
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -163,6 +163,9 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
    struct timeval currTime;
    rim::SlavePtr slave;
 
+   gettimeofday(&(tran->startTime_),NULL);
+   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
+
    {
       rogue::GilRelease noGil;
       boost::lock_guard<boost::mutex> lock(mastMtx_);
@@ -170,16 +173,8 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
       tranMap_[tran->id_] = tran;
    }
 
-   // Initial time update
-   gettimeofday(&(tran->startTime_),NULL);
-   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
-
    log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
    slave->doTransaction(tran);
-
-   // Refresh timer after transaction start
-   gettimeofday(&(tran->startTime_),NULL);
-   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
    return(tran->id_);
 }
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -142,6 +142,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 
 //! Frame received at transport interface
 void rpr::Controller::transportRx( ris::FramePtr frame ) {
+
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
    rogue::GilRelease noGil;

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -76,8 +76,6 @@ void rpr::Header::setup_python() {
 
 //! Creator
 rpr::Header::Header(ris::FramePtr frame) {
-   if ( frame->isEmpty() ) 
-      throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
    count_ = 0;
 
@@ -112,6 +110,8 @@ ris::FramePtr rpr::Header::getFrame() {
 //! Verify header contents
 bool rpr::Header::verify() {
    uint8_t size;
+
+   if ( frame_->isEmpty() ) return(false);
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
    uint8_t * data = buff->begin();
@@ -152,6 +152,9 @@ bool rpr::Header::verify() {
 //! Update checksum, set tx time and increment tx count
 void rpr::Header::update() {
    uint8_t size;
+
+   if ( frame_->isEmpty() )
+      throw(rogue::GeneralError("Header::update","Frame is empty!"));
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
    uint8_t * data = buff->begin();

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -167,7 +167,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Check frame size
    if ( (fSize = frame->getPayload()) < 16 ) {
-      log_->info("Got undersize frame size = %i",fSize);
+      log_->warning("Got undersize frame size = %i",fSize);
       return; // Invalid frame, drop it
    }
 
@@ -184,7 +184,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Find Transaction
    if ( (tran = getTransaction(id)) == NULL ) {
-     log_->debug("Invalid ID frame for id=%i",id);
+     log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
    delTransaction(id);
@@ -194,7 +194,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      log_->debug("Transaction expired. Id=%i",id);
+      log_->warning("Transaction expired. Id=%i",id);
       return;
    }
    tIter = tran->begin();

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -177,7 +177,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Check frame size
    if ( (fSize = frame->getPayload()) < HeadLen ) {
-      log_->info("Got undersize frame size = %i",fSize);
+      log_->warning("Got undersize frame size = %i",fSize);
       return; // Invalid frame, drop it
    }
 
@@ -194,7 +194,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Find Transaction
    if ( (tran = getTransaction(id)) == NULL ) {
-     log_->debug("Invalid ID frame for id=%i",id);
+     log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
    delTransaction(tran->id());
@@ -204,7 +204,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      log_->debug("Transaction expired. Id=%i",id);
+      log_->warning("Transaction expired. Id=%i",id);
       return;
    }
    tIter = tran->begin();


### PR DESCRIPTION
In the process of debugging ESROGUE-199, I found some areas for improvement.

1. Change some logging messages from info to warning.
2. Avoid throwing exception when bad data frames are received in RSSI.
3. Set transaction start timer earlier, and outside of master lock.
4. Properly count dropped frames that come out of sequence in RSSI.