### PR TITLE
Fix epics structures to avoid lock collisions

### DIFF
--- a/include/rogue/protocols/epicsV3/Pv.h
+++ b/include/rogue/protocols/epicsV3/Pv.h
@@ -40,6 +40,7 @@ namespace rogue {
                boost::shared_ptr<rogue::protocols::epicsV3::Value> value_;
                aitBool interest_;
                boost::mutex mtx_;
+               casEventMask valueMask_;
 
             public:
 
@@ -50,8 +51,6 @@ namespace rogue {
                Pv (caServer &cas, boost::shared_ptr<rogue::protocols::epicsV3::Value> value);
 
                ~Pv ();
-
-               bool interest();
 
                // Virtual methods in casPV
 
@@ -85,7 +84,7 @@ namespace rogue {
 
                const char * getName() const;
 
-               void postEvent ( const casEventMask & select, const gdd & event );
+               void updated(const gdd & event);
 
          };
       }

--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -91,8 +91,6 @@ namespace rogue {
 
                void setPv(rogue::protocols::epicsV3::Pv * pv);
 
-               void clrPv();
-
                rogue::protocols::epicsV3::Pv * getPv();
                
                //---------------------------------------

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -36,7 +36,6 @@ namespace rogue {
          class Variable: public Value {
                boost::python::object var_;
 
-               bool inSet_;
                bool syncRead_;
 
                // Lock held when called

--- a/src/rogue/protocols/epicsV3/Pv.cpp
+++ b/src/rogue/protocols/epicsV3/Pv.cpp
@@ -33,19 +33,18 @@ void rpe::Pv::setup_python() { }
 rpe::Pv::Pv (caServer &cas, rpe::ValuePtr value) : casPV(cas) {
    value_    = value;
    interest_ = aitFalse;
+
+//   valueMask_ = casEventMask(this->getCAS()->valueEventMask());
 }
 
 rpe::Pv::~Pv () { }
-
-bool rpe::Pv::interest() {
-   return interest_;
-}
 
 void rpe::Pv::show(unsigned level) const { }
 
 caStatus rpe::Pv::interestRegister() {
    boost::lock_guard<boost::mutex> lock(mtx_);
    interest_ = aitTrue;
+   valueMask_ = casEventMask(this->getCAS()->valueEventMask());
    return S_casApp_success;
 }
 
@@ -80,8 +79,7 @@ casChannel * rpe::Pv::createChannel(const casCtx &ctx,
 }
 
 void rpe::Pv::destroy() {
-   value_->clrPv();
-   delete this;
+   // Do nothing since we pre-allocate
 }
 
 aitEnum rpe::Pv::bestExternalType() const {
@@ -100,7 +98,7 @@ const char * rpe::Pv::getName() const {
    return value_->epicsName().c_str();
 }
 
-void rpe::Pv::postEvent ( const casEventMask & select, const gdd & event ) {
-   casPV::postEvent(select,event);
+void rpe::Pv::updated ( const gdd & event ) {
+   if ( interest_ == aitTrue ) casPV::postEvent(valueMask_,event);
 }
 

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -59,10 +59,13 @@ void rpe::Server::stop() {
 
 void rpe::Server::addValue(rpe::ValuePtr value) {
    std::map<std::string, rpe::ValuePtr>::iterator it;
-
+   rpe::Pv * pv;
+   
    boost::lock_guard<boost::mutex> lock(mtx_);
 
    if ( (it = values_.find(value->epicsName())) == values_.end()) {
+      pv = new Pv(*this, value);
+      value->setPv(pv);
       values_[value->epicsName()] = value;
    }
    else {
@@ -87,17 +90,11 @@ pvCreateReturn rpe::Server::createPV(const casCtx &ctx, const char *pvName) {
    boost::lock_guard<boost::mutex> lock(mtx_);
 
    std::map<std::string, rpe::ValuePtr>::iterator it;
-   rpe::Pv * pv;
 
    if ( (it = values_.find(pvName)) == values_.end())
       return S_casApp_pvNotFound;
 
-   if ( (pv = it->second->getPv()) == NULL ) {
-      pv = new Pv(*this, it->second);
-      it->second->setPv(pv);
-   }
-
-   return *pv;
+   return *(it->second->getPv());
 }
 
 pvAttachReturn rpe::Server::pvAttach(const casCtx &ctx, const char *pvName) {
@@ -109,12 +106,7 @@ pvAttachReturn rpe::Server::pvAttach(const casCtx &ctx, const char *pvName) {
    if ( (it = values_.find(pvName)) == values_.end())
       return S_casApp_pvNotFound;
 
-   if ( (pv = it->second->getPv()) == NULL ) {
-      pv = new Pv(*this, it->second);
-      it->second->setPv(pv);
-   }
-
-   return *pv;
+   return *(it->second->getPv());
 }
 
 //! Run thread


### PR DESCRIPTION
The primary purpose of this pull request is to avoid a lock collision between the Value() class lock, the GIL and the internal epics lock. In the process a few additional optimizations were made including pre-allocating the Pv structures so the server no longer has to create these dynamically.