### PR TITLE
Don't require name and description for Root() constructor

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -59,7 +59,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Root exit."""
         self.stop()
 
-    def __init__(self, *, name, description):
+    def __init__(self, *, name=None, description=''):
         """Init the node with passed attributes"""
 
         rogue.interfaces.stream.Master.__init__(self)


### PR DESCRIPTION
It's a bit annoying to require a `name=` and `description=` for `Root()`.
With this change, Root now acts like Device. If no `name` is specified, the class name is used. If no `description` is specified, an empty string is used.