### PR TITLE
Remove aes-stream-drivers as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "drivers"]
-	path = drivers
-	url = https://github.com/slaclab/aes-stream-drivers
-   branch = master
-   ignore = dirty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,6 @@ configure_file (
 
 # Add include directories
 include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_SOURCE_DIR}/drivers/include)
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${PYTHON_INCLUDE_DIRS})
@@ -185,7 +184,6 @@ endif()
 
 # Setup configuration file
 set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include
-                      ${PROJECT_SOURCE_DIR}/drivers/include
                       ${Boost_INCLUDE_DIRS}
                       ${PYTHON_INCLUDE_DIRS}
                       ${EPICSV3_INCLUDES})

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -20,7 +20,6 @@
 #define __ROGUE_HARDWARE_AXI_AXI_STREAM_DMA_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <DataDriver.h>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <rogue/Logging.h>

--- a/include/rogue/hardware/drivers/AxisDriver.h
+++ b/include/rogue/hardware/drivers/AxisDriver.h
@@ -1,0 +1,65 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : AXIS DMA Driver, Shared Header
+ * ----------------------------------------------------------------------------
+ * File       : AxisDriver.h
+ * Author     : Ryan Herbst, rherbst@slac.stanford.edu
+ * Created    : 2016-08-08
+ * Last update: 2016-08-08
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Defintions and inline functions for interacting with AXIS driver.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the aes_stream_drivers package, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ASIS_DRIVER_H__
+#define __ASIS_DRIVER_H__
+#include "DmaDriver.h"
+
+// Commands
+#define AXIS_Read_Ack 0x2001
+
+// Everything below is hidden during kernel module compile
+#ifndef DMA_IN_KERNEL
+
+// Set flags
+//static constexpr inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
+//   return ( ((cont & 0x1) << 16)  | ((luser & 0xFF) << 8) | ((fuser & 0xFF) << 0) );
+//}
+
+static inline uint32_t axisSetFlags(uint32_t fuser, uint32_t luser, uint32_t cont) {
+   uint32_t flags;
+
+   flags  = fuser & 0xFF;
+   flags += (luser << 8) & 0xFF00;
+   flags += (cont  << 16) & 0x10000;
+   return(flags);
+}
+
+static inline uint32_t axisGetFuser(uint32_t flags) {
+   return(flags & 0xFF);
+}
+
+static inline uint32_t axisGetLuser(uint32_t flags) {
+   return((flags >> 8) & 0xFF);
+}
+
+static inline uint32_t axisGetCont(uint32_t flags) {
+   return((flags >> 16) & 0x1);
+}
+
+// Read ACK
+static inline void axisReadAck (int32_t fd) {
+   ioctl(fd,AXIS_Read_Ack,0);
+}
+
+#endif
+#endif
+

