### PR TITLE
Add QT5 support

### DIFF
--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -62,10 +62,6 @@ class GuiTop(QWidget):
         self.newTree.connect(self.var.addTree)
         self.newTree.connect(self.cmd.addTree)
 
-        #self.connect(self.newTree,self._addTree)
-        #self.connect(self.newTree,self.var.addTree)
-        #self.connect(self.newTree,self.cmd.addTree)
-
         self._appTop = None
 
     def addTree(self,root):

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -22,7 +22,7 @@ try:
     from PyQt5.QtWidgets import *
     from PyQt5.QtCore    import *
     from PyQt5.QtGui     import *
-except:
+except ImportError:
     from PyQt4.QtCore    import *
     from PyQt4.QtGui     import *
 

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -18,8 +18,13 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 import pyrogue.gui
@@ -30,7 +35,12 @@ import threading
 import sys
 
 
+def application(argv):
+    return QApplication(argv)
+
 class GuiTop(QWidget):
+
+    newTree = pyqtSignal(pyrogue.Root)
 
     def __init__(self,*, group,parent=None):
         super(GuiTop,self).__init__(parent)
@@ -48,17 +58,22 @@ class GuiTop(QWidget):
         self.tab.addTab(self.cmd,'Commands')
         self.show()
 
-        self.connect(self,SIGNAL('newTree'),self._addTree)
-        self.connect(self,SIGNAL('newTree'),self.var.addTree)
-        self.connect(self,SIGNAL('newTree'),self.cmd.addTree)
+        self.newTree.connect(self._addTree)
+        self.newTree.connect(self.var.addTree)
+        self.newTree.connect(self.cmd.addTree)
+
+        #self.connect(self.newTree,self._addTree)
+        #self.connect(self.newTree,self.var.addTree)
+        #self.connect(self.newTree,self.cmd.addTree)
 
         self._appTop = None
 
     def addTree(self,root):
         if not root.running:
             raise Exception("GUI can not be attached to a tree which is not started")
-        self.emit(SIGNAL("newTree"),root)
+        self.newTree.emit(root)
 
+    @pyqtSlot(pyrogue.Root)
     def _addTree(self,root):
         self.sys = pyrogue.gui.system.SystemWidget(root=root,parent=self.tab)
         self.tab.addTab(self.sys,root.name)

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -22,7 +22,7 @@ try:
     from PyQt5.QtWidgets import *
     from PyQt5.QtCore    import *
     from PyQt5.QtGui     import *
-except:
+except ImportError:
     from PyQt4.QtCore    import *
     from PyQt4.QtGui     import *
 

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -18,8 +18,13 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 
@@ -42,6 +47,8 @@ class CommandDev(object):
             self._widget.setExpanded(False)
             self._tree.itemExpanded.connect(self.expandCb)
 
+
+    @pyqtSlot()
     def expandCb(self):
         if self._dummy is None or not self._widget.isExpanded():
             return
@@ -104,6 +111,7 @@ class CommandLink(QObject):
 
             self._tree.setItemWidget(self._item,3,self._widget)
 
+    @pyqtSlot()
     def execPressed(self):
         if self._widget is not None:
             value = str(self._widget.text())
@@ -143,6 +151,7 @@ class CommandWidget(QWidget):
 
         self.devTop = None
 
+    @pyqtSlot(pyrogue.Root)
     def addTree(self,root):
         self.roots.append(root)
         self._devTop = CommandDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -22,7 +22,7 @@ try:
     from PyQt5.QtWidgets import *
     from PyQt5.QtCore    import *
     from PyQt5.QtGui     import *
-except:
+except ImportError:
     from PyQt4.QtCore    import *
     from PyQt4.QtGui     import *
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -421,7 +421,7 @@ class SystemWidget(QWidget):
         name = path.split('.')[-1]
 
         if name == 'SystemLog':
