### PR TITLE
Optimize variable update processing

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -161,7 +161,7 @@ class LocalBlock(BaseBlock):
     def stale(self):
         return False
 
-    def set(self, value):
+    def set(self, var, value):
         with self._lock:
             changed = self._value != value
             self._value = value
@@ -174,7 +174,7 @@ class LocalBlock(BaseBlock):
 
                 pr.varFuncHelper(self._localSet, pargs, self._log, self._variable.path)
 
-    def get(self):
+    def get(self, var):
         if self._localGet is not None:
             with self._lock:
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -186,7 +186,7 @@ class LocalBlock(BaseBlock):
         return self._value
 
     def updated(self):
-        self._variable.updated()
+        self._variable._queueUpdate()
 
 
 class RemoteBlock(BaseBlock, rim.Master):
@@ -470,7 +470,7 @@ class RemoteBlock(BaseBlock, rim.Master):
     def updated(self):
         self._log.debug(f'Block {self._name} _update called')
         for v in self._variables:
-            v.updated()
+            v._queueUpdate()
 
         
 def setBitToBytes(ba, bitOffset, value):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -79,9 +79,8 @@ class EnableVariable(pr.BaseVariable):
             if old != value and old != 'parent' and old != 'deps':
                 self.parent.enableChanged(value)
 
-        root._startUpdate()
-        self._queueUpdate()
-        root._doneUpdate()
+        with parent_.root._trackUpdates:
+            self._queueUpdate()
 
     def _rootAttached(self,parent,root):
         pr.Node._rootAttached(self,parent,root)
@@ -305,20 +304,18 @@ class Device(pr.Node,rim.Hub):
         """Check errors in all blocks and generate variable update nofifications"""
         self._log.debug(f'Calling {self.path}._checkBlocks')
 
-        self._root._startUpdate()
+        with self._root._trackUpdates:
 
-        # Process local blocks
-        if variable is not None:
-            variable._block._checkTransaction()
-        else:
-            for block in self._blocks:
-                block._checkTransaction()
+            # Process local blocks
+            if variable is not None:
+                variable._block._checkTransaction()
+            else:
+                for block in self._blocks:
+                    block._checkTransaction()
 
-            if recurse:
-                for key,value in self.devices.items():
-                        value.checkBlocks(recurse=True)
-
-        self._root._doneUpdate()
+                if recurse:
+                    for key,value in self.devices.items():
+                            value.checkBlocks(recurse=True)
 
     def writeAndVerifyBlocks(self, force=False, recurse=True, variable=None, checkEach=False):
         """Perform a write, verify and check. Usefull for committing any stale variables"""

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -79,7 +79,7 @@ class EnableVariable(pr.BaseVariable):
             if old != value and old != 'parent' and old != 'deps':
                 self.parent.enableChanged(value)
 
-        with parent_.root._trackUpdates:
+        with self.parent.root._trackUpdates():
             self._queueUpdate()
 
     def _rootAttached(self,parent,root):
@@ -304,7 +304,7 @@ class Device(pr.Node,rim.Hub):
         """Check errors in all blocks and generate variable update nofifications"""
         self._log.debug(f'Calling {self.path}._checkBlocks')
 
-        with self._root._trackUpdates:
+        with self._root._trackUpdates():
 
             # Process local blocks
             if variable is not None:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -79,7 +79,7 @@ class EnableVariable(pr.BaseVariable):
             if old != value and old != 'parent' and old != 'deps':
                 self.parent.enableChanged(value)
 
-        with self.parent.root._trackUpdates():
+        with self.parent.root.updateGroup():
             self._queueUpdate()
 
     def _rootAttached(self,parent,root):
@@ -304,7 +304,7 @@ class Device(pr.Node,rim.Hub):
         """Check errors in all blocks and generate variable update nofifications"""
         self._log.debug(f'Calling {self.path}._checkBlocks')
 
-        with self._root._trackUpdates():
+        with self.root.updateGroup():
 
             # Process local blocks
             if variable is not None:

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -116,7 +116,7 @@ class PollQueue(object):
                     return
 
                 # Start update capture
-                with self._root._trackUpdates:
+                with self._root._trackUpdates():
 
                     # Pop all timed out entries from the queue
                     now = datetime.datetime.now()

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -116,7 +116,7 @@ class PollQueue(object):
                     return
 
                 # Start update capture
