### PR TITLE
Add bit manipulation helpers to memory::Master

### DIFF
--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -109,6 +109,15 @@ namespace rogue {
                // size and offset are optional to use a slice within the python buffer
                uint32_t reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type);
 
+               //! Copy bits from src to dst with lsbs and size
+               static void copyBits(boost::python::object dst, uint32_t dstLsb, boost::python::object src, uint32_t srcLsb, uint32_t size);
+
+               //! Set all bits in dest with lbs and size
+               static void setBits(boost::python::object dst, uint32_t lsb, uint32_t size);
+
+               //! Return true if any of the bits in a given range are set
+               static bool anyBits(boost::python::object src, uint32_t lsb, uint32_t size);
+
             protected:
 
                //! Internal transaction

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -115,9 +115,6 @@ namespace rogue {
                //! Set all bits in dest with lbs and size
                static void setBits(boost::python::object dst, uint32_t lsb, uint32_t size);
 
-               //! Return true if any of the bits in a given range are set
-               static bool anyBits(boost::python::object src, uint32_t lsb, uint32_t size);
-
             protected:
 
                //! Internal transaction

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -193,9 +193,9 @@ class RemoteBlock(BaseBlock, rim.Master):
     def __init__(self, *, offset, size, variables):
      
         rim.Master.__init__(self)
-        self._setSlave(variable.parent)
+        self._setSlave(variables[0].parent)
         
-        BaseBlock.__init__(self, name=variable.path, mode=variable.mode, device=variable.parent)
+        BaseBlock.__init__(self, name=variables[0].path, mode=variables[0].mode, device=variables[0].parent)
         self._verifyEn  = False
         self._bulkEn    = False
         self._doVerify  = False
@@ -216,13 +216,13 @@ class RemoteBlock(BaseBlock, rim.Master):
         if self._minSize == 0 or self._maxSize == 0:
             raise MemoryError(name=self.name, address=self.address, msg="Invalid min/max size")
 
+        # Range check
+        if self._size > self._maxSize:
+            msg = f'Block {self._name} size {self._size} exceeds maxSize {self._maxSize}'
+            raise MemoryError(name=self._name, address=self.address, msg=msg)
+
         # Go through variables
         for var in variables:
-
-            # Range check
-            if var.varBytes > self._maxSize:
-                msg = f'Variable {var.name} size {var.varBytes} exceeds maxSize {self._maxSize}'
-                raise MemoryError(name=self.name, address=self.address, msg=msg)
 
             # Link variable to block
             var._block = self

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -28,8 +28,9 @@ except ImportError:
 
 import pyrogue
 
-class CommandDev(object):
+class CommandDev(QObject):
     def __init__(self,*,tree,parent,dev,noExpand):
+        QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
         self._dev      = dev

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -30,8 +30,10 @@ import pyrogue
 import Pyro4
 import threading
 
-class VariableDev(object):
+class VariableDev(QObject):
+
     def __init__(self,*,tree,parent,dev,noExpand):
+        QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
         self._dev      = dev

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -48,6 +48,12 @@ void rim::Master::setup_python() {
       .def("_setTimeout",         &rim::Master::setTimeout)
       .def("_reqTransaction",     &rim::Master::reqTransactionPy)
       .def("_waitTransaction",    &rim::Master::waitTransaction)
+      .def("_copyBits",           &rim::Master::copyBits)
+      .staticmethod("_copyBits")
+      .def("_setBits",            &rim::Master::setBits)
+      .staticmethod("_setBits")
+      .def("_anyBits",            &rim::Master::anyBits)
+      .staticmethod("_anyBits")
    ;
 }
 
@@ -202,5 +208,164 @@ void rim::Master::waitTransaction(uint32_t id) {
       // Outside of lock
       if ( (error = tran->wait()) != 0 ) error_ = error;
    }
+}
+
+
+//! Copy bits from src to dst with lsbs and size
+void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::python::object src, uint32_t srcLsb, uint32_t size) {
+
+   Py_buffer srcBuf;
+   Py_buffer dstBuf;
+   uint32_t  srcBit;
+   uint32_t  srcByte;
+   uint8_t * srcData;
+   uint32_t  dstBit;
+   uint32_t  dstByte;
+   uint8_t * dstData;
+   uint32_t  rem;
+
+   if ( PyObject_GetBuffer(dst.ptr(),&dstBuf,PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError("Master::copyBits","Python Buffer Error"));
+
+   if ( (dstLsb + size) > (dstBuf.len*8) ) {
+      PyBuffer_Release(&dstBuf);
+      throw(rogue::GeneralError::boundary("Master::copyBits",(dstLsb + size),(dstBuf.len*8)));
+   }
+
+   if ( PyObject_GetBuffer(src.ptr(),&srcBuf,PyBUF_SIMPLE) < 0 ) {
+      PyBuffer_Release(&dstBuf);
+      throw(rogue::GeneralError("Master::copyBits","Python Buffer Error"));
+   }
+
+   if ( (srcLsb + size) > (srcBuf.len*8) ) {
+      PyBuffer_Release(&srcBuf);
+      PyBuffer_Release(&dstBuf);
+      throw(rogue::GeneralError::boundary("Master::copyBits",(srcLsb + size),(srcBuf.len*8)));
+   }
+
+   srcByte = srcLsb / 8;
+   srcBit  = srcLsb % 8;
+   srcData = (uint8_t *)srcBuf.buf;
+   dstByte = dstLsb / 8;
+   dstBit  = dstLsb % 8;
+   dstData = (uint8_t *)srcBuf.buf;
+   rem = size;
+
+   do {
+
+      // Aligned
+      if ( (srcBit == 0) && (dstBit == 0) && rem >= 8 ) {
+         dstData[dstByte] = srcData[srcByte];
+         ++dstByte;
+         ++srcByte;
+         printf("Full byte copy. rem=%i\n",rem);
+         rem -= 8;
+      }
+
+      // Not aligned
+      else {
+         dstData[dstByte] |= ((srcData[srcByte] >> srcBit) & 0x1) << dstBit;
+         srcByte += (++srcBit / 8);
+         dstByte += (++dstBit / 8);
+         srcBit %= 8;
+         dstBit %= 8;
+         printf("Bit level copy. rem=%i\n",rem);
+         rem -= 1;
+      }
+   } while (rem != 0);
+
+   PyBuffer_Release(&srcBuf);
+   PyBuffer_Release(&dstBuf);
+}
+
+//! Set all bits in dest with lbs and size
+void rim::Master::setBits(boost::python::object dst, uint32_t lsb, uint32_t size) {
+   Py_buffer dstBuf;
+   uint32_t  dstBit;
+   uint32_t  dstByte;
+   uint8_t * dstData;
+   uint32_t  rem;
+
+   if ( PyObject_GetBuffer(dst.ptr(),&dstBuf,PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError("Master::setBits","Python Buffer Error"));
+
+   if ( (lsb + size) > (dstBuf.len*8) ) {
+      PyBuffer_Release(&dstBuf);
+      throw(rogue::GeneralError::boundary("Master::setBits",(lsb + size),(dstBuf.len*8)));
+   }
+
+   dstByte = lsb / 8;
+   dstBit  = lsb % 8;
+   dstData = (uint8_t *)dstBuf.buf;
+   rem = size;
+
+   do {
+
+      // Aligned
+      if ( (dstBit == 0) && rem >= 8 ) {
+         dstData[dstByte] = 0xFF;
+         ++dstByte;
+         rem -= 8;
+      }
+
+      // Not aligned
+      else {
+         dstData[dstByte] |= (0x1 << dstBit);
+         dstByte += (++dstBit / 8);
+         dstBit %= 8;
+         rem -= 1;
+      }
+   } while (rem != 0);
+
+   PyBuffer_Release(&dstBuf);
+}
+
+//! Return true if any of the bits in a given range are set
+bool rim::Master::anyBits(boost::python::object src, uint32_t lsb, uint32_t size) {
+   Py_buffer srcBuf;
+   uint32_t  srcBit;
+   uint32_t  srcByte;
+   uint8_t * srcData;
+   uint32_t  rem;
+
+   if ( PyObject_GetBuffer(src.ptr(),&srcBuf,PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError("Master::setBits","Python Buffer Error"));
+
+   if ( (lsb + size) > (srcBuf.len*8) ) {
+      PyBuffer_Release(&srcBuf);
+      throw(rogue::GeneralError::boundary("Master::setBits",(lsb + size),(srcBuf.len*8)));
+   }
+
+   srcByte = lsb / 8;
+   srcBit  = lsb % 8;
+   srcData = (uint8_t *)srcBuf.buf;
+   rem = size;
+
+   do {
+
+      // Aligned
+      if ( (srcBit == 0) && rem >= 8 ) {
+         if ( srcData[srcByte] != 0 ) {
+            PyBuffer_Release(&srcBuf);
+            return true;
+         }
+         ++srcByte;
+         rem -= 8;
+      }
+
+      // Not aligned
+      else {
+         if ( ((srcData[srcByte] >> srcBit) & 0x1) != 0 ) {
+            PyBuffer_Release(&srcBuf);
+            return true;
+         }
+         srcByte += (++srcBit / 8);
+         srcBit %= 8;
+         rem -= 1;
+      }
+   } while (rem != 0);
+
+   PyBuffer_Release(&srcBuf);
+   return false;
 }
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -248,7 +248,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
    srcData = (uint8_t *)srcBuf.buf;
    dstByte = dstLsb / 8;
    dstBit  = dstLsb % 8;
-   dstData = (uint8_t *)srcBuf.buf;
+   dstData = (uint8_t *)dstBuf.buf;
    rem = size;
 
    do {
@@ -258,7 +258,6 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
          dstData[dstByte] = srcData[srcByte];
          ++dstByte;
          ++srcByte;
-         printf("Full byte copy. rem=%i\n",rem);
          rem -= 8;
       }
 
@@ -269,7 +268,6 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
          dstByte += (++dstBit / 8);
          srcBit %= 8;
          dstBit %= 8;
-         printf("Bit level copy. rem=%i\n",rem);
          rem -= 1;
       }
    } while (rem != 0);

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -221,6 +221,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
    uint32_t  dstByte;
    uint8_t * dstData;
    uint32_t  rem;
+   uint32_t  bytes;
 
    if ( PyObject_GetBuffer(dst.ptr(),&dstBuf,PyBUF_SIMPLE) < 0 )
       throw(rogue::GeneralError("Master::copyBits","Python Buffer Error"));
@@ -250,13 +251,14 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
    rem = size;
 
    do {
+      bytes = rem / 8;
 
       // Aligned
-      if ( (srcBit == 0) && (dstBit == 0) && rem >= 8 ) {
-         dstData[dstByte] = srcData[srcByte];
-         ++dstByte;
-         ++srcByte;
-         rem -= 8;
+      if ( (srcBit == 0) && (dstBit == 0) && (bytes > 0) ) {
+         memcpy(&(dstData[dstByte]),&(srcData[srcByte]),bytes);
+         dstByte += bytes;
+         srcByte += bytes;
+         rem -= (bytes * 8);
       }
 
       // Not aligned
@@ -281,6 +283,7 @@ void rim::Master::setBits(boost::python::object dst, uint32_t lsb, uint32_t size
    uint32_t  dstByte;
    uint8_t * dstData;
    uint32_t  rem;
+   uint32_t  bytes;
 
    if ( PyObject_GetBuffer(dst.ptr(),&dstBuf,PyBUF_SIMPLE) < 0 )
       throw(rogue::GeneralError("Master::setBits","Python Buffer Error"));
@@ -296,12 +299,13 @@ void rim::Master::setBits(boost::python::object dst, uint32_t lsb, uint32_t size
    rem = size;
 
    do {
+      bytes = rem / 8;
 
       // Aligned
-      if ( (dstBit == 0) && rem >= 8 ) {
-         dstData[dstByte] = 0xFF;
-         ++dstByte;
-         rem -= 8;
+      if ( (dstBit == 0) && (bytes > 0) ) {
+         memset(&(dstData[dstByte]),0xFF,bytes);
+         dstByte += bytes;
+         rem -= (bytes * 8);
       }
 
       // Not aligned


### PR DESCRIPTION
This PR adds bit field "copy", "set" and "check if set" methods to the memory::Master class to avoid doing bit manipulation for loops at the python level in the Block class.