### PR TITLE
Missing addr len initialization in udp socket.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@
 # copied, modified, propagated, or distributed except according to the terms 
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
+# See notes for compiling on macos under anaconda:
+#    https://conda.io/docs/user-guide/tasks/build-packages/compiler-tools.html
 
 # Add support for building in conda environment
 if (DEFINED ENV{CONDA_PREFIX})

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -176,6 +176,7 @@ void rpu::Server::runThread() {
          // Attempt receive
          buff = *(frame->beginBuffer());
          avail = buff->getAvailable();
+         tmpLen = sizeof(struct sockaddr_in);
          res = recvfrom(fd_, buff->begin(), avail, MSG_TRUNC, (struct sockaddr *)&tmpAddr, &tmpLen);
 
          if ( res > 0 ) {


### PR DESCRIPTION
This worked for some reason in Linux, but failed in MacOs.