-                with self._root._trackUpdates():
+                with self._root.updateGroup():
 
                     # Pop all timed out entries from the queue
                     now = datetime.datetime.now()

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -116,33 +116,30 @@ class PollQueue(object):
                     return
 
                 # Start update capture
-                self._root._startUpdate()
+                with self._root._trackUpdates:
 
-                # Pop all timed out entries from the queue
-                now = datetime.datetime.now()
-                blockEntries = []
-                for entry in self._expiredEntries(now):
-                    self._log.debug(f'Polling Block {entry.block.name}')
-                    blockEntries.append(entry)
+                    # Pop all timed out entries from the queue
+                    now = datetime.datetime.now()
+                    blockEntries = []
+                    for entry in self._expiredEntries(now):
+                        self._log.debug(f'Polling Block {entry.block.name}')
+                        blockEntries.append(entry)
+                        try:
+                            entry.block.startTransaction(rogue.interfaces.memory.Read, check=False)
+                        except Exception as e:
+                            self._log.exception(e)
+
+                        # Update the entry with new read time
+                        entry = entry._replace(readTime=(entry.readTime + entry.interval),
+                                               count=next(self._counter))
+                        # Push the updated entry back into the queue
+                        heapq.heappush(self._pq, entry)
+
                     try:
-                        entry.block.startTransaction(rogue.interfaces.memory.Read, check=False)
+                        for entry in blockEntries:
+                            entry.block._checkTransaction()
                     except Exception as e:
                         self._log.exception(e)
-
-                    # Update the entry with new read time
-                    entry = entry._replace(readTime=(entry.readTime + entry.interval),
-                                           count=next(self._counter))
-                    # Push the updated entry back into the queue
-                    heapq.heappush(self._pq, entry)
-
-                try:
-                    for entry in blockEntries:
-                        entry.block._checkTransaction()
-                except Exception as e:
-                    self._log.exception(e)
-
-                # End update capture
-                self._root._doneUpdate()
 
     def _expiredEntries(self, time=None):
         """An iterator of all entries that expire by a given time. 

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -116,7 +116,7 @@ class PollQueue(object):
                     return
 
                 # Start update capture
-                self._root._initUpdatedVars()
+                self._root._startUpdate()
 
                 # Pop all timed out entries from the queue
                 now = datetime.datetime.now()
@@ -140,8 +140,9 @@ class PollQueue(object):
                         entry.block._checkTransaction()
                 except Exception as e:
                     self._log.exception(e)
+
                 # End update capture
-                self._root._doneUpdatedVars()
+                self._root._doneUpdate()
 
     def _expiredEntries(self, time=None):
         """An iterator of all entries that expire by a given time. 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -299,7 +299,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         quanitty of variables.
         """
         d = yamlToDict(yml)
-        with self._trackUpdates():
+        with self.updateGroup():
 
             for key, value in d.items():
                 if key == self.name:
@@ -375,7 +375,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def _write(self):
         """Write all blocks"""
         self._log.info("Start root write")
-        with self._trackUpdates():
+        with self.updateGroup():
             try:
                 self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
                 self._log.info("Verify root read")
@@ -389,7 +389,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def _read(self):
         """Read all blocks"""
         self._log.info("Start root read")
-        with self._trackUpdates():
+        with self.updateGroup():
             try:
                 self.readBlocks(recurse=True)
                 self._log.info("Check root read")
@@ -434,7 +434,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.SystemLog.updated()
 
     @contextmanager
-    def _trackUpdates(self):
+    def updateGroup(self):
 
         # At wtih call
         with self._updatedLock:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -23,6 +23,7 @@ import Pyro4
 import Pyro4.naming
 import functools as ft
 import time
+from contextlib import contextmanager
 
 class RootLogHandler(logging.Handler):
     """ Class to listen to log entries and add them to syslog variable"""
@@ -415,6 +416,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self.SystemLog.set(value='',write=False)
         self.SystemLog.updated()
 
+    @contextmanager
     def _trackUpdates(self):
 
         # At wtih call

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -92,7 +92,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._updatedVars = {}
 
         # Variable update worker
-        self._updateQueue = queue.Queue(maxsize=100)
+        self._updateQueue = queue.Queue()
         self._updateThread = None
 
         # Init after _updatedLock exists

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -155,10 +155,6 @@ class BaseVariable(pr.Node):
     def dependencies(self):
         return self.__dependencies
 
-    @property
-    def dependents(self):
-        return self.__dependents
-
     def addListener(self, listener):
         """
         Add a listener Variable or function to call when variable changes. 
