### PR TITLE
Release v2.8.0 candidate.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
+# Add support for building in conda environment
+if (DEFINED ENV{CONDA_PREFIX})
+   set(CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+endif()
+
 # Check cmake version
 cmake_minimum_required(VERSION 2.8)
 include(InstallRequiredSystemLibraries)
@@ -50,8 +55,8 @@ if (NOT Boost_FOUND)
 endif()
 
 # Find python3
-find_package(PythonInterp 3 REQUIRED)
-find_package(PythonLibs 3 REQUIRED)
+find_package(PythonInterp 3.6 REQUIRED)
+find_package(PythonLibs 3.6 REQUIRED)
 
 message("----------------------------------------------------------------------")
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ described below.
 ### Optional Packages
 
 ZeroMq is used for some of the python based messaging interface, particularly
-the simulation interfaces. Python QT4 is used for the GUI interface.
+the simulation interfaces. To use the GUI interface you will need to install
+either pyqt5 or pyqt4.
+
 
 On Ubuntu:
 
 ````
 $ apt-get install libzmq-dev
+$ apt-get install python3-pyqt5
 $ apt-get install python3-pyqt4
 ````
 
@@ -87,6 +90,7 @@ On archlinux:
 
 ````
 $ pacman -S zeromq
+$ pacman -S python-pyqt5
 $ pacman -S python-pyqt4
 ````
 

--- a/README.md
+++ b/README.md
@@ -187,12 +187,6 @@ setting up the example projects or some SLAC projects.
 You may want to create a custom setup script to combine the rogue setup with 
 other environmental setups for your project.
 
-### Rogue on Windows 10
-
-Rogue will compile on windows 10 under the windows subsystem for Linux
-envrionment. Once the windows subsystem for Linux is setup the environment
-is the same as Unbuntu.
-
 ### Drivers
 
 Rogue is linked against the aes-stream-drivers package which is included 

--- a/include/rogue/protocols/packetizer/Application.h
+++ b/include/rogue/protocols/packetizer/Application.h
@@ -82,7 +82,7 @@ namespace rogue {
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::Application> ApplicationPtr;
 
       }

--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -98,7 +98,7 @@ namespace rogue {
                void setTimeout(uint32_t timeout);
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::Controller> ControllerPtr;
 
       }

--- a/include/rogue/protocols/packetizer/ControllerV1.h
+++ b/include/rogue/protocols/packetizer/ControllerV1.h
@@ -61,7 +61,7 @@ namespace rogue {
                void applicationRx( boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint8_t id);
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::ControllerV1> ControllerV1Ptr;
 
       }

--- a/include/rogue/protocols/packetizer/ControllerV2.h
+++ b/include/rogue/protocols/packetizer/ControllerV2.h
@@ -66,7 +66,7 @@ namespace rogue {
                void applicationRx( boost::shared_ptr<rogue::interfaces::stream::Frame> frame, uint8_t id);
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::ControllerV2> ControllerV2Ptr;
 
       }

--- a/include/rogue/protocols/packetizer/Core.h
+++ b/include/rogue/protocols/packetizer/Core.h
@@ -71,7 +71,7 @@ namespace rogue {
                void setTimeout(uint32_t timeout);
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::Core> CorePtr;
 
       }

--- a/include/rogue/protocols/packetizer/CoreV2.h
+++ b/include/rogue/protocols/packetizer/CoreV2.h
@@ -70,7 +70,7 @@ namespace rogue {
                void setTimeout(uint32_t timeout);
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::CoreV2> CoreV2Ptr;
 
       }

--- a/include/rogue/protocols/packetizer/Transport.h
+++ b/include/rogue/protocols/packetizer/Transport.h
@@ -65,7 +65,7 @@ namespace rogue {
                void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
          };
 
-         // Convienence
+         // Convenience
          typedef boost::shared_ptr<rogue::protocols::packetizer::Transport> TransportPtr;
 
       }

--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -82,6 +82,9 @@ namespace rogue {
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 
+               //! Stop connection
+               void stop();
+
          };
 
          // Convienence

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -78,6 +78,9 @@ namespace rogue {
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 
+               //! Stop
+               void stop();
+
          };
 
          // Convienence

