### PR TITLE
Add ability to pass variable list to block methods

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -405,7 +405,7 @@ class Device(pr.Node,rim.Hub):
 
         blocks = []
         for v in variables:
-            if v not in self:
+            if v.parent is not self:
                 raise DeviceError(
                     f'Variable {v.path} passed to {self.path}._getBlocks() is not a member of {self.path}')
             else:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -93,18 +93,13 @@ class DeviceError(Exception):
     pass
 
 
-# Get a list of unique blocks from a variable list
+
 def getBlocksFromVariables(variables):
-    blocks = []
-
-    if isinstance(variables,list):
-        for v in variables:
-            if not v._block in blocks:
-                blocks.append(v._block)
+    """Get a list of unique blocks from a list of Variables. """
+    if isinstance(variables, collections.Iterable):
+        return list(set(v._block for v in variables))
     else:
-        blocks.append(variables._block)
-
-    return blocks
+        return [variables._block]
 
 
 class Device(pr.Node,rim.Hub):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -265,7 +265,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in getBlocksFromVariables(variable):
+            for b in pr.getBlocksFromVariables(variable):
                 b.startTransaction(rim.Write, check=checkEach)
 
         else:
@@ -286,7 +286,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in getBlocksFromVariables(variable):
+            for b in pr.getBlocksFromVariables(variable):
                 b.startTransaction(rim.Verify, checkEach)
 
         else:
@@ -307,7 +307,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks. 
         if variable is not None:
-            for b in getBlocksFromVariables(variable):
+            for b in pr.getBlocksFromVariables(variable):
                 b.startTransaction(rim.Read, checkEach)
 
         else:
@@ -327,7 +327,7 @@ class Device(pr.Node,rim.Hub):
 
             # Process local blocks
             if variable is not None:
-                for b in getBlocksFromVariables(variable):
+                for b in pr.getBlocksFromVariables(variable):
                     b._checkTransaction()
 
             else:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -104,6 +104,8 @@ def getBlocksFromVariables(variables):
     else:
         blocks.append(variables._block)
 
+    return blocks
+
 
 class Device(pr.Node,rim.Hub):
     """Device class holder. TODO: Update comments"""

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -92,6 +92,19 @@ class DeviceError(Exception):
     """ Exception for device manipulation errors."""
     pass
 
+
+# Get a list of unique blocks from a variable list
+def getBlocksFromVariables(variables):
+    blocks = []
+
+    if isinstance(variables,list):
+        for v in variables:
+            if not v._block in blocks:
+                blocks.append(v._block)
+    else:
+        blocks.append(variables._block)
+
+
 class Device(pr.Node,rim.Hub):
     """Device class holder. TODO: Update comments"""
 
@@ -252,7 +265,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            variable._block.startTransaction(rim.Write, check=checkEach)
+            for b in getBlocksFromVariables(variable):
+                b.startTransaction(rim.Write, check=checkEach)
+
         else:
             for block in self._blocks:
                 if force or block.stale:
@@ -271,7 +286,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            variable._block.startTransaction(rim.Verify, checkEach)
+            for b in getBlocksFromVariables(variable):
+                b.startTransaction(rim.Verify, checkEach)
+
         else:
             for block in self._blocks:
                 if block.bulkEn:
@@ -290,7 +307,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks. 
         if variable is not None:
-            variable._block.startTransaction(rim.Read, checkEach)
+            for b in getBlocksFromVariables(variable):
+                b.startTransaction(rim.Read, checkEach)
+
         else:
             for block in self._blocks:
                 if block.bulkEn:
@@ -308,7 +327,9 @@ class Device(pr.Node,rim.Hub):
 
             # Process local blocks
             if variable is not None:
-                variable._block._checkTransaction()
+                for b in getBlocksFromVariables(variable):
+                    b._checkTransaction()
+
             else:
                 for block in self._blocks:
                     block._checkTransaction()

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -93,15 +93,6 @@ class DeviceError(Exception):
     pass
 
 
-
-def getBlocksFromVariables(variables):
-    """Get a list of unique blocks from a list of Variables. """
-    if isinstance(variables, collections.Iterable):
-        return list(set(v._block for v in variables))
-    else:
-        return [variables._block]
-
-
 class Device(pr.Node,rim.Hub):
     """Device class holder. TODO: Update comments"""
 
@@ -262,7 +253,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in pr.getBlocksFromVariables(variable):
+            for b in self._getBlocks(variable):
                 b.startTransaction(rim.Write, check=checkEach)
 
         else:
@@ -283,7 +274,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in pr.getBlocksFromVariables(variable):
+            for b in self._getBlocks(variable):
                 b.startTransaction(rim.Verify, checkEach)
 
         else:
@@ -304,7 +295,7 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks. 
         if variable is not None:
-            for b in pr.getBlocksFromVariables(variable):
+            for b in self._getBlocks(variable):
                 b.startTransaction(rim.Read, checkEach)
 
         else:
@@ -324,7 +315,7 @@ class Device(pr.Node,rim.Hub):
 
             # Process local blocks
             if variable is not None:
-                for b in pr.getBlocksFromVariables(variable):
+                for b in self._getBlocks(variable):
                     b._checkTransaction()
 
             else:
@@ -402,6 +393,26 @@ class Device(pr.Node,rim.Hub):
                 
             # If we get here an error has occured
             raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
+
+
+    def _getBlocks(self, variables):
+        """
+        Get a list of unique blocks from a list of Variables. 
+        Variables must belong to this device!
+        """
+        if isinstance(variables, pr.BaseVariable):
+            variables = [variables]
+
+        blocks = []
+        for v in variables:
+            if v not in self:
+                raise DeviceError(
+                    f'Variable {v.path} passed to {self.path}._getBlocks() is not a member of {self.path}')
+            else:
+                if v._block not in blocks:
+                    b.append(v._block)
+                
+        return blocks
 
     def _buildBlocks(self):
         remVars = []

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -125,6 +125,9 @@ class Node(object):
     def __dir__(self):
         return(super().__dir__() + [k for k,v in self._nodes.items()])
 
+    def __contains__(self, item):
+        return item in self._nodes.values()
+
     def add(self,node):
         """Add node as sub-node"""
 


### PR DESCRIPTION
With this PR in a device you can queue up a list of specific variables for operations using the device block methods. For example to read a list of variables to update a linked variable.

`````
self.readBlocks(variable=linkVar.dependencies)
self.checkBlocks(variable=linkVar.dependencies)
`````