@@ -176,7 +172,6 @@ class BaseVariable(pr.Node):
         Set the value and write to hardware if applicable
         Writes to hardware are blocking. An error will result in a logged exception.
         """
-
         self._log.debug("{}.set({})".format(self, value))
         try:
             if self._block is not None:
@@ -229,7 +224,7 @@ class BaseVariable(pr.Node):
         except Exception as e:
             self._log.exception(e)
             self._log.error("Error reading value from variable '{}'".format(self.path))
-            return None
+            ret = None
 
         return ret
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -51,6 +51,7 @@ class BaseVariable(pr.Node):
         self._default       = value
         self._pollInterval  = pollInterval
         self.__listeners    = []
+        self.__dependents   = []
         self.__dependencies = []
 
         # Build enum if specified
@@ -153,6 +154,10 @@ class BaseVariable(pr.Node):
     def dependencies(self):
         return self.__dependencies
 
+    @property
+    def dependents(self):
+        return self.__dependents
+
     def addListener(self, listener):
         """
         Add a listener Variable or function to call when variable changes. 
@@ -161,7 +166,7 @@ class BaseVariable(pr.Node):
         The variable, value and display string will be passed as an arg: func(path,value,disp)
         """
         if isinstance(listener, BaseVariable):
-            self.__listeners.append(listener.updated)
+            self.__dependents.append(listener)
         else:
             self.__listeners.append(listener)
 
@@ -182,7 +187,7 @@ class BaseVariable(pr.Node):
         return self.get(read=False)
 
     @Pyro4.expose
-    def updated(self, path=None, value=None, disp=None):
+    def updated(self):
         """Variable has been updated. Inform listeners."""
 
         value = self.value()

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -314,7 +314,7 @@ class BaseVariable(pr.Node):
             return None
 
     def _queueUpdate(self):
-        self._root._queueUpdate(self)
+        self._root._queueUpdates(self)
 
         for var in self.__listeners:
             var._queueUpdate()

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -49,6 +49,7 @@ class BaseVariable(pr.Node):
         self._minimum       = minimum # For base='range'
         self._maximum       = maximum # For base='range'
         self._default       = value
+        self._block         = None
         self._pollInterval  = pollInterval
         self.__listeners    = []
         self.__functions    = []
@@ -171,15 +172,66 @@ class BaseVariable(pr.Node):
 
     @Pyro4.expose
     def set(self, value, write=True):
-        pass
+        """
+        Set the value and write to hardware if applicable
+        Writes to hardware are blocking. An error will result in a logged exception.
+        """
+
+        self._log.debug("{}.set({})".format(self, value))
+        try:
+            if self._block is not None:
+                self._block.set(self, value)
+
+                if write:
+                    self._parent.writeBlocks(force=False, recurse=False, variable=self)
+                    self._parent.verifyBlocks(recurse=False, variable=self)
+                    self._parent.checkBlocks(recurse=False, variable=self)
+
+        except Exception as e:
+            self._log.exception(e)
+            self._log.error("Error setting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
 
     @Pyro4.expose
     def post(self,value):
-        pass
+        """
+        Set the value and write to hardware if applicable using a posted write.
+        This method does not call through parent.writeBlocks(), but rather
+        calls on self._block directly.
+        """
+        self._log.debug("{}.post({})".format(self, value))
+
+        try:
+            if self._block is not None:
+                self._block.set(self, value)
+                self._block.startTransaction(rogue.interfaces.memory.Post, check=True)
+
+        except Exception as e:
+            self._log.exception(e)
+            self._log.error("Error posting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
 
     @Pyro4.expose
     def get(self,read=True):
-        return self._default
+        """ 
+        Return the value after performing a read from hardware if applicable.
+        Hardware read is blocking. An error will result in a logged exception.
+        Listeners will be informed of the update.
+        """
+        try:
+            if self._block is not None:
+                if read:
+                    self._parent.readBlocks(recurse=False, variable=self)
+                    self._parent.checkBlocks(recurse=False, variable=self)
+
+                ret = self._block.get(self)
+            else:
+                ret = None
+
+        except Exception as e:
+            self._log.exception(e)
+            self._log.error("Error reading value from variable '{}'".format(self.path))
+            return None
+
+        return ret
 
     @Pyro4.expose
     def value(self):
@@ -267,8 +319,7 @@ class BaseVariable(pr.Node):
             return None
 
     def _queueUpdate(self):
-        if self._root is not None:
-            self._root._queueUpdate(self)
+        self._root._queueUpdate(self)
 
         for var in self.__listeners:
             var._queueUpdate()
@@ -373,82 +424,6 @@ class RemoteVariable(BaseVariable):
         return self._base
 
     @Pyro4.expose
-    def set(self, value, write=True):
-        """
-        Set the value and write to hardware if applicable
-        Writes to hardware are blocking. An error will result in a logged exception.
-        """
-
-        self._log.debug("{}.set({})".format(self, value))
-        try:
-
-            if self._block is None:
-                raise VariableError("set called before tree is started")
-
-            self._block.set(self, value)
-
-            if write and self._block.mode != 'RO':
-                self._parent.writeBlocks(force=False, recurse=False, variable=self)
-
-                if self._block.mode == 'RW':
-                    self._parent.verifyBlocks(recurse=False, variable=self)
-
-                self._parent.checkBlocks(recurse=False, variable=self)
-
-        except Exception as e:
-            self._log.exception(e)
-            self._log.error("Error setting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
-
-    @Pyro4.expose
-    def post(self,value):
-        """
-        Set the value and write to hardware if applicable using a posted write.
-        This method does not call through parent.writeBlocks(), but rather
-        calls on self._block directly.
-        """
-        self._log.debug("{}.post({})".format(self, value))
-
-        try:
-
-            if self._block is None:
-                raise VariableError("post called before tree is started")
-
-            self._block.set(self, value)
-
-
-            if self._block.mode != 'RO':
-                self._block.startTransaction(rogue.interfaces.memory.Post, check=False)
-                self._block._checkTransaction()
-
-        except Exception as e:
-            self._log.exception(e)
-            self._log.error("Error posting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
-
-    @Pyro4.expose
-    def get(self,read=True):
-        """ 
-        Return the value after performing a read from hardware if applicable.
-        Hardware read is blocking. An error will result in a logged exception.
-        Listeners will be informed of the update.
-        """
-        try:
-            if self._block is None:
-                raise VariableError("get called before tree is started")
-
-            if read and self._block.mode != 'WO':
-                self._parent.readBlocks(recurse=False, variable=self)
-                self._parent.checkBlocks(recurse=False, variable=self)
-
-            ret = self._block.get(self)
-
-        except Exception as e:
-            self._log.exception(e)
-            self._log.error("Error reading value from variable '{}'".format(self.path))
-            return None
-
-        return ret
-
-    @Pyro4.expose
     def parseDisp(self, sValue):
         if sValue is None or isinstance(sValue, self.nativeType()):
             return sValue
@@ -505,36 +480,6 @@ class LocalVariable(BaseVariable):
                               pollInterval=pollInterval)
 
         self._block = pr.LocalBlock(variable=self,localSet=localSet,localGet=localGet,value=self._default)
-
-        
-    @Pyro4.expose
-    def set(self, value, write=True):
-        try:
-            self._block.set(value)
-
-        except Exception as e:
-            self._log.exception(e)
-
-        if write: self._queueUpdate()
-
-    def __set__(self, value):
-        self.set(value, write=False)
-
-    @Pyro4.expose
-    def post(self,value):
-        self.set(self, value)
-
-    @Pyro4.expose
-    def get(self,read=True):
-        try:
-            ret = self._block.get()
-
-        except Exception as e:
-            self._log.exception(e)
-            return None
-
-        if read: self._queueUpdate()
-        return ret
 
     def __get__(self):
         return self.get(read=False)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -329,7 +329,7 @@ class BaseVariable(pr.Node):
             else:
                 func(self.path,value,disp)
 
-        return value,disp
+        return self.path,value,disp
 
 
 @Pyro4.expose


### PR DESCRIPTION
This change provides an interface to group variable updates into blocks, with overlap detection in order to minimize the redundant calls to each variable's update listener.

Anytime a variable is written or read a update tracker is created which keeps track of the variables that will need an update notification as a result. After the operation is completed, the update list is handed to a worker thread which will calls the associated update functions for each variable in the list. 

Users may also further limit the update rate by grouping updates outside of a series of calls:

````
with self.root.updateGroup():
     var1.set(value1)
     var2.set(value2)
     var1.set(value3)
````
