### PR TITLE
Default to conda if ROGUE_INSTALL not passed and inside conda environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,11 @@ endif()
 
 # Default install type
 if ( NOT ROGUE_INSTALL ) 
-   set (ROGUE_INSTALL "local")
+   if (DEFINED ENV{CONDA_PREFIX})
+      set (ROGUE_INSTALL "conda")
+   else()
+      set (ROGUE_INSTALL "local")
+   endif()
 endif()
 
 # Default Install directory


### PR DESCRIPTION
Remove the need to always pass -DROGUE_INSTALL=conda on the command line if within a conda environment. Outside a conda environment the install will still default to local.