--- a/include/rogue/hardware/drivers/DmaDriver.h
+++ b/include/rogue/hardware/drivers/DmaDriver.h
@@ -1,0 +1,376 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : DMA Driver, Common Header
+ * ----------------------------------------------------------------------------
+ * File       : DmaDriver.h
+ * Created    : 2016-08-08
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Defintions and inline functions for interacting drivers.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the aes_stream_drivers package, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __DMA_DRIVER_H__
+#define __DMA_DRIVER_H__
+
+#ifdef DMA_IN_KERNEL
+#include <linux/types.h>
+#else
+#include <stdint.h>
+#endif
+
+// API Version
+#define DMA_VERSION  0x04
+
+// Error values
+#define DMA_ERR_FIFO 0x01
+#define DMA_ERR_LEN  0x02
+#define DMA_ERR_MAX  0x04
+#define DMA_ERR_BUS  0x08
+
+// Commands
+#define DMA_Get_Buff_Count   0x1001
+#define DMA_Get_Buff_Size    0x1002
+#define DMA_Set_Debug        0x1003
+#define DMA_Set_Mask         0x1004
+#define DMA_Ret_Index        0x1005
+#define DMA_Get_Index        0x1006
+#define DMA_Read_Ready       0x1007
+#define DMA_Set_MaskBytes    0x1008
+#define DMA_Get_Version      0x1009
+#define DMA_Write_Register   0x100A
+#define DMA_Read_Register    0x100B
+#define DMA_Get_RxBuff_Count 0x100C
+#define DMA_Get_TxBuff_Count 0x100D
+
+// Mask size
+#define DMA_MASK_SIZE 32
+
+// TX Structure
+// Size = 0 for return index
+struct DmaWriteData {
+   uint64_t  data;
+   uint32_t  dest;
+   uint32_t  flags;
+   uint32_t  index;
+   uint32_t  size;
+   uint32_t  is32;
+   uint32_t  pad;
+};
+
+// RX Structure
+// Data = 0 for read index
+struct DmaReadData {
+   uint64_t   data;
+   uint32_t   dest;
+   uint32_t   flags;
+   uint32_t   index;
+   uint32_t   error;
+   uint32_t   size;
+   uint32_t   is32;
+};
+
+// Register data
+struct DmaRegisterData {
+   uint32_t   address;
+   uint32_t   data;
+};
+
+// Everything below is hidden during kernel module compile
+#ifndef DMA_IN_KERNEL
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/signal.h>
+#include <sys/fcntl.h>
+#include <sys/socket.h>
+
+// Write Frame
+static inline ssize_t dmaWrite(int32_t fd, const void * buf, size_t size, uint32_t flags, uint32_t dest) {
+   struct DmaWriteData w;
+
+   memset(&w,0,sizeof(struct DmaWriteData));
+   w.dest    = dest;
+   w.flags   = flags;
+   w.size    = size;
+   w.is32    = (sizeof(void *)==4);
+   w.data    = (uint64_t)buf;
+
+   return(write(fd,&w,sizeof(struct DmaWriteData)));
+}
+
+// Write Frame, memory mapped
+static inline ssize_t dmaWriteIndex(int32_t fd, uint32_t index, size_t size, uint32_t flags, uint32_t dest) {
+   struct DmaWriteData w;
+
+   memset(&w,0,sizeof(struct DmaWriteData));
+   w.dest    = dest;
+   w.flags   = flags;
+   w.size    = size;
+   w.is32    = (sizeof(void *)==4);
+   w.index   = index;
+
+   return(write(fd,&w,sizeof(struct DmaWriteData)));
+}
+
+// Write frame from iovector
+static inline ssize_t dmaWriteVector(int32_t fd, struct iovec *iov, size_t iovlen, 
+                                     uint32_t begFlags, uint32_t midFlags, uint32_t endFlags, uint32_t dest) {
+   uint32_t x;
+   ssize_t ret;
+   ssize_t res;
+   struct DmaWriteData w;
+
+   ret = 0;
+
+   for (x=0; x < iovlen; x++) {
+      memset(&w,0,sizeof(struct DmaWriteData));
+      w.dest    = dest;
+      w.flags   = (x==0)?begFlags:((x==(iovlen-1))?endFlags:midFlags);
+      w.size    = iov[x].iov_len;
+      w.is32    = (sizeof(void *)==4);
+      w.data    = (uint64_t)iov[x].iov_base;
+
+      do { 
+         res = write(fd,&w,sizeof(struct DmaWriteData));
+
+         if ( res < 0 ) return(res);
+         else if ( res == 0 ) usleep(10);
+         else ret += res;
+      } while (res == 0);
+   }
+   return(ret);
+}
+
+// Write Frame, memory mapped from iovector
+static inline ssize_t dmaWriteIndexVector(int32_t fd, struct iovec *iov, size_t iovlen, 
+                                          uint32_t begFlags, uint32_t midFlags, uint32_t endFlags, uint32_t dest) {
+   uint32_t x;
+   ssize_t ret;
+   ssize_t res;
+   struct DmaWriteData w;
+
+   ret = 0;
+
+   for (x=0; x < iovlen; x++) {
+      memset(&w,0,sizeof(struct DmaWriteData));
+      w.dest    = dest;
+      w.flags   = (x==0)?begFlags:((x==(iovlen-1))?endFlags:midFlags);
+      w.size    = iov[x].iov_len;
+      w.is32    = (sizeof(void *)==4);
+      w.index   = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);
+
+      do {
+         res = write(fd,&w,sizeof(struct DmaWriteData));
+
+         if ( res < 0 ) return(res);
+         else if ( res == 0 ) usleep(10);
+         else ret += res;
+      } while (res == 0);
+   }
+   return(ret);
+}
+
+// Receive Frame
+static inline ssize_t dmaRead(int32_t fd, void * buf, size_t maxSize, uint32_t * flags, uint32_t *error, uint32_t * dest) {
+   struct DmaReadData r;
+   ssize_t ret;
+
+   memset(&r,0,sizeof(struct DmaReadData));
+   r.size = maxSize;
+   r.is32 = (sizeof(void *)==4);
+   r.data = (uint64_t)buf;
+
+   ret = read(fd,&r,sizeof(struct DmaReadData));
+
+   if ( dest  != NULL ) *dest  = r.dest;
+   if ( flags != NULL ) *flags = r.flags;
+   if ( error != NULL ) *error = r.error;
+
+   return(ret);
+}
+
+// Receive Frame, access memory mapped buffer
+// Returns receive size
+static inline ssize_t dmaReadIndex(int32_t fd, uint32_t * index, uint32_t * flags, uint32_t *error, uint32_t * dest) {
+   struct DmaReadData r;
+   size_t ret;
+
+   memset(&r,0,sizeof(struct DmaReadData));
+
+   ret = read(fd,&r,sizeof(struct DmaReadData));
+
+   if ( dest  != NULL ) *dest  = r.dest;
+   if ( flags != NULL ) *flags = r.flags;
+   if ( index != NULL ) *index = r.index;
+   if ( error != NULL ) *error = r.error;
+
+   return(ret);
+}
+
+// Post Index
+static inline ssize_t dmaRetIndex(int32_t fd, uint32_t index) {
+   return(ioctl(fd,DMA_Ret_Index,index));
+}
+
+// Get write buffer index
+static inline uint32_t dmaGetIndex(int32_t fd) {
+   return(ioctl(fd,DMA_Get_Index,0));
+}
+
+// Get read ready status
+static inline ssize_t dmaReadReady(int32_t fd) {
+   return(ioctl(fd,DMA_Read_Ready,0));
+}
+
+// get rx buffer count
+static inline ssize_t dmaGetRxBuffCount(int32_t fd) {
+   return(ioctl(fd,DMA_Get_RxBuff_Count,0));
+}
+
+// get tx buffer count
+static inline ssize_t dmaGetTxBuffCount(int32_t fd) {
+   return(ioctl(fd,DMA_Get_TxBuff_Count,0));
+}
+
+// get buffer size
+static inline ssize_t dmaGetBuffSize(int32_t fd) {
+   return(ioctl(fd,DMA_Get_Buff_Size,0));
+}
+
+// Return user space mapping to dma buffers
+static inline void ** dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
+   void *   temp;
+   void **  ret;
+   uint32_t bCount;
+   uint32_t bSize;
+   uint32_t x;
+
+   bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
+   bCount = ioctl(fd,DMA_Get_Buff_Count,0);
+
+   if ( count != NULL ) *count = bCount;
+   if ( size  != NULL ) *size  = bSize;
+
+   if ( (ret = (void **)malloc(sizeof(void *) * bCount)) == 0 ) return(NULL);
+
+   for (x=0; x < bCount; x++) {
+
+      if ( (temp = mmap (0, bSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, (bSize*x))) == MAP_FAILED) {
+         free(ret);
+         return(NULL);
+      }
+
+      ret[x] = temp;
+   }
+
+   return(ret);
+}
+
+// Free space mapping to dma buffers
+static inline ssize_t dmaUnMapDma(int32_t fd, void ** buffer) {
+   uint32_t  bCount;
+   uint32_t  bSize;
+   uint32_t  x;;
+
+   bCount = ioctl(fd,DMA_Get_Buff_Count,0);
+   bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
+
+   // I don't think this is correct.....
+   for (x=0; x < bCount; x++) munmap (buffer, bSize);
+
+   free(buffer);
+   return(0);
+}
+
+// Set debug
+static inline ssize_t dmaSetDebug(int32_t fd, uint32_t level) {
+   return(ioctl(fd,DMA_Set_Debug,level));
+}
+
+// Assign interrupt handler
+static inline void dmaAssignHandler (int32_t fd, void (*handler)(int32_t)) {
+   struct sigaction act;
+   int32_t oflags;
+
+   act.sa_handler = handler;
+   sigemptyset(&act.sa_mask);
+   act.sa_flags = 0;
+
+   sigaction(SIGIO, &act, NULL);
+   fcntl(fd, F_SETOWN, getpid());
+   oflags = fcntl(fd, F_GETFL);
+   fcntl(fd, F_SETFL, oflags | FASYNC);
+}
+
+// set mask
+static inline ssize_t dmaSetMask(int32_t fd, uint32_t mask) {
+   return(ioctl(fd,DMA_Set_Mask,mask));
+}
+
+// Init mask byte array
+static inline void dmaInitMaskBytes(uint8_t * mask) {
+   memset(mask,0,DMA_MASK_SIZE);
+}
+
+// Add destination to mask byte array
+static inline void dmaAddMaskBytes(uint8_t * mask, uint32_t dest) {
+   uint32_t byte;
+   uint32_t bit;
+
+   if ( dest < 8*(DMA_MASK_SIZE)) {
+      byte = dest / 8;
+      bit  = dest % 8;
+      mask[byte] += (1 << bit);
+   }
+}
+
+// set mask byte array to driver
+static inline ssize_t dmaSetMaskBytes(int32_t fd, uint8_t * mask) {
+   return(ioctl(fd,DMA_Set_MaskBytes,mask));
+}
+
+// Check API version, return negative on error
+static inline ssize_t dmaCheckVersion(int32_t fd) {
+   int32_t version;
+   version = ioctl(fd,DMA_Get_Version);
+   return((version == DMA_VERSION)?-0:-1);
+}
+
+// Write Register
+static inline ssize_t dmaWriteRegister(int32_t fd, uint32_t address, uint32_t data) {
+   struct DmaRegisterData reg;
+
+   reg.address = address;
+   reg.data    = data;
+   return(ioctl(fd,DMA_Write_Register,&reg));
+}
+
+// Read Register
+static inline ssize_t dmaReadRegister(int32_t fd, uint32_t address, uint32_t *data) {
+   struct DmaRegisterData reg;
+   ssize_t res;
+
+   reg.address = address;
+   reg.data    = 0;
+   res = ioctl(fd,DMA_Read_Register,&reg);
+
+   if ( data != NULL ) *data = reg.data;
+
+   return(res);
+}
+
+#endif
+#endif
+

