### PR TITLE
Support for building rogue without python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (DEFINED ENV{CONDA_PREFIX})
 endif()
 
 # Check cmake version
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.9)
 include(InstallRequiredSystemLibraries)
 
 # Project name
@@ -36,31 +36,64 @@ if (GIT_FOUND)
       COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
       OUTPUT_VARIABLE ROGUE_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+   string(REGEX MATCH "^v([0-9]+)\\.([0-9]+)" ROGUE_SOVER ${ROGUE_VERSION})
 else()
-   message(FATAL_ERROR "Git is required to build rogue")
+   message(FATAL_ERROR "Git is required to build rogue!")
 endif()
 
+#####################################
+# Find python3
+#####################################
+set(DO_PYTHON 0)
+
+find_package(PythonInterp 3.6)
+
+if (PYTHONINTERP_FOUND)
+   find_package(PythonLibs 3.6)
+
+   if (PYTHONLIBS_FOUND)
+      set(DO_PYTHON 1)
+   endif()
+endif()
+
+#####################################
 # Boost Configuration
+#####################################
 set(Boost_USE_MULTITHREADED ON)
 
 # Boost may need help on SLAC machines
 set(BOOST_ROOT:PATHNAME $ENV{BOOST_PATH})
 
 # First try standard suffix for boost
-find_package(Boost 1.58 COMPONENTS system thread python3)
-
-# Next try Debian/Ubuntu suffix for boost
-if (NOT Boost_FOUND)
-   find_package(Boost 1.58 REQUIRED COMPONENTS system thread python-py35)
+if (DO_PYTHON)
+   find_package(Boost 1.58 COMPONENTS system thread python3)
 endif()
 
-# Find python3
-find_package(PythonInterp 3.6 REQUIRED)
-find_package(PythonLibs 3.6 REQUIRED)
+# Next try Debian/Ubuntu suffix for boost
+if ((NOT Boost_FOUND) AND DO_PYTHON)
+   find_package(Boost 1.58 COMPONENTS system thread python-py36)
+endif()
 
-message("----------------------------------------------------------------------")
+# Next try Mac with homebrew boost/python36
+if ((NOT Boost_FOUND) AND DO_PYTHON)
+   find_package(Boost 1.58 COMPONENTS system thread python36)
+endif()
 
+# Try without python
+if (NOT Boost_FOUND)
+   set(DO_PYTHON 0)
+   find_package(Boost 1.58 COMPONENTS system thread)
+endif()
+
+# Nothing worked
+if (NOT Boost_FOUND)
+   message(FATAL_ERROR "Failed to find boost libraries!")
+endif()
+
+#####################################
 # Optional EPICS V3
+#####################################
 if(DEFINED ENV{EPICS_BASE})
    set(DO_EPICS_V3 1)
    set(EPICSV3_BASE_DIR  $ENV{EPICS_BASE})
@@ -72,14 +105,13 @@ if(DEFINED ENV{EPICS_BASE})
                          ${EPICSV3_LIB_DIR}/libca.so 
                          ${EPICSV3_LIB_DIR}/libCom.so 
                          ${EPICSV3_LIB_DIR}/libgdd.so )
-   message("-- Found EPICS V3: ${EPICSV3_BASE_DIR}")
 else()
    set(DO_EPICS_V3 0)
 endif()
 
-message("-- Found boost: ${Boost_INCLUDE_DIRS}")
-message("-- Found python: ${PYTHON_LIBRARIES}")
-message("----------------------------------------------------------------------")
+#####################################
+# Setup build
+#####################################
 
 # Configuration File
 configure_file (
@@ -102,7 +134,8 @@ add_library(rogue-core SHARED "")
 add_subdirectory(src/rogue)
 
 # Set output to TOP/lib
-set_target_properties(rogue-core PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
+set_target_properties(rogue-core PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib 
+                                 VERSION ${ROGUE_VERSION} SOVERSION ${ROGUE_SOVER})
 
 # Link rogue core to boost, python and bzip
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${Boost_LIBRARIES})
@@ -110,23 +143,53 @@ TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${PYTHON_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${EPICSV3_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC bz2)
 
-# Create rogue python library
-add_library(rogue SHARED "")
+if (DO_PYTHON)
 
-# Find python package sources
-add_subdirectory(src)
+   # Create rogue python library
+   add_library(rogue SHARED "")
 
-# Set output to TOP/python, remove lib prefix
-set_target_properties(rogue PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/python)
-set_target_properties(rogue PROPERTIES PREFIX "")
+   # Find python package sources
+   add_subdirectory(src)
 
-# Link to rogue core
-TARGET_LINK_LIBRARIES(rogue LINK_PUBLIC rogue-core)
+   # Set output to TOP/python, remove lib prefix
+   set_target_properties(rogue PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/python)
+   set_target_properties(rogue PROPERTIES PREFIX "")
+
+   # Link to rogue core
+   TARGET_LINK_LIBRARIES(rogue LINK_PUBLIC rogue-core)
+
+endif()
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)
-set(CONF_LIBRARIES    ${PROJECT_SOURCE_DIR}/lib/librogue-core.so)
+set(CONF_LIBRARIES    ${PROJECT_SOURCE_DIR}/lib/librogue-core.so.${ROGUE_SOVER})
 
 # Create the config file
 configure_file(RogueConfig.cmake.in ${PROJECT_SOURCE_DIR}/lib/RogueConfig.cmake @ONLY)
+
+message("")
+message("----------------------------------------------------------------------")
+message("-- Success!")
+message("")
+message("-- Rogue Version: ${ROGUE_VERSION}")
+message("")
+message("-- Found boost: ${Boost_INCLUDE_DIRS}")
+message("")
+
+if (DO_PYTHON)
+   message("-- Found python: ${PYTHON_LIBRARIES}")
+else()
+   message("-- Compiling without python!")
+endif()
+
+message("")
+
+if (DO_EPICS_V3)
+   message("-- Found EPICS V3: ${EPICSV3_BASE_DIR}")
+else()
+   message("-- EPICS V3 not included!")
+endif()
+
+message("----------------------------------------------------------------------")
+message("")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,15 @@ endif()
 #####################################
 set(DO_PYTHON 0)
 
-find_package(PythonInterp 3.6)
+#find_package(PythonInterp 3.6)
 
-if (PYTHONINTERP_FOUND)
-   find_package(PythonLibs 3.6)
-
-   if (PYTHONLIBS_FOUND)
-      set(DO_PYTHON 1)
-   endif()
-endif()
+#if (PYTHONINTERP_FOUND)
+#   find_package(PythonLibs 3.6)
+#
+#   if (PYTHONLIBS_FOUND)
+#      set(DO_PYTHON 1)
+#   endif()
+#endif()
 
 #####################################
 # Boost Configuration
@@ -145,20 +145,23 @@ TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC bz2)
 
 if (DO_PYTHON)
 
-# Create rogue python library
-add_library(rogue SHARED "")
+   # Create rogue python library
+   add_library(rogue SHARED "")
 
-# Find python package sources
-add_subdirectory(src)
+   # Find python package sources
+   add_subdirectory(src)
 
-# Set output to TOP/python, remove lib prefix
-set_target_properties(rogue PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/python)
-set_target_properties(rogue PROPERTIES PREFIX "")
+   # Set output to TOP/python, remove lib prefix
+   set_target_properties(rogue PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/python)
+   set_target_properties(rogue PROPERTIES PREFIX "")
 
-# Link to rogue core
-TARGET_LINK_LIBRARIES(rogue LINK_PUBLIC rogue-core)
+   # Link to rogue core
+   TARGET_LINK_LIBRARIES(rogue LINK_PUBLIC rogue-core)
 
+else()
+   add_definitions( -DNO_PYTHON )
 endif()
+
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,15 @@ endif()
 #####################################
 set(DO_PYTHON 0)
 
-#find_package(PythonInterp 3.6)
+find_package(PythonInterp 3.6)
 
-#if (PYTHONINTERP_FOUND)
-#   find_package(PythonLibs 3.6)
-#
-#   if (PYTHONLIBS_FOUND)
-#      set(DO_PYTHON 1)
-#   endif()
-#endif()
+if (PYTHONINTERP_FOUND)
+   find_package(PythonLibs 3.6)
+
+   if (PYTHONLIBS_FOUND)
+      set(DO_PYTHON 1)
+   endif()
+endif()
 
 #####################################
 # Boost Configuration
@@ -94,7 +94,7 @@ endif()
 #####################################
 # Optional EPICS V3
 #####################################
-if(DEFINED ENV{EPICS_BASE})
+if(DO_PYTHON AND DEFINED ENV{EPICS_BASE})
    set(DO_EPICS_V3 1)
    set(EPICSV3_BASE_DIR  $ENV{EPICS_BASE})
    set(EPICSV3_LIB_DIR   ${EPICSV3_BASE_DIR}/lib/rhel6-x86_64 )

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ afs based SLAC python3 install mentioned above.
 $ pip3 install PyYAML
 $ pip3 install Pyro4 
 $ pip3 install parse
-$ pip3 install recordclass
 $ pip3 install click
 ````
 

--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -20,12 +20,17 @@
 #ifndef __ROGUE_GENERAL_ERROR_H__
 #define __ROGUE_GENERAL_ERROR_H__
 #include <exception>
-#include <boost/python.hpp>
 #include <stdint.h>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
 
+#ifndef NO_PYTHON
    extern PyObject * generalErrorObj;
+#endif
 
    //! General exception
    /*

--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -21,6 +21,7 @@
 #define __ROGUE_GENERAL_ERROR_H__
 #include <exception>
 #include <stdint.h>
+#include <string>
 
 #ifndef NO_PYTHON
 #include <boost/python.hpp>

--- a/include/rogue/GilRelease.h
+++ b/include/rogue/GilRelease.h
@@ -19,14 +19,21 @@
 **/
 #ifndef __ROGUE_GIL_RELEASE_H__
 #define __ROGUE_GIL_RELEASE_H__
-#include <boost/python.hpp>
 #include <stdint.h>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
 
    //! Logging
    class GilRelease {
+
+#ifndef NO_PYTHON
          PyThreadState *state_;
+#endif
+
       public:
          GilRelease();
          ~GilRelease();

--- a/include/rogue/GilRelease.h
+++ b/include/rogue/GilRelease.h
@@ -39,7 +39,6 @@ namespace rogue {
          ~GilRelease();
          void acquire();
          void release();
-         static void setup_python();
    };
 }
 

--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -20,7 +20,6 @@
 #ifndef __ROGUE_LOGGING_H__
 #define __ROGUE_LOGGING_H__
 #include <exception>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <boost/thread.hpp>
 

--- a/include/rogue/SMemControl.h
+++ b/include/rogue/SMemControl.h
@@ -16,9 +16,12 @@
 **/
 #ifndef __ROGUE_SMEM_CONTROL_H__
 #define __ROGUE_SMEM_CONTROL_H__
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <rogue/RogueSMemFunctions.h>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
 
@@ -47,6 +50,9 @@ namespace rogue {
 
          virtual std::string doRequest ( uint8_t type, std::string path, std::string arg );
    };
+   typedef boost::shared_ptr<rogue::SMemControl> SMemControlPtr;
+
+#ifndef NO_PYTHON
 
    //! Stream slave class, wrapper to enable pyton overload of virtual methods
    class SMemControlWrap : 