-            self.updateLog(disp)
+            self.updateLog.emit(disp)
 
     @pyqtSlot()
     def hardReset(self):
@@ -439,7 +439,7 @@ class SystemWidget(QWidget):
     def loadSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
-        dlg.setFilter('Config Files (*.yml)')
+        dlg.setNameFilter('Config Files (*.yml)')
 
         if dlg.exec_():
             loadFile = str(dlg.selectedFiles()[0])
@@ -449,7 +449,7 @@ class SystemWidget(QWidget):
     def saveSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
-        dlg.setFilter('Config Files (*.yml)')
+        dlg.setNameFilter('Config Files (*.yml)')
 
         if dlg.exec_():
             saveFile = str(dlg.selectedFiles()[0])

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -18,13 +18,25 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 import Pyro4
 
 class DataLink(QObject):
+
+    updateDataFile   = pyqtSignal(str)
+    updateOpenState  = pyqtSignal(int)
+    updateBufferSize = pyqtSignal(str)
+    updateMaxSize    = pyqtSignal(str)
+    updateFileSize   = pyqtSignal(str)
+    updateFrameCount = pyqtSignal(str)
 
     def __init__(self,*,layout,writer):
         QObject.__init__(self)
@@ -48,7 +60,9 @@ class DataLink(QObject):
         self.dataFile.setText(self.writer.dataFile.valueDisp())
         self.dataFile.textEdited.connect(self.dataFileEdited)
         self.dataFile.returnPressed.connect(self.dataFileChanged)
-        self.connect(self,SIGNAL('updateDataFile'),self.dataFile.setText)
+
+        #self.updateDataFile.connect(self.dataFile.setText)
+        self.connect(self.updateDataFile,self.dataFile.setText)
 
         fl.addRow('Data File:',self.dataFile)
 
@@ -67,7 +81,9 @@ class DataLink(QObject):
         self.openState.addItem('True')
         self.openState.setCurrentIndex(0)
         self.openState.activated.connect(self.openStateChanged)
-        self.connect(self,SIGNAL('updateOpenState'),self.openState.setCurrentIndex)
+
+        #self.updateOpenState.connect(self.openState.setCurrentIndex)
+        self.connect(self.updateOpenState,self.openState.setCurrentIndex)
 
         fl.addRow('File Open:',self.openState)
 
@@ -76,7 +92,9 @@ class DataLink(QObject):
         self.bufferSize.setText(self.writer.bufferSize.valueDisp())
         self.bufferSize.textEdited.connect(self.bufferSizeEdited)
         self.bufferSize.returnPressed.connect(self.bufferSizeChanged)
-        self.connect(self,SIGNAL('updateBufferSize'),self.bufferSize.setText)
+
+        #self.updateBufferSize.connect(self.bufferSize.setText)
+        self.connect(self.updateBufferSize,self.bufferSize.setText)
 
         fl.addRow('Buffer Size:',self.bufferSize)
 
@@ -84,7 +102,9 @@ class DataLink(QObject):
         self.totSize = QLineEdit()
         self.totSize.setText(self.writer.fileSize.valueDisp())
         self.totSize.setReadOnly(True)
-        self.connect(self,SIGNAL('updateFileSize'),self.totSize.setText)
+
+        #self.updateFileSize.connect(self.totSize.setText)
+        self.connect(self.updateFileSize,self.totSize.setText)
 
         fl.addRow('Total File Size:',self.totSize)
 
@@ -106,7 +126,9 @@ class DataLink(QObject):
         self.maxSize.setText(self.writer.maxFileSize.valueDisp())
         self.maxSize.textEdited.connect(self.maxSizeEdited)
         self.maxSize.returnPressed.connect(self.maxSizeChanged)
-        self.connect(self,SIGNAL('updateMaxSize'),self.maxSize.setText)
+
+        #self.updateMaxSize.connect(self.maxSize.setText)
+        self.connect(self.updateMaxSize,self.maxSize.setText)
 
         fl.addRow('Max Size:',self.maxSize)
 