--- a/include/rogue/hardware/drivers/PgpDriver.h
+++ b/include/rogue/hardware/drivers/PgpDriver.h
@@ -1,0 +1,234 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : PGP Card Driver, Shared Header
+ * ----------------------------------------------------------------------------
+ * File       : PgpDriver.h
+ * Author     : Ryan Herbst, rherbst@slac.stanford.edu
+ * Created    : 2016-08-08
+ * Last update: 2016-08-08
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Defintions and inline functions for interacting with PGP driver.
+ * ----------------------------------------------------------------------------
+ * This file is part of the aes_stream_drivers package. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the aes_stream_drivers package, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __PGP_DRIVER_H__
+#define __PGP_DRIVER_H__
+#include "DmaDriver.h"
+
+// Card Info
+struct PgpInfo {
+   uint64_t serial;
+   uint32_t type;
+   uint32_t version;
+   uint32_t laneMask;
+   uint32_t vcPerMask;
+   uint32_t pgpRate;
+   uint32_t promPrgEn;
+   uint32_t evrSupport;
+   uint32_t pad;
+   char     buildStamp[256];
+};
+
+// PCI Info
+struct PciStatus {
+   uint32_t pciCommand;
+   uint32_t pciStatus;
+   uint32_t pciDCommand;
+   uint32_t pciDStatus;
+   uint32_t pciLCommand;
+   uint32_t pciLStatus;
+   uint32_t pciLinkState;
+   uint32_t pciFunction;
+   uint32_t pciDevice;
+   uint32_t pciBus;
+   uint32_t pciLanes;
+   uint32_t pad;
+};
+
+// Lane status
+struct PgpStatus {
+   uint32_t lane;
+   uint32_t loopBack;
+   uint32_t locLinkReady;
+   uint32_t remLinkReady;
+   uint32_t rxReady;
+   uint32_t txReady;
+   uint32_t rxCount;
+   uint32_t cellErrCnt;
+   uint32_t linkDownCnt;
+   uint32_t linkErrCnt;
+   uint32_t fifoErr;
+   uint32_t remData;
+   uint32_t remBuffStatus;
+   uint32_t pad;
+};
+
+// EVR Control, per lane
+struct PgpEvrControl {
+   uint32_t  lane;
+   uint32_t  evrEnable;     // Global flag
+   uint32_t  laneRunMask;   // 1 = Run trigger enable
+   uint32_t  evrSyncEn;     // 1 = Start, 0 = Stop
+   uint32_t  evrSyncSel;    // 0 = async, 1 = sync for start/stop
+   uint32_t  headerMask;    // 1 = Enable header data checking, one bit per VC (4 bits)
+   uint32_t  evrSyncWord;   // fiducial to transition start stop
+   uint32_t  runCode;       // Run code
+   uint32_t  runDelay;      // Run delay
+   uint32_t  acceptCode;    // Accept code
+   uint32_t  acceptDelay;   // Accept delay
+   uint32_t  pad;
+};
+
+// EVR Status, per lane
+struct PgpEvrStatus {
+   uint32_t  lane;
+   uint32_t  linkErrors;
+   uint32_t  linkUp;
+   uint32_t  runStatus;    // 1 = Running, 0 = Stopped
+   uint32_t  evrSeconds;
+   uint32_t  runCounter;
+   uint32_t  acceptCounter;
+   uint32_t  pad;
+};
+
+// Card Types
+#define PGP_NONE     0x00
+#define PGP_GEN1     0x01
+#define PGP_GEN2     0x02
+#define PGP_GEN2_VCI 0x12
+#define PGP_GEN3     0x03
+#define PGP_GEN3_VCI 0x13
+
+// Error values
+#define PGP_ERR_EOFE 0x10
+
+// Commands
+#define PGP_Read_Info      0x2001
+#define PGP_Read_Pci       0x2002
+#define PGP_Read_Status    0x2003
+#define PGP_Set_Loop       0x2004
+#define PGP_Count_Reset    0x2005
+#define PGP_Send_OpCode    0x2006
+#define PGP_Set_Data       0x2007
+#define PGP_Set_Evr_Cntrl  0x3001
+#define PGP_Get_Evr_Cntrl  0x3002
+#define PGP_Get_Evr_Status 0x3003
+#define PGP_Rst_Evr_Count  0x3004
+
+// Everything below is hidden during kernel module compile
+#ifndef DMA_IN_KERNEL
+
+static inline uint32_t pgpSetDest(uint32_t lane, uint32_t vc) {
+   uint32_t dest;
+
+   dest  = lane * 4;
+   dest += vc;
+   return(dest);
+}
+
+static inline uint32_t pgpSetFlags(uint32_t cont){
+   return(cont & 0x1);
+}
+
+static inline uint32_t pgpGetLane(uint32_t dest) {
+   return(dest / 4);
+}
+
+static inline uint32_t pgpGetVc(uint32_t dest) {
+   return(dest % 4);
+}
+
+static inline uint32_t pgpGetCont(uint32_t flags) {
+   return(flags & 0x1);
+}
+
+// Read Card Info
+static inline ssize_t pgpGetInfo(int32_t fd, struct PgpInfo * info) {
+   return(ioctl(fd,PGP_Read_Info,info));
+}
+
+// Read PCI Status
+static inline ssize_t pgpGetPci(int32_t fd, struct PciStatus * status) {
+   return(ioctl(fd,PGP_Read_Pci,status));
+}
+
+// Read Lane Status
+static inline ssize_t pgpGetStatus(int32_t fd, uint32_t lane, struct PgpStatus * status) {
+   status->lane = lane;
+   return(ioctl(fd,PGP_Read_Status,status));
+}
+
+// Set Loopback State For Lane
+static inline ssize_t pgpSetLoop(int32_t fd, uint32_t lane, uint32_t state) {
+   uint32_t temp;
+
+   temp = lane & 0xFF;
+   temp |= ((state << 8) & 0x100);
+
+   return(ioctl(fd,PGP_Set_Loop,temp));
+}
+
+// Reset counters
+static inline ssize_t pgpCountReset(int32_t fd) {
+   return(ioctl(fd,PGP_Count_Reset,0));
+}
+
+// Set Sideband Data
+static inline ssize_t pgpSetData(int32_t fd, uint32_t lane, uint32_t data) {
+   uint32_t temp;
+
+   temp = lane & 0xFF;
+   temp |= ((data << 8) & 0xFF00);
+
+   return(ioctl(fd,PGP_Set_Data,temp));
+}
+
+// Send OpCode
+static inline ssize_t pgpSendOpCode(int32_t fd, uint32_t code) {
+   return(ioctl(fd,PGP_Send_OpCode,code));
+}
+
+// Set EVR Control
+static inline ssize_t pgpSetEvrControl(int32_t fd, uint32_t lane, struct PgpEvrControl * control) {
+   control->lane = lane;
+   return(ioctl(fd,PGP_Set_Evr_Cntrl,control));
+}
+
+// Get EVR Control
+static inline ssize_t pgpGetEvrControl(int32_t fd, uint32_t lane, struct PgpEvrControl * control) {
+   control->lane = lane;
+   return(ioctl(fd,PGP_Get_Evr_Cntrl,control));
+}
+
+// Get EVR Status
+static inline ssize_t pgpGetEvrStatus(int32_t fd, uint32_t lane, struct PgpEvrStatus * status) {
+   status->lane = lane;
+   return(ioctl(fd,PGP_Get_Evr_Status,status));
+}
+
+// Reset EVR Counters
+static inline ssize_t pgpResetEvrCount(int32_t fd, uint32_t lane) {
+   return(ioctl(fd,PGP_Rst_Evr_Count,lane));
+}
+
+// Add destination to mask byte array
+static inline void pgpAddMaskBytes(uint8_t * mask, uint32_t lane, uint32_t vc) {
+   dmaAddMaskBytes(mask,lane*4+vc);
+}
+
+// set lane/vc rx mask, one bit per vc
+static inline ssize_t pgpSetMask(int32_t fd, uint32_t lane, uint32_t vc) {
+   return(dmaSetMask(fd, lane*4+vc));
+}
+
+#endif
+#endif
+

