### PR TITLE
Fix: calling wrong method to get a string value

### DIFF
--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -127,7 +127,7 @@ void rpe::Variable::valueGet() {
          rogue::ScopedGil gil;
          log_->info("Synchronous read for %s",epicsName_.c_str());
          try {
-            if ( isString_ ) fromPython(var_.attr("disp")());
+            if ( isString_ ) fromPython(var_.attr("getDisp")());
             else fromPython(var_.attr("get")());
          } catch (...) {
             log_->error("Error getting values from epics: %s\n",epicsName_.c_str());


### PR DESCRIPTION
When reading a PV of a register larger that 32 bits, which is treated as a string in EPICS, I was getting error messages `pyrogue.epicsV3.Value: Error getting values from epics: <PV name>`. Calling `getDisp` instead of `disp` solved this problem. 