### PR TITLE
including boost/make_shared.hpp to avoid compile errors

### DIFF
--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -20,6 +20,7 @@
 #include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GilRelease.h>
+#include <boost/make_shared.hpp>
 
 namespace rim = rogue::interfaces::memory;
 

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -19,6 +19,7 @@
 **/
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Frame.h>
+#include <boost/make_shared.hpp>
 
 namespace ris = rogue::interfaces::stream;
 


### PR DESCRIPTION
including boost/make_shared.hpp to avoid compile errors