### PR TITLE
Allow commands to be run in background threads

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -73,14 +73,14 @@ class BaseCommand(pr.BaseVariable):
         if self._background:
             with self._lock:
                 if self._thread is not None and self._thread.isAlive():
-                    self._log.exception('Command execution is already in progress!')
+                    self._log.warning('Command execution is already in progress!')
                     return
                 else:
-                    self._thread = threading.Thread(target=_doFunc, args=(arg,))
+                    self._thread = threading.Thread(target=self._doFunc, args=(arg,))
+                    self._thread.start()
         else:
             self._doFunc(arg)
 
-    @Pyro4.expose
     def _doFunc(self,arg):
         """Execute command: TODO: Update comments"""
         if (self.parent.enable.value() is not True):

--- a/tests/test_localcommand.py
+++ b/tests/test_localcommand.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+from time import time, sleep
+
+import pyrogue
+
+# Test values
+delay=2
+
+class myDevice(pyrogue.Device):
+    def __init__(self, name="myDevice", description='My device', **kargs):
+        super().__init__(name=name, description=description, **kargs)
+
+        # This command calls _DelayFunction in the foreground
+        self.add(pyrogue.LocalCommand(
+            name='cmd_fg',
+            description='Commad running in the foreground',
+            function=self._DelayFunction))
+
+        # This command calls _DelayFunction in the background
+        self.add(pyrogue.LocalCommand(
+            name='cmd_bg',
+            description='Command running in the background',
+            background=True,
+            function=self._DelayFunction))
+
+    # Blocking function. The passed argument specify how many seconds
+    # it will block.
+    def _DelayFunction(self,arg):
+        sleep(arg)
+
+class LocalRoot(pyrogue.Root):
+    def __init__(self):
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
+        my_device=myDevice()
+        self.add(my_device)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+
+def test_local_cmd():
+    """
+    Test Local Commands
+    """
+    with LocalRoot() as root:
+
+        # Test a local command running in the foreground
+        start=time()
+        root.myDevice.cmd_fg.call(delay)
+        end=time()
+        duration=end-start
+        if duration < delay:
+            raise AssertionError('Comamnd running in foreground returned too soon: '
+                'delay was set to {} s, and the command took {} s.'.format(delay, duration))
+
+        # Test a local command running in the background
+        start=time()
+        root.myDevice.cmd_bg.call(2)
+        end=time()
+        duration=end-start
+        if duration > delay:
+            raise AssertionError('Comamnd running in background returned too late: '
+                'delay was set to {} s, and the command took {} s.'.format(delay, duration))


### PR DESCRIPTION

This pr adds the background attribute to the command class. If this attribute is set to true the command will be executed in the background, with the exec() call returning immediately. This allows for long duration commands to be supported in rogue without blocking the calling process (i.e. epics or GUI).  A second attempt to call the command while the first call is still in progress will result in an immediate return without re-starting the command. 

self.add(Command(name='test', background=True))