--- a/include/rogue/hardware/pgp/EvrControl.h
+++ b/include/rogue/hardware/pgp/EvrControl.h
@@ -21,7 +21,7 @@
 **/
 #ifndef __ROGUE_HARDWARE_PGP_EVR_CONTROL_H__
 #define __ROGUE_HARDWARE_PGP_EVR_CONTROL_H__
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>
 

--- a/include/rogue/hardware/pgp/EvrStatus.h
+++ b/include/rogue/hardware/pgp/EvrStatus.h
@@ -21,7 +21,7 @@
 **/
 #ifndef __ROGUE_HARDWARE_PGP_EVR_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_EVR_STATUS_H__
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>
 

--- a/include/rogue/hardware/pgp/Info.h
+++ b/include/rogue/hardware/pgp/Info.h
@@ -21,7 +21,7 @@
 **/
 #ifndef __ROGUE_HARDWARE_PGP_INFO_H__
 #define __ROGUE_HARDWARE_PGP_INFO_H__
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>
 

--- a/include/rogue/hardware/pgp/PciStatus.h
+++ b/include/rogue/hardware/pgp/PciStatus.h
@@ -21,7 +21,7 @@
 **/
 #ifndef __ROGUE_HARDWARE_PGP_PCI_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_PCI_STATUS_H__
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>
 

