### PR TITLE
Enable Variable Overlaps

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -167,7 +167,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
                  base=pr.UInt,
                  offset=None,
                  bitSize=32,
-                 bitOffset=0):
+                 bitOffset=0,
+                 overlapEn=False):
 
         # RemoteVariable constructor will handle assignment of most params
         BaseCommand.__init__(
@@ -189,6 +190,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             offset=offset,
             bitSize=bitSize,
             bitOffset=bitOffset,
+            overlapEn=overlapEn,
             verify=False)
 
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -351,6 +351,7 @@ class RemoteVariable(BaseVariable):
                  bitSize=32,
                  bitOffset=0,
                  pollInterval=0, 
+                 overlapEn=False,
                  verify=True, ):
 
         if disp is None:
@@ -387,6 +388,7 @@ class RemoteVariable(BaseVariable):
         self._verify    = verify
         self._typeStr   = base.name(sum(bitSize))
         self._bytes     = int(math.ceil(float(self._bitOffset[-1] + self._bitSize[-1]) / 8.0))
+        self._overlapEn = overlapEn
 
 
     @property


### PR DESCRIPTION
This PR provides an interface to enable multiple variables to overlap the same bits in a register space. To enable overlaps all overlapping variables must allow overlaps. The RemoteVariable and RemoteCommand class creators now accept an overlapEn arg.