### PR TITLE
Add no-copy mode for FIFO

### DIFF
--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -39,6 +39,7 @@ namespace rogue {
                // Configurations
                uint32_t trimSize_;
                uint32_t maxDepth_;
+               bool     noCopy_;
 
                // Queue
                rogue::Queue<boost::shared_ptr<rogue::interfaces::stream::Frame>> queue_;
@@ -53,13 +54,13 @@ namespace rogue {
 
                //! Class creation
                static boost::shared_ptr<rogue::interfaces::stream::Fifo> 
-                  create(uint32_t maxDepth, uint32_t trimSize);
+                  create(uint32_t maxDepth, uint32_t trimSize, bool noCopy);
 
                //! Setup class in python
                static void setup_python();
 
                //! Creator
-               Fifo(uint32_t maxDepth, uint32_t trimSize);
+               Fifo(uint32_t maxDepth, uint32_t trimSize, bool noCopy);
 
                //! Deconstructor
                ~Fifo();


### PR DESCRIPTION
This change allows the stream FIFO to operation in a no-copy mode. 

This also attempts to improve the copy efficiency in cases where there are a lot of buffers in the incoming frame.

This changed will break existing code which uses the FIFO due to an additional creation parameter.