### PR TITLE
Allow software configurable parameters for RSSI server and client

### DIFF
--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -96,6 +96,7 @@ namespace rogue {
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();
 
+               void     setLocMaxSegment(uint16_t val);
                uint16_t getLocMaxSegment();
 
                void     setLocCumAckTout(uint16_t val);

--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -74,7 +74,7 @@ namespace rogue {
 
                //! Get Retran Count
                uint32_t getRetranCount();
-
+               
                //! Get locBusy
                bool getLocBusy();
 
@@ -86,30 +86,40 @@ namespace rogue {
 
                //! Get remBusyCnt
                uint32_t getRemBusyCnt();
-               
-               //! Get maxRetran
-               uint32_t getMaxRetran();
-               
-               //! Get remMaxBuffers
-               uint32_t getRemMaxBuffers();           
 
-               //! Get remMaxSegment
-               uint32_t getRemMaxSegment();    
+               void     setLocTryPeriod(uint32_t val);
+               uint32_t getLocTryPeriod();
 
-               //! Get retranTout
-               uint32_t getRetranTout();
+               void     setLocBusyThold(uint32_t val);
+               uint32_t getLocBusyThold();
 
-               //! Get cumAckTout
-               uint32_t getCumAckTout();               
-               
-               //! Get nullTout
-               uint32_t getNullTout();
-               
-               //! Get maxCumAck
-               uint32_t getMaxCumAck();
+               void     setLocMaxBuffers(uint8_t val);
+               uint8_t  getLocMaxBuffers();
 
-               //! Get segmentSize
-               uint32_t getSegmentSize();               
+               uint16_t getLocMaxSegment();
+
+               void     setLocCumAckTout(uint16_t val);
+               uint16_t getLocCumAckTout();
+
+               void     setLocRetranTout(uint16_t val);
+               uint16_t getLocRetranTout();
+
+               void     setLocNullTout(uint16_t val);
+               uint16_t getLocNullTout();
+
+               void     setLocMaxRetran(uint8_t val);
+               uint8_t  getLocMaxRetran();
+
+               void     setLocMaxCumAck(uint8_t val);
+               uint8_t  getLocMaxCumAck();
+
+               uint8_t  curMaxBuffers();
+               uint16_t curMaxSegment();
+               uint16_t curCumAckTout();
+               uint16_t curRetranTout();
+               uint16_t curNullTout();
+               uint8_t  curMaxRetran();
+               uint8_t  curMaxCumAck();
 
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -196,6 +196,7 @@ namespace rogue {
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();
 
+               void     setLocMaxSegment(uint16_t val);
                uint16_t getLocMaxSegment();
 
                void     setLocCumAckTout(uint16_t val);

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -38,21 +38,31 @@ namespace rogue {
          //! RSSI Controller Class
          class Controller : public boost::enable_shared_from_this<rogue::protocols::rssi::Controller> {
 
+               //! Hard coded values
                static const uint8_t  Version       = 1;
                static const uint8_t  TimeoutUnit   = 3; // rssiTime * std::pow(10,-TimeoutUnit) = 3 = ms
-               
-               static const uint8_t  LocMaxBuffers = 32; // MAX_NUM_OUTS_SEG_G in FW
-               static const uint32_t BusyThold     = 64;
-               
-               // RSSI Timeouts (units of TimeoutUnit)
-               static const uint32_t TryPeriod     = 100;  // 100 mS
-               static const uint16_t ReqCumAckTout = 5;    // ACK_TOUT_G in FW, 5mS
-               static const uint16_t ReqRetranTout = 20;   // RETRANS_TOUT_G in FW, 2hmS
-               static const uint16_t ReqNullTout   = 1000; // NULL_TOUT_G in FW, 1S
-               
-               // Counters
-               static const uint8_t  ReqMaxRetran  = 15;   // MAX_RETRANS_CNT_G in FW
-               static const uint8_t  ReqMaxCumAck  = 2;    // MAX_CUM_ACK_CNT_G in FW
+
+               //! Local parameters
+               uint32_t locTryPeriod_;
+               uint32_t locBusyThold_;
+
+               //! Configurable parameters, requested by software
+               uint8_t  locMaxBuffers_;
+               uint16_t locMaxSegment_;
+               uint16_t locCumAckTout_;
+               uint16_t locRetranTout_;
+               uint16_t locNullTout_;
+               uint8_t  locMaxRetran_;
+               uint8_t  locMaxCumAck_;
+
+               //! Negotiated parameters
+               uint8_t  curMaxBuffers_;
+               uint16_t curMaxSegment_;
+               uint16_t curCumAckTout_;
+               uint16_t curRetranTout_;
+               uint16_t curNullTout_;
+               uint8_t  curMaxRetran_;
+               uint8_t  curMaxCumAck_;
 
                //! Connection states
                enum States : uint32_t { StClosed     = 0,
@@ -97,6 +107,10 @@ namespace rogue {
                struct timeval stTime_;
                uint32_t downCount_;
                uint32_t retranCount_;
+               uint32_t locBusyCnt_;
+               uint32_t remBusyCnt_;
+               uint32_t locConnId_;
+               uint32_t remConnId_;
 
                // Transmit tracking
                boost::shared_ptr<rogue::protocols::rssi::Header> txList_[256];
@@ -105,20 +119,6 @@ namespace rogue {
                uint8_t lastAckTx_;
                uint8_t locSequence_;
                struct timeval txTime_;
-
-               // Connection parameters
-               uint32_t locConnId_;
-               uint8_t  remMaxBuffers_;
-               uint16_t remMaxSegment_;
-               uint32_t retranTout_;
-               uint16_t cumAckTout_;
-               uint16_t nullTout_;
-               uint8_t  maxRetran_;
-               uint8_t  maxCumAck_;
-               uint32_t remConnId_;
-               uint32_t segmentSize_;
-               uint32_t locBusyCnt_;
-               uint32_t remBusyCnt_;
 
                // Time values
                struct timeval retranToutD1_;  // retranTout_ / 1
@@ -186,30 +186,40 @@ namespace rogue {
 
                //! Get remBusyCnt
                uint32_t getRemBusyCnt();
-               
-               //! Get maxRetran
-               uint32_t getMaxRetran();
-               
-               //! Get remMaxBuffers
-               uint32_t getRemMaxBuffers();           
 
-               //! Get remMaxSegment
-               uint32_t getRemMaxSegment();    
+               void     setLocTryPeriod(uint32_t val);
+               uint32_t getLocTryPeriod();
 
-               //! Get retranTout
-               uint32_t getRetranTout();
+               void     setLocBusyThold(uint32_t val);
+               uint32_t getLocBusyThold();
 
-               //! Get cumAckTout
-               uint32_t getCumAckTout();               
-               
-               //! Get nullTout
-               uint32_t getNullTout();
-               
-               //! Get maxCumAck
-               uint32_t getMaxCumAck();
+               void     setLocMaxBuffers(uint8_t val);
+               uint8_t  getLocMaxBuffers();
 
-               //! Get segmentSize
-               uint32_t getSegmentSize();
+               uint16_t getLocMaxSegment();
+
+               void     setLocCumAckTout(uint16_t val);
+               uint16_t getLocCumAckTout();
+
+               void     setLocRetranTout(uint16_t val);
+               uint16_t getLocRetranTout();
+
+               void     setLocNullTout(uint16_t val);
+               uint16_t getLocNullTout();
+
+               void     setLocMaxRetran(uint8_t val);
+               uint8_t  getLocMaxRetran();
+
+               void     setLocMaxCumAck(uint8_t val);
+               uint8_t  getLocMaxCumAck();
+
+               uint8_t  curMaxBuffers();
+               uint16_t curMaxSegment();
+               uint16_t curCumAckTout();
+               uint16_t curRetranTout();
+               uint16_t curNullTout();
+               uint8_t  curMaxRetran();
+               uint8_t  curMaxCumAck();
 
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -82,40 +82,49 @@ namespace rogue {
 
                //! Get remBusyCnt
                uint32_t getRemBusyCnt();
-               
-               //! Get maxRetran
-               uint32_t getMaxRetran();
-               
-               //! Get remMaxBuffers
-               uint32_t getRemMaxBuffers();           
 
-               //! Get remMaxSegment
-               uint32_t getRemMaxSegment();    
+               void     setLocTryPeriod(uint32_t val);
+               uint32_t getLocTryPeriod();
 
-               //! Get retranTout
-               uint32_t getRetranTout();
+               void     setLocBusyThold(uint32_t val);
+               uint32_t getLocBusyThold();
 
-               //! Get cumAckTout
-               uint32_t getCumAckTout();               
-               
-               //! Get nullTout
-               uint32_t getNullTout();
-               
-               //! Get maxCumAck
-               uint32_t getMaxCumAck();
+               void     setLocMaxBuffers(uint8_t val);
+               uint8_t  getLocMaxBuffers();
 
-               //! Get segmentSize
-               uint32_t getSegmentSize();               
+               uint16_t getLocMaxSegment();
+
+               void     setLocCumAckTout(uint16_t val);
+               uint16_t getLocCumAckTout();
+
+               void     setLocRetranTout(uint16_t val);
+               uint16_t getLocRetranTout();
+
+               void     setLocNullTout(uint16_t val);
+               uint16_t getLocNullTout();
+
+               void     setLocMaxRetran(uint8_t val);
+               uint8_t  getLocMaxRetran();
+
+               void     setLocMaxCumAck(uint8_t val);
+               uint8_t  getLocMaxCumAck();
+
+               uint8_t  curMaxBuffers();
+               uint16_t curMaxSegment();
+               uint16_t curCumAckTout();
+               uint16_t curRetranTout();
+               uint16_t curNullTout();
+               uint8_t  curMaxRetran();
+               uint8_t  curMaxCumAck();
 
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 
-               //! Stop
+               //! Stop connection
                void stop();
 
-               //! Start
+               //! Start connection
                void start();
-
          };
 
          // Convienence

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -92,6 +92,7 @@ namespace rogue {
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();
 
+               void     setLocMaxSegment(uint16_t val);
                uint16_t getLocMaxSegment();
 
                void     setLocCumAckTout(uint16_t val);

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -459,8 +459,8 @@ class LocalVariable(BaseVariable):
                  localGet=None,
                  pollInterval=0):
 
-        if value is None:
-            raise VariableError(f'LocalVariable {self.path} must specify value= argument in constructor')
+        if value is None and localGet is None:
+            raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
 
         BaseVariable.__init__(self, name=name, description=description, 
                               mode=mode, value=value, disp=disp, 

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -60,13 +60,12 @@ class UdpRssiPack(pr.Device):
                     self._log.warning("host=%s, port=%d -> Establishing link ..." % (host,port))
                     last = curr
 
-        self._udp.setRxBufferCount(self._rssi.getRemMaxBuffers());
+        self._udp.setRxBufferCount(self._rssi.curMaxBuffers());
 
         # Add variables
         self.add(pr.LocalVariable(
             name        = 'rssiOpen',
             mode        = 'RO', 
-            value       = False, 
             localGet    = lambda: self._rssi.getOpen(),
             pollInterval= pollInterval, 
         ))
@@ -74,7 +73,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiDownCount',
             mode        = 'RO', 
-            value       = 0, 
             localGet    = lambda: self._rssi.getDownCount(),
             pollInterval= pollInterval, 
         )) 
@@ -82,7 +80,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiDropCount',
             mode        = 'RO', 
-            value       = 0, 
             localGet    = lambda: self._rssi.getDropCount(),
             pollInterval= pollInterval, 
         ))  
@@ -90,7 +87,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiRetranCount',
             mode        = 'RO', 
-            value       = 0, 
             localGet    = lambda: self._rssi.getRetranCount(),
             pollInterval= pollInterval, 
         ))  
@@ -98,7 +94,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locBusy',
             mode        = 'RO', 
-            value       = False, 
             localGet    = lambda: self._rssi.getLocBusy(),
             hidden      = True,
             pollInterval= pollInterval, 
@@ -107,7 +102,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locBusyCnt',
             mode        = 'RO', 
-            value       = 0, 
             localGet    = lambda: self._rssi.getLocBusyCnt(),
             pollInterval= pollInterval, 
         ))         
@@ -115,7 +109,6 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'remBusy',
             mode        = 'RO', 
-            value       = False, 
             localGet    = lambda: self._rssi.getRemBusy(),
             hidden      = True,
             pollInterval= pollInterval, 
@@ -124,79 +117,120 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'remBusyCnt',
             mode        = 'RO', 
-            value       = 0, 
             localGet    = lambda: self._rssi.getRemBusyCnt(),
             pollInterval= pollInterval, 
         ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'maxRetran',
+            name        = 'locTryPeriod',
             mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getMaxRetran(),
-            pollInterval= pollInterval, 
-        ))    
+            localGet    = lambda: self._rssi.getLocTryPeriod(),
+            localSet    = lambda value: self._rssi.setLocTryPeriod(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'remMaxBuffers',
-            mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getRemMaxBuffers(),
-            pollInterval= pollInterval, 
-        )) 
+            name        = 'locBusyThold',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocBusyThold(),
+            localSet    = lambda value: self._rssi.setLocBusyThold(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'remMaxSegment',
-            mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getRemMaxSegment(),
-            units       = 'Bytes', 
-            pollInterval= pollInterval, 
-        ))   
+            name        = 'locMaxBuffers',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocMaxBuffers(),
+            localSet    = lambda value: self._rssi.setLocMaxBuffers(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'retranTout',
+            name        = 'locMaxSegment',
             mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getRetranTout(),
-            units       = 'ms', 
-            pollInterval= pollInterval, 
-        ))  
+            localGet    = lambda: self._rssi.getLocMaxSegment()
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'cumAckTout',
-            mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getCumAckTout(),
-            units       = 'ms', 
-            pollInterval= pollInterval, 
-        ))  
+            name        = 'locCumAckTout',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocCumAckTout(),
+            localSet    = lambda value: self._rssi.setLocCumAckTout(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'nullTout',
-            mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getNullTout(),
-            units       = 'ms', 
-            pollInterval= pollInterval, 
-        ))
+            name        = 'locRetranTout',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocRetranTout(),
+            localSet    = lambda value: self._rssi.setLocRetranTout(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'maxCumAck',
-            mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getMaxCumAck(),
-            pollInterval= pollInterval, 
-        ))  
+            name        = 'locNullTout',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocNullTout(),
+            localSet    = lambda value: self._rssi.setLocNullTout(value)
+        ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'segmentSize',
+            name        = 'locMaxRetran',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocMaxRetran(),
+            localSet    = lambda value: self._rssi.setLocMaxRetran(value)
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'locMaxCumAck',
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocMaxCumAck(),
+            localSet    = lambda value: self._rssi.setLocMaxCumAck(value)
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curMaxBuffers',
             mode        = 'RO', 