@@ -114,7 +136,9 @@ class DataLink(QObject):
         self.frameCount = QLineEdit()
         self.frameCount.setText(self.writer.frameCount.valueDisp())
         self.frameCount.setReadOnly(True)
-        self.connect(self,SIGNAL('updateFrameCount'),self.frameCount.setText)
+
+        #self.updateFrameCount.connect(self.frameCount.setText)
+        self.connect(updateFrameCount,self.frameCount.setText)
 
         fl.addRow('Frame Count:',self.frameCount)
 
@@ -139,29 +163,31 @@ class DataLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'dataFile':
-            self.emit(SIGNAL("updateDataFile"),disp)
+            self.emit.updateDataFile(disp)
 
         elif name == 'open':
-            self.emit(SIGNAL("updateOpenState"),self.openState.findText(disp))
+            self.emit.updateOpenState(self.openState.findText(disp))
 
         elif name == 'bufferSize':
-            self.emit(SIGNAL("updateBufferSize"),disp)
+            self.emit.updateBufferSize(disp)
 
         elif name == 'maxFileSize':
-            self.emit(SIGNAL("updateMaxSize"),disp)
+            self.emit.updateMaxSize(disp)
 
         elif name == 'fileSize':
-            self.emit(SIGNAL("updateFileSize"),disp)
+            self.emit.updateFileSize(disp)
 
         elif name == 'frameCount':
-            self.emit(SIGNAL("updateFrameCount"),disp)
+            self.emit.updateFrameCount(disp)
 
+    @pyqtSlot()
     def dataFileEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.dataFile.setPalette(p)
 
+    @pyqtSlot()
     def dataFileChanged(self):
         p = QPalette()
         self.dataFile.setPalette(p)
@@ -170,17 +196,20 @@ class DataLink(QObject):
         self.writer.dataFile.setDisp(self.dataFile.text())
         self.block = False
 
+    @pyqtSlot(int)
     def openStateChanged(self,value):
         self.block = True
         self.writer.open.setDisp(self.openState.itemText(value))
         self.block = False
 
+    @pyqtSlot()
     def bufferSizeEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.bufferSize.setPalette(p)
 
+    @pyqtSlot()
     def bufferSizeChanged(self):
         p = QPalette()
         self.bufferSize.setPalette(p)
@@ -189,12 +218,14 @@ class DataLink(QObject):
         self.writer.bufferSize.setDisp(self.bufferSize.text())
         self.block = False
 
+    @pyqtSlot()
     def maxSizeEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.maxSize.setPalette(p)
 
+    @pyqtSlot()
     def maxSizeChanged(self):
         p = QPalette()
         self.maxSize.setPalette(p)
@@ -205,6 +236,10 @@ class DataLink(QObject):
 
 
 class ControlLink(QObject):
+
+    updateState = pyqtSignal(int)
+    updateRate  = pyqtSignal(int)
+    updateCount = pyqtSignal(str)
 
     def __init__(self,*,layout,control):
         QObject.__init__(self)
@@ -226,7 +261,7 @@ class ControlLink(QObject):
         self.control.runRate.addListener(self)
         self.runRate = QComboBox()
         self.runRate.activated.connect(self.runRateChanged)
-        self.connect(self,SIGNAL('updateRate'),self.runRate.setCurrentIndex)
+        self.updateRate.connect(self.runRate.setCurrentIndex)
         for key in sorted(self.control.runRate.enum):
             self.runRate.addItem(self.control.runRate.enum[key])
         self.runRate.setCurrentIndex(self.runRate.findText(self.control.runRate.valueDisp()))
@@ -245,7 +280,7 @@ class ControlLink(QObject):
         self.control.runState.addListener(self)
         self.runState = QComboBox()
         self.runState.activated.connect(self.runStateChanged)
