### PR TITLE
Add SSI support for packetizer

### DIFF
--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -41,6 +41,7 @@ namespace rogue {
             protected:
 
                // parameters
+               bool     enSsi_;
                uint32_t appIndex_;
                uint32_t tranIndex_;
                bool     transSof_[256];
@@ -71,7 +72,7 @@ namespace rogue {
                //! Creator
                Controller( boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
                            boost::shared_ptr<rogue::protocols::packetizer::Application> * app,
-                           uint32_t headSize, uint32_t tailSize, uint32_t alignSize );
+                           uint32_t headSize, uint32_t tailSize, uint32_t alignSize, bool enSsi );
 
                //! Destructor
                ~Controller();

--- a/include/rogue/protocols/packetizer/ControllerV1.h
+++ b/include/rogue/protocols/packetizer/ControllerV1.h
@@ -43,12 +43,14 @@ namespace rogue {
 
                //! Class creation
                static boost::shared_ptr<rogue::protocols::packetizer::ControllerV1> 
-                  create ( boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
+                  create ( bool enSsi,
+                           boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
                            boost::shared_ptr<rogue::protocols::packetizer::Application> * app );
 
                //! Creator
-               ControllerV1( boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
-                           boost::shared_ptr<rogue::protocols::packetizer::Application> * app );
+               ControllerV1( bool enSsi,
+                             boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
+                             boost::shared_ptr<rogue::protocols::packetizer::Application> * app );
 
                //! Destructor
                ~ControllerV1();

--- a/include/rogue/protocols/packetizer/ControllerV2.h
+++ b/include/rogue/protocols/packetizer/ControllerV2.h
@@ -46,12 +46,12 @@ namespace rogue {
 
                //! Class creation
                static boost::shared_ptr<rogue::protocols::packetizer::ControllerV2> 
-                  create ( bool enIbCrc, bool enObCrc,
+                  create ( bool enIbCrc, bool enObCrc, bool enSsi,
                            boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
                            boost::shared_ptr<rogue::protocols::packetizer::Application> * app );
 
                //! Creator
-               ControllerV2( bool enIbCrc, bool enObCrc,
+               ControllerV2( bool enIbCrc, bool enObCrc, bool enSsi,
                            boost::shared_ptr<rogue::protocols::packetizer::Transport> tran,
                            boost::shared_ptr<rogue::protocols::packetizer::Application> * app );
 

--- a/include/rogue/protocols/packetizer/Core.h
+++ b/include/rogue/protocols/packetizer/Core.h
@@ -46,13 +46,13 @@ namespace rogue {
             public:
 
                //! Class creation
-               static boost::shared_ptr<rogue::protocols::packetizer::Core> create ();
+               static boost::shared_ptr<rogue::protocols::packetizer::Core> create (bool enSsi);
 
                //! Setup class in python
                static void setup_python();
 
                //! Creator
-               Core();
+               Core(bool enSsi);
 
                //! Destructor
                ~Core();

--- a/include/rogue/protocols/packetizer/CoreV2.h
+++ b/include/rogue/protocols/packetizer/CoreV2.h
@@ -45,13 +45,13 @@ namespace rogue {
             public:
 
                //! Class creation
-               static boost::shared_ptr<rogue::protocols::packetizer::CoreV2> create (bool enIbCrc, bool enObCrc);
+               static boost::shared_ptr<rogue::protocols::packetizer::CoreV2> create (bool enIbCrc, bool enObCrc, bool enSsi);
 
                //! Setup class in python
                static void setup_python();
 
                //! Creator
-               CoreV2(bool enIbCrc, bool enObCrc);
+               CoreV2(bool enIbCrc, bool enObCrc, bool enSsi);
 
                //! Destructor
                ~CoreV2();

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -24,7 +24,7 @@ import time
 
 class UdpRssiPack(pr.Device):
 
-    def __init__(self,*,host,port,size=None, jumbo=False, wait=True, packVer=1, pollInterval=1, **kwargs):
+    def __init__(self,*,host,port,size=None, jumbo=False, wait=True, packVer=1, pollInterval=1, enSsi=True, **kwargs):
         super(self.__class__, self).__init__(**kwargs)
         self._host = host
         self._port = port
@@ -37,9 +37,9 @@ class UdpRssiPack(pr.Device):
         self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
 
         if packVer == 2:
-            self._pack = rogue.protocols.packetizer.CoreV2(False,True) # ibCRC = False, obCRC = True
+            self._pack = rogue.protocols.packetizer.CoreV2(False,True,enSsi) # ibCRC = False, obCRC = True
         else:
-            self._pack = rogue.protocols.packetizer.Core()
+            self._pack = rogue.protocols.packetizer.Core(enSsi)
 
         self._udp._setSlave(self._rssi.transport())
         self._rssi.transport()._setSlave(self._udp)

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -35,11 +35,12 @@ namespace ris = rogue::interfaces::stream;
 
 //! Creator
 rpp::Controller::Controller ( rpp::TransportPtr tran, rpp::ApplicationPtr * app,
-                              uint32_t headSize, uint32_t tailSize, uint32_t alignSize ) {
+                              uint32_t headSize, uint32_t tailSize, uint32_t alignSize, bool enSsi ) {
    uint32_t x;
 
-   app_  = app;
-   tran_ = tran;
+   enSsi_ = enSsi
+   app_   = app;
+   tran_  = tran;
    appIndex_ = 0;
    tranIndex_ = 0;
    tranDest_ = 0;

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -38,7 +38,7 @@ rpp::Controller::Controller ( rpp::TransportPtr tran, rpp::ApplicationPtr * app,
                               uint32_t headSize, uint32_t tailSize, uint32_t alignSize, bool enSsi ) {
    uint32_t x;
 
-   enSsi_ = enSsi
+   enSsi_ = enSsi;
    app_   = app;
    tran_  = tran;
    appIndex_ = 0;

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -40,7 +40,7 @@ rpp::ControllerV1Ptr rpp::ControllerV1::create (bool enSsi, rpp::TransportPtr tr
 }
 
 //! Creator
-rpp::ControllerV1::ControllerV1 (bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(enSsi, tran, app, 8, 1, 8) {
+rpp::ControllerV1::ControllerV1 (bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(tran, app, 8, 1, 8, enSsi) {
 }
 
 //! Destructor
@@ -152,7 +152,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
       tranFrame_[0].reset();
 
       // Detect SSI error
-      if ( enSsi_ & (tmpLuser & 0x1) ) tranFrame_[tmpDest].setError(0x80);
+      if ( enSsi_ & (tmpLuser & 0x1) ) tranFrame_[tmpDest]->setError(0x80);
    }
    else tranCount_[0]++;
 }

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -41,7 +41,7 @@ rpp::ControllerV2Ptr rpp::ControllerV2::create ( bool enIbCrc, bool enObCrc, boo
 }
 
 //! Creator
-rpp::ControllerV2::ControllerV2 ( bool enIbCrc, bool enObCrc, bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(enSsi, tran, app, 8, 8, 8) {
+rpp::ControllerV2::ControllerV2 ( bool enIbCrc, bool enObCrc, bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(tran, app, 8, 8, 8, enSsi) {
 
    enIbCrc_ = enIbCrc;
    enObCrc_ = enObCrc;
@@ -189,7 +189,7 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
       tranFrame_[tmpDest].reset();
 
       // Detect SSI error
-      if ( enSsi_ & (tmpLuser & 0x1) ) tranFrame_[tmpDest].setError(0x80);
+      if ( enSsi_ & (tmpLuser & 0x1) ) tranFrame_[tmpDest]->setError(0x80);
    }
    else {
       tranCount_[tmpDest] = (tranCount_[tmpDest] + 1) & 0xFFFF;

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -35,13 +35,13 @@ namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
 
 //! Class creation
-rpp::ControllerV2Ptr rpp::ControllerV2::create ( bool enIbCrc, bool enObCrc, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {
-   rpp::ControllerV2Ptr r = boost::make_shared<rpp::ControllerV2>(enIbCrc,enObCrc,tran,app);
+rpp::ControllerV2Ptr rpp::ControllerV2::create ( bool enIbCrc, bool enObCrc, bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) {
+   rpp::ControllerV2Ptr r = boost::make_shared<rpp::ControllerV2>(enIbCrc,enObCrc,enSsi,tran,app);
    return(r);
 }
 
 //! Creator
-rpp::ControllerV2::ControllerV2 ( bool enIbCrc, bool enObCrc, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(tran, app, 8, 8, 8) {
+rpp::ControllerV2::ControllerV2 ( bool enIbCrc, bool enObCrc, bool enSsi, rpp::TransportPtr tran, rpp::ApplicationPtr * app ) : rpp::Controller::Controller(enSsi, tran, app, 8, 8, 8) {
 
    enIbCrc_ = enIbCrc;
    enObCrc_ = enObCrc;
@@ -187,6 +187,9 @@ void rpp::ControllerV2::transportRx( ris::FramePtr frame ) {
       }
       crcInit_[tmpDest]   = 0xFFFFFFFF;
       tranFrame_[tmpDest].reset();
+
+      // Detect SSI error
+      if ( enSsi_ & (tmpLuser & 0x1) ) tranFrame_[tmpDest].setError(0x80);
    }
    else {
       tranCount_[tmpDest] = (tranCount_[tmpDest] + 1) & 0xFFFF;
@@ -238,6 +241,9 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
    fUser = frame->getFlags() & 0xFF;
    lUser = (frame->getFlags() >> 8) & 0xFF;
    tId   = (frame->getFlags() >> 16) & 0xFF;
+
+   // Inject SOF
+   if ( enSsi_ ) fUser |= 0x2;
 
    segment = 0;
    for (it=frame->beginBuffer(); it != frame->endBuffer(); ++it) {

--- a/src/rogue/protocols/packetizer/Core.cpp
+++ b/src/rogue/protocols/packetizer/Core.cpp
@@ -35,15 +35,15 @@ namespace bp  = boost::python;
 #endif
 
 //! Class creation
-rpp::CorePtr rpp::Core::create () {
-   rpp::CorePtr r = boost::make_shared<rpp::Core>();
+rpp::CorePtr rpp::Core::create (bool enSsi) {
+   rpp::CorePtr r = boost::make_shared<rpp::Core>(enSsi);
    return(r);
 }
 
 void rpp::Core::setup_python() {
 #ifndef NO_PYTHON
 
-   bp::class_<rpp::Core, rpp::CorePtr, boost::noncopyable >("Core",bp::init<>())
+   bp::class_<rpp::Core, rpp::CorePtr, boost::noncopyable >("Core",bp::init<bool>())
       .def("transport",      &rpp::Core::transport)
       .def("application",    &rpp::Core::application)
       .def("getDropCount",   &rpp::Core::getDropCount)
@@ -53,9 +53,9 @@ void rpp::Core::setup_python() {
 }
 
 //! Creator
-rpp::Core::Core () {
+rpp::Core::Core (bool enSsi) {
    tran_  = rpp::Transport::create();
-   cntl_  = rpp::ControllerV1::create(tran_,app_);
+   cntl_  = rpp::ControllerV1::create(enSsi,tran_,app_);
 
    tran_->setController(cntl_);
 }

--- a/src/rogue/protocols/packetizer/CoreV2.cpp
+++ b/src/rogue/protocols/packetizer/CoreV2.cpp
@@ -34,15 +34,15 @@ namespace bp  = boost::python;
 #endif
 
 //! Class creation
-rpp::CoreV2Ptr rpp::CoreV2::create (bool enIbCrc, bool enObCrc) {
-   rpp::CoreV2Ptr r = boost::make_shared<rpp::CoreV2>(enIbCrc,enObCrc);
+rpp::CoreV2Ptr rpp::CoreV2::create (bool enIbCrc, bool enObCrc, bool enSsi) {
+   rpp::CoreV2Ptr r = boost::make_shared<rpp::CoreV2>(enIbCrc,enObCrc,enSsi);
    return(r);
 }
 
 void rpp::CoreV2::setup_python() {
 #ifndef NO_PYTHON
 
-   bp::class_<rpp::CoreV2, rpp::CoreV2Ptr, boost::noncopyable >("CoreV2",bp::init<bool,bool>())
+   bp::class_<rpp::CoreV2, rpp::CoreV2Ptr, boost::noncopyable >("CoreV2",bp::init<bool,bool,bool>())
       .def("transport",      &rpp::CoreV2::transport)
       .def("application",    &rpp::CoreV2::application)
       .def("getDropCount",   &rpp::CoreV2::getDropCount)
@@ -52,9 +52,9 @@ void rpp::CoreV2::setup_python() {
 }
 
 //! Creator
-rpp::CoreV2::CoreV2 (bool enIbCrc, bool enObCrc) {
+rpp::CoreV2::CoreV2 (bool enIbCrc, bool enObCrc, bool enSsi) {
    tran_  = rpp::Transport::create();
-   cntl_  = rpp::ControllerV2::create(enIbCrc,enObCrc,tran_,app_);
+   cntl_  = rpp::ControllerV2::create(enIbCrc,enObCrc,enSsi,tran_,app_);
 
    tran_->setController(cntl_);
 }


### PR DESCRIPTION
This PR adds SOF generation and EFOE detection for packetizer V1 & V2. if an EOFE is detected in the last user field, the frame error field is properly set. 

This PR may break C++ only versions of the RSSI receiver (i.e. DUNE)