### PR TITLE
Add helper macros to C++

### DIFF
--- a/include/rogue/Helpers.h
+++ b/include/rogue/Helpers.h
@@ -1,0 +1,38 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Helpfull Functions
+ * ----------------------------------------------------------------------------
+ * File       : Helpers.h
+ * Created    : 2018-11-28
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Helper functions for Rogue
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_HELPERS_H__
+#define __ROGUE_HELPERS_H__
+
+// Connect stream 
+#define streamConnect(src,dst) src->setSlave(dst);
+
+// Add stream tap
+#define streamTap(src,dst) src->addSlave(dst);
+
+// Connect stream bi-directionally
+#define streamConnectBiDir(devA,devB) \
+   devA->setSlave(devB); \
+   devB->setSlave(devA);
+
+// Connect memory bus
+#define busConnect(src,dst) src->setSlave(dst);
+
+#endif
+


### PR DESCRIPTION

This PR adds the following helper macros to make the c++ code look more like the python code:

streamConnect(src,dst)
streamTap(src,dst)
streamConnectBiDir(devA,devB)
busConnect(src,dst)

