### PR TITLE
Make writeBlocks() obey force when passed a Variable list

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -254,13 +254,13 @@ class Device(pr.Node,rim.Hub):
         # Process local blocks.
         if variable is not None:
             for b in self._getBlocks(variable):
-                b.startTransaction(rim.Write, check=checkEach)
+                if (force or block.stale):                
+                    b.startTransaction(rim.Write, check=checkEach)
 
         else:
             for block in self._blocks:
-                if force or block.stale:
-                    if block.bulkEn:
-                        block.startTransaction(rim.Write, check=checkEach)
+                if (force or block.stale) and block.bulkEn:
+                    block.startTransaction(rim.Write, check=checkEach)
 
             if recurse:
                 for key,value in self.devices.items():

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -178,7 +178,7 @@ class BaseVariable(pr.Node):
                 self._block.set(self, value)
 
                 if write:
-                    self._parent.writeBlocks(force=False, recurse=False, variable=self)
+                    self._parent.writeBlocks(force=True, recurse=False, variable=self)
                     self._parent.verifyBlocks(recurse=False, variable=self)
                     self._parent.checkBlocks(recurse=False, variable=self)
 


### PR DESCRIPTION
Fixed a bug where `writeBlocks()` would always force if a list of variables was passed to `variable=`.
It now obeys the `force` parameter.