--- a/include/rogue/hardware/pgp/PgpCard.h
+++ b/include/rogue/hardware/pgp/PgpCard.h
@@ -23,7 +23,7 @@
 #define __ROGUE_HARDWARE_PGP_PGP_CARD_H__
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <boost/thread.hpp>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>

--- a/include/rogue/hardware/pgp/Status.h
+++ b/include/rogue/hardware/pgp/Status.h
@@ -21,7 +21,7 @@
 **/
 #ifndef __ROGUE_HARDWARE_PGP_STATUS_H__
 #define __ROGUE_HARDWARE_PGP_STATUS_H__
-#include <PgpDriver.h>
+#include <rogue/hardware/drivers/PgpDriver.h>
 #include <stdint.h>
 #include <boost/shared_ptr.hpp>
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -471,9 +471,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             try:
 
                                 if isinstance(func,Pyro4.core.Proxy) or hasattr(func,'varListener'):
-                                    func.varListener(p,val.raw,val.disp)
+                                    func.varListener(p,val.value,val.valueDisp)
                                 else:
-                                    func(p,val.raw,val.disp)
+                                    func(p,val.value.val.valueDisp)
 
                             except Pyro4.errors.CommunicationError as msg:
                                 if 'Connection refused' in str(msg):
@@ -581,14 +581,18 @@ def dictToYaml(data, stream=None, Dumper=yaml.Dumper, **kwds):
         pass
 
     def _var_representer(dumper, data):