-        self.connect(self,SIGNAL('updateState'),self.runState.setCurrentIndex)
+        self.updateState.connect(self.runState.setCurrentIndex)
         for key in sorted(self.control.runState.enum):
             self.runState.addItem(self.control.runState.enum[key])
         self.runState.setCurrentIndex(self.runState.findText(self.control.runState.valueDisp()))
@@ -262,7 +297,7 @@ class ControlLink(QObject):
         self.runCount = QLineEdit()
         self.runCount.setText(self.control.runCount.valueDisp())
         self.runCount.setReadOnly(True)
-        self.connect(self,SIGNAL('updateCount'),self.runCount.setText)
+        self.updateCount.connect(self.runCount.setText)
 
         fl.addRow('Run Count:',self.runCount)
 
@@ -273,19 +308,21 @@ class ControlLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'runState':
-            self.emit(SIGNAL("updateState"),self.runState.findText(disp))
+            self.emit.updateState(self.runState.findText(disp))
 
         elif name == 'runRate':
-            self.emit(SIGNAL("updateRate"),self.runRate.findText(disp))
+            self.emit.updateRate(self.runRate.findText(disp))
 
         elif name == 'runCount':
-            self.emit(SIGNAL("updateCount"),disp)
+            self.emit.updateCount(disp)
 
+    @pyqtSlot(int)
     def runStateChanged(self,value):
         self.block = True
         self.control.runState.setDisp(self.runState.itemText(value))
         self.block = False
 
+    @pyqtSlot(int)
     def runRateChanged(self,value):
         self.block = True
         self.control.runRate.setDisp(self.runRate.itemText(value))
@@ -293,6 +330,9 @@ class ControlLink(QObject):
 
 
 class SystemWidget(QWidget):
+
+    updateLog = pyqtSignal(str)
+
     def __init__(self, *, root, parent=None):
         super(SystemWidget, self).__init__(parent)
 
@@ -363,7 +403,7 @@ class SystemWidget(QWidget):
         vb.addWidget(self.systemLog)
 
         root.SystemLog.addListener(self)
-        self.connect(self,SIGNAL('updateLog'),self.systemLog.setText)
+        self.updateLog.connect(self.systemLog.setText)
         self.systemLog.setText(root.SystemLog.valueDisp())
         
         pb = QPushButton('Clear Log')
@@ -372,6 +412,7 @@ class SystemWidget(QWidget):
 
         QCoreApplication.processEvents()
 
+    @pyqtSlot()
     def resetLog(self):
         self.root.ClearLog()
 
@@ -380,17 +421,21 @@ class SystemWidget(QWidget):
         name = path.split('.')[-1]
 
         if name == 'SystemLog':
-            self.emit(SIGNAL("updateLog"),disp)
+            self.updateLog(disp)
 
+    @pyqtSlot()
     def hardReset(self):
         self.root.HardReset()
 
+    @pyqtSlot()
     def softReset(self):
         self.root.SoftReset()
 
+    @pyqtSlot()
     def countReset(self):
         self.root.CountReset()
 
+    @pyqtSlot()
     def loadSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
@@ -400,6 +445,7 @@ class SystemWidget(QWidget):
             loadFile = str(dlg.selectedFiles()[0])
             self.root.ReadConfig(loadFile)
 
+    @pyqtSlot()
     def saveSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
@@ -408,9 +454,4 @@ class SystemWidget(QWidget):
         if dlg.exec_():
             saveFile = str(dlg.selectedFiles()[0])
             self.root.WriteConfig(saveFile)
-
-
-
-
-
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -61,8 +61,7 @@ class DataLink(QObject):
         self.dataFile.textEdited.connect(self.dataFileEdited)
         self.dataFile.returnPressed.connect(self.dataFileChanged)
 
-        #self.updateDataFile.connect(self.dataFile.setText)
-        self.connect(self.updateDataFile,self.dataFile.setText)
+        self.updateDataFile.connect(self.dataFile.setText)
 
         fl.addRow('Data File:',self.dataFile)
 
