### PR TITLE
Fix RSSI busy generation and reception

### DIFF
--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -90,9 +90,6 @@ namespace rogue {
                void     setLocTryPeriod(uint32_t val);
                uint32_t getLocTryPeriod();
 
-               void     setLocBusyThold(uint32_t val);
-               uint32_t getLocBusyThold();
-
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();
 

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -44,7 +44,6 @@ namespace rogue {
 
                //! Local parameters
                uint32_t locTryPeriod_;
-               uint32_t locBusyThold_;
 
                //! Configurable parameters, requested by software
                uint8_t  locMaxBuffers_;
@@ -99,6 +98,7 @@ namespace rogue {
 
                // Application tracking
                uint8_t lastSeqRx_;
+               uint8_t ackSeqRx_;
 
                // State Tracking
                boost::condition_variable stCond_;
@@ -189,9 +189,6 @@ namespace rogue {
 
                void     setLocTryPeriod(uint32_t val);
                uint32_t getLocTryPeriod();
-
-               void     setLocBusyThold(uint32_t val);
-               uint32_t getLocBusyThold();
 
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -86,9 +86,6 @@ namespace rogue {
                void     setLocTryPeriod(uint32_t val);
                uint32_t getLocTryPeriod();
 
-               void     setLocBusyThold(uint32_t val);
-               uint32_t getLocBusyThold();
-
                void     setLocMaxBuffers(uint8_t val);
                uint8_t  getLocMaxBuffers();
 

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -129,13 +129,6 @@ class UdpRssiPack(pr.Device):
         ))                 
 
         self.add(pr.LocalVariable(
-            name        = 'locBusyThold',
-            mode        = 'RW', 
-            localGet    = lambda: self._rssi.getLocBusyThold(),
-            localSet    = lambda value: self._rssi.setLocBusyThold(value)
-        ))                 
-
-        self.add(pr.LocalVariable(
             name        = 'locMaxBuffers',
             mode        = 'RW', 
             localGet    = lambda: self._rssi.getLocMaxBuffers(),

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -56,8 +56,6 @@ void rpr::Client::setup_python() {
       .def("getRemBusyCnt",    &rpr::Client::getRemBusyCnt)
       .def("setLocTryPeriod",  &rpr::Client::setLocTryPeriod)
       .def("getLocTryPeriod",  &rpr::Client::getLocTryPeriod)
-      .def("setLocBusyThold",  &rpr::Client::setLocBusyThold)
-      .def("getLocBusyThold",  &rpr::Client::getLocBusyThold)
       .def("setLocMaxBuffers", &rpr::Client::setLocMaxBuffers)
       .def("getLocMaxBuffers", &rpr::Client::getLocMaxBuffers)
       .def("setLocMaxSegment", &rpr::Client::setLocMaxSegment)
@@ -157,14 +155,6 @@ void rpr::Client::setLocTryPeriod(uint32_t val) {
 
 uint32_t rpr::Client::getLocTryPeriod() {
    return cntl_->getLocTryPeriod();
-}
-
-void rpr::Client::setLocBusyThold(uint32_t val) {
-   cntl_->setLocBusyThold(val);
-}
-
-uint32_t rpr::Client::getLocBusyThold() {
-   return cntl_->getLocBusyThold();
 }
 
 void rpr::Client::setLocMaxBuffers(uint8_t val) {

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -549,12 +549,6 @@ int8_t rpr::Controller::retransmit(uint8_t id) {
    rpr::HeaderPtr head = txList_[id];
    if ( head == NULL ) return 0;
 
-   // Busy set, reset timeout
-   if ( remBusy_ ) {
-      head->rstTime();
-      return 0;
-   }
-
    // retransmit timer has not expired
    if ( ! timePassed(head->getTime(),retranToutD1_) ) return 0;
 
@@ -839,9 +833,9 @@ struct timeval & rpr::Controller::stateOpen () {
       transportTx(head,doNull,false);
    }
 
-   // Retransmission processing
+   // Retransmission processing, don't process when busy
    idx = lastAckRx_;
-   while ( idx != locSequence_ ) {
+   while ( (! remBusy_) && (idx != locSequence_) ) {
       if ( retransmit(idx++) < 0 ) {
          state_ = StError;
          gettimeofday(&stTime_,NULL);

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -827,7 +827,7 @@ struct timeval & rpr::Controller::stateOpen () {
    else doNull = false;
 
    // Outbound frame required
-   if ( ( doNull || ackPend >= curMaxCumAck_ || 
+   if ( ( doNull || ((! getLocBusy()) && ackPend >= curMaxCumAck_) || 
         ((ackPend > 0 || getLocBusy()) && timePassed(locTime,cumAckToutD1_)) ) ) {
 
       head = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -314,10 +314,10 @@ ris::FramePtr rpr::Controller::applicationTx() {
          head.reset();
          frame.reset();
       }
+      else (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
 
    } while (! frame);
 
-   (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
    return(frame);
 }
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -185,8 +185,8 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
       return;
    }
 
-   log_->debug("RX frame: state=%i server=%i size=%i syn=%i ack=%i nul=%i, rst=%i, ack#=%i seq=%i, nxt=%i",
-         state_, server_,frame->getPayload(),head->syn,head->ack,head->nul,head->rst,
+   log_->debug("RX frame: state=%i server=%i size=%i syn=%i ack=%i nul=%i, bst=%i, rst=%i, ack#=%i seq=%i, nxt=%i",
+         state_, server_,frame->getPayload(),head->syn,head->ack,head->nul,head->busy,head->rst,
          head->acknowledge,head->sequence,nextSeqRx_);
 
    // Ack set
@@ -195,7 +195,7 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
 
       do {
          txList_[++lastAckRx_].reset();
-         txListCount_--;
+         if ( txListCount_ != 0 ) txListCount_--;
       } while (lastAckRx_ != head->acknowledge);
    }
 
@@ -534,8 +534,8 @@ void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool txRe
    head->update();
 
    log_->log(rogue::Logging::Debug,
-         "TX frame: state=%i server=%i size=%i syn=%i ack=%i nul=%i, rst=%i, ack#=%i, seq=%i, recount=%i, ptr=%p",
-         state_,server_,head->getFrame()->getPayload(),head->syn,head->ack,head->nul,head->rst,
+         "TX frame: state=%i server=%i size=%i syn=%i ack=%i nul=%i, bsy=%i, rst=%i, ack#=%i, seq=%i, recount=%i, ptr=%p",
+         state_,server_,head->getFrame()->getPayload(),head->syn,head->ack,head->nul,head->busy,head->rst,
          head->acknowledge,head->sequence,retranCount_,head->getFrame().get());
 
    flock->unlock();
@@ -833,7 +833,6 @@ struct timeval & rpr::Controller::stateOpen () {
       head = rpr::Header::create(tran_->reqFrame(rpr::Header::HeaderSize,false));
       head->ack = true;
       head->nul = doNull;
-
       transportTx(head,doNull,false);
    }
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -309,8 +309,13 @@ ris::FramePtr rpr::Controller::applicationTx() {
 
       ackSeqRx_ = head->sequence;
 
-   // Drop NULL frames
-   } while (head->nul);
+      // Drop NULL frames
+      if (head->nul) {
+         head.reset();
+         frame.reset();
+      }
+
+   } while (! frame);
 
    (*(frame->beginBuffer()))->adjustHeader(rpr::Header::HeaderSize);
    return(frame);

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -52,8 +52,6 @@ void rpr::Server::setup_python() {
       .def("getRemBusyCnt",    &rpr::Server::getRemBusyCnt)
       .def("setLocTryPeriod",  &rpr::Server::setLocTryPeriod)
       .def("getLocTryPeriod",  &rpr::Server::getLocTryPeriod)
-      .def("setLocBusyThold",  &rpr::Server::setLocBusyThold)
-      .def("getLocBusyThold",  &rpr::Server::getLocBusyThold)
       .def("setLocMaxBuffers", &rpr::Server::setLocMaxBuffers)
       .def("getLocMaxBuffers", &rpr::Server::getLocMaxBuffers)
       .def("setLocMaxSegment", &rpr::Server::setLocMaxSegment)
@@ -153,14 +151,6 @@ void rpr::Server::setLocTryPeriod(uint32_t val) {
 
 uint32_t rpr::Server::getLocTryPeriod() {
    return cntl_->getLocTryPeriod();
-}
-
-void rpr::Server::setLocBusyThold(uint32_t val) {
-   cntl_->setLocBusyThold(val);
-}
-
-uint32_t rpr::Server::getLocBusyThold() {
-   return cntl_->getLocBusyThold();
 }
 
 void rpr::Server::setLocMaxBuffers(uint8_t val) {

--- a/tests/test_udpPacketizer.py
+++ b/tests/test_udpPacketizer.py
@@ -16,8 +16,11 @@
 import rogue.utilities 
 import rogue.protocols.udp
 import rogue.interfaces.stream
+import rogue
 import pyrogue
 import time
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
 
 FrameCount = 10000
 FrameSize  = 10000


### PR DESCRIPTION
The previous versions of Rogue were not fully compliant with the RSSI specification when it came to busy handling. 

Acks are now generated as the buffers are pulled from the receive buffer from the application and busy is generated when more than 2 entries are in the buffer.

When busy is received the re-transmit logic is disabled. 