-        if type(data.raw) == int:
+        if type(data.value) == bool:
+            enc = 'tag:yaml.org,2002:bool'
+        elif data.enum is not None:
+            enc = 'tag:yaml.org,2002:str'
+        elif type(data.value) == int:
             enc = 'tag:yaml.org,2002:int'
-        elif type(data.raw) == float:
+        elif type(data.value) == float:
             enc = 'tag:yaml.org,2002:float'
         else:
             enc = 'tag:yaml.org,2002:str'
 
-        return dumper.represent_scalar(enc, data.disp)
+        return dumper.represent_scalar(enc, data.valueDisp)
 
     def _dict_representer(dumper, data):
         return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -597,7 +597,7 @@ def dictToYaml(data, stream=None, Dumper=yaml.Dumper, **kwds):
     def _dict_representer(dumper, data):
         return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
 
-    OrderedDumper.add_representer(pr.VariableValue, _var_representer)
+    OrderedDumper.add_representer(pr._VariableValue, _var_representer)
     OrderedDumper.add_representer(odict, _dict_representer)
 
     try:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -473,7 +473,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                 if isinstance(func,Pyro4.core.Proxy) or hasattr(func,'varListener'):
                                     func.varListener(p,val.value,val.valueDisp)
                                 else:
-                                    func(p,val.value.val.valueDisp)
+                                    func(p,val.value.val,valueDisp)
 
                             except Pyro4.errors.CommunicationError as msg:
                                 if 'Connection refused' in str(msg):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -459,13 +459,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             if count == 0 and len(uvars) > 0:
 
                 self._log.debug(F"Process update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}")
