### PR TITLE
Use the EPICS tool EpicsHostArch to get the host architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,9 @@ endif()
 if(DO_PYTHON AND DEFINED ENV{EPICS_BASE})
    set(DO_EPICS_V3 1)
    set(EPICSV3_BASE_DIR  $ENV{EPICS_BASE})
-   set(EPICSV3_LIB_DIR   ${EPICSV3_BASE_DIR}/lib/rhel6-x86_64 )
+   execute_process(COMMAND ${EPICSV3_BASE_DIR}/startup/EpicsHostArch OUTPUT_VARIABLE EPICSV3_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+   string(REGEX REPLACE "\n$" "" EPICSV3_ARCH "${EPICSV3_ARCH}")
+   set(EPICSV3_LIB_DIR   ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH} )
    set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
                          ${EPICSV3_BASE_DIR}/include/compiler/gcc 
                          ${EPICSV3_BASE_DIR}/include/os/Linux)


### PR DESCRIPTION
EPICS base provides a script `EpicsHostArch` which gives the host architecture. The hard-coded `rhel6-x86_64` don't work in other OS, like Ubuntu.