@@ -82,8 +81,7 @@ class DataLink(QObject):
         self.openState.setCurrentIndex(0)
         self.openState.activated.connect(self.openStateChanged)
 
-        #self.updateOpenState.connect(self.openState.setCurrentIndex)
-        self.connect(self.updateOpenState,self.openState.setCurrentIndex)
+        self.updateOpenState.connect(self.openState.setCurrentIndex)
 
         fl.addRow('File Open:',self.openState)
 
@@ -93,8 +91,7 @@ class DataLink(QObject):
         self.bufferSize.textEdited.connect(self.bufferSizeEdited)
         self.bufferSize.returnPressed.connect(self.bufferSizeChanged)
 
-        #self.updateBufferSize.connect(self.bufferSize.setText)
-        self.connect(self.updateBufferSize,self.bufferSize.setText)
+        self.updateBufferSize.connect(self.bufferSize.setText)
 
         fl.addRow('Buffer Size:',self.bufferSize)
 
@@ -103,8 +100,7 @@ class DataLink(QObject):
         self.totSize.setText(self.writer.fileSize.valueDisp())
         self.totSize.setReadOnly(True)
 
-        #self.updateFileSize.connect(self.totSize.setText)
-        self.connect(self.updateFileSize,self.totSize.setText)
+        self.updateFileSize.connect(self.totSize.setText)
 
         fl.addRow('Total File Size:',self.totSize)
 
@@ -127,8 +123,7 @@ class DataLink(QObject):
         self.maxSize.textEdited.connect(self.maxSizeEdited)
         self.maxSize.returnPressed.connect(self.maxSizeChanged)
 
-        #self.updateMaxSize.connect(self.maxSize.setText)
-        self.connect(self.updateMaxSize,self.maxSize.setText)
+        self.updateMaxSize.connect(self.maxSize.setText)
 
         fl.addRow('Max Size:',self.maxSize)
 
@@ -137,8 +132,7 @@ class DataLink(QObject):
         self.frameCount.setText(self.writer.frameCount.valueDisp())
         self.frameCount.setReadOnly(True)
 
-        #self.updateFrameCount.connect(self.frameCount.setText)
-        self.connect(updateFrameCount,self.frameCount.setText)
+        self.updateFrameCount.connect(self.frameCount.setText)
 
         fl.addRow('Frame Count:',self.frameCount)
 

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -167,7 +167,8 @@ class VariableLink(QObject):
         self._inEdit = False
         self.updateGui.emit(self._variable.valueDisp())
 
-    @pyqtSlot()
+    @pyqtSlot(int)
+    @pyqtSlot(str)
     def guiChanged(self, value):
         if self._swSet:
             return

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -22,7 +22,7 @@ try:
     from PyQt5.QtWidgets import *
     from PyQt5.QtCore    import *
     from PyQt5.QtGui     import *
-except:
+except ImportError:
     from PyQt4.QtCore    import *
     from PyQt4.QtGui     import *
 

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -18,8 +18,13 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 import Pyro4
@@ -44,6 +49,7 @@ class VariableDev(object):
             self._widget.setExpanded(False)
             self._tree.itemExpanded.connect(self.expandCb)
 
+    @pyqtSlot()
     def expandCb(self):
         if self._dummy is None or not self._widget.isExpanded():
             return
@@ -69,6 +75,8 @@ class VariableDev(object):
 class VariableLink(QObject):
     """Bridge between the pyrogue tree and the display element"""
 
+    updateGui = pyqtSignal([int],[str])
+
     def __init__(self,*,tree,parent,variable):
         QObject.__init__(self)
         self._variable = variable
@@ -90,8 +98,9 @@ class VariableLink(QObject):
         if self._variable.disp == 'enum' and self._variable.enum is not None and self._variable.mode != 'RO':
             self._widget = QComboBox()
             self._widget.activated.connect(self.guiChanged)