@@ -62,8 +68,9 @@ namespace rogue {
          std::string defDoRequest ( uint8_t type, std::string path, std::string arg );
    };
 
-   typedef boost::shared_ptr<rogue::SMemControl> SMemControlPtr;
    typedef boost::shared_ptr<rogue::SMemControlWrap> SMemControlWrapPtr;
+
+#endif
 }
 
 #endif

--- a/include/rogue/ScopedGil.h
+++ b/include/rogue/ScopedGil.h
@@ -19,13 +19,20 @@
 **/
 #ifndef __ROGUE_SCOPED_GIL_H__
 #define __ROGUE_SCOPED_GIL_H__
+
+#ifndef NO_PYTHON
 #include <boost/python.hpp>
+#endif
 
 namespace rogue {
 
    //! Logging
    class ScopedGil {
+
+#ifndef NO_PYTHON
          PyGILState_STATE state_;
+#endif
+
       public:
          ScopedGil();
          ~ScopedGil();

--- a/include/rogue/ScopedGil.h
+++ b/include/rogue/ScopedGil.h
@@ -36,7 +36,6 @@ namespace rogue {
       public:
          ScopedGil();
          ~ScopedGil();
-         static void setup_python();
    };
 }
 

--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -19,7 +19,6 @@
 **/
 #ifndef __ROGUE_VERSION_H__
 #define __ROGUE_VERSION_H__
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -20,6 +20,7 @@
 #ifndef __ROGUE_VERSION_H__
 #define __ROGUE_VERSION_H__
 #include <stdint.h>
+#include <string>
 
 namespace rogue {
 

--- a/include/rogue/hardware/axi/AxiMemMap.h
+++ b/include/rogue/hardware/axi/AxiMemMap.h
@@ -18,7 +18,6 @@
 #define __ROGUE_HARDWARE_AXI_MEM_MAP_H__
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Transaction.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -21,7 +21,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <DataDriver.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/hardware/data/DataCard.h
+++ b/include/rogue/hardware/data/DataCard.h
@@ -24,7 +24,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <DataDriver.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/hardware/data/DataMap.h
+++ b/include/rogue/hardware/data/DataMap.h
@@ -20,7 +20,6 @@
 #ifndef __ROGUE_HARDWARE_DATA_DATA_MAP_H__
 #define __ROGUE_HARDWARE_DATA_DATA_MAP_H__
 #include <rogue/interfaces/memory/Slave.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/hardware/pgp/EvrControl.h
+++ b/include/rogue/hardware/pgp/EvrControl.h
@@ -23,6 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_EVR_CONTROL_H__
 #include <PgpDriver.h>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 namespace rogue {
    namespace hardware {

--- a/include/rogue/hardware/pgp/EvrControl.h
+++ b/include/rogue/hardware/pgp/EvrControl.h
@@ -22,7 +22,6 @@
 #ifndef __ROGUE_HARDWARE_PGP_EVR_CONTROL_H__
 #define __ROGUE_HARDWARE_PGP_EVR_CONTROL_H__
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/hardware/pgp/EvrStatus.h
+++ b/include/rogue/hardware/pgp/EvrStatus.h
@@ -22,7 +22,6 @@
 #ifndef __ROGUE_HARDWARE_PGP_EVR_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_EVR_STATUS_H__
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/hardware/pgp/EvrStatus.h
+++ b/include/rogue/hardware/pgp/EvrStatus.h
@@ -23,6 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_EVR_STATUS_H__
 #include <PgpDriver.h>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 namespace rogue {
    namespace hardware {

--- a/include/rogue/hardware/pgp/Info.h
+++ b/include/rogue/hardware/pgp/Info.h
@@ -23,6 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_INFO_H__
 #include <PgpDriver.h>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 namespace rogue {
    namespace hardware {

--- a/include/rogue/hardware/pgp/Info.h
+++ b/include/rogue/hardware/pgp/Info.h
@@ -22,7 +22,6 @@
 #ifndef __ROGUE_HARDWARE_PGP_INFO_H__
 #define __ROGUE_HARDWARE_PGP_INFO_H__
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/hardware/pgp/PciStatus.h
+++ b/include/rogue/hardware/pgp/PciStatus.h
@@ -22,7 +22,6 @@
 #ifndef __ROGUE_HARDWARE_PGP_PCI_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_PCI_STATUS_H__
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/hardware/pgp/PciStatus.h
+++ b/include/rogue/hardware/pgp/PciStatus.h
@@ -23,6 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_PCI_STATUS_H__
 #include <PgpDriver.h>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 namespace rogue {
    namespace hardware {

--- a/include/rogue/hardware/pgp/PgpCard.h
+++ b/include/rogue/hardware/pgp/PgpCard.h
@@ -26,6 +26,7 @@
 #include <PgpDriver.h>
 #include <boost/thread.hpp>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 
 namespace rogue {

--- a/include/rogue/hardware/pgp/PgpCard.h
+++ b/include/rogue/hardware/pgp/PgpCard.h
@@ -24,7 +24,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 

--- a/include/rogue/hardware/pgp/Status.h
+++ b/include/rogue/hardware/pgp/Status.h
@@ -23,6 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_STATUS_H__
 #include <PgpDriver.h>
 #include <stdint.h>
+#include <boost/shared_ptr.hpp>
 
 namespace rogue {
    namespace hardware {

--- a/include/rogue/hardware/pgp/Status.h
+++ b/include/rogue/hardware/pgp/Status.h
@@ -22,7 +22,6 @@
 #ifndef __ROGUE_HARDWARE_PGP_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_STATUS_H__
 #include <PgpDriver.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/hardware/rce/AxiStream.h
+++ b/include/rogue/hardware/rce/AxiStream.h
@@ -24,7 +24,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <AxisDriver.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <rogue/Logging.h>
 #include <stdint.h>

--- a/include/rogue/hardware/rce/MapMemory.h
+++ b/include/rogue/hardware/rce/MapMemory.h
@@ -23,7 +23,6 @@
 #define __ROGUE_HARDWARE_RCE_MAP_MEMORY_H__
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Transaction.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/interfaces/memory/Constants.h
+++ b/include/rogue/interfaces/memory/Constants.h
@@ -20,7 +20,6 @@
 #ifndef __ROGUE_INTERFACES_MEMORY_ERRORS_H__
 #define __ROGUE_INTERFACES_MEMORY_ERRORS_H__
 #include <stdint.h>
-#include <boost/python.hpp>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -28,8 +28,11 @@
 
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/interfaces/memory/Slave.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
    namespace interfaces {
@@ -73,7 +76,12 @@ namespace rogue {
                //! Post a transaction. Master will call this method with the access attributes.
                virtual void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
          };
-         
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::memory::Hub> HubPtr;
+       
+#ifndef NO_PYTHON
+
          //! Memory Hub class, wrapper to enable pyton overload of virtual methods
          class HubWrap : 
             public rogue::interfaces::memory::Hub, 
@@ -92,8 +100,8 @@ namespace rogue {
          };
          
          // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::memory::Hub> HubPtr;
          typedef boost::shared_ptr<rogue::interfaces::memory::HubWrap> HubWrapPtr;
+#endif
 
       }
    }

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -113,13 +113,14 @@ namespace rogue {
                //! Post a transaction, called locally, forwarded to slave, python version
                // size and offset are optional to use a slice within the python buffer
                uint32_t reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type);
-#endif
 
                //! Copy bits from src to dst with lsbs and size
                static void copyBits(boost::python::object dst, uint32_t dstLsb, boost::python::object src, uint32_t srcLsb, uint32_t size);
 
                //! Set all bits in dest with lbs and size
                static void setBits(boost::python::object dst, uint32_t lsb, uint32_t size);
+
+#endif
 
             protected:
 

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -23,9 +23,12 @@
 #define __ROGUE_INTERFACES_MEMORY_MASTER_H__
 #include <stdint.h>
 #include <vector>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <rogue/Logging.h>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
    namespace interfaces {
@@ -105,9 +108,12 @@ namespace rogue {
                //! Post a transaction, called locally, forwarded to slave, data pointer is optional
                uint32_t reqTransaction(uint64_t address, uint32_t size, void *data, uint32_t type);
 
+#ifndef NO_PYTHON
+
                //! Post a transaction, called locally, forwarded to slave, python version
                // size and offset are optional to use a slice within the python buffer
                uint32_t reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type);
+#endif
 
             protected:
 

--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -22,7 +22,10 @@
 #include <stdint.h>
 #include <vector>
 #include <rogue/interfaces/memory/Master.h>
+
+#ifndef NO_PYTHON
 #include <boost/python.hpp>
+#endif
 
 namespace rogue {
    namespace interfaces {
@@ -106,6 +109,11 @@ namespace rogue {
                virtual void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);
          };
 
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::memory::Slave> SlavePtr;
+
+#ifndef NO_PYTHON
+
          //! Memory slave class, wrapper to enable pyton overload of virtual methods
          class SlaveWrap : 
             public rogue::interfaces::memory::Slave, 
@@ -142,9 +150,8 @@ namespace rogue {
 
          };
 
-         // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::memory::Slave> SlavePtr;
          typedef boost::shared_ptr<rogue::interfaces::memory::SlaveWrap> SlaveWrapPtr;
+#endif
 
       }
    }

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -66,8 +66,10 @@ namespace rogue {
                //! Transaction start time
                struct timeval startTime_;
 
+#ifndef NO_PYTHON
                //! Transaction python buffer
                Py_buffer pyBuf_;
+#endif
 
                //! Python buffer is valid
                bool pyValid_;

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -22,8 +22,11 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <stdint.h>
 #include <vector>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
    namespace interfaces {
@@ -134,11 +137,14 @@ namespace rogue {
                //! end iterator, caller must lock around access
                rogue::interfaces::memory::Transaction::iterator end();
 
+#ifndef NO_PYTHON
+
                //! Get transaction data from python
                void getData ( boost::python::object p, uint32_t offset );
 
                //! Set transaction data from python
                void setData ( boost::python::object p, uint32_t offset );
+#endif
          };
 
          // Convienence

--- a/include/rogue/interfaces/memory/TransactionLock.h
+++ b/include/rogue/interfaces/memory/TransactionLock.h
@@ -20,7 +20,6 @@
 #ifndef __ROGUE_INTERFACES_MEMORY_TRANSACTION_LOCK_H__
 #define __ROGUE_INTERFACES_MEMORY_TRANSACTION_LOCK_H__
 #include <stdint.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -27,7 +27,6 @@
 #define __ROGUE_INTERFACES_STREAM_BUFFER_H__
 #include <stdint.h>
 
-#include <boost/python.hpp>
 #include <rogue/interfaces/stream/Frame.h>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -90,9 +90,6 @@ namespace rogue {
                      boost::shared_ptr<rogue::interfaces::stream::Pool> source, 
                         void * data, uint32_t meta, uint32_t size, uint32_t alloc);
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Create a buffer.
                /*
                 * Pass owner, raw data buffer, and meta data

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -30,7 +30,10 @@
 #include <stdint.h>
 #include <vector>
 
+#ifndef NO_PYTHON
 #include <boost/python.hpp>
+#endif
+
 namespace rogue {
    namespace interfaces {
       namespace stream {
@@ -198,11 +201,14 @@ namespace rogue {
                //! Get write end iterator
                rogue::interfaces::stream::FrameIterator endWrite();
 
+#ifndef NO_PYTHON
+
                //! Read count bytes from frame payload, starting from offset. Python version.
                void readPy ( boost::python::object p, uint32_t offset );
 
                //! Write count bytes to frame payload, starting at offset. Python Version
                void writePy ( boost::python::object p, uint32_t offset );
+#endif
          };
 
          // Convienence

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -21,7 +21,6 @@
 #define __ROGUE_INTERFACES_STREAM_FRAME_ITERATOR_H__
 #include <stdint.h>
 #include <vector>
-#include <boost/python.hpp>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -66,9 +66,6 @@ namespace rogue {
                //! Creator
                FrameIterator();
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Copy assignment
                const rogue::interfaces::stream::FrameIterator operator =(
                      const rogue::interfaces::stream::FrameIterator &rhs);

--- a/include/rogue/interfaces/stream/FrameLock.h
+++ b/include/rogue/interfaces/stream/FrameLock.h
@@ -20,7 +20,6 @@
 #ifndef __ROGUE_INTERFACES_MEMORY_FRAME_LOCK_H__
 #define __ROGUE_INTERFACES_MEMORY_FRAME_LOCK_H__
 #include <stdint.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -26,8 +26,6 @@
 #include <pthread.h>
 #include <string>
 #include <vector>
-
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/Pool.h
+++ b/include/rogue/interfaces/stream/Pool.h
@@ -24,7 +24,6 @@
 #define __ROGUE_INTERFACES_STREAM_POOL_H__
 #include <stdint.h>
 
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <rogue/Queue.h>

--- a/include/rogue/interfaces/stream/Slave.h
+++ b/include/rogue/interfaces/stream/Slave.h
@@ -26,10 +26,13 @@
 #define __ROGUE_INTERFACES_STREAM_SLAVE_H__
 #include <stdint.h>
 
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <rogue/interfaces/stream/Pool.h>
 #include <rogue/Logging.h>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+#endif
 
 namespace rogue {
    namespace interfaces {
@@ -84,6 +87,11 @@ namespace rogue {
 
          };
 
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::Slave> SlavePtr;
+
+#ifndef NO_PYTHON
+
          //! Stream slave class, wrapper to enable pyton overload of virtual methods
          class SlaveWrap : 
             public rogue::interfaces::stream::Slave, 
@@ -98,9 +106,9 @@ namespace rogue {
                void defAcceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
          };
 
-         // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::stream::Slave> SlavePtr;
          typedef boost::shared_ptr<rogue::interfaces::stream::SlaveWrap> SlaveWrapPtr;
+#endif
+
       }
    }
 }

--- a/include/rogue/module.h
+++ b/include/rogue/module.h
@@ -1,12 +1,14 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : Scoped GIL 
+ * Title      : Python Module
  * ----------------------------------------------------------------------------
- * File       : ScopedGil.h
- * Created    : 2017-06-08
+ * File       : module.h
+ * Author     : Ryan Herbst, rherbst@slac.stanford.edu
+ * Created    : 2016-08-08
+ * Last update: 2016-08-08
  * ----------------------------------------------------------------------------
  * Description:
- * Acquire the GIL for the scope of this class.
+ * Python module setup
  * ----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -17,19 +19,12 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <rogue/ScopedGil.h>
+#ifndef __ROGUE_MODULE_H__
+#define __ROGUE_MODULE_H__
 
-rogue::ScopedGil::ScopedGil() {
-#ifndef NO_PYTHON
-   state_ = PyGILState_Ensure();
-#endif
+namespace rogue {
+   void setup_module();
 }
 
-rogue::ScopedGil::~ScopedGil() {
-#ifndef NO_PYTHON
-   PyGILState_Release(state_);
 #endif
-}
-
-void rogue::ScopedGil::setup_python() {}
 

--- a/include/rogue/protocols/epicsV3/Pv.h
+++ b/include/rogue/protocols/epicsV3/Pv.h
@@ -44,9 +44,6 @@ namespace rogue {
 
             public:
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Class creation
                Pv (caServer &cas, boost::shared_ptr<rogue::protocols::epicsV3::Value> value);
 

--- a/include/rogue/protocols/packetizer/Application.h
+++ b/include/rogue/protocols/packetizer/Application.h
@@ -22,7 +22,6 @@
 #define __ROGUE_PROTOCOLS_PACKETIZER_APPLICATION_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 

--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -67,9 +67,6 @@ namespace rogue {
 
             public:
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Creator
                Controller( boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
                            boost::shared_ptr<rogue::protocols::packetizer::Application> * app,

--- a/include/rogue/protocols/packetizer/ControllerV1.h
+++ b/include/rogue/protocols/packetizer/ControllerV1.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/packetizer/ControllerV2.h
+++ b/include/rogue/protocols/packetizer/ControllerV2.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/packetizer/Core.h
+++ b/include/rogue/protocols/packetizer/Core.h
@@ -20,7 +20,6 @@
 **/
 #ifndef __ROGUE_PROTOCOLS_PACKETIZER_CORE_H__
 #define __ROGUE_PROTOCOLS_PACKETIZER_CORE_H__
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 

--- a/include/rogue/protocols/packetizer/CoreV2.h
+++ b/include/rogue/protocols/packetizer/CoreV2.h
@@ -19,7 +19,6 @@
 **/
 #ifndef __ROGUE_PROTOCOLS_PACKETIZER_CORE_V2_H__
 #define __ROGUE_PROTOCOLS_PACKETIZER_CORE_V2_H__
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 

--- a/include/rogue/protocols/packetizer/Transport.h
+++ b/include/rogue/protocols/packetizer/Transport.h
@@ -22,7 +22,6 @@
 #define __ROGUE_PROTOCOLS_PACKETIZER_TRANSPORT_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/protocols/rssi/Application.h
+++ b/include/rogue/protocols/rssi/Application.h
@@ -22,7 +22,6 @@
 #define __ROGUE_PROTOCOLS_RSSI_APPLICATION_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -20,7 +20,6 @@
 **/
 #ifndef __ROGUE_PROTOCOLS_RSSI_CLIENT_H__
 #define __ROGUE_PROTOCOLS_RSSI_CLIENT_H__
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <boost/enable_shared_from_this.hpp>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -134,9 +134,6 @@ namespace rogue {
                            boost::shared_ptr<rogue::protocols::rssi::Transport> tran,
                            boost::shared_ptr<rogue::protocols::rssi::Application> app, bool server );
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Creator
                Controller( uint32_t segSize,
                            boost::shared_ptr<rogue::protocols::rssi::Transport> tran,

--- a/include/rogue/protocols/rssi/Header.h
+++ b/include/rogue/protocols/rssi/Header.h
@@ -69,9 +69,6 @@ namespace rogue {
                static boost::shared_ptr<rogue::protocols::rssi::Header>
                   create(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
-               //! Setup class in python
-               static void setup_python();
-
                //! Creator
                Header(boost::shared_ptr<rogue::interfaces::stream::Frame> frame);
 

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -16,7 +16,6 @@
 **/
 #ifndef __ROGUE_PROTOCOLS_RSSI_SERVER_H__
 #define __ROGUE_PROTOCOLS_RSSI_SERVER_H__
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 

--- a/include/rogue/protocols/rssi/Transport.h
+++ b/include/rogue/protocols/rssi/Transport.h
@@ -22,7 +22,6 @@
 #define __ROGUE_PROTOCOLS_RSSI_TRANSPORT_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/Queue.h>
 

--- a/include/rogue/protocols/udp/Client.h
+++ b/include/rogue/protocols/udp/Client.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <netdb.h>

--- a/include/rogue/protocols/udp/Server.h
+++ b/include/rogue/protocols/udp/Server.h
@@ -23,7 +23,6 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>
-#include <boost/python.hpp>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <netdb.h>

--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -139,8 +139,10 @@ namespace rogue {
             //! Set taps
             void setTaps(uint32_t tapCnt, uint8_t * taps);
 
+#ifndef NO_PYTHON
             //! Set taps, python
             void setTapsPy(boost::python::object p);
+#endif
 
             //! Send counter value
             void sendCount(bool state);

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -21,6 +21,7 @@
 **/
 
 #include <boost/python.hpp>
+#include <rogue/Version.h>
 #include <rogue/module.h>
 
 BOOST_PYTHON_MODULE(rogue) {

--- a/src/pyrogue/README.md
+++ b/src/pyrogue/README.md
@@ -1,1 +1,0 @@
-Rogue project pyrogue package source

--- a/src/rogue/CMakeLists.txt
+++ b/src/rogue/CMakeLists.txt
@@ -17,7 +17,7 @@
 add_subdirectory("hardware")
 add_subdirectory("interfaces")
 #add_subdirectory("protocols")
-#add_subdirectory("utilities")
+add_subdirectory("utilities")
 
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/GeneralError.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/GilRelease.cpp")

--- a/src/rogue/CMakeLists.txt
+++ b/src/rogue/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Add sub directories
 add_subdirectory("hardware")
 add_subdirectory("interfaces")
-#add_subdirectory("protocols")
+add_subdirectory("protocols")
 add_subdirectory("utilities")
 
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/GeneralError.cpp")

--- a/src/rogue/CMakeLists.txt
+++ b/src/rogue/CMakeLists.txt
@@ -14,7 +14,7 @@
 # ----------------------------------------------------------------------------
 
 # Add sub directories
-#add_subdirectory("hardware")
+add_subdirectory("hardware")
 add_subdirectory("interfaces")
 #add_subdirectory("protocols")
 #add_subdirectory("utilities")

--- a/src/rogue/CMakeLists.txt
+++ b/src/rogue/CMakeLists.txt
@@ -14,11 +14,19 @@
 # ----------------------------------------------------------------------------
 
 # Add sub directories
-add_subdirectory("hardware")
+#add_subdirectory("hardware")
 add_subdirectory("interfaces")
-add_subdirectory("protocols")
-add_subdirectory("utilities")
+#add_subdirectory("protocols")
+#add_subdirectory("utilities")
 
-# Local sources
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/GeneralError.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/GilRelease.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Logging.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/SMemControl.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/ScopedGil.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Version.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/ApiWrapper.cpp")
+endif()

--- a/src/rogue/GilRelease.cpp
+++ b/src/rogue/GilRelease.cpp
@@ -17,30 +17,44 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <boost/python.hpp>
 #include <stdint.h>
 #include <rogue/GilRelease.h>
 
+#ifndef NO_PYTHON
+
+#include <boost/python.hpp>
+namespace bp = boost::python;
+
 extern PyThreadState * _PyThreadState_Current;
 
+#endif
+
 rogue::GilRelease::GilRelease() {
+#ifndef NO_PYTHON
    state_ = NULL;
    release();
+#endif
 }
 
 rogue::GilRelease::~GilRelease() {
+#ifndef NO_PYTHON
    acquire();
+#endif
 }
 
 void rogue::GilRelease::acquire() {
+#ifndef NO_PYTHON
    if ( state_ != NULL ) PyEval_RestoreThread(state_);
    state_ = NULL;
+#endif
 }
 
 void rogue::GilRelease::release() {
+#ifndef NO_PYTHON
    PyThreadState * tstate = _PyThreadState_Current;
    if ( tstate && (tstate == PyGILState_GetThisThreadState()) ) state_ = PyEval_SaveThread();
    else state_ = NULL;
+#endif
 }
 
 void rogue::GilRelease::setup_python() {}

--- a/src/rogue/GilRelease.cpp
+++ b/src/rogue/GilRelease.cpp
@@ -57,5 +57,3 @@ void rogue::GilRelease::release() {
 #endif
 }
 
-void rogue::GilRelease::setup_python() {}
-

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/Logging.h>
 #include <boost/make_shared.hpp>
+#include <stdarg.h>
 
 #if defined(__linux__)
 #include <sys/syscall.h>
@@ -26,13 +27,16 @@
 #include <pthread.h>
 #endif
 
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
+
 const uint32_t rogue::Logging::Critical;
 const uint32_t rogue::Logging::Error;
 const uint32_t rogue::Logging::Warning;
 const uint32_t rogue::Logging::Info;
 const uint32_t rogue::Logging::Debug;
-
-namespace bp = boost::python;
 
 // Logging level
 uint32_t rogue::Logging::gblLevel_ = rogue::Logging::Error;
@@ -155,6 +159,7 @@ void rogue::Logging::logThreadId(uint32_t level) {
 }
 
 void rogue::Logging::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<rogue::Logging, rogue::LoggingPtr, boost::noncopyable>("Logging",bp::no_init)
       .def("setLevel", &rogue::Logging::setLevel)
       .staticmethod("setLevel")
@@ -166,6 +171,7 @@ void rogue::Logging::setup_python() {
       .def_readonly("Info",     &rogue::Logging::Info)
       .def_readonly("Debug",    &rogue::Logging::Debug)
    ;
+#endif
 }
 
 

--- a/src/rogue/SMemControl.cpp
+++ b/src/rogue/SMemControl.cpp
@@ -14,7 +14,6 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <boost/python.hpp>
 #include <rogue/RogueSMemFunctions.h>
 #include <rogue/SMemControl.h>
 #include <rogue/GeneralError.h>
@@ -23,7 +22,10 @@
 #include <rogue/ScopedGil.h>
 #include <string>
 
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp = boost::python;
+#endif
 
 const uint8_t rogue::SMemControl::Get;
 const uint8_t rogue::SMemControl::Set;
@@ -37,6 +39,7 @@ rogue::SMemControlPtr rogue::SMemControl::create(std::string group) {
 
 //! Setup class in python
 void rogue::SMemControl::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rogue::SMemControlWrap, rogue::SMemControlWrapPtr, boost::noncopyable>("SMemControl",bp::init<std::string>())
       .def("_doRequest",     &rogue::SMemControl::doRequest, &rogue::SMemControlWrap::defDoRequest)
@@ -45,6 +48,7 @@ void rogue::SMemControl::setup_python() {
       .def_readonly("Exec",  &rogue::SMemControl::Exec)
       .def_readonly("Value", &rogue::SMemControl::Value)
    ;
+#endif
 }
 
 rogue::SMemControl::SMemControl (std::string group) {
@@ -68,6 +72,8 @@ std::string rogue::SMemControl::doRequest ( uint8_t type, std::string path, std:
    return(std::string(""));
 }
 
+#ifndef NO_PYTHON
+
 rogue::SMemControlWrap::SMemControlWrap (std::string group) : rogue::SMemControl(group) {}
 
 std::string rogue::SMemControlWrap::doRequest ( uint8_t type, std::string path, std::string arg ) {
@@ -88,6 +94,8 @@ std::string rogue::SMemControlWrap::doRequest ( uint8_t type, std::string path, 
 std::string rogue::SMemControlWrap::defDoRequest ( uint8_t type, std::string path, std::string arg ) {
    return(rogue::SMemControl::doRequest(type,path,arg));
 }
+
+#endif
 
 void rogue::SMemControl::runThread() {
    std::string ret;

--- a/src/rogue/ScopedGil.cpp
+++ b/src/rogue/ScopedGil.cpp
@@ -31,5 +31,3 @@ rogue::ScopedGil::~ScopedGil() {
 #endif
 }
 
-void rogue::ScopedGil::setup_python() {}
-

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -21,14 +21,18 @@
 #include <rogue/Version.h>
 #include <rogue/GeneralError.h>
 #include <string>
+#include <sstream>
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 const char rogue::Version::_version[] = ROGUE_VERSION;
 uint32_t   rogue::Version::_major     = 0;
 uint32_t   rogue::Version::_minor     = 0;
 uint32_t   rogue::Version::_maint     = 0;
 uint32_t   rogue::Version::_devel     = 0;
-
-namespace bp = boost::python;
 
 void rogue::Version::init() {
    char     dump[100];
@@ -109,6 +113,7 @@ std::string rogue::Version::pythonVersion() {
 }
 
 void rogue::Version::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<rogue::Version, boost::noncopyable>("Version",bp::no_init)
       .def("current", &rogue::Version::current)
       .staticmethod("current")
@@ -129,6 +134,6 @@ void rogue::Version::setup_python() {
       .def("pythonVersion", &rogue::Version::pythonVersion)
       .staticmethod("pythonVersion")
    ;
-
+#endif
 }
 

--- a/src/rogue/hardware/CMakeLists.txt
+++ b/src/rogue/hardware/CMakeLists.txt
@@ -18,5 +18,6 @@ add_subdirectory("pgp")
 add_subdirectory("rce")
 add_subdirectory("axi")
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -32,7 +32,11 @@
 
 namespace rha = rogue::hardware::axi;
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rha::AxiMemMapPtr rha::AxiMemMap::create (std::string path) {
@@ -92,9 +96,11 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
 }
 
 void rha::AxiMemMap::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rha::AxiMemMap, rha::AxiMemMapPtr, bp::bases<rim::Slave>, boost::noncopyable >("AxiMemMap",bp::init<std::string>());
 
    bp::implicitly_convertible<rha::AxiMemMapPtr, rim::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -28,7 +28,11 @@
 
 namespace rha = rogue::hardware::axi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rha::AxiStreamDmaPtr rha::AxiStreamDma::create (std::string path, uint32_t dest, bool ssiEnable) {
@@ -390,6 +394,7 @@ void rha::AxiStreamDma::runThread() {
 }
 
 void rha::AxiStreamDma::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rha::AxiStreamDma, rha::AxiStreamDmaPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("AxiStreamDma",bp::init<std::string,uint32_t,bool>())
       .def("setDriverDebug", &rha::AxiStreamDma::setDriverDebug)
@@ -399,5 +404,6 @@ void rha::AxiStreamDma::setup_python () {
 
    bp::implicitly_convertible<rha::AxiStreamDmaPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rha::AxiStreamDmaPtr, ris::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/hardware/axi/CMakeLists.txt
+++ b/src/rogue/hardware/axi/CMakeLists.txt
@@ -13,5 +13,9 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/AxiMemMap.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/AxiStreamDma.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/hardware/data/CMakeLists.txt
+++ b/src/rogue/hardware/data/CMakeLists.txt
@@ -13,5 +13,9 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/DataCard.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/DataMap.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/hardware/data/DataCard.cpp
+++ b/src/rogue/hardware/data/DataCard.cpp
@@ -28,7 +28,11 @@
 
 namespace rhd = rogue::hardware::data;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rhd::DataCardPtr rhd::DataCard::create (std::string path, uint32_t dest) {
@@ -393,6 +397,7 @@ void rhd::DataCard::runThread() {
 }
 
 void rhd::DataCard::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhd::DataCard, rhd::DataCardPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("DataCard",bp::init<std::string,uint32_t>())
       .def("enableSsi",      &rhd::DataCard::enableSsi)
@@ -402,5 +407,6 @@ void rhd::DataCard::setup_python () {
 
    bp::implicitly_convertible<rhd::DataCardPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rhd::DataCardPtr, ris::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/hardware/data/DataMap.cpp
+++ b/src/rogue/hardware/data/DataMap.cpp
@@ -35,7 +35,11 @@
 
 namespace rhd = rogue::hardware::data;
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rhd::DataMapPtr rhd::DataMap::create (std::string path) {
@@ -98,9 +102,11 @@ void rhd::DataMap::doTransaction(rim::TransactionPtr tran) {
 }
 
 void rhd::DataMap::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhd::DataMap, rhd::DataMapPtr, bp::bases<rim::Slave>, boost::noncopyable >("DataMap",bp::init<std::string>());
 
    bp::implicitly_convertible<rhd::DataMapPtr, rim::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/hardware/pgp/CMakeLists.txt
+++ b/src/rogue/hardware/pgp/CMakeLists.txt
@@ -13,6 +13,13 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EvrControl.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/EvrStatus.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Info.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/PciStatus.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/PgpCard.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Status.cpp")
 
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/hardware/pgp/EvrControl.cpp
+++ b/src/rogue/hardware/pgp/EvrControl.cpp
@@ -23,7 +23,11 @@
 #include <boost/make_shared.hpp>
 
 namespace rhp = rogue::hardware::pgp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create the info class with pointer
 rhp::EvrControlPtr rhp::EvrControl::create() {
@@ -32,6 +36,7 @@ rhp::EvrControlPtr rhp::EvrControl::create() {
 }
 
 void rhp::EvrControl::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::EvrControl, rhp::EvrControlPtr >("EvrControl",bp::no_init)
       .def_readonly ("lane",        &rhp::EvrControl::lane)
@@ -46,6 +51,6 @@ void rhp::EvrControl::setup_python () {
       .def_readwrite("acceptCode",  &rhp::EvrControl::acceptCode)
       .def_readwrite("acceptDelay", &rhp::EvrControl::acceptDelay)
    ;
-
+#endif
 }
 

--- a/src/rogue/hardware/pgp/EvrStatus.cpp
+++ b/src/rogue/hardware/pgp/EvrStatus.cpp
@@ -23,7 +23,11 @@
 #include <boost/make_shared.hpp>
 
 namespace rhp = rogue::hardware::pgp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create the info class with pointer
 rhp::EvrStatusPtr rhp::EvrStatus::create() {
@@ -32,6 +36,7 @@ rhp::EvrStatusPtr rhp::EvrStatus::create() {
 }
 
 void rhp::EvrStatus::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::EvrStatus, rhp::EvrStatusPtr >("EvrStatus",bp::no_init)
       .def_readonly("lane",          &rhp::EvrStatus::lane)
@@ -42,6 +47,6 @@ void rhp::EvrStatus::setup_python () {
       .def_readonly("runCounter",    &rhp::EvrStatus::runCounter)
       .def_readonly("acceptCounter", &rhp::EvrStatus::acceptCounter)
    ;
-
+#endif
 }
 

--- a/src/rogue/hardware/pgp/Info.cpp
+++ b/src/rogue/hardware/pgp/Info.cpp
@@ -24,7 +24,11 @@
 #include <boost/make_shared.hpp>
 
 namespace rhp = rogue::hardware::pgp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create the info class with pointer
 rhp::InfoPtr rhp::Info::create() {
@@ -38,6 +42,7 @@ std::string rhp::Info::buildString() {
 }
 
 void rhp::Info::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::Info, rhp::InfoPtr>("Info",bp::no_init)
       .def_readonly("serial",     &rhp::Info::serial)
@@ -50,5 +55,6 @@ void rhp::Info::setup_python() {
       .def_readonly("evrSupport", &rhp::Info::evrSupport)
       .def("buildString",         &rhp::Info::buildString)
    ; 
+#endif
 }
 

--- a/src/rogue/hardware/pgp/PciStatus.cpp
+++ b/src/rogue/hardware/pgp/PciStatus.cpp
@@ -23,7 +23,11 @@
 #include <boost/make_shared.hpp>
 
 namespace rhp = rogue::hardware::pgp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create the info class with pointer
 rhp::PciStatusPtr rhp::PciStatus::create() {
@@ -32,6 +36,7 @@ rhp::PciStatusPtr rhp::PciStatus::create() {
 }
 
 void rhp::PciStatus::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::PciStatus, rhp::PciStatusPtr>("PciStatus",bp::no_init)
       .def_readonly("pciCommand",   &rhp::PciStatus::pciCommand)
@@ -46,5 +51,5 @@ void rhp::PciStatus::setup_python() {
       .def_readonly("pciBus",       &rhp::PciStatus::pciBus)
       .def_readonly("pciLanes",     &rhp::PciStatus::pciLanes)
    ; 
-
+#endif
 }

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -35,7 +35,11 @@
 
 namespace rhp = rogue::hardware::pgp;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rhp::PgpCardPtr rhp::PgpCard::create (std::string path, uint32_t lane, uint32_t vc) {
@@ -388,6 +392,7 @@ void rhp::PgpCard::runThread() {
 }
 
 void rhp::PgpCard::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::PgpCard, rhp::PgpCardPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("PgpCard",bp::init<std::string,uint32_t,uint32_t>())
       .def("getInfo",        &rhp::PgpCard::getInfo)
@@ -405,6 +410,6 @@ void rhp::PgpCard::setup_python () {
 
    bp::implicitly_convertible<rhp::PgpCardPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rhp::PgpCardPtr, ris::SlavePtr>();
-
+#endif
 }
 

--- a/src/rogue/hardware/pgp/Status.cpp
+++ b/src/rogue/hardware/pgp/Status.cpp
@@ -23,7 +23,11 @@
 #include <boost/make_shared.hpp>
 
 namespace rhp = rogue::hardware::pgp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create the info class with pointer
 rhp::StatusPtr rhp::Status::create() {
@@ -32,6 +36,7 @@ rhp::StatusPtr rhp::Status::create() {
 }
 
 void rhp::Status::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhp::Status, rhp::StatusPtr>("Status",bp::no_init)
       .def_readonly("lane",          &rhp::Status::lane)
@@ -48,5 +53,5 @@ void rhp::Status::setup_python () {
       .def_readonly("remData",       &rhp::Status::remData)
       .def_readonly("remBuffStatus", &rhp::Status::remBuffStatus)
    ;
-
+#endif
 }

--- a/src/rogue/hardware/rce/AxiStream.cpp
+++ b/src/rogue/hardware/rce/AxiStream.cpp
@@ -30,7 +30,11 @@
 
 namespace rhr = rogue::hardware::rce;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rhr::AxiStreamPtr rhr::AxiStream::create (std::string path, uint32_t dest) {
@@ -394,6 +398,7 @@ void rhr::AxiStream::runThread() {
 }
 
 void rhr::AxiStream::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhr::AxiStream, rhr::AxiStreamPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("AxiStream",bp::init<std::string,uint32_t>())
       .def("enableSsi",      &rhr::AxiStream::enableSsi)
@@ -403,5 +408,6 @@ void rhr::AxiStream::setup_python () {
 
    bp::implicitly_convertible<rhr::AxiStreamPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rhr::AxiStreamPtr, ris::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/hardware/rce/CMakeLists.txt
+++ b/src/rogue/hardware/rce/CMakeLists.txt
@@ -13,6 +13,9 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/AxiStream.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/MapMemory.cpp")
 
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/hardware/rce/MapMemory.cpp
+++ b/src/rogue/hardware/rce/MapMemory.cpp
@@ -36,7 +36,11 @@
 
 namespace rhr = rogue::hardware::rce;
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rhr::MapMemoryPtr rhr::MapMemory::create () {
@@ -145,11 +149,13 @@ void rhr::MapMemory::doTransaction(rim::TransactionPtr tran) {
 }
 
 void rhr::MapMemory::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rhr::MapMemory, rhr::MapMemoryPtr, bp::bases<rim::Slave>, boost::noncopyable >("MapMemory",bp::init<>())
       .def("addMap",         &rhr::MapMemory::addMap)
    ;
 
    bp::implicitly_convertible<rhr::MapMemoryPtr, rim::SlavePtr>();
+#endif
 }
 

--- a/src/rogue/interfaces/CMakeLists.txt
+++ b/src/rogue/interfaces/CMakeLists.txt
@@ -16,5 +16,6 @@
 add_subdirectory("memory")
 add_subdirectory("stream")
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/interfaces/memory/CMakeLists.txt
+++ b/src/rogue/interfaces/memory/CMakeLists.txt
@@ -13,5 +13,13 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Hub.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Master.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Transaction.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/TransactionLock.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()
+

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -26,10 +26,13 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <boost/make_shared.hpp>
-#include <boost/python.hpp>
 
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create a block, class creator
 rim::HubPtr rim::Hub::create (uint64_t offset) {
@@ -82,6 +85,7 @@ void rim::Hub::doTransaction(rim::TransactionPtr tran) {
 
 void rim::Hub::setup_python() {
 
+#ifndef NO_PYTHON
    bp::class_<rim::HubWrap, rim::HubWrapPtr, bp::bases<rim::Master,rim::Slave>, boost::noncopyable>("Hub",bp::init<uint64_t>())
        .def("_getAddress",    &rim::Hub::doAddress)
        .def("_getOffset",     &rim::Hub::getOffset)
@@ -89,7 +93,10 @@ void rim::Hub::setup_python() {
    ;
 
    bp::implicitly_convertible<rim::HubPtr, rim::MasterPtr>();
+#endif
 }
+
+#ifndef NO_PYTHON
 
 //! Constructor
 rim::HubWrap::HubWrap(uint64_t offset) : rim::Hub(offset) {}
@@ -115,4 +122,6 @@ void rim::HubWrap::doTransaction(rim::TransactionPtr transaction) {
 void rim::HubWrap::defDoTransaction(rim::TransactionPtr transaction) {
    rim::Hub::doTransaction(transaction);
 }
+
+#endif
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -28,7 +28,11 @@
 #include <stdlib.h>
 
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create a master container
 rim::MasterPtr rim::Master::create () {
@@ -37,6 +41,7 @@ rim::MasterPtr rim::Master::create () {
 }
 
 void rim::Master::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<rim::Master, rim::MasterPtr, boost::noncopyable>("Master",bp::init<>())
       .def("_setSlave",           &rim::Master::setSlave)
       .def("_getSlave",           &rim::Master::getSlave)
@@ -54,6 +59,7 @@ void rim::Master::setup_python() {
       .def("_setBits",            &rim::Master::setBits)
       .staticmethod("_setBits")
    ;
+#endif
 }
 
 //! Create object
@@ -145,6 +151,8 @@ uint32_t rim::Master::reqTransaction(uint64_t address, uint32_t size, void *data
    return(intTransaction(tran));
 }
 
+#ifndef NO_PYTHON
+
 //! Post a transaction, called locally, forwarded to slave, python version
 uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p, uint32_t size, uint32_t offset, uint32_t type) {
    rim::TransactionPtr tran = rim::Transaction::create(sumTime_);
@@ -167,6 +175,8 @@ uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p
 
    return(intTransaction(tran));
 }
+
+#endif
 
 uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
    TransactionMap::iterator it;
@@ -212,6 +222,8 @@ void rim::Master::waitTransaction(uint32_t id) {
       if ( (error = tran->wait()) != 0 ) error_ = error;
    }
 }
+
+#ifndef NO_PYTHON
 
 //! Copy bits from src to dst with lsbs and size
 void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::python::object src, uint32_t srcLsb, uint32_t size) {
@@ -323,4 +335,6 @@ void rim::Master::setBits(boost::python::object dst, uint32_t lsb, uint32_t size
 
    PyBuffer_Release(&dstBuf);
 }
+
+#endif
 

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -26,8 +26,12 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
+
 namespace rim = rogue::interfaces::memory;
-namespace bp = boost::python;
 
 // Init class counter
 uint32_t rim::Slave::classIdx_ = 0;
@@ -134,6 +138,7 @@ void rim::Slave::doTransaction(rim::TransactionPtr transaction) {
 }
 
 void rim::Slave::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<rim::SlaveWrap, rim::SlaveWrapPtr, boost::noncopyable>("Slave",bp::init<uint32_t,uint32_t>())
       .def("_addTransaction", &rim::Slave::addTransaction)
       .def("_getTransaction", &rim::Slave::getTransaction)
@@ -142,7 +147,10 @@ void rim::Slave::setup_python() {
       .def("_doAddress",      &rim::Slave::doAddress,     &rim::SlaveWrap::defDoAddress)
       .def("_doTransaction",  &rim::Slave::doTransaction, &rim::SlaveWrap::defDoTransaction)
    ;
+#endif
 }
+
+#ifndef NO_PYTHON
 
 //! Constructor
 rim::SlaveWrap::SlaveWrap(uint32_t min, uint32_t max) : rim::Slave(min,max) {}
@@ -231,4 +239,6 @@ void rim::SlaveWrap::doTransaction(rim::TransactionPtr transaction) {
 void rim::SlaveWrap::defDoTransaction(rim::TransactionPtr transaction) {
    rim::Slave::doTransaction(transaction);
 }
+
+#endif
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -29,7 +29,11 @@
 #include <rogue/ScopedGil.h>
 
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 // Init class counter
 uint32_t rim::Transaction::classIdx_ = 0;
@@ -44,6 +48,7 @@ rim::TransactionPtr rim::Transaction::create (struct timeval timeout) {
 }
 
 void rim::Transaction::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<rim::Transaction, rim::TransactionPtr, boost::noncopyable>("Transaction",bp::no_init)
       .def("lock",    &rim::Transaction::lock)
       .def("id",      &rim::Transaction::id)
@@ -55,6 +60,7 @@ void rim::Transaction::setup_python() {
       .def("setData", &rim::Transaction::setData)
       .def("getData", &rim::Transaction::getData)
    ;
+#endif
 }
 
 //! Create object
@@ -134,7 +140,9 @@ uint32_t rim::Transaction::wait() {
    // Reset
    if ( pyValid_ ) {
       rogue::ScopedGil gil;
+#ifndef NO_PYTHON
       PyBuffer_Release(&(pyBuf_));
+#endif
    }
    iter_    = NULL;
    pyValid_ = false;
@@ -164,6 +172,8 @@ rim::Transaction::iterator rim::Transaction::end() {
    if ( iter_ == NULL ) throw(rogue::GeneralError("Transaction::end","Invalid data"));
    return iter_ + size_;
 }
+
+#ifndef NO_PYTHON
 
 //! Set transaction data from python
 void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
@@ -204,4 +214,6 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    std::copy(begin()+offset,begin()+offset+count,data);
    PyBuffer_Release(&pyBuf);
 }
+
+#endif
 

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -22,7 +22,11 @@
 #include <rogue/GilRelease.h>
 
 namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create a container
 rim::TransactionLockPtr rim::TransactionLock::create (rim::TransactionPtr tran) {
@@ -40,11 +44,13 @@ rim::TransactionLock::TransactionLock(rim::TransactionPtr tran) {
 
 //! Setup class in python
 void rim::TransactionLock::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rim::TransactionLock, rim::TransactionLockPtr, boost::noncopyable>("TransactionLock",bp::no_init)
       .def("lock",      &rim::TransactionLock::lock)
       .def("unlock",    &rim::TransactionLock::unlock)
    ;
+#endif
 }
 
 //! Destructor

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -38,10 +38,6 @@ ris::BufferPtr ris::Buffer::create ( ris::PoolPtr source, void * data, uint32_t 
    return(buff);
 }
 
-void ris::Buffer::setup_python() {
-   // Nothing to do
-}
-
 //! Create a buffer.
 /*
  * Pass owner, raw data buffer, and meta data

--- a/src/rogue/interfaces/stream/CMakeLists.txt
+++ b/src/rogue/interfaces/stream/CMakeLists.txt
@@ -13,5 +13,16 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Buffer.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Fifo.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Frame.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/FrameIterator.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/FrameLock.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Master.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Pool.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()
+

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -31,8 +31,12 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 
-namespace bp = boost::python;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
 
 //! Class creation
 ris::FifoPtr ris::Fifo::create(uint32_t maxDepth, uint32_t trimSize) {
@@ -42,7 +46,9 @@ ris::FifoPtr ris::Fifo::create(uint32_t maxDepth, uint32_t trimSize) {
 
 //! Setup class in python
 void ris::Fifo::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<ris::Fifo, ris::FifoPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Fifo",bp::init<uint32_t,uint32_t>());
+#endif
 }
 
 //! Creator with version constant

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -24,10 +24,13 @@
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
-#include <boost/python.hpp>
 
-namespace ris = rogue::interfaces::stream;
+namespace ris  = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Create an empty frame
 ris::FramePtr ris::Frame::create() {
@@ -280,6 +283,8 @@ ris::Frame::iterator ris::Frame::endWrite() {
    return ris::Frame::iterator(shared_from_this(),true,true);
 }
 
+#ifndef NO_PYTHON
+
 //! Read up to count bytes from frame, starting from offset. Python version.
 void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    Py_buffer pyBuf;
@@ -329,7 +334,10 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
    PyBuffer_Release(&pyBuf);
 }
 
+#endif
+
 void ris::Frame::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ris::Frame, ris::FramePtr, boost::noncopyable>("Frame",bp::no_init)
       .def("lock",         &ris::Frame::lock)
@@ -343,5 +351,6 @@ void ris::Frame::setup_python() {
       .def("setFlags",     &ris::Frame::setFlags)
       .def("getFlags",     &ris::Frame::getFlags)
    ;
+#endif
 }
 

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -21,10 +21,13 @@
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
-#include <boost/python.hpp>
 
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 ris::FrameIterator::FrameIterator(ris::FramePtr frame, bool write, bool end) {
    write_     = write;

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -24,11 +24,6 @@
 
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
 ris::FrameIterator::FrameIterator(ris::FramePtr frame, bool write, bool end) {
    write_     = write;
    frame_     = frame;
@@ -264,5 +259,4 @@ ris::FrameIterator & ris::FrameIterator::operator -=(const int32_t &sub) {
    return *this;
 }
 
-void ris::FrameIterator::setup_python() { }
 

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -21,7 +21,12 @@
 #include <rogue/interfaces/stream/Frame.h>
 
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
+
 
 //! Create a frame container
 ris::FrameLockPtr ris::FrameLock::create (ris::FramePtr frame) {
@@ -38,11 +43,13 @@ ris::FrameLock::FrameLock(ris::FramePtr frame) {
 
 //! Setup class in python
 void ris::FrameLock::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ris::FrameLock, ris::FrameLockPtr, boost::noncopyable>("FrameLock",bp::no_init)
       .def("lock",      &ris::FrameLock::lock)
       .def("unlock",    &ris::FrameLock::unlock)
    ;
+#endif
 }
 
 //! Destructor

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -22,11 +22,14 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GilRelease.h>
-#include <boost/python.hpp>
 #include <boost/make_shared.hpp>
 
-namespace ris = rogue::interfaces::stream;
+namespace ris  = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 ris::MasterPtr ris::Master::create () {
@@ -85,6 +88,7 @@ void ris::Master::sendFrame ( FramePtr frame) {
 }
 
 void ris::Master::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ris::Master, ris::MasterPtr, boost::noncopyable>("Master",bp::init<>())
       .def("_setSlave",      &ris::Master::setSlave)
@@ -92,5 +96,6 @@ void ris::Master::setup_python() {
       .def("_reqFrame",      &ris::Master::reqFrame)
       .def("_sendFrame",     &ris::Master::sendFrame)
    ;
+#endif
 }
 

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -29,7 +29,11 @@
 #include <rogue/GilRelease.h>
 
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Creator
 ris::Pool::Pool() { 
@@ -87,6 +91,7 @@ void ris::Pool::retBuffer(uint8_t * data, uint32_t meta, uint32_t rawSize) {
 }
 
 void ris::Pool::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<ris::Pool, ris::PoolPtr, boost::noncopyable>("Pool",bp::init<>())
       .def("getAllocCount",  &ris::Pool::getAllocCount)
       .def("getAllocBytes",  &ris::Pool::getAllocBytes)
@@ -95,6 +100,7 @@ void ris::Pool::setup_python() {
       .def("setPoolSize",    &ris::Pool::setPoolSize)
       .def("getPoolSize",    &ris::Pool::getPoolSize)
    ;
+#endif
 }
 
 //! Set fixed size mode

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -34,7 +34,11 @@
 #include <rogue/Logging.h>
 
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 ris::SlavePtr ris::Slave::create () {
@@ -93,6 +97,8 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
    }
 }
 
+#ifndef NO_PYTHON
+
 //! Accept frame
 void ris::SlaveWrap::acceptFrame ( ris::FramePtr frame ) {
    {
@@ -115,6 +121,7 @@ void ris::SlaveWrap::defAcceptFrame ( ris::FramePtr frame ) {
    ris::Slave::acceptFrame(frame);
 }
 
+#endif
 
 //! Get frame counter
 uint64_t ris::Slave::getFrameCount() {
@@ -127,6 +134,7 @@ uint64_t ris::Slave::getByteCount() {
 }
 
 void ris::Slave::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ris::SlaveWrap, ris::SlaveWrapPtr, boost::noncopyable>("Slave",bp::init<>())
       .def("setDebug",       &ris::Slave::setDebug)
@@ -142,6 +150,6 @@ void ris::Slave::setup_python() {
    ;
 
    bp::implicitly_convertible<ris::SlavePtr, ris::PoolPtr>();
-
+#endif
 }
 

--- a/src/rogue/interfaces/stream/module.cpp
+++ b/src/rogue/interfaces/stream/module.cpp
@@ -21,12 +21,10 @@
 **/
 
 #include <rogue/interfaces/module.h>
-#include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/FrameLock.h>
-#include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/interfaces/stream/module.h>
 #include <boost/python.hpp>
@@ -45,10 +43,8 @@ void ris::setup_module() {
    // set the current scope to the new sub-module
    bp::scope io_scope = module;
 
-   ris::Buffer::setup_python();
    ris::Frame::setup_python();
    ris::FrameLock::setup_python();
-   ris::FrameIterator::setup_python();
    ris::Master::setup_python();
    ris::Slave::setup_python();
    ris::Pool::setup_python();

--- a/src/rogue/module.cpp
+++ b/src/rogue/module.cpp
@@ -21,6 +21,7 @@
 **/
 
 #include <boost/python.hpp>
+#include <rogue/module.h>
 #include <rogue/interfaces/module.h>
 #include <rogue/hardware/module.h>
 #include <rogue/utilities/module.h>
@@ -28,13 +29,11 @@
 #include <rogue/GeneralError.h>
 #include <rogue/Logging.h>
 #include <rogue/SMemControl.h>
-#include <rogue/GilRelease.h>
-#include <rogue/ScopedGil.h>
 #include <rogue/Version.h>
 
 namespace bp  = boost::python;
 
-void rogue::hardware::setup_module() {
+void rogue::setup_module() {
 
    rogue::interfaces::setup_module();
    rogue::protocols::setup_module();
@@ -43,8 +42,6 @@ void rogue::hardware::setup_module() {
 
    rogue::GeneralError::setup_python();
    rogue::Logging::setup_python();
-   rogue::GilRelease::setup_python();
-   rogue::ScopedGil::setup_python();
    rogue::Version::setup_python();
    rogue::SMemControl::setup_python();
 

--- a/src/rogue/module.cpp
+++ b/src/rogue/module.cpp
@@ -1,14 +1,14 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : Python Package
+ * Title      : Python Module
  * ----------------------------------------------------------------------------
- * File       : package.cpp
+ * File       : module.cpp
  * Author     : Ryan Herbst, rherbst@slac.stanford.edu
  * Created    : 2016-08-08
  * Last update: 2016-08-08
  * ----------------------------------------------------------------------------
  * Description:
- * Python package setup
+ * Python module setup
  * ----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 
@@ -21,15 +21,32 @@
 **/
 
 #include <boost/python.hpp>
-#include <rogue/module.h>
+#include <rogue/interfaces/module.h>
+#include <rogue/hardware/module.h>
+#include <rogue/utilities/module.h>
+#include <rogue/protocols/module.h>
+#include <rogue/GeneralError.h>
+#include <rogue/Logging.h>
+#include <rogue/SMemControl.h>
+#include <rogue/GilRelease.h>
+#include <rogue/ScopedGil.h>
+#include <rogue/Version.h>
 
-BOOST_PYTHON_MODULE(rogue) {
+namespace bp  = boost::python;
 
-   PyEval_InitThreads();
+void rogue::hardware::setup_module() {
 
-   rogue::setup_module();
+   rogue::interfaces::setup_module();
+   rogue::protocols::setup_module();
+   rogue::hardware::setup_module();
+   rogue::utilities::setup_module();
 
-   printf("Rogue/pyrogue version %s. https://github.com/slaclab/rogue\n",rogue::Version::current().c_str());
+   rogue::GeneralError::setup_python();
+   rogue::Logging::setup_python();
+   rogue::GilRelease::setup_python();
+   rogue::ScopedGil::setup_python();
+   rogue::Version::setup_python();
+   rogue::SMemControl::setup_python();
 
-};
+}
 

--- a/src/rogue/protocols/CMakeLists.txt
+++ b/src/rogue/protocols/CMakeLists.txt
@@ -22,5 +22,6 @@ if (DO_EPICS_V3)
    add_subdirectory("epicsV3")
 endif()
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/protocols/epicsV3/CMakeLists.txt
+++ b/src/rogue/protocols/epicsV3/CMakeLists.txt
@@ -13,5 +13,11 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Command.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Master.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Pv.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Server.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Value.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Variable.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")

--- a/src/rogue/protocols/epicsV3/Command.cpp
+++ b/src/rogue/protocols/epicsV3/Command.cpp
@@ -18,15 +18,15 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Command.h>
 #include <rogue/protocols/epicsV3/Pv.h>
 #include <rogue/protocols/epicsV3/Server.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
-#include <boost/make_shared.hpp>
 
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Master.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
@@ -28,6 +27,8 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Pv.cpp
+++ b/src/rogue/protocols/epicsV3/Pv.cpp
@@ -18,12 +18,13 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Pv.h>
 #include <rogue/protocols/epicsV3/Value.h>
 #include <time.h>
 
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Pv.cpp
+++ b/src/rogue/protocols/epicsV3/Pv.cpp
@@ -27,9 +27,6 @@ namespace rpe = rogue::protocols::epicsV3;
 #include <boost/python.hpp>
 namespace bp  = boost::python;
 
-//! Setup class in python
-void rpe::Pv::setup_python() { }
-
 //! Class creation
 rpe::Pv::Pv (caServer &cas, rpe::ValuePtr value) : casPV(cas) {
    value_    = value;

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Server.h>
 #include <rogue/protocols/epicsV3/Value.h>
 #include <rogue/protocols/epicsV3/Pv.h>
@@ -27,6 +26,8 @@
 #include <fdManager.h>
 
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Slave.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/FrameLock.h>
@@ -30,6 +29,8 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Value.h>
 #include <rogue/protocols/epicsV3/Pv.h>
 #include <rogue/protocols/epicsV3/Server.h>
@@ -28,6 +27,8 @@
 #include <aitTypes.h>
 
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -18,7 +18,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/epicsV3/Variable.h>
 #include <rogue/protocols/epicsV3/Pv.h>
 #include <rogue/protocols/epicsV3/Server.h>
@@ -29,6 +28,8 @@
 #include <boost/make_shared.hpp>
 
 namespace rpe = rogue::protocols::epicsV3;
+
+#include <boost/python.hpp>
 namespace bp  = boost::python;
 
 //! Setup class in python

--- a/src/rogue/protocols/packetizer/Application.cpp
+++ b/src/rogue/protocols/packetizer/Application.cpp
@@ -29,7 +29,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::ApplicationPtr rpp::Application::create (uint8_t id) {
@@ -38,11 +42,13 @@ rpp::ApplicationPtr rpp::Application::create (uint8_t id) {
 }
 
 void rpp::Application::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpp::Application, rpp::ApplicationPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Application",bp::init<uint8_t>());
 
    bp::implicitly_convertible<rpp::ApplicationPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpp::ApplicationPtr, ris::SlavePtr>();
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/packetizer/CMakeLists.txt
+++ b/src/rogue/protocols/packetizer/CMakeLists.txt
@@ -13,5 +13,14 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Application.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Controller.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/ControllerV1.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/ControllerV2.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Core.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/CoreV2.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Transport.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -32,7 +32,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 void rpp::Controller::setup_python() {
    // Nothing to do

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -33,15 +33,6 @@
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
-void rpp::Controller::setup_python() {
-   // Nothing to do
-}
-
 //! Creator
 rpp::Controller::Controller ( rpp::TransportPtr tran, rpp::ApplicationPtr * app,
                               uint32_t headSize, uint32_t tailSize, uint32_t alignSize ) {

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -32,7 +32,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::ControllerV1Ptr rpp::ControllerV1::create ( rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -33,11 +33,6 @@
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
 //! Class creation
 rpp::ControllerV1Ptr rpp::ControllerV1::create ( rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {
    rpp::ControllerV1Ptr r = boost::make_shared<rpp::ControllerV1>(tran,app);

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -33,7 +33,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::ControllerV2Ptr rpp::ControllerV2::create ( bool enIbCrc, bool enObCrc, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -34,11 +34,6 @@
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
 //! Class creation
 rpp::ControllerV2Ptr rpp::ControllerV2::create ( bool enIbCrc, bool enObCrc, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {
    rpp::ControllerV2Ptr r = boost::make_shared<rpp::ControllerV2>(enIbCrc,enObCrc,tran,app);

--- a/src/rogue/protocols/packetizer/Core.cpp
+++ b/src/rogue/protocols/packetizer/Core.cpp
@@ -28,7 +28,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::CorePtr rpp::Core::create () {
@@ -37,6 +41,7 @@ rpp::CorePtr rpp::Core::create () {
 }
 
 void rpp::Core::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpp::Core, rpp::CorePtr, boost::noncopyable >("Core",bp::init<>())
       .def("transport",      &rpp::Core::transport)
@@ -44,7 +49,7 @@ void rpp::Core::setup_python() {
       .def("getDropCount",   &rpp::Core::getDropCount)
 
    ;
-
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/packetizer/CoreV2.cpp
+++ b/src/rogue/protocols/packetizer/CoreV2.cpp
@@ -27,7 +27,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::CoreV2Ptr rpp::CoreV2::create (bool enIbCrc, bool enObCrc) {
@@ -36,6 +40,7 @@ rpp::CoreV2Ptr rpp::CoreV2::create (bool enIbCrc, bool enObCrc) {
 }
 
 void rpp::CoreV2::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpp::CoreV2, rpp::CoreV2Ptr, boost::noncopyable >("CoreV2",bp::init<bool,bool>())
       .def("transport",      &rpp::CoreV2::transport)
@@ -43,7 +48,7 @@ void rpp::CoreV2::setup_python() {
       .def("getDropCount",   &rpp::CoreV2::getDropCount)
 
    ;
-
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/packetizer/Transport.cpp
+++ b/src/rogue/protocols/packetizer/Transport.cpp
@@ -29,7 +29,11 @@
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpp::TransportPtr rpp::Transport::create () {
@@ -38,11 +42,13 @@ rpp::TransportPtr rpp::Transport::create () {
 }
 
 void rpp::Transport::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpp::Transport, rpp::TransportPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Transport",bp::init<>());
 
    bp::implicitly_convertible<rpp::TransportPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpp::TransportPtr, ris::SlavePtr>();
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/packetizer/module.cpp
+++ b/src/rogue/protocols/packetizer/module.cpp
@@ -24,9 +24,6 @@
 #include <rogue/protocols/packetizer/module.h>
 #include <rogue/protocols/packetizer/Application.h>
 #include <rogue/protocols/packetizer/Transport.h>
-#include <rogue/protocols/packetizer/Controller.h>
-#include <rogue/protocols/packetizer/ControllerV1.h>
-#include <rogue/protocols/packetizer/ControllerV2.h>
 #include <rogue/protocols/packetizer/Core.h>
 #include <rogue/protocols/packetizer/CoreV2.h>
 
@@ -46,9 +43,6 @@ void rpp::setup_module() {
 
    rpp::Application::setup_python();
    rpp::Transport::setup_python();
-   rpp::Controller::setup_python();
-   rpp::ControllerV1::setup_python();
-   rpp::ControllerV2::setup_python();
    rpp::Core::setup_python();
    rpp::CoreV2::setup_python();
 

--- a/src/rogue/protocols/rssi/Application.cpp
+++ b/src/rogue/protocols/rssi/Application.cpp
@@ -29,7 +29,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpr::ApplicationPtr rpr::Application::create () {
@@ -38,11 +42,13 @@ rpr::ApplicationPtr rpr::Application::create () {
 }
 
 void rpr::Application::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpr::Application, rpr::ApplicationPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Application",bp::init<>());
 
    bp::implicitly_convertible<rpr::ApplicationPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpr::ApplicationPtr, ris::SlavePtr>();
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/CMakeLists.txt
+++ b/src/rogue/protocols/rssi/CMakeLists.txt
@@ -13,5 +13,13 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Application.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Client.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Controller.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Header.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Server.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Transport.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -28,7 +28,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpr::ClientPtr rpr::Client::create (uint32_t segSize) {
@@ -37,6 +41,7 @@ rpr::ClientPtr rpr::Client::create (uint32_t segSize) {
 }
 
 void rpr::Client::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpr::Client, rpr::ClientPtr, boost::noncopyable >("Client",bp::init<uint32_t>())
       .def("transport",       &rpr::Client::transport)
@@ -59,7 +64,7 @@ void rpr::Client::setup_python() {
       .def("getMaxCumAck",    &rpr::Client::getMaxCumAck)
       .def("getSegmentSize",  &rpr::Client::getSegmentSize)
    ;
-
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -37,21 +37,12 @@
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
 //! Class creation
 rpr::ControllerPtr rpr::Controller::create ( uint32_t segSize, 
                                              rpr::TransportPtr tran, 
                                              rpr::ApplicationPtr app, bool server ) {
    rpr::ControllerPtr r = boost::make_shared<rpr::Controller>(segSize,tran,app,server);
    return(r);
-}
-
-void rpr::Controller::setup_python() {
-   // Nothing to do
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -36,7 +36,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpr::ControllerPtr rpr::Controller::create ( uint32_t segSize, 

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -30,11 +30,6 @@
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
 
-#ifndef NO_PYTHON
-#include <boost/python.hpp>
-namespace bp  = boost::python;
-#endif
-
 //! Set 16-bit uint value
 void rpr::Header::setUInt16 ( uint8_t *data, uint8_t byte, uint16_t value) {
    *((uint16_t *)(&(data[byte]))) = htons(value);
@@ -72,10 +67,6 @@ uint16_t rpr::Header::compSum (uint8_t *data, uint8_t size) {
 rpr::HeaderPtr rpr::Header::create(ris::FramePtr frame) {
    rpr::HeaderPtr r = boost::make_shared<rpr::Header>(frame);
    return(r);
-}
-
-void rpr::Header::setup_python() {
-   // Nothing to do
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -29,7 +29,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Set 16-bit uint value
 void rpr::Header::setUInt16 ( uint8_t *data, uint8_t byte, uint16_t value) {

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -24,7 +24,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpr::ServerPtr rpr::Server::create (uint32_t segSize) {
@@ -33,6 +37,7 @@ rpr::ServerPtr rpr::Server::create (uint32_t segSize) {
 }
 
 void rpr::Server::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpr::Server, rpr::ServerPtr, boost::noncopyable >("Server",bp::init<uint32_t>())
       .def("transport",       &rpr::Server::transport)
@@ -55,7 +60,7 @@ void rpr::Server::setup_python() {
       .def("getMaxCumAck",    &rpr::Server::getMaxCumAck)
       .def("getSegmentSize",  &rpr::Server::getSegmentSize)      
    ;
-
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/Transport.cpp
+++ b/src/rogue/protocols/rssi/Transport.cpp
@@ -29,7 +29,11 @@
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpr::TransportPtr rpr::Transport::create () {
@@ -38,11 +42,13 @@ rpr::TransportPtr rpr::Transport::create () {
 }
 
 void rpr::Transport::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rpr::Transport, rpr::TransportPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Transport",bp::init<>());
 
    bp::implicitly_convertible<rpr::TransportPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpr::TransportPtr, ris::SlavePtr>();
+#endif
 }
 
 //! Creator

--- a/src/rogue/protocols/rssi/module.cpp
+++ b/src/rogue/protocols/rssi/module.cpp
@@ -22,10 +22,8 @@
 
 #include <rogue/protocols/rssi/module.h>
 #include <rogue/protocols/rssi/Application.h>
-#include <rogue/protocols/rssi/Controller.h>
 #include <rogue/protocols/rssi/Client.h>
 #include <rogue/protocols/rssi/Server.h>
-#include <rogue/protocols/rssi/Header.h>
 #include <rogue/protocols/rssi/Transport.h>
 #include <boost/python.hpp>
 
@@ -44,10 +42,8 @@ void rpr::setup_module() {
    bp::scope io_scope = module;
 
    rpr::Application::setup_python();
-   rpr::Controller::setup_python();
    rpr::Client::setup_python();
    rpr::Server::setup_python();
-   rpr::Header::setup_python();
    rpr::Transport::setup_python();
 
 }

--- a/src/rogue/protocols/rssi/module.cpp
+++ b/src/rogue/protocols/rssi/module.cpp
@@ -20,7 +20,6 @@
  * ----------------------------------------------------------------------------
 **/
 
-#include <boost/python.hpp>
 #include <rogue/protocols/rssi/module.h>
 #include <rogue/protocols/rssi/Application.h>
 #include <rogue/protocols/rssi/Controller.h>
@@ -28,9 +27,10 @@
 #include <rogue/protocols/rssi/Server.h>
 #include <rogue/protocols/rssi/Header.h>
 #include <rogue/protocols/rssi/Transport.h>
+#include <boost/python.hpp>
 
-namespace bp  = boost::python;
 namespace rpr = rogue::protocols::rssi;
+namespace bp  = boost::python;
 
 void rpr::setup_module() {
 

--- a/src/rogue/protocols/srp/CMakeLists.txt
+++ b/src/rogue/protocols/srp/CMakeLists.txt
@@ -13,5 +13,10 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Cmd.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/SrpV0.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/SrpV3.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/protocols/srp/Cmd.cpp
+++ b/src/rogue/protocols/srp/Cmd.cpp
@@ -27,9 +27,13 @@
 #include <rogue/interfaces/stream/FrameIterator.h>
 #include <rogue/protocols/srp/Cmd.h>
 
-namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rps::CmdPtr rps::Cmd::create () {
@@ -39,11 +43,12 @@ rps::CmdPtr rps::Cmd::create () {
 
 //! Setup class in python
 void rps::Cmd::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rps::Cmd, rps::CmdPtr, bp::bases<ris::Master>, boost::noncopyable >("Cmd",bp::init<>())
        .def("sendCmd", &rps::Cmd::sendCmd)
    ;
-
+#endif
 }
 
 //! Creator with version constant

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -35,10 +35,14 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 
-namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
 namespace rim = rogue::interfaces::memory;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rps::SrpV0Ptr rps::SrpV0::create () {
@@ -48,9 +52,10 @@ rps::SrpV0Ptr rps::SrpV0::create () {
 
 //! Setup class in python
 void rps::SrpV0::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rps::SrpV0, rps::SrpV0Ptr, bp::bases<ris::Master,ris::Slave,rim::Slave>, boost::noncopyable >("SrpV0",bp::init<>());
-
+#endif
 }
 
 //! Creator with version constant

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -35,10 +35,14 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 
-namespace bp = boost::python;
 namespace rps = rogue::protocols::srp;
 namespace rim = rogue::interfaces::memory;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rps::SrpV3Ptr rps::SrpV3::create () {
@@ -48,13 +52,14 @@ rps::SrpV3Ptr rps::SrpV3::create () {
 
 //! Setup class in python
 void rps::SrpV3::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<rps::SrpV3, rps::SrpV3Ptr, bp::bases<ris::Master,ris::Slave,rim::Slave>,boost::noncopyable >("SrpV3",bp::init<>());
 
    bp::implicitly_convertible<rps::SrpV3Ptr, ris::MasterPtr>();
    bp::implicitly_convertible<rps::SrpV3Ptr, ris::SlavePtr>();
    bp::implicitly_convertible<rps::SrpV3Ptr, rim::SlavePtr>();
-
+#endif
 }
 
 //! Creator with version constant

--- a/src/rogue/protocols/udp/CMakeLists.txt
+++ b/src/rogue/protocols/udp/CMakeLists.txt
@@ -13,5 +13,10 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Client.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Core.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Server.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -31,7 +31,11 @@
 
 namespace rpu = rogue::protocols::udp;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpu::ClientPtr rpu::Client::create (std::string host, uint16_t port, bool jumbo) {
@@ -203,12 +207,13 @@ void rpu::Client::runThread() {
 }
 
 void rpu::Client::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rpu::Client, rpu::ClientPtr, bp::bases<rpu::Core,ris::Master,ris::Slave>, boost::noncopyable >("Client",bp::init<std::string,uint16_t,bool>());
 
    bp::implicitly_convertible<rpu::ClientPtr, rpu::CorePtr>();
    bp::implicitly_convertible<rpu::ClientPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpu::ClientPtr, ris::SlavePtr>();
-
+#endif
 }
 

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -22,7 +22,11 @@
 #include <unistd.h>
 
 namespace rpu = rogue::protocols::udp;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Creator
 rpu::Core::Core (bool jumbo) {
@@ -65,10 +69,12 @@ void rpu::Core::setTimeout(uint32_t timeout) {
 }
 
 void rpu::Core::setup_python () {
+#ifndef NO_PYTHON
    bp::class_<rpu::Core, rpu::CorePtr, boost::noncopyable >("Core",bp::no_init)
       .def("maxPayload",        &rpu::Core::maxPayload)
       .def("setRxBufferCount",  &rpu::Core::setRxBufferCount)
       .def("setTimeout",        &rpu::Core::setTimeout)
    ;
+#endif
 }
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -32,7 +32,11 @@
 
 namespace rpu = rogue::protocols::udp;
 namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
 namespace bp  = boost::python;
+#endif
 
 //! Class creation
 rpu::ServerPtr rpu::Server::create (uint16_t port, bool jumbo) {
@@ -216,6 +220,7 @@ void rpu::Server::runThread() {
 }
 
 void rpu::Server::setup_python () {
+#ifndef NO_PYTHON
 
    bp::class_<rpu::Server, rpu::ServerPtr, bp::bases<rpu::Core,ris::Master,ris::Slave>, boost::noncopyable >("Server",bp::init<uint16_t,bool>())
       .def("getPort",        &rpu::Server::getPort)
@@ -224,6 +229,6 @@ void rpu::Server::setup_python () {
    bp::implicitly_convertible<rpu::ServerPtr, rpu::CorePtr>();
    bp::implicitly_convertible<rpu::ServerPtr, ris::MasterPtr>();
    bp::implicitly_convertible<rpu::ServerPtr, ris::SlavePtr>();
-
+#endif
 }
 

--- a/src/rogue/utilities/CMakeLists.txt
+++ b/src/rogue/utilities/CMakeLists.txt
@@ -15,5 +15,10 @@
 
 add_subdirectory("fileio")
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Prbs.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/StreamUnZip.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/StreamZip.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -36,7 +36,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ru::PrbsPtr ru::Prbs::create () {
@@ -143,6 +147,8 @@ void ru::Prbs::setTaps(uint32_t tapCnt, uint8_t * taps) {
    for (i=0; i < tapCnt_; i++) taps_[i] = taps[i];
 }
 
+#ifndef NO_PYTHON
+
 //! Set taps, python
 void ru::Prbs::setTapsPy(boost::python::object p) {
    Py_buffer pyBuf;
@@ -154,6 +160,7 @@ void ru::Prbs::setTapsPy(boost::python::object p) {
    PyBuffer_Release(&pyBuf);
 }
 
+#endif
 
 //! Send counter value
 void ru::Prbs::sendCount(bool state) {
@@ -443,6 +450,7 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
 }
 
 void ru::Prbs::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ru::Prbs, ru::PrbsPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Prbs",bp::init<>())
       .def("genFrame",       &ru::Prbs::genFrame)
@@ -468,6 +476,7 @@ void ru::Prbs::setup_python() {
 
    bp::implicitly_convertible<ru::PrbsPtr, ris::SlavePtr>();
    bp::implicitly_convertible<ru::PrbsPtr, ris::MasterPtr>();
+#endif
 }
 
 

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -31,7 +31,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ru::StreamUnZipPtr ru::StreamUnZip::create () {
@@ -119,12 +123,13 @@ ris::FramePtr ru::StreamUnZip::acceptReq ( uint32_t size, bool zeroCopyEn ) {
 }
 
 void ru::StreamUnZip::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ru::StreamUnZip, ru::StreamUnZipPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("StreamUnZip",bp::init<>());
 
    bp::implicitly_convertible<ru::StreamUnZipPtr, ris::SlavePtr>();
    bp::implicitly_convertible<ru::StreamUnZipPtr, ris::MasterPtr>();
-
+#endif
 }
 
 

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -31,7 +31,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ru::StreamZipPtr ru::StreamZip::create () {
@@ -120,12 +124,13 @@ ris::FramePtr ru::StreamZip::acceptReq ( uint32_t size, bool zeroCopyEn ) {
 }
 
 void ru::StreamZip::setup_python() {
+#ifndef NO_PYTHON
 
    bp::class_<ru::StreamZip, ru::StreamZipPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("StreamZip",bp::init<>());
 
    bp::implicitly_convertible<ru::StreamZipPtr, ris::SlavePtr>();
    bp::implicitly_convertible<ru::StreamZipPtr, ris::MasterPtr>();
-
+#endif
 }
 
 

--- a/src/rogue/utilities/fileio/CMakeLists.txt
+++ b/src/rogue/utilities/fileio/CMakeLists.txt
@@ -13,5 +13,10 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-file(GLOB rogue_SRC "*.cpp")
-target_sources(rogue-core PRIVATE ${rogue_SRC})
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/StreamReader.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/StreamWriter.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/StreamWriterChannel.cpp")
+
+if (DO_PYTHON)
+   target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
+endif()

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -34,7 +34,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ruf::StreamReaderPtr ruf::StreamReader::create () {
@@ -44,12 +48,14 @@ ruf::StreamReaderPtr ruf::StreamReader::create () {
 
 //! Setup class in python
 void ruf::StreamReader::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<ruf::StreamReader, ruf::StreamReaderPtr,bp::bases<ris::Master>, boost::noncopyable >("StreamReader",bp::init<>())
       .def("open",           &ruf::StreamReader::open)
       .def("close",          &ruf::StreamReader::close)
       .def("closeWait",      &ruf::StreamReader::closeWait)
       .def("isActive",       &ruf::StreamReader::isActive)
    ;
+#endif
 }
 
 //! Creator

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -46,7 +46,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ruf::StreamWriterPtr ruf::StreamWriter::create () {
@@ -56,6 +60,7 @@ ruf::StreamWriterPtr ruf::StreamWriter::create () {
 
 //! Setup class in python
 void ruf::StreamWriter::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<ruf::StreamWriter, ruf::StreamWriterPtr, boost::noncopyable >("StreamWriter",bp::init<>())
       .def("open",           &ruf::StreamWriter::open)
       .def("close",          &ruf::StreamWriter::close)
@@ -66,6 +71,7 @@ void ruf::StreamWriter::setup_python() {
       .def("getFrameCount",  &ruf::StreamWriter::getFrameCount)
       .def("waitFrameCount", &ruf::StreamWriter::waitFrameCount)
    ;
+#endif
 }
 
 //! Creator

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -32,7 +32,11 @@
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
-namespace bp  = boost::python;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp = boost::python;
+#endif
 
 //! Class creation
 ruf::StreamWriterChannelPtr ruf::StreamWriterChannel::create (ruf::StreamWriterPtr writer, uint8_t channel) {
@@ -42,11 +46,13 @@ ruf::StreamWriterChannelPtr ruf::StreamWriterChannel::create (ruf::StreamWriterP
 
 //! Setup class in python
 void ruf::StreamWriterChannel::setup_python() {
+#ifndef NO_PYTHON
    bp::class_<ruf::StreamWriterChannel, ruf::StreamWriterChannelPtr, bp::bases<ris::Slave>, boost::noncopyable >("StreamWriterChannel",bp::no_init)
        .def("getFrameCount", &ruf::StreamWriterChannel::getFrameCount)
        .def("waitFrameCount", &ruf::StreamWriterChannel::waitFrameCount)
        ;
    bp::implicitly_convertible<ruf::StreamWriterChannelPtr, ris::SlavePtr>();
+#endif
 }
 
 //! Creator


### PR DESCRIPTION
This PR provides support for building rogue without python or boost python. This is for systems which will use the rogue data processing c++ libraries but not the variable & device trees in python.