### PR TITLE
Support channelized ports on file writer

### DIFF
--- a/include/rogue/utilities/fileio/StreamWriterChannel.h
+++ b/include/rogue/utilities/fileio/StreamWriterChannel.h
@@ -40,7 +40,7 @@ namespace rogue {
                boost::shared_ptr<rogue::utilities::fileio::StreamWriter> writer_;
 
                //! Channel information
-               uint16_t channel_;
+               uint8_t channel_;
 
                //! Number of frames received by channel
                uint32_t frameCount_;

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -74,7 +74,7 @@ void ruf::StreamWriterChannel::acceptFrame ( ris::FramePtr frame ) {
    boost::unique_lock<boost::mutex> lock(mtx_);
 
    // Support for channelized traffic
-   if ( (channel_ == 0) && (frame->getChannel() != 0) ) ichan = frame->getChannel();
+   if ( channel_ == 0 ) ichan = frame->getChannel();
    else ichan = channel_;
 
    writer_->writeFile (ichan, frame);

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -67,10 +67,17 @@ ruf::StreamWriterChannel::~StreamWriterChannel() { }
 
 //! Accept a frame from master
 void ruf::StreamWriterChannel::acceptFrame ( ris::FramePtr frame ) {
+   uint8_t ichan;
+
    rogue::GilRelease noGil;
    ris::FrameLockPtr fLock = frame->lock();
    boost::unique_lock<boost::mutex> lock(mtx_);
-   writer_->writeFile (channel_, frame);
+
+   // Support for channelized traffic
+   if ( (channel_ == 0) && (frame->getChannel() != 0) ) ichan = frame->getChannel();
+   else ichan = channel_;
+
+   writer_->writeFile (ichan, frame);
    frameCount_++;
    lock.unlock();
    cond_.notify_all();


### PR DESCRIPTION
This PR allows channel 0 on the file writer to support incoming frames which have a non-zero channel field, as is the case with the batcher output frames.