### PR TITLE
Add scipy to conda recipe

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -17,9 +17,11 @@ dependencies:
   - click
   - pyro4
   - numpy
+  - scipy  
   - pyqt
   - pyepics
   - boost
   - bzip2
   - matplotlib
   - epics-base=3.14.12.8
+

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -17,6 +17,7 @@ dependencies:
   - click
   - pyro4
   - numpy
+  - scipy
   - pyqt
   - pyepics
   - boost


### PR DESCRIPTION
I think scipy has enough useful data analysis tools that we should have it as part of the default rogue env.

Separately, we should write up a procedure for how a project should add it's own conda dependencies on top of the rogue ones.