### PR TITLE
Added adaptive timeout for memory transactions

### DIFF
--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -44,10 +44,10 @@ namespace rogue {
                uint32_t id_;
 
                //! Alias for map
-               typedef std::map<uint32_t, boost::weak_ptr<rogue::interfaces::memory::Transaction> > TransactionMap;
+               typedef std::vector<boost::shared_ptr<rogue::interfaces::memory::Transaction> > TransactionList;
 
                //! Transaction map
-               TransactionMap tranMap_;
+               TransactionList tranList_;
 
                //! Slave lock
                boost::mutex slaveMtx_;
@@ -77,9 +77,6 @@ namespace rogue {
 
                //! Get Transaction with index
                boost::shared_ptr<rogue::interfaces::memory::Transaction> getTransaction(uint32_t index);
-
-               //! Remove transaction from the list, also cleanup stale transactions
-               void delTransaction(uint32_t index);
 
                //! Get min size from slave
                uint32_t min();

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -54,6 +54,9 @@ namespace rogue {
 
             protected:
 
+               //! Transaction timeout 
+               struct timeval timeout_;
+
                //! Transaction start time
                struct timeval endTime_;
 
@@ -93,13 +96,13 @@ namespace rogue {
             public:
 
                //! Create a transaction container
-               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create ();
+               static boost::shared_ptr<rogue::interfaces::memory::Transaction> create (struct timeval timeout);
 
                //! Setup class in python
                static void setup_python();
 
                //! Constructor
-               Transaction();
+               Transaction(struct timeval timeout);
 
                //! Destructor
                ~Transaction();
@@ -127,6 +130,9 @@ namespace rogue {
 
                //! Wait for the transaction to complete
                uint32_t wait();
+
+               //! Refresh timer
+               void refreshTimer();
 
                //! start iterator, caller must lock around access
                rogue::interfaces::memory::Transaction::iterator begin();

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -38,8 +38,8 @@ uint32_t rim::Transaction::classIdx_ = 0;
 boost::mutex rim::Transaction::classMtx_;
 
 //! Create a master container
-rim::TransactionPtr rim::Transaction::create () {
-   rim::TransactionPtr m = boost::make_shared<rim::Transaction>();
+rim::TransactionPtr rim::Transaction::create (struct timeval timeout) {
+   rim::TransactionPtr m = boost::make_shared<rim::Transaction>(timeout);
    return(m);
 }
 
@@ -58,11 +58,11 @@ void rim::Transaction::setup_python() {
 }
 
 //! Create object
-rim::Transaction::Transaction() {
+rim::Transaction::Transaction(struct timeval timeout) : timeout_(timeout) {
+   gettimeofday(&startTime_,NULL);
+
    endTime_.tv_sec    = 0;
    endTime_.tv_usec   = 0;
-   startTime_.tv_sec  = 0;
-   startTime_.tv_usec = 0;
 
    pyValid_ = false;
 
@@ -90,7 +90,7 @@ rim::TransactionLockPtr rim::Transaction::lock() {
 
 //! Get expired state
 bool rim::Transaction::expired() { 
-   return (iter_ == NULL); 
+   return (iter_ == NULL || done_); 
 }
 
 //! Get id
@@ -140,6 +140,14 @@ uint32_t rim::Transaction::wait() {
    pyValid_ = false;
 
    return (error_);
+}
+
+//! Refresh the timer
+void rim::Transaction::refreshTimer() {
+   struct timeval currTime;
+   gettimeofday(&currTime,NULL);
+   boost::lock_guard<boost::mutex> lock(lock_);
+   timeradd(&currTime,&timeout_,&endTime_);
 }
 
 //! start iterator, caller must lock around access

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -187,7 +187,6 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
      log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
-   delTransaction(id);
 
    // Setup transaction iterator
    rim::TransactionLockPtr lock = tran->lock();

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -199,7 +199,6 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
      log_->warning("Invalid ID frame for id=%i",id);
      return; // Bad id or post, drop frame
    }
-   delTransaction(tran->id());
 
    // Lock transaction
    rim::TransactionLockPtr lock = tran->lock();


### PR DESCRIPTION
This PR adds a requirement that memory slave interfaces process transactions in order. The getTransaction() record will now expire old transactions and update the timer for future transactions. delTransaction() is removed. 