### PR TITLE
Fix get for commands

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -146,6 +146,8 @@ class BaseCommand(pr.BaseVariable):
     def _getDict(self,modes):
         return None
 
+    def get(self,read=True):
+        return self._default
 
 # LocalCommand is the same as BaseCommand
 LocalCommand = BaseCommand


### PR DESCRIPTION
Maintenance pull request for ESROGUE-209

The architectural changes to the variable base class ended up breaking the get() method for commands. get() on commands is used to obtain a default arg value.