-            self.connect(self,SIGNAL('updateGui'),self._widget.setCurrentIndex)
             self._widget.setToolTip(self._variable.description)
+
+            self.updateGui.connect(self._widget.setCurrentIndex)
 
             for i in self._variable.enum:
                 self._widget.addItem(self._variable.enum[i])
@@ -101,15 +110,17 @@ class VariableLink(QObject):
             self._widget.setMinimum(self._variable.minimum)
             self._widget.setMaximum(self._variable.maximum)
             self._widget.valueChanged.connect(self.guiChanged)
-            self.connect(self,SIGNAL('updateGui'),self._widget.setValue)
             self._widget.setToolTip(self._variable.description)
+
+            self.updateGui.connect(self._widget.setValue)
 
         else:
             self._widget = QLineEdit()
             self._widget.returnPressed.connect(self.returnPressed)
             self._widget.textEdited.connect(self.valueChanged)
-            self.connect(self,SIGNAL('updateGui'),self._widget.setText)
             self._widget.setToolTip(self._variable.description)
+
+            self.updateGui[str].connect(self._widget.setText)
 
         if self._variable.mode == 'RO':
             self._widget.setReadOnly(True)
@@ -121,7 +132,6 @@ class VariableLink(QObject):
 
     @Pyro4.expose
     def varListener(self, path, value, disp):
-        #print('{} varListener ( {} {} )'.format(self.variable, type(value), value))
         with self._lock:
             if self._widget is None or self._inEdit is True:
                 return
@@ -130,16 +140,17 @@ class VariableLink(QObject):
 
             if isinstance(self._widget, QComboBox):
                 if self._widget.currentIndex() != self._widget.findText(disp):
-                    self.emit(SIGNAL("updateGui"), self._widget.findText(disp))
+                    self.updateGui.emit(self._widget.findText(disp))
             elif isinstance(self._widget, QSpinBox):
                 if self._widget.value != value:
-                    self.emit(SIGNAL("updateGui"), value)
+                    self.updateGui.emit(value)
             else:
                 if self._widget.text() != disp:
-                    self.emit(SIGNAL("updateGui"), disp)
+                    self.updateGui[str].emit(disp)
 
             self._swSet = False
 
+    @pyqtSlot()
     def valueChanged(self):
         self._inEdit = True
         p = QPalette()
@@ -147,14 +158,16 @@ class VariableLink(QObject):
         p.setColor(QPalette.Text,Qt.black)
         self._widget.setPalette(p)
 
+    @pyqtSlot()
     def returnPressed(self):
         p = QPalette()
         self._widget.setPalette(p)
 
         self.guiChanged(self._widget.text())
         self._inEdit = False
-        self.emit(SIGNAL("updateGui"), self._variable.valueDisp())
+        self.updateGui.emit(self._variable.valueDisp())
 
+    @pyqtSlot()
     def guiChanged(self, value):
         if self._swSet:
             return
@@ -197,10 +210,12 @@ class VariableWidget(QWidget):
 
         self.devTop = None
 
+    @pyqtSlot(pyrogue.Root)
     def addTree(self,root):
         self.roots.append(root)
         self.devTop = VariableDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)
 
+    @pyqtSlot()
     def readPressed(self):
         for root in self.roots:
             root.ReadAll()


### PR DESCRIPTION
This PR changes the GUI code to use proper signal/slot generation and calls. This allows both QT4 and QT5 to be supported in the same code. The QT5 import is tried first with a fallback to QT4 if that fails.

In order to simplify the top level GUI code, a wrapper on the QT application class is supported. Existing lines such as:

````
import PyQt4.QtCore
appTop = PyQt4.QtGui.QApplication(sys.arg)
````

Will now be replaced with:

````
appTop = pyrogue.gui.application(sys.argv)
````