### PR TITLE
Add error catch for setDisp

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -282,7 +282,11 @@ class BaseVariable(pr.Node):
 
     @Pyro4.expose
     def setDisp(self, sValue, write=True):
-        self.set(self.parseDisp(sValue), write)
+        try:
+            self.set(self.parseDisp(sValue), write)
+        except Exception as e:
+            self._log.exception(e)
+            self._log.error("Error setting value '{}' to variable '{}' with type {}".format(sValue,self.path,self.typeStr))
 
     @Pyro4.expose
     def nativeType(self):


### PR DESCRIPTION

set, get and getDisp had log catches for exceptions. This was missing with setDisp and was causing rogue to crash when invalid strings were entered.