### PR TITLE
Added list dump to epics interface

### DIFF
--- a/python/pyrogue/protocols/epics.py
+++ b/python/pyrogue/protocols/epics.py
@@ -63,11 +63,19 @@ class EpicsCaServer(object):
     def start(self):
         self._srv.start()
 
+    def list(self):
+        return self._pvMap
+
+    def dump(self):
+        for k,v in self._pvMap.items():
+            print("{} -> {}".format(v,k))
+
     def _addPv(self,node,doAll):
         eName = self._base + ':'
 
         if doAll:
             eName += node.path.replace('.',':')
+            self._pvMap[node.path] = eName
         elif node.path in self._pvMap:
             eName = self._pvMap[node.path]
         else:


### PR DESCRIPTION
Given a pyrogue root with an  epics interface:
`````
class DummyTree(pyrogue.Root):
    def __init__(self):
        self.epics = pyrogue.protocols.epics.EpicsCaServer(base='test',root=self)
        self.epics.dump()
`````
This PR allows the user to get a dictionary of epics variables:

`````
self.epics.list()
`````
or dump a list of epics variables to the console:
`````
self.epics.dump()
`````