### PR TITLE
Fix recursive device list generation.

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -231,7 +231,6 @@ class Node(object):
         for key,value in self._nodes.items():
             if isinstance(value,pr.Device):
                 lst.append(value)
-            else:
                 lst.extend(value.deviceList)
         return lst
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -147,8 +147,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         for i in range(1,len(tmpDevs)):
 
-            print("Comparing Device {} at address={:#x} to {} at address={:#x} with size={}".format(
-                  tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
+            self._log.debug("Comparing Device {} at address={:#x} to {} at address={:#x} with size={}".format(
+                            tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
 
             if (tmpDevs[i].size != 0) and (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and \
                 (tmpDevs[i].address < (tmpDevs[i-1].address + tmpDevs[i-1].size)):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -146,6 +146,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         tmpDevs.sort(key=lambda x: (x.memBaseId, x.address, x.size))
 
         for i in range(1,len(tmpDevs)):
+
+            print("Comparing Device {} at address={:#x} to {} at address={:#x} with size={}".format(
+                  tmpDevs[i].path,tmpDevs[i].address,tmpDevs[i-1].path,tmpDevs[i-1].address,tmpDevs[i-1].size))
+
             if (tmpDevs[i].size != 0) and (tmpDevs[i].memBaseId == tmpDevs[i-1].memBaseId) and \
                 (tmpDevs[i].address < (tmpDevs[i-1].address + tmpDevs[i-1].size)):
 


### PR DESCRIPTION

The device list generation which is used to search for device overlaps was not properly recursive. Because of this devices deeper in the tree where not properly. Checked.

Because of this I will defer moving this warning to an exception for a bit longer.