### PR TITLE
Add support for conda builds & set min python to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ if (NOT Boost_FOUND)
 endif()
 
 # Find python3
-find_package(PythonInterp 3 REQUIRED)
-find_package(PythonLibs 3 REQUIRED)
+find_package(PythonInterp 3.6 REQUIRED)
+find_package(PythonLibs 3.6 REQUIRED)
 
 message("----------------------------------------------------------------------")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
+# Add support for building in conda environment
+if (DEFINED ENV{CONDA_PREFIX})
+   set(CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+endif()
+
 # Check cmake version
 cmake_minimum_required(VERSION 2.8)
 include(InstallRequiredSystemLibraries)


### PR DESCRIPTION
Add support for building rogue in the conda environment. 

Set min python version to 3.6 in cmake.