### PR TITLE
Clean up Frame flags and error fields.

### DIFF
--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -57,10 +57,13 @@ namespace rogue {
                friend class FrameLock;
 
                //! Interface specific flags
-               uint32_t flags_;
+               uint16_t flags_;
 
                //! Error state
-               uint32_t error_;
+               uint8_t error_;
+
+               //! Channel
+               uint8_t chan_;
 
                //! List of buffers which hold real data
                std::vector<boost::shared_ptr<rogue::interfaces::stream::Buffer> > buffers_;
@@ -181,16 +184,34 @@ namespace rogue {
                void setPayloadEmpty();
 
                //! Get flags
-               uint32_t getFlags();
+               uint16_t getFlags();
 
                //! Set flags
-               void setFlags(uint32_t flags);
+               void setFlags(uint16_t flags);
+
+               //! Get channel
+               uint8_t getChannel();
+
+               //! Set channel
+               void setChannel(uint8_t channel);
+
+               // Get first user field portion of flags (SSI/axi-stream)
+               uint8_t getFirstUser();
+
+               // Set first user field portion of flags (SSI/axi-stream)
+               void setFirstUser(uint8_t fuser);
+
+               // Get last user field portion of flags (SSI/axi-stream)
+               uint8_t getLastUser();
+
+               // Set last user field portion of flags (SSI/axi-stream)
+               void setLastUser(uint8_t fuser);
 
                //! Get error state
-               uint32_t getError();
+               uint8_t getError();
 
                //! Set error state
-               void setError(uint32_t error);
+               void setError(uint8_t error);
 
                //! Get read start iterator
                rogue::interfaces::stream::FrameIterator beginRead();

--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -20,7 +20,8 @@
  *          [31:0] = Length of data block in bytes
  *       headerB
  *          31:24  = Channel ID
- *          23:9   = Frame flags
+ *          23:16  = Frame error
+ *          15:0   = Frame flags
  *
  *-----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -81,9 +81,8 @@ class StreamSim(rogue.interfaces.stream.Master,
         """ Forward frame to simulation """
 
         flock = frame.lock();
-        flags = frame.getFlags()
-        fuser = flags & 0xFF
-        luser = (flags >> 8) & 0xFF
+        fuser = frame.getFirstUser();
+        luser = frame.getLastUser();
 
         if ( self._ssi ):
             fuser = fuser | 0x2 # SOF
@@ -117,7 +116,10 @@ class StreamSim(rogue.interfaces.stream.Master,
 
             frame = self._reqFrame(len(data),True)
 
-            if ( self._ssi and (luser & 0x1)): frame.setError(1)
+            frame.setFirstUser(fuser);
+            frame.setLastUser(luser);
+
+            if ( self._ssi and (luser & 0x1)): frame.setError(0x80)
 
             frame.write(data,0)
             self.rxCount += 1

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -43,6 +43,7 @@ ris::Frame::Frame() {
    flags_     = 0;
    error_     = 0;
    size_      = 0;
+   chan_      = 0;
    payload_   = 0;
    sizeDirty_ = false;
 }
@@ -249,23 +250,56 @@ void ris::Frame::setPayloadEmpty() {
 }
 
 //! Get flags
-uint32_t ris::Frame::getFlags() {
+uint16_t ris::Frame::getFlags() {
    return(flags_);
 }
 
 //! Set error state
-void ris::Frame::setFlags(uint32_t flags) {
+void ris::Frame::setFlags(uint16_t flags) {
    flags_ = flags;
 }
 
+// Get first user field portion of flags (SSI/axi-stream)
+uint8_t ris::Frame::getFirstUser() {
+   uint8_t ret = flags_ & 0xFF;
+   return ret;
+}
+
+// Set first user field portion of flags (SSI/axi-stream)
+void ris::Frame::setFirstUser(uint8_t fuser) {
+    flags_ |= fuser;
+}
+
+// Get last user field portion of flags (SSI/axi-stream)
+uint8_t ris::Frame::getLastUser() {
+   uint8_t ret = (flags_ >> 8) & 0xFF;
+   return ret;
+}
+
+// Set last user field portion of flags (SSI/axi-stream)
+void ris::Frame::setLastUser(uint8_t fuser) {
+    uint16_t tmp = fuser;
+    flags_ |= (tmp << 8) & 0xFF00;
+}
+
 //! Get error state
-uint32_t ris::Frame::getError() {
+uint8_t ris::Frame::getError() {
    return(error_);
 }
 
 //! Set error state
-void ris::Frame::setError(uint32_t error) {
+void ris::Frame::setError(uint8_t error) {
    error_ = error;
+}
+
+//! Get channel
+uint8_t ris::Frame::getChannel() {
+   return chan_;
+}
+
+//! Set channel
+void ris::Frame::setChannel(uint8_t channel) {
+   chan_ = channel;
 }
 
 //! Get write start iterator
@@ -355,6 +389,12 @@ void ris::Frame::setup_python() {
       .def("getError",     &ris::Frame::getError)
       .def("setFlags",     &ris::Frame::setFlags)
       .def("getFlags",     &ris::Frame::getFlags)
+      .def("setFirstUser", &ris::Frame::setFirstUser)
+      .def("getFirstUser", &ris::Frame::getFirstUser)
+      .def("setLastUser",  &ris::Frame::setLastUser)
+      .def("getLastUser",  &ris::Frame::getLastUser)
+      .def("setChannel",   &ris::Frame::setChannel)
+      .def("getChannel",   &ris::Frame::getChannel)
    ;
 #endif
 }

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -20,7 +20,8 @@
  *          [31:0] = Length of data block in bytes
  *       headerB
  *          31:24  = Channel ID
- *          23:o   = Frame flags
+ *          23:16  = Frame error
+ *          15:0   = Frame flags
  *
  *-----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 
@@ -209,7 +210,8 @@ void ruf::StreamWriter::writeFile ( uint8_t channel, boost::shared_ptr<rogue::in
       intWrite(&size,4);
 
       // Create EVIO header
-      value  = frame->getFlags() & 0xFFFFFF;
+      value  = frame->getFlags();
+      value |= (frame->getError() << 16);
       value |= (channel << 24);
       intWrite(&value,4);
 


### PR DESCRIPTION

The flags field is now reduced to 16-bits. A new setup of access methods are added to allow the flags to be set and get as Axi-Stream like first and last user fields.

The error field is now reduced to 8-bits.

A set and get method for channel is added for when frames are read from a data file.