### PR TITLE
Add buffer end point return to frame iterator

### DIFF
--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -74,6 +74,9 @@ namespace rogue {
                const rogue::interfaces::stream::FrameIterator operator =(
                      const rogue::interfaces::stream::FrameIterator &rhs);
 
+               //! Get iterator to end of buffer or end of frame, whichever is lower
+               rogue::interfaces::stream::FrameIterator endBuffer();
+
                //! De-reference
                uint8_t & operator *() const;
 

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -146,6 +146,13 @@ const ris::FrameIterator ris::FrameIterator::operator=(const ris::FrameIterator 
    return *this;
 }
 
+//! Get iterator to end of buffer or end of frame, whichever is lower
+ris::FrameIterator ris::FrameIterator::endBuffer() {
+   ris::FrameIterator ret(*this);
+   ret.adjust(buffSize_-buffPos_);
+   return ret;
+}
+
 //! De-reference
 uint8_t & ris::FrameIterator::operator *() const {
    if ( framePos_ == frameSize_ ) 


### PR DESCRIPTION
This pull request adds a method to the frame iterator which returns the end pointer for the current buffer. This allows the user to take advantage of the flexibility of the frame iterator while ensuring bulk operations do not span buffer boundaries. For example an efficient copy from the Frame to a contiguous memory block would do the following: 

`````
uint32_t size = frame->getPayload();
uint8_t *data = (uint8_t *)malloc(size);
uint8_t *dst = data;

rogue::interfaces::stream::Frame::iterator iter = frame->beginRead();
rogue::interfaces::stream::Frame::iterator end = frame->endRead();

// Jump over header (as an example)
iter += HeaderSize;

while ( iter != end ) {
   dst = std::copy(iter, iter->endBuffer(), dst);
   iter = iter->endBuffer();
}
`````
