### PR TITLE
Remove matplotlib from conda dependencies.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
      - numpy
      - pyqt
      - pyepics
-     - matplotlib
 
 about:
    home: https://github.com/slaclab/rogue

--- a/conda.yml
+++ b/conda.yml
@@ -21,5 +21,4 @@ dependencies:
   - pyepics
   - boost
   - bzip2
-  - matplotlib
   - epics-base=3.14.12.8

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -21,5 +21,4 @@ dependencies:
   - pyepics
   - boost
   - bzip2
-  - matplotlib
   - epics-base=3.14.12.8


### PR DESCRIPTION

Matplotlib should not be included as a required dependency.