-                yml = ""
+                d = odict()
 
                 for p,v in uvars.items():
                     path,value,disp = v._doUpdate()
 
                     # Update yaml string
-                    yml += (f"{path}: {disp}" + "\n")
+                    d[path] = disp
 
                     # Call listener functions,
                     with self._varListenLock:
@@ -485,7 +485,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                     self._log.error("Pyro callback failed for {}: {}".format(self.name,msg))
 
                 # Generate yaml stream
-                self._sendYamlFrame(yml)
+                self._sendYamlFrame(dictToYaml(d,default_flow_style=False))
 
                 # Init var list
                 uvars = {}

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -465,7 +465,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                     path,value,disp = v._doUpdate()
 
                     # Update yaml string
-                    yml += (f"{path}:{disp}" + "\n")
+                    yml += (f"{path}: {disp}" + "\n")
 
                     # Call listener functions,
                     with self._varListenLock:
@@ -561,7 +561,6 @@ class PyroClient(object):
             return ret
         except:
             raise pr.NodeError("PyroClient Failed to find {}.{}.".format(self._group,name))
-
 
 def yamlToDict(stream, Loader=yaml.Loader, object_pairs_hook=odict):
     """Load yaml to ordered dictionary"""

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -29,9 +29,11 @@ class VariableError(Exception):
 
 
 class VariableValue(object):