--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -85,6 +85,9 @@ namespace rogue {
             //! Check payload
             bool       checkPl_;
 
+            //! Send count
+            bool       sendCount_;
+
             //! Logger
             rogue::LoggingPtr rxLog_;
             rogue::LoggingPtr txLog_;
@@ -120,6 +123,9 @@ namespace rogue {
 
             //! Set taps, python
             void setTapsPy(boost::python::object p);
+
+            //! Send counter value
+            void sendCount(bool state);
 
             //! Generate a data frame
             void genFrame (uint32_t size);

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -161,7 +161,7 @@ class LocalBlock(BaseBlock):
     def stale(self):
         return False
 
-    def set(self, value):
+    def set(self, var, value):
         with self._lock:
             changed = self._value != value
             self._value = value
@@ -174,7 +174,7 @@ class LocalBlock(BaseBlock):
 
                 pr.varFuncHelper(self._localSet, pargs, self._log, self._variable.path)
 
-    def get(self):
+    def get(self, var):
         if self._localGet is not None:
             with self._lock:
 
@@ -186,7 +186,7 @@ class LocalBlock(BaseBlock):
         return self._value
 
     def updated(self):
-        self._variable.updated()
+        self._variable._queueUpdate()
 
 
 class RemoteBlock(BaseBlock, rim.Master):
@@ -470,7 +470,7 @@ class RemoteBlock(BaseBlock, rim.Master):
     def updated(self):
         self._log.debug(f'Block {self._name} _update called')
         for v in self._variables:
-            v.updated()
+            v._queueUpdate()
 
         
 def setBitToBytes(ba, bitOffset, value):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -362,6 +362,7 @@ class Device(pr.Node,rim.Hub):
                 self._waitTransaction(0)
 
                 if self._getError() == 0: return
+                self._log.warning("Retrying raw write transaction")
 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
@@ -378,6 +379,7 @@ class Device(pr.Node,rim.Hub):
                         return base.fromBytes(base.mask(ldata, wordBitSize),wordBitSize)
                     else:
                         return [base.fromBytes(base.mask(ldata[i:i+stride], wordBitSize),wordBitSize) for i in range(0, len(ldata), stride)]
+                self._log.warning("Retrying raw read transaction")
                 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -470,7 +470,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.info("Stopping update thread")
                 return
 
-            self._log.info(F"Got update entry. Length={len(vlist)}. Entry={list(vlist.keys())[0]}")
+            self._log.info(F"Got update entry. Length={len(vlist)}.")
 
             for p,v in vlist.items():
                 path,value,disp = v._doUpdate()

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -23,6 +23,8 @@ import Pyro4
 import Pyro4.naming
 import functools as ft
 import time
+import queue
+from contextlib import contextmanager
 
 class RootLogHandler(logging.Handler):
     """ Class to listen to log entries and add them to syslog variable"""
@@ -70,20 +72,28 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         # Keep of list of errors, exposed as a variable
         self._sysLogLock = threading.Lock()
 
-        # Background threads
+        # Running status
+        self._running = False
+
+        # Polling worker
         self._pollQueue = None
-        self._running   = False
 
         # Remote object export
         self._pyroThread = None
         self._pyroDaemon = None
 
-        # Variable update list
-        self._updatedYaml = None
-        self._updatedLock = threading.Lock()
-
-        # Variable update listener
+        # List of variable listeners
         self._varListeners  = []
+        self._varListenLock = threading.Lock()
+
+        # Variable update list
+        self._updatedLock = threading.RLock()
+        self._updatedCnt  = 0
+        self._updatedVars = {}
+
+        # Variable update worker
+        self._updateQueue = queue.Queue()
+        self._updateThread = None
 
         # Init after _updatedLock exists
         pr.Device.__init__(self, name=name, description=description)
@@ -209,6 +219,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         if initWrite:
             self._write()
 
+        # Start update thread
+        self._updateThread = threading.Thread(target=self._updateWorker)
+        self._updateThread.start()
+
         # Start poller if enabled
         if pollEn:
             self._pollQueue._start()
@@ -217,10 +231,14 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     def stop(self):
         """Stop the polling thread. Must be called for clean exit."""
+        self._updateQueue.put(None)
+
         if self._pollQueue:
             self._pollQueue.stop()
+
         if self._pyroDaemon:
             self._pyroDaemon.shutdown()
+
         self._running=False
 
     @Pyro4.expose
@@ -248,10 +266,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         Add a variable update listener function.
         The variable, value and display string will be passed as an arg: func(path,value,disp)
         """
-        self._varListeners.append(func)
+        with self._varListenLock:
+            self._varListeners.append(func)
 
-        if isinstance(func,Pyro4.core.Proxy):                                    
-            func._pyroOneway.add("varListener")                                  
+            if isinstance(func,Pyro4.core.Proxy):                                    
+                func._pyroOneway.add("varListener")                                  
 
     def getYaml(self,readFirst,modes=['RW']):
         """
@@ -280,20 +299,18 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         quanitty of variables.
         """
         d = yamlToDict(yml)
-        self._initUpdatedVars()
+        with self.updateGroup():
 
-        for key, value in d.items():
-            if key == self.name:
-                self._setDict(value,writeEach,modes)
-            else:
-                try:
-                    self._getPath(key).setDisp(value)
-                except:
-                    self._log.error("Entry {} not found".format(key))
+            for key, value in d.items():
+                if key == self.name:
+                    self._setDict(value,writeEach,modes)
+                else:
+                    try:
+                        self._getPath(key).setDisp(value)
+                    except:
+                        self._log.error("Entry {} not found".format(key))
 
-        self._doneUpdatedVars()
-
-        if not writeEach: self._write()
+            if not writeEach: self._write()
 
     @Pyro4.expose
     def get(self,path):
@@ -330,6 +347,26 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         obj = self.getNode(path)
         return obj.call(arg)
 
+    @contextmanager
+    def updateGroup(self):
+
+        # At wtih call
+        with self._updatedLock:
+            self._updatedCnt += 1
+
+            # Return to block within with call
+            try:
+                yield
+            finally:
+
+                # After with is done
+                self._updatedCnt -= 1
+
+                # Done with updates, queue to worker
+                if self._updatedCnt == 0:
+                    self._updateQueue.put(self._updatedVars)
+                    self._updatedVars = {}
+
     def setTimeout(self,timeout):
         """
         Set timeout value on all devices & blocks
@@ -355,42 +392,30 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """
         self._sendYamlFrame(self.getYaml(False,modes))
 
-    def _initUpdatedVars(self):
-        """Initialize the update tracking log before a bulk variable update"""
-        with self._updatedLock:
-            self._updatedYaml = ""
-
-    def _doneUpdatedVars(self):
-        """Stream the results of a bulk variable update and update listeners"""
-        with self._updatedLock:
-            if self._updatedYaml:
-                self._sendYamlFrame(self._updatedYaml)
-                self._updatedYaml = None
-
     def _write(self):
         """Write all blocks"""
         self._log.info("Start root write")
-        try:
-            self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
-            self._log.info("Verify root read")
-            self.verifyBlocks(recurse=True)
-            self._log.info("Check root read")
-            self.checkBlocks(recurse=True)
-        except Exception as e:
-            self._log.exception(e)
+        with self.updateGroup():
+            try:
+                self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
+                self._log.info("Verify root read")
+                self.verifyBlocks(recurse=True)
+                self._log.info("Check root read")
+                self.checkBlocks(recurse=True)
+            except Exception as e:
+                self._log.exception(e)
         self._log.info("Done root write")
 
     def _read(self):
         """Read all blocks"""
         self._log.info("Start root read")
-        self._initUpdatedVars()
-        try:
-            self.readBlocks(recurse=True)
-            self._log.info("Check root read")
-            self.checkBlocks(recurse=True)
-        except Exception as e:
-            self._log.exception(e)
-        self._doneUpdatedVars()
+        with self.updateGroup():
+            try:
+                self.readBlocks(recurse=True)
+                self._log.info("Check root read")
+                self.checkBlocks(recurse=True)
+            except Exception as e:
+                self._log.exception(e)
         self._log.info("Done root read")
 
     def _writeConfig(self,arg):
@@ -428,31 +453,53 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self.SystemLog.set(value='',write=False)
         self.SystemLog.updated()
 
-    def _varUpdated(self,path,value,disp):
-        for func in self._varListeners:
-
-            try:
-
-                if isinstance(func,Pyro4.core.Proxy) or hasattr(func,'varListener'):
-                    func.varListener(path,value,disp)
-                else:
-                    func(path,value,disp)
-
-            except Pyro4.errors.CommunicationError as msg:
-                if 'Connection refused' in str(msg):
-                    self._log.info("Pyro Disconnect. Removing callback")
-                    self._varListeners.remove(func)
-                else:
-                    self._log.error("Pyro callback failed for {}: {}".format(self.name,msg))
-
+    def _queueUpdates(self,var):
         with self._updatedLock:
-            yml = (f"{path}:{disp}" + "\n")
+            self._updatedVars[var.path] = var
 
-            # Log is active add to log
-            if self._updatedYaml is not None: self._updatedYaml += yml
+    # Worker thread
+    def _updateWorker(self):
+        self._log.info("Starting update thread")
 
-            # Otherwise act directly
-            else: self._sendYamlFrame(yml)
+        while True:
+            yml = ""
+            vlist = self._updateQueue.get()
+
+            # Done
+            if vlist is None:
+                self._log.info("Stopping update thread")
+                return
+
+            self._log.info(F"Got update entry. Length={len(vlist)}. Entry={list(vlist.keys())[0]}")
+
+            for p,v in vlist.items():
+                path,value,disp = v._doUpdate()
+
+                # Update yaml string
+                yml += (f"{path}:{disp}" + "\n")
+
+                # Call listener functions, (should this be a list)
+                with self._varListenLock:
+                    for func in self._varListeners:
+                        try:
+
+                            if isinstance(func,Pyro4.core.Proxy) or hasattr(func,'varListener'):
+                                func.varListener(path,value,disp)
+                            else:
+                                func(path,value,disp)
+
+                        except Pyro4.errors.CommunicationError as msg:
+                            if 'Connection refused' in str(msg):
+                                self._log.info("Pyro Disconnect. Removing callback")
+                                self._varListeners.remove(func)
+                            else:
+                                self._log.error("Pyro callback failed for {}: {}".format(self.name,msg))
+
+                # Generate yaml stream
+                self._sendYamlFrame(yml)
+
+            # Set done
+            self._updateQueue.task_done()
 
 
 class PyroRoot(pr.PyroNode):

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -18,8 +18,13 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except ImportError:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 import pyrogue.gui
@@ -30,7 +35,12 @@ import threading
 import sys
 
 
+def application(argv):
+    return QApplication(argv)
+
 class GuiTop(QWidget):
+
+    newTree = pyqtSignal(pyrogue.Root)
 
     def __init__(self,*, group,parent=None):
         super(GuiTop,self).__init__(parent)
@@ -48,17 +58,18 @@ class GuiTop(QWidget):
         self.tab.addTab(self.cmd,'Commands')
         self.show()
 
-        self.connect(self,SIGNAL('newTree'),self._addTree)
-        self.connect(self,SIGNAL('newTree'),self.var.addTree)
-        self.connect(self,SIGNAL('newTree'),self.cmd.addTree)
+        self.newTree.connect(self._addTree)
+        self.newTree.connect(self.var.addTree)
+        self.newTree.connect(self.cmd.addTree)
 
         self._appTop = None
 
     def addTree(self,root):
         if not root.running:
             raise Exception("GUI can not be attached to a tree which is not started")
-        self.emit(SIGNAL("newTree"),root)
+        self.newTree.emit(root)
 
+    @pyqtSlot(pyrogue.Root)
     def _addTree(self,root):
         self.sys = pyrogue.gui.system.SystemWidget(root=root,parent=self.tab)
         self.tab.addTab(self.sys,root.name)

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -18,8 +18,13 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except ImportError:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 
@@ -42,6 +47,8 @@ class CommandDev(object):
             self._widget.setExpanded(False)
             self._tree.itemExpanded.connect(self.expandCb)
 
+
+    @pyqtSlot()
     def expandCb(self):
         if self._dummy is None or not self._widget.isExpanded():
             return
@@ -104,6 +111,7 @@ class CommandLink(QObject):
 
             self._tree.setItemWidget(self._item,3,self._widget)
 
+    @pyqtSlot()
     def execPressed(self):
         if self._widget is not None:
             value = str(self._widget.text())
@@ -143,6 +151,7 @@ class CommandWidget(QWidget):
 
         self.devTop = None
 
+    @pyqtSlot(pyrogue.Root)
     def addTree(self,root):
         self.roots.append(root)
         self._devTop = CommandDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -18,13 +18,25 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-from PyQt4.QtCore   import *
-from PyQt4.QtGui    import *
+try:
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtCore    import *
+    from PyQt5.QtGui     import *
+except ImportError:
+    from PyQt4.QtCore    import *
+    from PyQt4.QtGui     import *
 
 import pyrogue
 import Pyro4
 
 class DataLink(QObject):
+
+    updateDataFile   = pyqtSignal(str)
+    updateOpenState  = pyqtSignal(int)
+    updateBufferSize = pyqtSignal(str)
+    updateMaxSize    = pyqtSignal(str)
+    updateFileSize   = pyqtSignal(str)
+    updateFrameCount = pyqtSignal(str)
 
     def __init__(self,*,layout,writer):
         QObject.__init__(self)
@@ -48,7 +60,8 @@ class DataLink(QObject):
         self.dataFile.setText(self.writer.dataFile.valueDisp())
         self.dataFile.textEdited.connect(self.dataFileEdited)
         self.dataFile.returnPressed.connect(self.dataFileChanged)
-        self.connect(self,SIGNAL('updateDataFile'),self.dataFile.setText)
+
+        self.updateDataFile.connect(self.dataFile.setText)
 
         fl.addRow('Data File:',self.dataFile)
 
@@ -67,7 +80,8 @@ class DataLink(QObject):
         self.openState.addItem('True')
         self.openState.setCurrentIndex(0)
         self.openState.activated.connect(self.openStateChanged)
-        self.connect(self,SIGNAL('updateOpenState'),self.openState.setCurrentIndex)
+
+        self.updateOpenState.connect(self.openState.setCurrentIndex)
 
         fl.addRow('File Open:',self.openState)
 
@@ -76,7 +90,8 @@ class DataLink(QObject):
         self.bufferSize.setText(self.writer.bufferSize.valueDisp())
         self.bufferSize.textEdited.connect(self.bufferSizeEdited)
         self.bufferSize.returnPressed.connect(self.bufferSizeChanged)
-        self.connect(self,SIGNAL('updateBufferSize'),self.bufferSize.setText)
+
+        self.updateBufferSize.connect(self.bufferSize.setText)
 
         fl.addRow('Buffer Size:',self.bufferSize)
 
@@ -84,7 +99,8 @@ class DataLink(QObject):
         self.totSize = QLineEdit()
         self.totSize.setText(self.writer.fileSize.valueDisp())
         self.totSize.setReadOnly(True)
-        self.connect(self,SIGNAL('updateFileSize'),self.totSize.setText)
+
+        self.updateFileSize.connect(self.totSize.setText)
 
         fl.addRow('Total File Size:',self.totSize)
 
@@ -106,7 +122,8 @@ class DataLink(QObject):
         self.maxSize.setText(self.writer.maxFileSize.valueDisp())
         self.maxSize.textEdited.connect(self.maxSizeEdited)
         self.maxSize.returnPressed.connect(self.maxSizeChanged)
-        self.connect(self,SIGNAL('updateMaxSize'),self.maxSize.setText)
+
+        self.updateMaxSize.connect(self.maxSize.setText)
 
         fl.addRow('Max Size:',self.maxSize)
 
@@ -114,7 +131,8 @@ class DataLink(QObject):
         self.frameCount = QLineEdit()
         self.frameCount.setText(self.writer.frameCount.valueDisp())
         self.frameCount.setReadOnly(True)
-        self.connect(self,SIGNAL('updateFrameCount'),self.frameCount.setText)
+
+        self.updateFrameCount.connect(self.frameCount.setText)
 
         fl.addRow('Frame Count:',self.frameCount)
 
@@ -139,29 +157,31 @@ class DataLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'dataFile':
-            self.emit(SIGNAL("updateDataFile"),disp)
+            self.emit.updateDataFile(disp)
 
         elif name == 'open':
-            self.emit(SIGNAL("updateOpenState"),self.openState.findText(disp))
+            self.emit.updateOpenState(self.openState.findText(disp))
 
         elif name == 'bufferSize':
-            self.emit(SIGNAL("updateBufferSize"),disp)
+            self.emit.updateBufferSize(disp)
 
         elif name == 'maxFileSize':
-            self.emit(SIGNAL("updateMaxSize"),disp)
+            self.emit.updateMaxSize(disp)
 
         elif name == 'fileSize':
-            self.emit(SIGNAL("updateFileSize"),disp)
+            self.emit.updateFileSize(disp)
 
         elif name == 'frameCount':
-            self.emit(SIGNAL("updateFrameCount"),disp)
+            self.emit.updateFrameCount(disp)
 
+    @pyqtSlot()
     def dataFileEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.dataFile.setPalette(p)
 
+    @pyqtSlot()
     def dataFileChanged(self):
         p = QPalette()
         self.dataFile.setPalette(p)
@@ -170,17 +190,20 @@ class DataLink(QObject):
         self.writer.dataFile.setDisp(self.dataFile.text())
         self.block = False
 
+    @pyqtSlot(int)
     def openStateChanged(self,value):
         self.block = True
         self.writer.open.setDisp(self.openState.itemText(value))
         self.block = False
 
+    @pyqtSlot()
     def bufferSizeEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.bufferSize.setPalette(p)
 
+    @pyqtSlot()
     def bufferSizeChanged(self):
         p = QPalette()
         self.bufferSize.setPalette(p)
@@ -189,12 +212,14 @@ class DataLink(QObject):
         self.writer.bufferSize.setDisp(self.bufferSize.text())
         self.block = False
 
+    @pyqtSlot()
     def maxSizeEdited(self):
         p = QPalette()
         p.setColor(QPalette.Base,Qt.yellow)
         p.setColor(QPalette.Text,Qt.black)
         self.maxSize.setPalette(p)
 
+    @pyqtSlot()
     def maxSizeChanged(self):
         p = QPalette()
         self.maxSize.setPalette(p)
@@ -205,6 +230,10 @@ class DataLink(QObject):
 
 
 class ControlLink(QObject):
+
+    updateState = pyqtSignal(int)
+    updateRate  = pyqtSignal(int)
+    updateCount = pyqtSignal(str)
 
     def __init__(self,*,layout,control):
         QObject.__init__(self)
@@ -226,7 +255,7 @@ class ControlLink(QObject):
         self.control.runRate.addListener(self)
         self.runRate = QComboBox()
         self.runRate.activated.connect(self.runRateChanged)
-        self.connect(self,SIGNAL('updateRate'),self.runRate.setCurrentIndex)
+        self.updateRate.connect(self.runRate.setCurrentIndex)
         for key in sorted(self.control.runRate.enum):
             self.runRate.addItem(self.control.runRate.enum[key])
         self.runRate.setCurrentIndex(self.runRate.findText(self.control.runRate.valueDisp()))
@@ -245,7 +274,7 @@ class ControlLink(QObject):
         self.control.runState.addListener(self)
         self.runState = QComboBox()
         self.runState.activated.connect(self.runStateChanged)
-        self.connect(self,SIGNAL('updateState'),self.runState.setCurrentIndex)
+        self.updateState.connect(self.runState.setCurrentIndex)
         for key in sorted(self.control.runState.enum):
             self.runState.addItem(self.control.runState.enum[key])
         self.runState.setCurrentIndex(self.runState.findText(self.control.runState.valueDisp()))
@@ -262,7 +291,7 @@ class ControlLink(QObject):
         self.runCount = QLineEdit()
         self.runCount.setText(self.control.runCount.valueDisp())
         self.runCount.setReadOnly(True)
-        self.connect(self,SIGNAL('updateCount'),self.runCount.setText)
+        self.updateCount.connect(self.runCount.setText)
 
         fl.addRow('Run Count:',self.runCount)
 
@@ -273,19 +302,21 @@ class ControlLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'runState':
-            self.emit(SIGNAL("updateState"),self.runState.findText(disp))
+            self.emit.updateState(self.runState.findText(disp))
 
         elif name == 'runRate':
-            self.emit(SIGNAL("updateRate"),self.runRate.findText(disp))
+            self.emit.updateRate(self.runRate.findText(disp))
 
         elif name == 'runCount':
-            self.emit(SIGNAL("updateCount"),disp)
+            self.emit.updateCount(disp)
 
+    @pyqtSlot(int)
     def runStateChanged(self,value):
         self.block = True
         self.control.runState.setDisp(self.runState.itemText(value))
         self.block = False
 
+    @pyqtSlot(int)
     def runRateChanged(self,value):
         self.block = True
         self.control.runRate.setDisp(self.runRate.itemText(value))
@@ -293,6 +324,9 @@ class ControlLink(QObject):
 
 
 class SystemWidget(QWidget):
+
+    updateLog = pyqtSignal(str)
+
     def __init__(self, *, root, parent=None):
         super(SystemWidget, self).__init__(parent)
 
@@ -363,7 +397,7 @@ class SystemWidget(QWidget):
         vb.addWidget(self.systemLog)
 
         root.SystemLog.addListener(self)
-        self.connect(self,SIGNAL('updateLog'),self.systemLog.setText)
+        self.updateLog.connect(self.systemLog.setText)
         self.systemLog.setText(root.SystemLog.valueDisp())
         
         pb = QPushButton('Clear Log')
@@ -372,6 +406,7 @@ class SystemWidget(QWidget):
 
         QCoreApplication.processEvents()
 
+    @pyqtSlot()
     def resetLog(self):
         self.root.ClearLog()
 
@@ -380,37 +415,37 @@ class SystemWidget(QWidget):
         name = path.split('.')[-1]
 
         if name == 'SystemLog':
-            self.emit(SIGNAL("updateLog"),disp)
+            self.updateLog.emit(disp)
 
+    @pyqtSlot()
     def hardReset(self):
         self.root.HardReset()
 
+    @pyqtSlot()
     def softReset(self):
         self.root.SoftReset()
 
+    @pyqtSlot()
     def countReset(self):
         self.root.CountReset()
 
+    @pyqtSlot()
     def loadSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
-        dlg.setFilter('Config Files (*.yml)')
+        dlg.setNameFilter('Config Files (*.yml)')
 
         if dlg.exec_():
             loadFile = str(dlg.selectedFiles()[0])
             self.root.ReadConfig(loadFile)
 
+    @pyqtSlot()
     def saveSettings(self):
         dlg = QFileDialog()
         dlg.setFileMode(QFileDialog.AnyFile)
-        dlg.setFilter('Config Files (*.yml)')
+        dlg.setNameFilter('Config Files (*.yml)')
 
         if dlg.exec_():
             saveFile = str(dlg.selectedFiles()[0])
             self.root.WriteConfig(saveFile)
-
-
-
-
-
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -157,22 +157,22 @@ class DataLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'dataFile':
-            self.emit.updateDataFile(disp)
+            self.updateDataFile.emit(disp)
 
         elif name == 'open':
-            self.emit.updateOpenState(self.openState.findText(disp))
+            self.updateOpenState.emit(self.openState.findText(disp))
 
         elif name == 'bufferSize':
-            self.emit.updateBufferSize(disp)
+            self.updateBufferSize.emit(disp)
 
         elif name == 'maxFileSize':
-            self.emit.updateMaxSize(disp)
+            self.updateMaxSize.emit(disp)
 
         elif name == 'fileSize':
-            self.emit.updateFileSize(disp)
+            self.updateFileSize.emit(disp)
 
         elif name == 'frameCount':
-            self.emit.updateFrameCount(disp)
+            self.updateFrameCount.emit(disp)
 
     @pyqtSlot()
     def dataFileEdited(self):
@@ -302,13 +302,13 @@ class ControlLink(QObject):
         name = path.split('.')[-1]
 
         if name == 'runState':
-            self.emit.updateState(self.runState.findText(disp))
+            self.updateState.emit(self.runState.findText(disp))
 
         elif name == 'runRate':
-            self.emit.updateRate(self.runRate.findText(disp))
+            self.updateRate.emit(self.runRate.findText(disp))
 
         elif name == 'runCount':
-            self.emit.updateCount(disp)
+            self.updateCount.emit(disp)
 
     @pyqtSlot(int)
     def runStateChanged(self,value):

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -85,3 +85,5 @@ class UdpRssiPack(pr.Device):
     def getRssiBusy(self,dev=None,cmd=None):
         return(self._rssi.getBusy())
 
+    def stop(self):
+        self._rssi.stop()

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -24,10 +24,16 @@ import pyrogue
 class PrbsRx(pyrogue.Device):
     """PRBS RX Wrapper"""
 
-    def __init__(self, *, name):
+    def __init__(self, *, name, width=None, taps=None, **kwargs ):
 
-        pyrogue.Device.__init__(self, name=name, description='PRBS Software Receiver')
+        pyrogue.Device.__init__(self, name=name, description='PRBS Software Receiver', **kwargs)
         self._prbs = rogue.utilities.Prbs()
+
+        if width is not None:
+            self._prbs.setWidth(width)
+
+        if taps is not None:
+            self._prbs.setTaps(taps)
 
         self.add(pyrogue.LocalVariable(name='rxErrors', description='RX Error Count',
                                        mode='RO', pollInterval=1, value=0,
@@ -62,11 +68,16 @@ class PrbsRx(pyrogue.Device):
 class PrbsTx(pyrogue.Device):
     """PRBS TX Wrapper"""
 
-    def __init__(self, *, name):
+    def __init__(self, *, name, width=None, taps=None, **kwargs ):
 
-        pyrogue.Device.__init__(self, name=name, description='PRBS Software Transmitter')
-
+        pyrogue.Device.__init__(self, name=name, description='PRBS Software Transmitter', **kwargs)
         self._prbs = rogue.utilities.Prbs()
+
+        if width is not None:
+            self._prbs.setWidth(width)
+
+        if taps is not None:
+            self._prbs.setTaps(taps)
 
         self.add(pyrogue.LocalVariable(name='txSize', description='PRBS Frame Size', 
                                        mode='RW', value=0))

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -68,7 +68,7 @@ class PrbsRx(pyrogue.Device):
 class PrbsTx(pyrogue.Device):
     """PRBS TX Wrapper"""
 
-    def __init__(self, *, name, width=None, taps=None, **kwargs ):
+    def __init__(self, *, name, sendCount=False, width=None, taps=None, **kwargs ):
 
         pyrogue.Device.__init__(self, name=name, description='PRBS Software Transmitter', **kwargs)
         self._prbs = rogue.utilities.Prbs()
@@ -78,6 +78,8 @@ class PrbsTx(pyrogue.Device):
 
         if taps is not None:
             self._prbs.setTaps(taps)
+
+        self._prbs.sendCount(sendCount)
 
         self.add(pyrogue.LocalVariable(name='txSize', description='PRBS Frame Size', 
                                        mode='RW', value=0))
@@ -118,4 +120,7 @@ class PrbsTx(pyrogue.Device):
 
     def setTaps(self,taps):
         self._prbs.setTaps(taps)
+
+    def sendCount(self,en):
+        self._prbs.sendCount(en)
 

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -82,7 +82,7 @@ class PrbsTx(pyrogue.Device):
         self._prbs.sendCount(sendCount)
 
         self.add(pyrogue.LocalVariable(name='txSize', description='PRBS Frame Size', 
-                                       mode='RW', value=0))
+                                       localSet=self._txSize, mode='RW', value=0))
 
         self.add(pyrogue.LocalVariable(name='txEnable', description='PRBS Run Enable', mode='RW',
                                        value=False, localSet=self._txEnable))
@@ -104,6 +104,11 @@ class PrbsTx(pyrogue.Device):
 
     def _genFrame(self):
         self._prbs.genFrame(self.txSize.value())
+
+    def _txSize(self,value,changed):
+        if changed and int(self.txEnable.value()) == 1:
+            self._prbs.disable()
+            self._prbs.enable(value)
 
     def _txEnable(self,value,changed):
         if changed:

--- a/releaseNotes.py
+++ b/releaseNotes.py
@@ -38,11 +38,11 @@ from github import Github # PyGithub
 import re
 import argparse
 import pyperclip
+from getpass import getpass
 
 parser = argparse.ArgumentParser('Release notes generator')
 parser.add_argument('tag', type=str, help='reference tag or range. (i.e. v2.5.0 or v2.5.0..v2.6.0)')
-parser.add_argument('--user', type=str, help='Username for github')
-parser.add_argument('--password', type=str, help='Password for github')
+parser.add_argument('--user', type=str, help='Username for github, password will be prompted')
 parser.add_argument('--nosort', help='Disable sort by change counts', action="store_true")
 parser.add_argument('--copy', help='Copy to clipboard', action="store_true")
 args = parser.parse_args()
@@ -59,8 +59,14 @@ g = git.Git('.')
 g.fetch()
 project = re.compile(r'slaclab/(?P<name>.*?).git').search(g.remote('get-url','origin')).group('name')
 
+user = args.user
+password = None
+
+if user is not None:
+    password = getpass("Password for github: ")
+
 # Git server
-gh = Github(args.user,args.password)
+gh = Github(user,password)
 repo = gh.get_repo(f'slaclab/{project}')
 
 loginfo = g.log(tags,'--grep','Merge pull request')

--- a/releaseNotes.py
+++ b/releaseNotes.py
@@ -109,7 +109,7 @@ if args.nosort is False:
 md = '# Pull Requests\n'
 
 for i, entry in enumerate(records):
-    md += f" {i+1}. {entry['PR']} - {entry['Title']}\n"
+    md += f" 1. {entry['PR']} - {entry['Title']}\n"
 
 md += '## Pull Request Details\n'
 
@@ -126,8 +126,10 @@ for entry in records:
     md += '\n**Notes:**\n'
     for line in entry['body'].splitlines():
         md += '> ' + line + '\n'
-    md += '-------\n'         
+    md += '\n-------\n'         
     md += '\n\n'
+
+print(md)
 
 if args.copy:
     try:	
@@ -136,4 +138,3 @@ if args.copy:
     except:	
         print("Copy to clipboard failed!")
 
-print(md)

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -163,13 +163,13 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
    struct timeval currTime;
    rim::SlavePtr slave;
 
+   gettimeofday(&(tran->startTime_),NULL);
+   timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
+
    {
       rogue::GilRelease noGil;
       boost::lock_guard<boost::mutex> lock(mastMtx_);
       slave = slave_;
-
-      gettimeofday(&(tran->startTime_),NULL);
-      timeradd(&(tran->startTime_),&sumTime_,&(tran->endTime_));
       tranMap_[tran->id_] = tran;
    }
 

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -95,8 +95,8 @@ ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {
       buff = *(rFrame->beginBuffer());
   
       // Use buffer tail reservation to align available payload
-      if ((buff->getAvailable() % alignSize_) != 0)
-         buff->adjustTail(buff->getAvailable() % alignSize_);
+      if (((buff->getAvailable()-tailSize_) % alignSize_) != 0)
+         buff->adjustTail((buff->getAvailable()-tailSize_) % alignSize_);  
   
       // Buffer should support our header/tail plus at least one payload byte 
       if ( buff->getAvailable() < (headSize_ + tailSize_ + 1) )

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -40,7 +40,7 @@ rpp::ControllerV1Ptr rpp::ControllerV1::create ( rpp::TransportPtr tran, rpp::Ap
 }
 
 //! Creator
-rpp::ControllerV1::ControllerV1 ( rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(tran, app, 8, 1, 1) {
+rpp::ControllerV1::ControllerV1 ( rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(tran, app, 8, 1, 8) {
 }
 
 //! Destructor
@@ -49,6 +49,7 @@ rpp::ControllerV1::~ControllerV1() { }
 //! Frame received at transport interface
 void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    ris::BufferPtr buff;
+   uint32_t  size;
    uint32_t  tmpIdx;
    uint32_t  tmpCount;
    uint8_t   tmpFuser;
@@ -68,27 +69,37 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
 
    buff = *(frame->beginBuffer());
    data = buff->begin();
+   size = buff->getPayload();
 
    // Drop invalid data
-   if ( frame->getError() || (buff->getPayload() < 9) || ((data[0] & 0xF) != 0) ) {
-      log_->warning("Dropping frame due to contents: error=0x%x, payload=%i, Version=0x%x",frame->getError(),buff->getPayload(),data[0]&0xF);
+   if ( frame->getError() ||     // Check for frame ERROR
+      (size < 10) ||             // Check for min. size (64-bit header + 8-bit min. payload + 8-bit tail)
+      ((data[0] & 0xF) != 0) ) { // Check for invalid version only
+      log_->warning("Dropping frame due to contents: error=0x%x, payload=%i, Version=0x%x",frame->getError(),size,data[0]&0xF);
       dropCount_++;
       return;
    }
 
-   tmpIdx  = (data[0] >> 4);
-   tmpIdx += data[1] * 16;
+   tmpIdx  = uint32_t(data[0]) >> 4;
+   tmpIdx |= uint32_t(data[1]) << 4;
 
-   tmpCount  = data[2];
-   tmpCount += data[3] * 256;
-   tmpCount += data[4] * 0x10000;
+   tmpCount  = uint32_t(data[2]);
+   tmpCount |= uint32_t(data[3]) << 8;
+   tmpCount |= uint32_t(data[4]) << 16;
 
    tmpDest  = data[5];
    tmpId    = data[6];
    tmpFuser = data[7];
 
-   tmpLuser = data[buff->getPayload()-1] & 0x7F;
-   tmpEof   = data[buff->getPayload()-1] & 0x80;
+   tmpLuser = data[size-1] & 0x7F;
+   tmpEof   = data[size-1] & 0x80;
+
+   log_->debug("transportRx: Raw header: 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x",
+         data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
+   log_->debug("transportRx: Raw footer: 0x%x",
+         data[size-1]);
+   log_->debug("transportRx: Got frame: Fuser=0x%x, Dest=0x%x, Id=0x%x, Count=%i, Luser=0x%x, Eof=%i, size=%i",
+         tmpFuser, tmpDest, tmpIdx, tmpCount, tmpLuser, tmpEof, size);
 
    // Shorten message by one byte (before adjusting tail)
    buff->adjustPayload(-1);
@@ -201,12 +212,12 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       size = (*it)->getPayload();
       data = (*it)->begin();
 
-      data[0] = ((appIndex_ % 16) << 4);
-      data[1] = (appIndex_ / 16) & 0xFF;
+      data[0] = (appIndex_ & 0xF) << 4; // Note: BIT3:0 = 0x0 (Version)
+      data[1] = (appIndex_ >> 4)  & 0xFF;
 
-      data[2] = segment % 256;
-      data[3] = (segment % 0xFFFF) / 256;
-      data[4] = segment / 0xFFFF;
+      data[2] = (segment >> 0)  & 0xFF;
+      data[3] = (segment >> 8)  & 0xFF;
+      data[4] = (segment >> 16) & 0xFF;
 
       data[5] = tDest;
       data[6] = tId;

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -247,7 +247,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) {
       ris::FramePtr tFrame = ris::Frame::create();
 
-      // Compute last, and alignt payload to 64-bits
+      // Compute last, and aligned payload to 64-bits
       last = (*it)->getPayload() % 8;
       if ( last == 0 ) last = 8;
       (*it)->adjustPayload(8-last);

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -46,6 +46,7 @@ void rpr::Client::setup_python() {
       .def("getDropCount",   &rpr::Client::getDropCount)
       .def("getRetranCount", &rpr::Client::getRetranCount)
       .def("getBusy",        &rpr::Client::getBusy)
+      .def("stop",           &rpr::Client::stop)
    ;
 
 }
@@ -105,3 +106,7 @@ void rpr::Client::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
 }
 
+//! Send reset
+void rpr::Client::stop() {
+   return(cntl_->stop());
+}

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -142,13 +142,14 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 
 //! Frame received at transport interface
 void rpr::Controller::transportRx( ris::FramePtr frame ) {
+
    rpr::HeaderPtr head = rpr::Header::create(frame);
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr flock = frame->lock();
 
    if ( frame->isEmpty() || ! head->verify() ) {
-      log_->info("Dumping frame state=%i server=%i",state_,server_);
+      log_->warning("Dumping bad frame state=%i server=%i",state_,server_);
       dropCount_++;
       return;
    }
@@ -181,14 +182,20 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
    }
 
    // Data or NULL in the correct sequence go to application
-   else if ( state_ == StOpen && head->sequence == nextSeqRx_ && 
-        ( head->nul || frame->getPayload() > rpr::Header::HeaderSize ) ) {
-      lastSeqRx_ = nextSeqRx_;
-      nextSeqRx_ = nextSeqRx_ + 1;
-      stCond_.notify_all();
+   else if ( state_ == StOpen && ( head->nul || frame->getPayload() > rpr::Header::HeaderSize ) ) {
+      if ( head->sequence == nextSeqRx_ ) {
 
-      if ( !head->nul ) {
-         appQueue_.push(head);
+         lastSeqRx_ = nextSeqRx_;
+         nextSeqRx_ = nextSeqRx_ + 1;
+         stCond_.notify_all();
+
+         if ( !head->nul ) {
+            appQueue_.push(head);
+         }
+      }
+      else {
+         log_->warning("Dropping out of sequence frame. server=%i",server_);
+         dropCount_++;
       }
    }
 }
@@ -222,7 +229,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
    ris::FrameLockPtr flock = frame->lock();
 
    if ( frame->isEmpty() ) {
-      log_->info("Dumping empty application frame");
+      log_->warning("Dumping empty application frame");
       return;
    }
 
@@ -305,7 +312,7 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool retr
    // Track last tx time
    gettimeofday(&txTime_,NULL);
 
-   log_->log(retransmit ? rogue::Logging::Info : rogue::Logging::Debug,
+   log_->log(retransmit ? rogue::Logging::Warning : rogue::Logging::Debug,
          "TX frame: state=%i server=%i size=%i syn=%i ack=%i nul=%i, rst=%i, ack#=%i, seq=%i, recount=%i",
          state_,server_,head->getFrame()->getPayload(),head->syn,head->ack,head->nul,head->rst,
          head->acknowledge,head->sequence,retranCount_);

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -76,8 +76,6 @@ void rpr::Header::setup_python() {
 
 //! Creator
 rpr::Header::Header(ris::FramePtr frame) {
-   if ( frame->isEmpty() ) 
-      throw(rogue::GeneralError("Header::Header","Frame must not be empty!"));
    frame_ = frame;
    count_ = 0;
 
@@ -112,6 +110,8 @@ ris::FramePtr rpr::Header::getFrame() {
 //! Verify header contents
 bool rpr::Header::verify() {
    uint8_t size;
+
+   if ( frame_->isEmpty() ) return(false);
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
    uint8_t * data = buff->begin();
@@ -152,6 +152,9 @@ bool rpr::Header::verify() {
 //! Update checksum, set tx time and increment tx count
 void rpr::Header::update() {
    uint8_t size;
+
+   if ( frame_->isEmpty() )
+      throw(rogue::GeneralError("Header::update","Frame is empty!"));
 
    ris::BufferPtr buff = *(frame_->beginBuffer());
    uint8_t * data = buff->begin();

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -42,6 +42,7 @@ void rpr::Server::setup_python() {
       .def("getDropCount",   &rpr::Server::getDropCount)
       .def("getRetranCount", &rpr::Server::getRetranCount)
       .def("getBusy",        &rpr::Server::getBusy)
+      .def("stop",           &rpr::Server::stop)
    ;
 
 }
@@ -99,5 +100,10 @@ bool rpr::Server::getBusy() {
 //! Set timeout for frame transmits in microseconds
 void rpr::Server::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
+}
+
+//! Send reset
+void rpr::Server::stop() {
+   return(cntl_->stop());
 }
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -167,7 +167,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Check frame size
    if ( (fSize = frame->getPayload()) < 16 ) {
-      log_->info("Got undersize frame size = %i",fSize);
+      log_->warning("Got undersize frame size = %i",fSize);
       return; // Invalid frame, drop it
    }
 
@@ -184,7 +184,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Find Transaction
    if ( (tran = getTransaction(id)) == NULL ) {
-     log_->debug("Invalid ID frame for id=%i",id);
+     log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
    delTransaction(id);
@@ -194,7 +194,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      log_->debug("Transaction expired. Id=%i",id);
+      log_->warning("Transaction expired. Id=%i",id);
       return;
    }
    tIter = tran->begin();

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -177,7 +177,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Check frame size
    if ( (fSize = frame->getPayload()) < HeadLen ) {
-      log_->info("Got undersize frame size = %i",fSize);
+      log_->warning("Got undersize frame size = %i",fSize);
       return; // Invalid frame, drop it
    }
 
@@ -194,7 +194,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Find Transaction
    if ( (tran = getTransaction(id)) == NULL ) {
-     log_->debug("Invalid ID frame for id=%i",id);
+     log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
    delTransaction(tran->id());
@@ -204,7 +204,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      log_->debug("Transaction expired. Id=%i",id);
+      log_->warning("Transaction expired. Id=%i",id);
       return;
    }
    tIter = tran->begin();

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -225,6 +225,9 @@ void ru::Prbs::genFrame (uint32_t size) {
    uint32_t      wCount[4];
    ris::FramePtr fr;
 
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lock(pMtx_);
+
    // Verify size first
    if ((( size % byteWidth_ ) != 0) || size < minSize_ ) 
       throw rogue::GeneralError("Prbs::genFrame","Invalid frame size");
@@ -273,7 +276,6 @@ void ru::Prbs::genFrame (uint32_t size) {
    sendFrame(fr);
 
    // Update counters
-   boost::lock_guard<boost::mutex> lock(pMtx_);
    txSeq_++;
    txCount_++;
    txBytes_ += size;

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -375,6 +375,7 @@ void ru::Prbs::setup_python() {
       .def("getTxBytes",     &ru::Prbs::getTxBytes)
       .def("checkPayload",   &ru::Prbs::checkPayload)
       .def("resetCount",     &ru::Prbs::resetCount)
+      .def("sendCount",      &ru::Prbs::sendCount)
    ;
 
    bp::implicitly_convertible<ru::PrbsPtr, ris::SlavePtr>();


### PR DESCRIPTION
# Pull Requests
 1. #194 - Optimize variable update processing
 1. #202 - Add QT5 support
 1. #199 - Move update context count tracking to worker thread
 1. #197 - Add ability to change PRBS transmit size while running
 1. #196 - Add counter transmit option for PRBS transmitter
 1. #198 - bug fix for PacketizerV1's SW-to-FW path
 1. #193 - Update logging message and address minor issues found when debugging.
 1. #195 - Add width and taps args to PRBS creator
 1. #201 - Add stop call to RSSI
 1. #192 - Updated release notes
## Pull Request Details
### Optimize variable update processing
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Fri Mar 30 10:14:35 2018 -0700|
|**Pull:**|#194 (228 additions, 236 deletions, 5 files changed)|
|**Branch:**|slaclab/ESROGUE-200|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-200|

**Notes:**
> This change provides an interface to group variable updates into blocks, with overlap detection in order to minimize the redundant calls to each variable's update listener.
> 
> Anytime a variable is written or read a update tracker is created which keeps track of the variables that will need an update notification as a result. After the operation is completed, the update list is handed to a worker thread which will calls the associated update functions for each variable in the list. 
> 
> Users may also further limit the update rate by grouping updates outside of a series of calls:
> 
> ````
> with self.root.updateGroup():
>      var1.set(value1)
>      var2.set(value2)
>      var1.set(value3)
> ````

-------


### Add QT5 support
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Tue Apr 3 09:30:39 2018 -0700|
|**Pull:**|#202 (118 additions, 47 deletions, 4 files changed)|
|**Branch:**|slaclab/ESROGUE-207|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-207|

**Notes:**
> This PR changes the GUI code to use proper signal/slot generation and calls. This allows both QT4 and QT5 to be supported in the same code. The QT5 import is tried first with a fallback to QT4 if that fails.
> 
> In order to simplify the top level GUI code, a wrapper on the QT application class is supported. Existing lines such as:
> 
> ````
> import PyQt4.QtCore
> appTop = PyQt4.QtGui.QApplication(sys.arg)
> ````
> 
> Will now be replaced with:
> 
> ````
> appTop = pyrogue.gui.application(sys.argv)
> ````

-------


### Move update context count tracking to worker thread
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Wed Apr 4 10:03:49 2018 -0700|
|**Pull:**|#199 (54 additions, 43 deletions, 1 files changed)|
|**Branch:**|slaclab/ESROGUE-200-2|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-200-2|

**Notes:**
> This is a possible enhancement to PR #194.
> 
> This version passes the context increment and decrement request as well as the variable to the worker thread through the work queue. The worker thread then tracks the context count as well as the update list. This allows the tracking operation to occur outside of a re-enterent lock context. 

-------


### Add ability to change PRBS transmit size while running
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Mon Apr 2 13:32:17 2018 -0700|
|**Pull:**|#197 (61 additions, 11 deletions, 3 files changed)|
|**Branch:**|slaclab/ESROGUE-204|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-204|

**Notes:**
> Also fix lock in transmitter.
> 
> Contains changes from PR #195 and PR #196 

-------


### Add counter transmit option for PRBS transmitter
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Mon Apr 2 13:32:02 2018 -0700|
|**Pull:**|#196 (52 additions, 9 deletions, 3 files changed)|
|**Branch:**|slaclab/ESROGUE-203|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-203|

**Notes:**
> Add option to transmit running counter instead of PRBS data.
> 
> This PR contains changes from PR #195.
> 

-------


### bug fix for PacketizerV1's SW-to-FW path
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Thu Mar 29 20:25:14 2018 -0700|
|**Pull:**|#198 (36 additions, 25 deletions, 10 files changed)|
|**Branch:**|slaclab/ControllerV1|

**Notes:**
> ### Description
> 1)  bug fix for PacketizerV1's SW-to-FW path
> 2) Fixed some typos in the comments
> 3) Minor performance enhancements (avoiding modulo operator because not high performance)
> 
> I have regression tested this with both PacketizerV1 and PacketizerV2.  We still have the PacketizerV1 FW-to-SW corner case (FW bug) that needs to be results (discovered during this development). 
> 
> ### JIRA
> ESROGUE-199
> ESCORE-339
> 

-------


### Update logging message and address minor issues found when debugging.
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Tue Mar 27 16:04:32 2018 -0700|
|**Pull:**|#193 (33 additions, 21 deletions, 6 files changed)|
|**Branch:**|slaclab/ESROGUE-199|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-199|

**Notes:**
> In the process of debugging ESROGUE-199, I found some areas for improvement.
> 
> 1. Change some logging messages from info to warning.
> 2. Avoid throwing exception when bad data frames are received in RSSI.
> 3. Set transaction start timer earlier, and outside of master lock.
> 4. Properly count dropped frames that come out of sequence in RSSI.

-------


### Add width and taps args to PRBS creator
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Mon Apr 2 13:31:45 2018 -0700|
|**Pull:**|#195 (16 additions, 5 deletions, 1 files changed)|
|**Branch:**|slaclab/ESROGUE-201|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-201|

**Notes:**
> The TX and RX prbs software classes now accept width and taps args during creation. Pass through args are also supported for Device attributes.

-------


### Add stop call to RSSI
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Wed Apr 4 10:05:54 2018 -0700|
|**Pull:**|#201 (19 additions, 0 deletions, 5 files changed)|
|**Branch:**|slaclab/ESROGUE-206|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-206|

**Notes:**
> Add stop call to RSSI. This ensures that the server is put into the reset state before the client disconnects.
> 
> The following line will need to be added to the "stop" method of the custom root class or at the end of the python script:
> 
> ````
> rudp.stop()
> ````

-------


### Updated release notes
|||
|---:|:---|
|**Author:**|Ryan Herbst <rherbst@slac.stanford.edu>|
|**Date:**|Fri Mar 30 10:14:02 2018 -0700|
|**Pull:**|#192 (4 additions, 3 deletions, 1 files changed)|
|**Branch:**|slaclab/rel_notes|

**Notes:**
> The following are changed:
> 
> Let github auto number the PR summary list.
> Add newline after notes and before the separator line
> Dump note data before attempting to set clipboard.
> 
> The password is now prompted instead of provided on the command line.

-------


