### PR TITLE
Allow value=None when localGet exists in LocalVariable

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -459,8 +459,8 @@ class LocalVariable(BaseVariable):
                  localGet=None,
                  pollInterval=0):
 
-        if value is None:
-            raise VariableError(f'LocalVariable {self.path} must specify value= argument in constructor')
+        if value is None and localGet is None:
+            raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
 
         BaseVariable.__init__(self, name=name, description=description, 
                               mode=mode, value=value, disp=disp, 


### PR DESCRIPTION
LocalVariable use to demand that value bet set so that the type is know. This is not necessary, and sometimes unwanted, when localGet exists.