### PR TITLE
Convert yaml to bytes before requesting config dump frame size

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -367,8 +367,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """
         Generate a frame containing the passed string.
         """
-        frame = self._reqFrame(len(yml),True)
         b = bytearray(yml,'utf-8')
+        frame = self._reqFrame(len(b),True)
         frame.write(b,0)
         self._sendFrame(frame)
 


### PR DESCRIPTION
This PR fixes a bug which resulted in a overflow error when converting a yaml string into bytes and then putting those bytes in a stream Frame. The frame size requested was computed using the yaml string length and not the byte length, which may be longer for unicode strings.