### PR TITLE
Add EPICS to Docker container & use system build for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,12 @@ RUN apt-get update && apt-get -y    install wget git \
                                     libreadline6-dev
 
 # Install EPICS
-WORKDIR /
-RUN mkdir epics
-WORKDIR epics
-RUN mkdir base-3.15.5
-WORKDIR base-3.15.5
+RUN mkdir -p /usr/src/epics/base-3.15.5
+WORKDIR /usr/src/epics/base-3.15.5
 RUN wget -O base-3.15.5.tar.gz https://epics.anl.gov/download/base/base-3.15.5.tar.gz
 RUN tar xzf base-3.15.5.tar.gz --strip 1
 RUN make clean && make && make install
-ENV EPICS_BASE /epics/base-3.15.5/
+ENV EPICS_BASE /usr/src/epics/base-3.15.5
 
 # PIP Packages
 RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy pyepics

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,14 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get -y    install wget git \
                                     cmake python3 python3-dev libboost-all-dev \
                                     libbz2-dev python3-pip libzmq3-dev python3-pyqt5
-RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging
+RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy
 
 # Install Rogue
 ARG branch
-WORKDIR /
-RUN git clone https://github.com/slaclab/rogue.git -b $branch
+WORKDIR /usr/src
+RUN git clone https://github.com/slaclab/rogue.git -b pre-release
 WORKDIR rogue
-RUN git submodule update --init --recursive
 RUN mkdir build
 WORKDIR build
-RUN cmake ..
-RUN make
-ENV ROGUE_DIR /rogue
-ENV PYTHONPATH ${PYTHONPATH}:${ROGUE_DIR}/python
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${ROGUE_DIR}/lib
+RUN cmake .. -DROGUE_INSTALL=system
+RUN make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,24 @@ FROM ubuntu:18.04
 # Install system tools
 RUN apt-get update && apt-get -y    install wget git \
                                     cmake python3 python3-dev libboost-all-dev \
-                                    libbz2-dev python3-pip libzmq3-dev python3-pyqt5
-RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy
+                                    libbz2-dev python3-pip libzmq3-dev python3-pyqt5 \
+                                    libreadline6-dev
+
+# Install EPICS
+ARG branch
+WORKDIR /
+RUN mkdir epics
+WORKDIR epics
+RUN mkdir base-3.15.5
+WORKDIR base-3.15.5
+RUN wget -O base-3.15.5.tar.gz https://epics.anl.gov/download/base/base-3.15.5.tar.gz
+RUN tar xzf base-3.15.5.tar.gz --strip 1
+RUN make clean && make && make install
+ENV EPICS_BASE /epics/base-3.15.5/
+
+# PIP Packages
+ARG branch
+RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy pyepics
 
 # Install Rogue
 ARG branch
@@ -15,3 +31,4 @@ RUN mkdir build
 WORKDIR build
 RUN cmake .. -DROGUE_INSTALL=system
 RUN make install
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update && apt-get -y    install wget git \
                                     libreadline6-dev
 
 # Install EPICS
-ARG branch
 WORKDIR /
 RUN mkdir epics
 WORKDIR epics
@@ -19,16 +18,14 @@ RUN make clean && make && make install
 ENV EPICS_BASE /epics/base-3.15.5/
 
 # PIP Packages
-ARG branch
 RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy pyepics
 
 # Install Rogue
 ARG branch
 WORKDIR /usr/src
-RUN git clone https://github.com/slaclab/rogue.git -b pre-release
+RUN git clone https://github.com/slaclab/rogue.git -b $branch
 WORKDIR rogue
 RUN mkdir build
 WORKDIR build
 RUN cmake .. -DROGUE_INSTALL=system
 RUN make install
-

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,7 +1,6 @@
 PyYAML
 Pyro4
 parse
-recordclass
 click
 coverage
 codecov


### PR DESCRIPTION
This PR adds an EPICS base build to the docker file and changes the rogue install type to be "system", putting rogue in the standard library directories.

I also removed recordclass from the pip requirements.

The python packages matplotlib, numpy, pyepics are also now installed.