### PR TITLE
Add stop call to RSSI

### DIFF
--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -82,6 +82,9 @@ namespace rogue {
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 
+               //! Stop connection
+               void stop();
+
          };
 
          // Convienence

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -78,6 +78,9 @@ namespace rogue {
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 
+               //! Stop
+               void stop();
+
          };
 
          // Convienence

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -85,3 +85,5 @@ class UdpRssiPack(pr.Device):
     def getRssiBusy(self,dev=None,cmd=None):
         return(self._rssi.getBusy())
 
+    def stop(self):
+        self._rssi.stop()

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -46,6 +46,7 @@ void rpr::Client::setup_python() {
       .def("getDropCount",   &rpr::Client::getDropCount)
       .def("getRetranCount", &rpr::Client::getRetranCount)
       .def("getBusy",        &rpr::Client::getBusy)
+      .def("stop",           &rpr::Client::stop)
    ;
 
 }
@@ -105,3 +106,7 @@ void rpr::Client::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
 }
 
+//! Send reset
+void rpr::Client::stop() {
+   return(cntl_->stop());
+}

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -42,6 +42,7 @@ void rpr::Server::setup_python() {
       .def("getDropCount",   &rpr::Server::getDropCount)
       .def("getRetranCount", &rpr::Server::getRetranCount)
       .def("getBusy",        &rpr::Server::getBusy)
+      .def("stop",           &rpr::Server::stop)
    ;
 
 }
@@ -99,5 +100,10 @@ bool rpr::Server::getBusy() {
 //! Set timeout for frame transmits in microseconds
 void rpr::Server::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
+}
+
+//! Send reset
+void rpr::Server::stop() {
+   return(cntl_->stop());
 }
 


### PR DESCRIPTION
Add stop call to RSSI. This ensures that the server is put into the reset state before the client disconnects.

The following line will need to be added to the "stop" method of the custom root class or at the end of the python script:

````
rudp.stop()
````