### PR TITLE
Update buffer pool interfaces

### DIFF
--- a/include/rogue/interfaces/stream/Pool.h
+++ b/include/rogue/interfaces/stream/Pool.h
@@ -58,7 +58,7 @@ namespace rogue {
                uint32_t fixedSize_;
 
                //! Buffer queue count
-               uint32_t maxCount_;
+               uint32_t poolSize_;
 
             public:
 
@@ -90,10 +90,19 @@ namespace rogue {
                //! Setup class in python
                static void setup_python();
 
-            protected:
-
                //! Set fixed size mode
-               void enBufferPool(uint32_t size, uint32_t count);
+               void setFixedSize(uint32_t size);
+               
+               //! Get fixed size mode
+               uint32_t getFixedSize();
+
+               //! Set buffer pool size
+               void setPoolSize(uint32_t size);
+               
+               //! Get pool size
+               uint32_t getPoolSize();
+
+            protected:
 
                //! Allocate and Create a Buffer
                boost::shared_ptr<rogue::interfaces::stream::Buffer> allocBuffer ( uint32_t size, uint32_t *total );

--- a/include/rogue/protocols/udp/Core.h
+++ b/include/rogue/protocols/udp/Core.h
@@ -34,6 +34,9 @@ namespace rogue {
          const uint32_t MaxJumboPayload = 8900;
          const uint32_t MaxStdPayload   = 1400;
 
+         const uint32_t JumboMTU = 9000;
+         const uint32_t StdMTU   = 1500;
+
          //! UDP Core
          class Core {
 
@@ -72,8 +75,8 @@ namespace rogue {
                //! Return max payload
                uint32_t maxPayload();
 
-               //! Set UDP RX Size
-               bool setRxSize(uint32_t size);
+               //! Set number of expected incoming buffers
+               bool setRxBufferCount(uint32_t count);
 
                //! Set timeout for frame transmits in microseconds
                void setTimeout(uint32_t timeout);

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -33,6 +33,8 @@ class UdpRssiPack(pr.Device):
             self._log.critical("Size arg is deprecated. Use jumbo arg instead")
 
         self._udp  = rogue.protocols.udp.Client(host,port,jumbo)
+        self._udp.setRxBufferCount(64);
+
         self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
 
         if packVer == 2:

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -37,7 +37,7 @@ ris::Pool::Pool() {
    allocBytes_ = 0;
    allocCount_ = 0;
    fixedSize_  = 0;
-   maxCount_   = 0;
+   poolSize_   = 0;
 }
 
 //! Destructor
@@ -79,7 +79,7 @@ void ris::Pool::retBuffer(uint8_t * data, uint32_t meta, uint32_t rawSize) {
    boost::lock_guard<boost::mutex> lock(mtx_);
 
    if ( data != NULL ) {
-      if ( rawSize == fixedSize_ && maxCount_ > dataQ_.size() ) dataQ_.push(data);
+      if ( rawSize == fixedSize_ && poolSize_ > dataQ_.size() ) dataQ_.push(data);
       else free(data);
    }
    allocBytes_ -= rawSize;
@@ -90,15 +90,37 @@ void ris::Pool::setup_python() {
    bp::class_<ris::Pool, ris::PoolPtr, boost::noncopyable>("Pool",bp::init<>())
       .def("getAllocCount",  &ris::Pool::getAllocCount)
       .def("getAllocBytes",  &ris::Pool::getAllocBytes)
+      .def("setFixedSize",   &ris::Pool::setFixedSize)
+      .def("getFixedSize",   &ris::Pool::getFixedSize)
+      .def("setPoolSize",    &ris::Pool::setPoolSize)
+      .def("getPoolSize",    &ris::Pool::getPoolSize)
    ;
 }
 
 //! Set fixed size mode
-void ris::Pool::enBufferPool(uint32_t size, uint32_t count) {
-   if ( fixedSize_ != 0 ) 
-      throw(rogue::GeneralError("Pool::enBufferPool","Method can only be called once!"));
-   fixedSize_  = size;
-   maxCount_   = count;
+void ris::Pool::setFixedSize(uint32_t size) {
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lock(mtx_);
+
+   fixedSize_ = size;
+}
+
+//! Get fixed size mode
+uint32_t ris::Pool::getFixedSize() {
+   return fixedSize_;
+}
+
+//! Set buffer pool size
+void ris::Pool::setPoolSize(uint32_t size) {
+   rogue::GilRelease noGil;
+   boost::lock_guard<boost::mutex> lock(mtx_);
+
+   poolSize_ = size;
+}
+
+//! Get pool size
+uint32_t ris::Pool::getPoolSize() {
+   return fixedSize_;
 }
 
 //! Allocate a buffer passed size

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -74,7 +74,8 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    ((struct sockaddr_in *)(&remAddr_))->sin_port=htons(port_);
 
    // Fixed size buffer pool
-   enBufferPool(maxPayload(),1024*256);
+   setFixedSize(maxPayload());
+   setPoolSize(1024); // Initial value
 
    // Start rx thread
    thread_ = new boost::thread(boost::bind(&rpu::Client::runThread, this));

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -40,9 +40,11 @@ uint32_t rpu::Core::maxPayload() {
 }
 
 //! Set UDP RX Size
-bool rpu::Core::setRxSize(uint32_t size) {
+bool rpu::Core::setRxBufferCount(uint32_t count) {
    uint32_t   rwin;
    socklen_t  rwin_size=4;
+
+   uint32_t size = count * (jumbo_)?(JumboMTU):(StdMTU);
 
    setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, (char*)&size, sizeof(size));
    getsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &rwin, &rwin_size);
@@ -65,7 +67,7 @@ void rpu::Core::setTimeout(uint32_t timeout) {
 void rpu::Core::setup_python () {
    bp::class_<rpu::Core, rpu::CorePtr, boost::noncopyable >("Core",bp::no_init)
       .def("maxPayload",        &rpu::Core::maxPayload)
-      .def("setRxSize",         &rpu::Core::setRxSize)
+      .def("setRxBufferCount",  &rpu::Core::setRxBufferCount)
       .def("setTimeout",        &rpu::Core::setTimeout)
    ;
 }

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -73,7 +73,8 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    }
 
    // Fixed size buffer pool
-   enBufferPool(maxPayload(),1024*256);
+   setFixedSize(maxPayload());
+   setPoolSize(1024); // Initial value
 
    // Start rx thread
    thread_ = new boost::thread(boost::bind(&rpu::Server::runThread, this));


### PR DESCRIPTION
This PR separates the existing:

`````
 rogue::interfaces::stream::Pool::enBufferPool(size,count)
`````
 into two separate calls as well as the associated read back calls:
`````
rogue::interfaces::stream::Pool::setFixedSize(size)
rogue::interfaces::stream::Pool::getFixedSize()
rogue::interfaces::stream::Pool::setPoolSize(count)
rogue::interfaces::stream::Pool::getPoolSize()
`````
Which allows the user to adjust the pool size dynamically. 

This PR also changes the UDP client and server interfaces to expose a method for setting the rx receive buffer size:
`````
setRxBufferCount(uint32_t count);
`````
