### PR TITLE
Fix typo in Device.writeBlocks

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -230,7 +230,7 @@ class Device(pr.Node,rim.Hub):
         # Process local blocks.
         if variable is not None:
             for b in self._getBlocks(variable):
-                if (force or block.stale):                
+                if (force or b.stale):                
                     b.startTransaction(rim.Write, check=checkEach)
 
         else:


### PR DESCRIPTION
Wrong variable name was being referenced due to typo.