### PR TITLE
Fix sync read from epics

### DIFF
--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -135,8 +135,8 @@ void rpe::Variable::valueGet() {
          rogue::ScopedGil gil;
          log_->info("Synchronous read for %s",epicsName_.c_str());
          try {
-            if ( isString_ ) fromPython(var_.attr("valueDisp")());
-            else fromPython(var_.attr("value")());
+            if ( isString_ ) fromPython(var_.attr("disp")());
+            else fromPython(var_.attr("get")());
          } catch (...) {
             log_->error("Error getting values from epics: %s\n",epicsName_.c_str());
          }


### PR DESCRIPTION
The epics interface should generate a read from hardware with caget() if the syncRead flag is set to true. A mistake in the current implementation was going directly to the variable but calling the valueDisp() and value() methods instead of disp() and get().