-            value       = 0, 
-            localGet    = lambda: self._rssi.getSegmentSize(),
-            units       = 'Bytes',
-            pollInterval= pollInterval, 
-        ))                    
+            localGet    = lambda: self._rssi.curMaxBuffers(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curMaxSegment',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curMaxSegment(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curCumAckTout',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curCumAckTout(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curRetranTout',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curRetranTout(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curNullTout',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curNullTout(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curMaxRetran',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curMaxRetran(),
+            pollInterval= pollInterval 
+        ))                 
+
+        self.add(pr.LocalVariable(
+            name        = 'curMaxCumAck',
+            mode        = 'RO', 
+            localGet    = lambda: self._rssi.curMaxCumAck(),
+            pollInterval= pollInterval 
+        ))                 
                             
         self.add(pr.LocalCommand(
             name        = 'stop',

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -123,7 +123,7 @@ class UdpRssiPack(pr.Device):
 
         self.add(pr.LocalVariable(
             name        = 'locTryPeriod',
-            mode        = 'RO', 
+            mode        = 'RW', 
             localGet    = lambda: self._rssi.getLocTryPeriod(),
             localSet    = lambda value: self._rssi.setLocTryPeriod(value)
         ))                 
@@ -144,8 +144,9 @@ class UdpRssiPack(pr.Device):
 
         self.add(pr.LocalVariable(
             name        = 'locMaxSegment',
-            mode        = 'RO', 
-            localGet    = lambda: self._rssi.getLocMaxSegment()
+            mode        = 'RW', 
+            localGet    = lambda: self._rssi.getLocMaxSegment(),
+            localSet    = lambda value: self._rssi.setLocMaxSegment(value)
         ))                 
 
         self.add(pr.LocalVariable(

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -44,26 +44,43 @@ void rpr::Client::setup_python() {
 #ifndef NO_PYTHON
 
    bp::class_<rpr::Client, rpr::ClientPtr, boost::noncopyable >("Client",bp::init<uint32_t>())
-      .def("transport",       &rpr::Client::transport)
-      .def("application",     &rpr::Client::application)
-      .def("getOpen",         &rpr::Client::getOpen)
-      .def("getDownCount",    &rpr::Client::getDownCount)
-      .def("getDropCount",    &rpr::Client::getDropCount)
-      .def("getRetranCount",  &rpr::Client::getRetranCount)
-      .def("getLocBusy",      &rpr::Client::getLocBusy)
-      .def("getLocBusyCnt",   &rpr::Client::getLocBusyCnt)
-      .def("getRemBusy",      &rpr::Client::getRemBusy)
-      .def("getRemBusyCnt",   &rpr::Client::getRemBusyCnt)
-      .def("stop",            &rpr::Client::stop)
-      .def("start",           &rpr::Client::start)
-      .def("getMaxRetran",    &rpr::Client::getMaxRetran)
-      .def("getRemMaxBuffers",&rpr::Client::getRemMaxBuffers)
-      .def("getRemMaxSegment",&rpr::Client::getRemMaxSegment)
-      .def("getRetranTout",   &rpr::Client::getRetranTout)
-      .def("getCumAckTout",   &rpr::Client::getCumAckTout)
-      .def("getNullTout",     &rpr::Client::getNullTout)
-      .def("getMaxCumAck",    &rpr::Client::getMaxCumAck)
-      .def("getSegmentSize",  &rpr::Client::getSegmentSize)
+      .def("transport",        &rpr::Client::transport)
+      .def("application",      &rpr::Client::application)
+      .def("getOpen",          &rpr::Client::getOpen)
+      .def("getDownCount",     &rpr::Client::getDownCount)
+      .def("getDropCount",     &rpr::Client::getDropCount)
+      .def("getRetranCount",   &rpr::Client::getRetranCount)
+      .def("getLocBusy",       &rpr::Client::getLocBusy)
+      .def("getLocBusyCnt",    &rpr::Client::getLocBusyCnt)
+      .def("getRemBusy",       &rpr::Client::getRemBusy)
+      .def("getRemBusyCnt",    &rpr::Client::getRemBusyCnt)
+      .def("setLocTryPeriod",  &rpr::Client::setLocTryPeriod)
+      .def("getLocTryPeriod",  &rpr::Client::getLocTryPeriod)
+      .def("setLocBusyThold",  &rpr::Client::setLocBusyThold)
+      .def("getLocBusyThold",  &rpr::Client::getLocBusyThold)
+      .def("setLocMaxBuffers", &rpr::Client::setLocMaxBuffers)
+      .def("getLocMaxBuffers", &rpr::Client::getLocMaxBuffers)
+      .def("getLocMaxSegment", &rpr::Client::getLocMaxSegment)
+      .def("setLocCumAckTout", &rpr::Client::setLocCumAckTout)
+      .def("getLocCumAckTout", &rpr::Client::getLocCumAckTout)
+      .def("setLocRetranTout", &rpr::Client::setLocRetranTout)
+      .def("getLocRetranTout", &rpr::Client::getLocRetranTout)
+      .def("setLocNullTout",   &rpr::Client::setLocNullTout)
+      .def("getLocNullTout",   &rpr::Client::getLocNullTout)
+      .def("setLocMaxRetran",  &rpr::Client::setLocMaxRetran)
+      .def("getLocMaxRetran",  &rpr::Client::getLocMaxRetran)
+      .def("setLocMaxCumAck",  &rpr::Client::setLocMaxCumAck)
+      .def("getLocMaxCumAck",  &rpr::Client::getLocMaxCumAck)
+      .def("curMaxBuffers",    &rpr::Client::curMaxBuffers)
+      .def("curMaxSegment",    &rpr::Client::curMaxSegment)
+      .def("curCumAckTout",    &rpr::Client::curCumAckTout)
+      .def("curRetranTout",    &rpr::Client::curRetranTout)
+      .def("curNullTout",      &rpr::Client::curNullTout)
+      .def("curMaxRetran",     &rpr::Client::curMaxRetran)
+      .def("curMaxCumAck",     &rpr::Client::curMaxCumAck)
+      .def("setTimeout",       &rpr::Client::setTimeout)
+      .def("stop",             &rpr::Client::stop)
+      .def("start",            &rpr::Client::start)
    ;
 #endif
 }
@@ -133,44 +150,100 @@ uint32_t rpr::Client::getRemBusyCnt() {
    return(cntl_->getRemBusyCnt());
 }
 
-//! Get maxRetran
-uint32_t rpr::Client::getMaxRetran() {
-   return(cntl_->getMaxRetran());
+void rpr::Client::setLocTryPeriod(uint32_t val) {
+   cntl_->setLocTryPeriod(val);
 }
 
-//! Get remMaxBuffers
-uint32_t rpr::Client::getRemMaxBuffers() {
-   return(cntl_->getRemMaxBuffers());
+uint32_t rpr::Client::getLocTryPeriod() {
+   return cntl_->getLocTryPeriod();
 }
 
-//! Get remMaxSegment
-uint32_t rpr::Client::getRemMaxSegment() {
-   return(cntl_->getRemMaxSegment());
+void rpr::Client::setLocBusyThold(uint32_t val) {
+   cntl_->setLocBusyThold(val);
 }
 
-//! Get retranTout
-uint32_t rpr::Client::getRetranTout() {
-   return(cntl_->getRetranTout());
+uint32_t rpr::Client::getLocBusyThold() {
+   return cntl_->getLocBusyThold();
 }
 
-//! Get cumAckTout
-uint32_t rpr::Client::getCumAckTout() {
-   return(cntl_->getCumAckTout());
+void rpr::Client::setLocMaxBuffers(uint8_t val) {
+   cntl_->setLocMaxBuffers(val);
 }
 
-//! Get nullTout
-uint32_t rpr::Client::getNullTout() {
-   return(cntl_->getNullTout());
+uint8_t rpr::Client::getLocMaxBuffers() {
+   return cntl_->getLocMaxBuffers();
 }
 
-//! Get maxCumAck
-uint32_t rpr::Client::getMaxCumAck() {
-   return(cntl_->getMaxCumAck());
+uint16_t rpr::Client::getLocMaxSegment() {
+   return cntl_->getLocMaxSegment();
 }
 
-//! Get segmentSize
-uint32_t rpr::Client::getSegmentSize() {
-   return(cntl_->getSegmentSize());
+void rpr::Client::setLocCumAckTout(uint16_t val) {
+   cntl_->setLocCumAckTout(val);
+}
+
+uint16_t rpr::Client::getLocCumAckTout() {
+   return cntl_->getLocCumAckTout();
+}
+
+void rpr::Client::setLocRetranTout(uint16_t val) {
+   cntl_->setLocRetranTout(val);
+}
+
+uint16_t rpr::Client::getLocRetranTout() {
+   return cntl_->getLocRetranTout();
+}
+
+void rpr::Client::setLocNullTout(uint16_t val) {
+   cntl_->setLocNullTout(val);
+}
+
+uint16_t rpr::Client::getLocNullTout() {
+   return cntl_->getLocNullTout();
+}
+
+void rpr::Client::setLocMaxRetran(uint8_t val) {
+   cntl_->setLocMaxRetran(val);
+}
+
+uint8_t rpr::Client::getLocMaxRetran() {
+   return cntl_->getLocMaxRetran();
+}
+
+void rpr::Client::setLocMaxCumAck(uint8_t val) {
+   cntl_->setLocMaxCumAck(val);
+}
+
+uint8_t  rpr::Client::getLocMaxCumAck() {
+   return cntl_->getLocMaxCumAck();
+}
+
+uint8_t  rpr::Client::curMaxBuffers() {
+   return cntl_->curMaxBuffers();
+}
+
+uint16_t rpr::Client::curMaxSegment() {
+   return cntl_->curMaxSegment();
+}
+
+uint16_t rpr::Client::curCumAckTout() {
+   return cntl_->curCumAckTout();
+}
+
+uint16_t rpr::Client::curRetranTout() {
+   return cntl_->curRetranTout();
+}
+
+uint16_t rpr::Client::curNullTout() {
+   return cntl_->curNullTout();
+}
+
+uint8_t  rpr::Client::curMaxRetran() {
+   return cntl_->curMaxRetran();
+}
+
+uint8_t  rpr::Client::curMaxCumAck() {
+   return cntl_->curMaxCumAck();
 }
 
 //! Set timeout for frame transmits in microseconds

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -60,6 +60,7 @@ void rpr::Client::setup_python() {
       .def("getLocBusyThold",  &rpr::Client::getLocBusyThold)
       .def("setLocMaxBuffers", &rpr::Client::setLocMaxBuffers)
       .def("getLocMaxBuffers", &rpr::Client::getLocMaxBuffers)
+      .def("setLocMaxSegment", &rpr::Client::setLocMaxSegment)
       .def("getLocMaxSegment", &rpr::Client::getLocMaxSegment)
       .def("setLocCumAckTout", &rpr::Client::setLocCumAckTout)
       .def("getLocCumAckTout", &rpr::Client::getLocCumAckTout)
@@ -172,6 +173,10 @@ void rpr::Client::setLocMaxBuffers(uint8_t val) {
 
 uint8_t rpr::Client::getLocMaxBuffers() {
    return cntl_->getLocMaxBuffers();
+}
+
+void rpr::Client::setLocMaxSegment(uint16_t val) {
+   cntl_->setLocMaxSegment(val);
 }
 
 uint16_t rpr::Client::getLocMaxSegment() {

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -419,6 +419,10 @@ uint8_t rpr::Controller::getLocMaxBuffers() {
    return locMaxBuffers_;
 }
 
+void rpr::Controller::setLocMaxSegment(uint16_t val) {
+   locMaxSegment_ = val;
+}
+
 uint16_t rpr::Controller::getLocMaxSegment() {
    return locMaxSegment_;
 }

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -51,7 +51,10 @@ rpr::Controller::Controller ( uint32_t segSize, rpr::TransportPtr tran, rpr::App
    tran_   = tran;
    server_ = server;
 
-   appQueue_.setThold(BusyThold);
+   locTryPeriod_ = 100;
+   locBusyThold_ = 64;
+
+   appQueue_.setThold(locBusyThold_);
 
    dropCount_   = 0;
    nextSeqRx_   = 0;
@@ -71,23 +74,31 @@ rpr::Controller::Controller ( uint32_t segSize, rpr::TransportPtr tran, rpr::App
    locSequence_ = 100;
    gettimeofday(&txTime_,NULL);
 
+   locMaxBuffers_ = 32;   // MAX_NUM_OUTS_SEG_G in FW
+   locMaxSegment_ = segSize;
+   locCumAckTout_ = 5;    // ACK_TOUT_G in FW, 5mS
+   locRetranTout_ = 20;   // RETRANS_TOUT_G in FW, 2hmS
+   locNullTout_   = 1000; // NULL_TOUT_G in FW, 1S
+   locMaxRetran_  = 15;   // MAX_RETRANS_CNT_G in FW
+   locMaxCumAck_  = 2;    // MAX_CUM_ACK_CNT_G in FW
+
+   curMaxBuffers_ = 32;   // MAX_NUM_OUTS_SEG_G in FW
+   curMaxSegment_ = segSize;
+   curCumAckTout_ = 5;    // ACK_TOUT_G in FW, 5mS
+   curRetranTout_ = 20;   // RETRANS_TOUT_G in FW, 2hmS
+   curNullTout_   = 1000; // NULL_TOUT_G in FW, 1S
+   curMaxRetran_  = 15;   // MAX_RETRANS_CNT_G in FW
+   curMaxCumAck_  = 2;    // MAX_CUM_ACK_CNT_G in FW
+
    locConnId_     = 0x12345678;
-   remMaxBuffers_ = 0;
-   remMaxSegment_ = LocMaxBuffers;
-   retranTout_    = ReqRetranTout;
-   cumAckTout_    = ReqCumAckTout;
-   nullTout_      = ReqNullTout;
-   maxRetran_     = ReqMaxRetran;
-   maxCumAck_     = ReqMaxCumAck;
    remConnId_     = 0;
-   segmentSize_   = segSize;
   
-   convTime(retranToutD1_, retranTout_);
-   convTime(tryPeriodD1_,  TryPeriod);
-   convTime(tryPeriodD4_,  TryPeriod / 4);
-   convTime(cumAckToutD1_, cumAckTout_);
-   convTime(cumAckToutD2_, cumAckTout_ / 2);
-   convTime(nullToutD3_,   nullTout_ / 3);
+   convTime(tryPeriodD1_,  locTryPeriod_);
+   convTime(tryPeriodD4_,  locTryPeriod_ / 4);
+   convTime(retranToutD1_, curRetranTout_);
+   convTime(nullToutD3_,   curNullTout_ / 3);
+   convTime(cumAckToutD1_, curCumAckTout_);
+   convTime(cumAckToutD2_, curCumAckTout_ / 2);
 
    memset(&zeroTme_, 0, sizeof(struct timeval));
    
@@ -134,8 +145,8 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
    // Frame size returned is never greater than remote max size
    // or local segment size
    nSize = size + rpr::Header::HeaderSize;
-   if ( nSize > remMaxSegment_ && remMaxSegment_ > 0 ) nSize = remMaxSegment_;
-   if ( nSize > segmentSize_  ) nSize = segmentSize_;
+   if ( nSize > curMaxSegment_ && curMaxSegment_ > 0 ) nSize = curMaxSegment_;
+   if ( nSize > locMaxSegment_ ) nSize = locMaxSegment_;
 
    // Forward frame request to transport slave
    frame = tran_->reqFrame (nSize, false);
@@ -262,7 +273,7 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
       // to do this while hanlding the 8 bit rollover
       else {
          uint8_t x = nextSeqRx_;
-         uint8_t windowEnd = (nextSeqRx_ + LocMaxBuffers + 1);
+         uint8_t windowEnd = (nextSeqRx_ + curMaxBuffers_ + 1);
 
          while ( ++x != windowEnd ) {
             if (head->sequence == x) {
@@ -325,7 +336,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
    if ( state_ != StOpen ) return;
 
    // Wait while busy either by flow control or buffer starvation
-   while ( txListCount_ >= remMaxBuffers_ ) {
+   while ( txListCount_ >= curMaxBuffers_ ) {
       usleep(10);
       if ( timePassed(startTime,timeout_) ) {
          gettimeofday(&startTime,NULL);
@@ -381,44 +392,103 @@ uint32_t rpr::Controller::getRemBusyCnt() {
    return(remBusyCnt_);
 }
 
-//! Get maxRetran
-uint32_t rpr::Controller::getMaxRetran() {
-   return(uint32_t(maxRetran_));
+void rpr::Controller::setLocTryPeriod(uint32_t val) {
+   locTryPeriod_ = val;
+   convTime(tryPeriodD1_,  locTryPeriod_);
+   convTime(tryPeriodD4_,  locTryPeriod_ / 4);
 }
 
-//! Get remMaxBuffers
-uint32_t rpr::Controller::getRemMaxBuffers() {
-   return(uint32_t(remMaxBuffers_));
+uint32_t rpr::Controller::getLocTryPeriod() {
+   return locTryPeriod_;
 }
 
-//! Get remMaxSegment
-uint32_t rpr::Controller::getRemMaxSegment() {
-   return(uint32_t(remMaxSegment_));
+void rpr::Controller::setLocBusyThold(uint32_t val) {
+   locBusyThold_ = val;
+   appQueue_.setThold(locBusyThold_);
 }
 
-//! Get retranTout
-uint32_t rpr::Controller::getRetranTout() {
-   return(uint32_t(retranTout_));
+uint32_t rpr::Controller::getLocBusyThold() {
+   return locBusyThold_;
 }
 
-//! Get cumAckTout
-uint32_t rpr::Controller::getCumAckTout() {
-   return(uint32_t(cumAckTout_));
+void rpr::Controller::setLocMaxBuffers(uint8_t val) {
+   locMaxBuffers_ = val;
 }
 
-//! Get nullTout
-uint32_t rpr::Controller::getNullTout() {
-   return(uint32_t(nullTout_));
+uint8_t rpr::Controller::getLocMaxBuffers() {
+   return locMaxBuffers_;
 }
 
-//! Get maxCumAck
-uint32_t rpr::Controller::getMaxCumAck() {
-   return(uint32_t(maxCumAck_));
+uint16_t rpr::Controller::getLocMaxSegment() {
+   return locMaxSegment_;
 }
 
-//! Get segmentSize
-uint32_t rpr::Controller::getSegmentSize() {
-   return(uint32_t(segmentSize_));
+void rpr::Controller::setLocCumAckTout(uint16_t val) {
+   locCumAckTout_ = val;
+}
+
+uint16_t rpr::Controller::getLocCumAckTout() {
+   return locCumAckTout_;
+}
+
+void rpr::Controller::setLocRetranTout(uint16_t val) {
+   locRetranTout_ = val;
+}
+
+uint16_t rpr::Controller::getLocRetranTout() {
+   return locRetranTout_;
+}
+
+void rpr::Controller::setLocNullTout(uint16_t val) {
+   locNullTout_ = val;
+}
+
+uint16_t rpr::Controller::getLocNullTout() {
+   return locNullTout_;
+}
+
+void rpr::Controller::setLocMaxRetran(uint8_t val) {
+   locMaxRetran_ = val;
+}
+
+uint8_t rpr::Controller::getLocMaxRetran() {
+   return locMaxRetran_;
+}
+
+void rpr::Controller::setLocMaxCumAck(uint8_t val) {
+   locMaxCumAck_ = val;
+}
+
+uint8_t  rpr::Controller::getLocMaxCumAck() {
+   return locMaxCumAck_;
+}
+
+uint8_t  rpr::Controller::curMaxBuffers() {
+   return curMaxBuffers_;
+}
+
+uint16_t rpr::Controller::curMaxSegment() {
+   return curMaxSegment_;
+}
+
+uint16_t rpr::Controller::curCumAckTout() {
+   return curCumAckTout_;
+}
+
+uint16_t rpr::Controller::curRetranTout() {
+   return curRetranTout_;
+}
+
+uint16_t rpr::Controller::curNullTout() {
+   return curNullTout_;
+}
+
+uint8_t  rpr::Controller::curMaxRetran() {
+   return curMaxRetran_;
+}
+
+uint8_t  rpr::Controller::curMaxCumAck() {
+   return curMaxCumAck_;
 }
 
 // Method to transit a frame with proper updates
@@ -484,7 +554,7 @@ int8_t rpr::Controller::retransmit(uint8_t id) {
    if ( ! timePassed(head->getTime(),retranToutD1_) ) return 0;
 
    // max retransmission count has been reached
-   if ( head->count() >= maxRetran_ ) return -1;
+   if ( head->count() >= curMaxRetran_ ) return -1;
 
    retranCount_++;
 
@@ -607,22 +677,20 @@ struct timeval & rpr::Controller::stateClosedWait () {
 
       // Syn ack
       else if ( head->syn && (head->ack || server_) ) {
-         remMaxBuffers_ = head->maxOutstandingSegments;
-         remMaxSegment_ = head->maxSegmentSize;
-         retranTout_    = head->retransmissionTimeout;
-         cumAckTout_    = head->cumulativeAckTimeout;
-         nullTout_      = head->nullTimeout;
-         maxRetran_     = head->maxRetransmissions;
-         maxCumAck_     = head->maxCumulativeAck;
+         curMaxBuffers_ = head->maxOutstandingSegments;
+         curMaxSegment_ = head->maxSegmentSize;
+         curCumAckTout_ = head->cumulativeAckTimeout;
+         curRetranTout_ = head->retransmissionTimeout;
+         curNullTout_   = head->nullTimeout;
+         curMaxRetran_  = head->maxRetransmissions;
+         curMaxCumAck_  = head->maxCumulativeAck;
          lastAckRx_     = head->acknowledge;
 
          // Convert times
-         convTime(retranToutD1_, retranTout_);
-         convTime(tryPeriodD1_,  TryPeriod);
-         convTime(tryPeriodD4_,  TryPeriod / 4);
-         convTime(cumAckToutD1_, cumAckTout_);
-         convTime(cumAckToutD2_, cumAckTout_ / 2);
-         convTime(nullToutD3_,   nullTout_ / 3);
+         convTime(retranToutD1_, curRetranTout_);
+         convTime(cumAckToutD1_, curCumAckTout_);
+         convTime(cumAckToutD2_, curCumAckTout_ / 2);
+         convTime(nullToutD3_,   curNullTout_ / 3);
 
          if ( server_ ) {
             state_ = StSendSynAck;
@@ -630,6 +698,17 @@ struct timeval & rpr::Controller::stateClosedWait () {
          }
          else state_ = StSendSeqAck;
          gettimeofday(&stTime_,NULL);
+      }
+
+      // Init counters
+      else {
+         curMaxBuffers_ = locMaxBuffers_;
+         curMaxSegment_ = locMaxSegment_;
+         curCumAckTout_ = locCumAckTout_;
+         curRetranTout_ = locRetranTout_;
+         curNullTout_   = locNullTout_;
+         curMaxRetran_  = locMaxRetran_;
+         curMaxCumAck_  = locMaxCumAck_;
       }
    }
 
@@ -643,15 +722,15 @@ struct timeval & rpr::Controller::stateClosedWait () {
       head->syn = true;
       head->version = Version;
       head->chk = true;
-      head->maxOutstandingSegments = LocMaxBuffers;
-      head->maxSegmentSize = segmentSize_;
-      head->retransmissionTimeout = retranTout_;
-      head->cumulativeAckTimeout = cumAckTout_;
-      head->nullTimeout = nullTout_;
-      head->maxRetransmissions = maxRetran_;
-      head->maxCumulativeAck = maxCumAck_;
-      head->timeoutUnit = TimeoutUnit;
-      head->connectionId = locConnId_;
+      head->maxOutstandingSegments = locMaxBuffers_;
+      head->maxSegmentSize         = locMaxSegment_;
+      head->retransmissionTimeout  = locRetranTout_;
+      head->cumulativeAckTimeout   = locCumAckTout_;
+      head->nullTimeout            = locNullTout_;
+      head->maxRetransmissions     = locMaxRetran_;
+      head->maxCumulativeAck       = locMaxCumAck_;
+      head->timeoutUnit            = TimeoutUnit;
+      head->connectionId           = locConnId_;
 
       transportTx(head,true,false);
 
@@ -676,15 +755,15 @@ struct timeval & rpr::Controller::stateSendSynAck () {
    head->ack = true;
    head->version = Version;
    head->chk = true;
-   head->maxOutstandingSegments = LocMaxBuffers;
-   head->maxSegmentSize = segmentSize_;
-   head->retransmissionTimeout = retranTout_;
-   head->cumulativeAckTimeout = cumAckTout_;
-   head->nullTimeout = nullTout_;
-   head->maxRetransmissions = maxRetran_;
-   head->maxCumulativeAck = maxCumAck_;
-   head->timeoutUnit = TimeoutUnit;
-   head->connectionId = locConnId_;
+   head->maxOutstandingSegments = curMaxBuffers_;
+   head->maxSegmentSize         = curMaxSegment_;
+   head->retransmissionTimeout  = curRetranTout_;
+   head->cumulativeAckTimeout   = curCumAckTout_;
+   head->nullTimeout            = curNullTout_;
+   head->maxRetransmissions     = curMaxRetran_;
+   head->maxCumulativeAck       = curMaxCumAck_;
+   head->timeoutUnit            = TimeoutUnit;
+   head->connectionId           = locConnId_;
 
    transportTx(head,true,true);
 
@@ -743,7 +822,7 @@ struct timeval & rpr::Controller::stateOpen () {
    else doNull = false;
 
    // Outbound frame required
-   if ( ( doNull || ackPend >= maxCumAck_ || 
+   if ( ( doNull || ackPend >= curMaxCumAck_ || 
         ((ackPend > 0 || getLocBusy()) && timePassed(locTime,cumAckToutD1_)) ) ) {
 
       head = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -40,25 +40,44 @@ void rpr::Server::setup_python() {
 #ifndef NO_PYTHON
 
    bp::class_<rpr::Server, rpr::ServerPtr, boost::noncopyable >("Server",bp::init<uint32_t>())
-      .def("transport",       &rpr::Server::transport)
-      .def("application",     &rpr::Server::application)
-      .def("getOpen",         &rpr::Server::getOpen)
-      .def("getDownCount",    &rpr::Server::getDownCount)
-      .def("getDropCount",    &rpr::Server::getDropCount)
-      .def("getRetranCount",  &rpr::Server::getRetranCount)
-      .def("getLocBusy",      &rpr::Server::getLocBusy)
-      .def("getLocBusyCnt",   &rpr::Server::getLocBusyCnt)
-      .def("getRemBusy",      &rpr::Server::getRemBusy)
-      .def("getRemBusyCnt",   &rpr::Server::getRemBusyCnt)
-      .def("stop",            &rpr::Server::stop)
-      .def("getMaxRetran",    &rpr::Server::getMaxRetran)
-      .def("getRemMaxBuffers",&rpr::Server::getRemMaxBuffers)
-      .def("getRemMaxSegment",&rpr::Server::getRemMaxSegment)
-      .def("getRetranTout",   &rpr::Server::getRetranTout)
-      .def("getCumAckTout",   &rpr::Server::getCumAckTout)
-      .def("getNullTout",     &rpr::Server::getNullTout)
-      .def("getMaxCumAck",    &rpr::Server::getMaxCumAck)
-      .def("getSegmentSize",  &rpr::Server::getSegmentSize)      
+      .def("transport",        &rpr::Server::transport)
+      .def("application",      &rpr::Server::application)
+      .def("getOpen",          &rpr::Server::getOpen)
+      .def("getDownCount",     &rpr::Server::getDownCount)
+      .def("getDropCount",     &rpr::Server::getDropCount)
+      .def("getRetranCount",   &rpr::Server::getRetranCount)
+      .def("getLocBusy",       &rpr::Server::getLocBusy)
+      .def("getLocBusyCnt",    &rpr::Server::getLocBusyCnt)
+      .def("getRemBusy",       &rpr::Server::getRemBusy)
+      .def("getRemBusyCnt",    &rpr::Server::getRemBusyCnt)
+      .def("setLocTryPeriod",  &rpr::Server::setLocTryPeriod)
+      .def("getLocTryPeriod",  &rpr::Server::getLocTryPeriod)
+      .def("setLocBusyThold",  &rpr::Server::setLocBusyThold)
+      .def("getLocBusyThold",  &rpr::Server::getLocBusyThold)
+      .def("setLocMaxBuffers", &rpr::Server::setLocMaxBuffers)
+      .def("getLocMaxBuffers", &rpr::Server::getLocMaxBuffers)
+      .def("setLocMaxSegment", &rpr::Server::setLocMaxSegment)
+      .def("getLocMaxSegment", &rpr::Server::getLocMaxSegment)
+      .def("setLocCumAckTout", &rpr::Server::setLocCumAckTout)
+      .def("getLocCumAckTout", &rpr::Server::getLocCumAckTout)
+      .def("setLocRetranTout", &rpr::Server::setLocRetranTout)
+      .def("getLocRetranTout", &rpr::Server::getLocRetranTout)
+      .def("setLocNullTout",   &rpr::Server::setLocNullTout)
+      .def("getLocNullTout",   &rpr::Server::getLocNullTout)
+      .def("setLocMaxRetran",  &rpr::Server::setLocMaxRetran)
+      .def("getLocMaxRetran",  &rpr::Server::getLocMaxRetran)
+      .def("setLocMaxCumAck",  &rpr::Server::setLocMaxCumAck)
+      .def("getLocMaxCumAck",  &rpr::Server::getLocMaxCumAck)
+      .def("curMaxBuffers",    &rpr::Server::curMaxBuffers)
+      .def("curMaxSegment",    &rpr::Server::curMaxSegment)
+      .def("curCumAckTout",    &rpr::Server::curCumAckTout)
+      .def("curRetranTout",    &rpr::Server::curRetranTout)
+      .def("curNullTout",      &rpr::Server::curNullTout)
+      .def("curMaxRetran",     &rpr::Server::curMaxRetran)
+      .def("curMaxCumAck",     &rpr::Server::curMaxCumAck)
+      .def("setTimeout",       &rpr::Server::setTimeout)
+      .def("stop",             &rpr::Server::stop)
+      .def("start",            &rpr::Server::start)
    ;
 #endif
 }
@@ -128,44 +147,104 @@ uint32_t rpr::Server::getRemBusyCnt() {
    return(cntl_->getRemBusyCnt());
 }
 
-//! Get maxRetran
-uint32_t rpr::Server::getMaxRetran() {
-   return(cntl_->getMaxRetran());
+void rpr::Server::setLocTryPeriod(uint32_t val) {
+   cntl_->setLocTryPeriod(val);
 }
 
-//! Get remMaxBuffers
-uint32_t rpr::Server::getRemMaxBuffers() {
-   return(cntl_->getRemMaxBuffers());
+uint32_t rpr::Server::getLocTryPeriod() {
+   return cntl_->getLocTryPeriod();
 }
 
-//! Get remMaxSegment
-uint32_t rpr::Server::getRemMaxSegment() {
-   return(cntl_->getRemMaxSegment());
+void rpr::Server::setLocBusyThold(uint32_t val) {
+   cntl_->setLocBusyThold(val);
 }
 
-//! Get retranTout
-uint32_t rpr::Server::getRetranTout() {
-   return(cntl_->getRetranTout());
+uint32_t rpr::Server::getLocBusyThold() {
+   return cntl_->getLocBusyThold();
 }
 
-//! Get cumAckTout
-uint32_t rpr::Server::getCumAckTout() {
-   return(cntl_->getCumAckTout());
+void rpr::Server::setLocMaxBuffers(uint8_t val) {
+   cntl_->setLocMaxBuffers(val);
 }
 
-//! Get nullTout
-uint32_t rpr::Server::getNullTout() {
-   return(cntl_->getNullTout());
+uint8_t rpr::Server::getLocMaxBuffers() {
+   return cntl_->getLocMaxBuffers();
 }
 
-//! Get maxCumAck
-uint32_t rpr::Server::getMaxCumAck() {
-   return(cntl_->getMaxCumAck());
+void rpr::Server::setLocMaxSegment(uint16_t val) {
+   cntl_->setLocMaxSegment(val);
 }
 
-//! Get segmentSize
-uint32_t rpr::Server::getSegmentSize() {
-   return(cntl_->getSegmentSize());
+uint16_t rpr::Server::getLocMaxSegment() {
+   return cntl_->getLocMaxSegment();
+}
+
+void rpr::Server::setLocCumAckTout(uint16_t val) {
+   cntl_->setLocCumAckTout(val);
+}
+
+uint16_t rpr::Server::getLocCumAckTout() {
+   return cntl_->getLocCumAckTout();
+}
+
+void rpr::Server::setLocRetranTout(uint16_t val) {
+   cntl_->setLocRetranTout(val);
+}
+
+uint16_t rpr::Server::getLocRetranTout() {
+   return cntl_->getLocRetranTout();
+}
+
+void rpr::Server::setLocNullTout(uint16_t val) {
+   cntl_->setLocNullTout(val);
+}
+
+uint16_t rpr::Server::getLocNullTout() {
+   return cntl_->getLocNullTout();
+}
+
+void rpr::Server::setLocMaxRetran(uint8_t val) {
+   cntl_->setLocMaxRetran(val);
+}
+
+uint8_t rpr::Server::getLocMaxRetran() {
+   return cntl_->getLocMaxRetran();
+}
+
+void rpr::Server::setLocMaxCumAck(uint8_t val) {
+   cntl_->setLocMaxCumAck(val);
+}
+
+uint8_t  rpr::Server::getLocMaxCumAck() {
+   return cntl_->getLocMaxCumAck();
+}
+
+uint8_t  rpr::Server::curMaxBuffers() {
+   return cntl_->curMaxBuffers();
+}
+
+uint16_t rpr::Server::curMaxSegment() {
+   return cntl_->curMaxSegment();
+}
+
+uint16_t rpr::Server::curCumAckTout() {
+   return cntl_->curCumAckTout();
+}
+
+uint16_t rpr::Server::curRetranTout() {
+   return cntl_->curRetranTout();
+}
+
+uint16_t rpr::Server::curNullTout() {
+   return cntl_->curNullTout();
+}
+
+uint8_t  rpr::Server::curMaxRetran() {
+   return cntl_->curMaxRetran();
+}
+
+uint8_t  rpr::Server::curMaxCumAck() {
+   return cntl_->curMaxCumAck();
 }
 
 //! Set timeout for frame transmits in microseconds
@@ -173,7 +252,7 @@ void rpr::Server::setTimeout(uint32_t timeout) {
    cntl_->setTimeout(timeout);
 }
 
-//! Send reset
+//! Send reset and close
 void rpr::Server::stop() {
    return(cntl_->stop());
 }


### PR DESCRIPTION
Software may now set the initial negotiation parameters for the RSSI link. With the exception of locMaxSegment (which is defined at class creation) all parameters can be adjusted and are used at the next link initialization.