### PR TITLE
Add read Command

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -90,6 +90,10 @@ class BaseCommand(pr.BaseVariable):
         pass
 
     @staticmethod
+    def read(cmd):
+        cmd.get(read=True)
+
+    @staticmethod
     def createToggle(sets):
         def toggle(cmd):
             for s in sets:


### PR DESCRIPTION
Some devices have registers that Clear-on-Read (CoR). It is useful to have `read` command to use with these registers.