-    def __init__(self, raw, disp):
-        self.raw  = raw
-        self.disp = disp
+    def __init__(self, var):
+        self.value     = var.value()
+        self.valueDisp = var.genDisp(self.value)
+        self.disp      = var.disp
+        self.enum      = var.enum
 
 
 class BaseVariable(pr.Node):
@@ -321,7 +323,7 @@ class BaseVariable(pr.Node):
 
     def _getDict(self,modes):
         if self._mode in modes:
-            return VariableValue(self.value(), self.valueDisp())
+            return VariableValue(self)
         else:
             return None
 
@@ -333,13 +335,13 @@ class BaseVariable(pr.Node):
 
     def _doUpdate(self):
 
-        val = VariableValue(self.value(), self.valueDisp())
+        val = VariableValue(self)
 
         for func in self.__functions:
             if hasattr(func,'varListener'):
-                func.varListener(self.path,val.raw,val.disp)
+                func.varListener(self.path,val.value,val.valueDisp)
             else:
-                func(self.path,val.raw,val.disp)
+                func(self.path,val.value,val.valueDisp)
 
         return val
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -28,7 +28,7 @@ class VariableError(Exception):
     pass
 
 
-class VariableValue(object):
+class _VariableValue(object):
     def __init__(self, var):
         self.value     = var.value()
         self.valueDisp = var.genDisp(self.value)
@@ -323,7 +323,7 @@ class BaseVariable(pr.Node):
 
     def _getDict(self,modes):
         if self._mode in modes:
-            return VariableValue(self)
+            return _VariableValue(self)
         else:
             return None
 
@@ -335,7 +335,7 @@ class BaseVariable(pr.Node):
 
     def _doUpdate(self):
 
-        val = VariableValue(self)
+        val = _VariableValue(self)
 
         for func in self.__functions:
             if hasattr(func,'varListener'):

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -15,6 +15,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/hardware/axi/AxiMemMap.h>
+#include <rogue/hardware/drivers/AxisDriver.h>
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/interfaces/memory/TransactionLock.h>
@@ -28,7 +29,6 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
-#include <DataDriver.h>
 
 namespace rha = rogue::hardware::axi;
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -18,6 +18,7 @@
  * ----------------------------------------------------------------------------
 **/
 #include <rogue/hardware/axi/AxiStreamDma.h>
+#include <rogue/hardware/drivers/AxisDriver.h>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>


### PR DESCRIPTION
I have decided to remove the aes-stream-drivers as a submoule to simplify the release process and building as an anaconda recipe. Only three headers files are required to be copied from aes-stream-drivers and they change very rarely.