### PR TITLE
Cleanup compile errors for MAC target.

### DIFF
--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -82,6 +82,8 @@ namespace rogue {
          void info(const char * fmt, ...);
          void debug(const char * fmt, ...);
 
+         void logThreadId(uint32_t level);
+
          static void setup_python();
    };
 

--- a/src/rogue/GeneralError.cpp
+++ b/src/rogue/GeneralError.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/GeneralError.h>
-#include <sys/syscall.h>
 namespace bp = boost::python;
 
 PyObject * rogue::generalErrorObj = 0;

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -145,6 +145,8 @@ void rogue::Logging::logThreadId(uint32_t level) {
    uint64_t tid64;
    pthread_threadid_np(NULL,&tid64);
    tid = (uint32_t)tid64;
+#else
+   tid = 0;
 #endif
 
    this->log(level, "PID=%i, TID=%i", getpid(), tid);

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 #include <boost/make_shared.hpp>
 
 const uint32_t rogue::Logging::Critical;
@@ -129,6 +128,12 @@ void rogue::Logging::debug(const char * fmt, ...) {
    va_start(arg,fmt);
    intLog(rogue::Logging::Debug,fmt,arg);
    va_end(arg);
+}
+
+void rogue::Logging::logThreadId(uint32_t level) {
+   std::string id = boost::lexical_cast<std::string>(boost::this_thread::get_id());
+
+   this->log(level, "PID=%i, TID=%s", getpid(), id.c_str());
 }
 
 void rogue::Logging::setup_python() {

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -100,7 +100,7 @@ void ris::Buffer::adjustHeader(int32_t value) {
    if ( payload_ < headRoom_ ) payload_ = headRoom_;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 //! Clear the header reservation
@@ -108,7 +108,7 @@ void ris::Buffer::zeroHeader() {
    headRoom_ = 0;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 //! Adjust tail by passed value
@@ -127,7 +127,7 @@ void ris::Buffer::adjustTail(int32_t value) {
    tailRoom_ += value;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 //! Clear the tail reservation
@@ -135,7 +135,7 @@ void ris::Buffer::zeroTail() {
    tailRoom_ = 0;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 /* 
@@ -208,7 +208,7 @@ void ris::Buffer::setPayload(uint32_t size) {
    payload_ = size + headRoom_;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 /* 
@@ -231,7 +231,7 @@ void ris::Buffer::setPayloadFull() {
    payload_ = rawSize_ - tailRoom_;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 
 //! Set the buffer as empty (minus header reservation)
@@ -239,6 +239,6 @@ void ris::Buffer::setPayloadEmpty() {
    payload_ = headRoom_;
 
    ris::FramePtr tmpPtr;
-   if ( tmpPtr = frame_.lock() ) tmpPtr->setSizeDirty(); 
+   if ( (tmpPtr = frame_.lock()) ) tmpPtr->setSizeDirty(); 
 }
 

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -30,7 +30,6 @@
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
-#include <sys/syscall.h>
 
 namespace bp = boost::python;
 namespace ris = rogue::interfaces::stream;
@@ -91,7 +90,7 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
 
 //! Thread background
 void ris::Fifo::runThread() {
-   log_->info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log_->logThreadId(rogue::Logging::Info);
 
    try {
       while(1) {

--- a/src/rogue/protocols/packetizer/Application.cpp
+++ b/src/rogue/protocols/packetizer/Application.cpp
@@ -26,7 +26,6 @@
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
@@ -81,7 +80,7 @@ void rpp::Application::pushFrame( ris::FramePtr frame ) {
 //! Thread background
 void rpp::Application::runThread() {
    Logging log("packetizer.Application");
-   log.info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log.logThreadId(rogue::Logging::Info);
 
    try {
       while(1) {

--- a/src/rogue/protocols/packetizer/Transport.cpp
+++ b/src/rogue/protocols/packetizer/Transport.cpp
@@ -26,7 +26,6 @@
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
@@ -71,7 +70,7 @@ void rpp::Transport::acceptFrame ( ris::FramePtr frame ) {
 //! Thread background
 void rpp::Transport::runThread() {
    Logging log("packetizer.Transport");
-   log.info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log.logThreadId(rogue::Logging::Info);
 
    try {
       while(1) {

--- a/src/rogue/protocols/rssi/Application.cpp
+++ b/src/rogue/protocols/rssi/Application.cpp
@@ -26,7 +26,6 @@
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
@@ -76,7 +75,7 @@ void rpr::Application::acceptFrame ( ris::FramePtr frame ) {
 //! Thread background
 void rpr::Application::runThread() {
    Logging log("rssi.Application");
-   log.info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log.logThreadId(rogue::Logging::Info);
 
    try {
       while(1) {

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -31,7 +31,6 @@
 #include <boost/pointer_cast.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 #include <math.h>
 
 namespace rpr = rogue::protocols::rssi;
@@ -349,7 +348,7 @@ bool rpr::Controller::timePassed ( struct timeval *lastTime, uint32_t time, bool
 void rpr::Controller::runThread() {
    uint32_t wait;
 
-   log_->info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log_->logThreadId(rogue::Logging::Info);
 
    wait = 0;
 

--- a/src/rogue/protocols/rssi/Transport.cpp
+++ b/src/rogue/protocols/rssi/Transport.cpp
@@ -26,7 +26,6 @@
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
@@ -70,7 +69,7 @@ void rpr::Transport::acceptFrame ( ris::FramePtr frame ) {
 //! Thread background
 void rpr::Transport::runThread() {
    Logging log("rssi.Transport");
-   log.info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   log.logThreadId(rogue::Logging::Info);
 
    try {
       while(1) {

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -162,7 +162,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    bool     doWrite;
    uint32_t fSize;
 
-   rogue::GilRelease noGil();
+   rogue::GilRelease noGil;
    ris::FrameLockPtr fLock = frame->lock();
 
    // Check frame size

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -138,7 +138,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    frame->setPayload(frameSize);
 
    // Setup iterators
-   rogue::GilRelease noGil();
+   rogue::GilRelease noGil;
    rim::TransactionLockPtr lock = tran->lock();
    fIter = frame->beginWrite();
    tIter = tran->begin();
@@ -172,7 +172,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    bool     doWrite;
    uint32_t fSize;
 
-   rogue::GilRelease noGil();
+   rogue::GilRelease noGil;
    ris::FrameLockPtr frLock = frame->lock();
 
    // Check frame size

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -27,7 +27,6 @@
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 
 namespace rpu = rogue::protocols::udp;
 namespace ris = rogue::interfaces::stream;
@@ -151,9 +150,9 @@ void rpu::Client::runThread() {
    fd_set         fds;
    int32_t        res;
    struct timeval tout;
-   uint32_t           avail;
+   uint32_t       avail;
 
-   udpLog_->info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   udpLog_->logThreadId(rogue::Logging::Info);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -19,7 +19,6 @@
 **/
 #include <rogue/protocols/udp/Core.h>
 #include <rogue/Logging.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -27,7 +27,6 @@
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
 #include <iostream>
-#include <sys/syscall.h>
 #include <unistd.h>
 
 namespace rpu = rogue::protocols::udp;
@@ -160,7 +159,7 @@ void rpu::Server::runThread() {
    uint32_t           tmpLen;
    uint32_t           avail;
 
-   udpLog_->info("PID=%i, TID=%li",getpid(),syscall(SYS_gettid));
+   udpLog_->logThreadId(rogue::Logging::Info);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);


### PR DESCRIPTION
Fix check on assignment calls with extra layer of parenthesis.

Centralize thread ID logging in the Logging class and adjust call for the target platform. The following rogue::Logging call is now supported:

`````
rogue::Logging::logThreadId(uint32_t level);
`````