### PR TITLE
Make sure to zero unused fields in aiHints structure before use.

### DIFF
--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -58,16 +58,17 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
-      throw(rogue::GeneralError::network("Client::Client",address_.c_str(),port_));
+      throw(rogue::GeneralError::network("Client::Client(socket)",address_.c_str(),port_));
 
    // Lookup host address
+   bzero(&aiHints, sizeof(aiHints));
    aiHints.ai_flags    = AI_CANONNAME;
    aiHints.ai_family   = AF_INET;
    aiHints.ai_socktype = SOCK_DGRAM;
    aiHints.ai_protocol = IPPROTO_UDP;
 
    if ( ::getaddrinfo(address_.c_str(), 0, &aiHints, &aiList) || !aiList)
-      throw(rogue::GeneralError::network("Client::Client",address_.c_str(),port_));
+      throw(rogue::GeneralError::network("Client::Client(getaddrinfo)",address_.c_str(),port_));
 
    addr = (const sockaddr_in*)(aiList->ai_addr);
 


### PR DESCRIPTION
This prevents garbage from the stack from being used to getaddrinfo(), which could return an error or silently give the wrong result at random. Problem observed on FreeBSD 11.2 with clang 6.0 as compiler.

Also adds a bit better debug information to the error messages for socket() and getaddrinfo() calls, which were previously degenerate.