### PR TITLE
Generate error and display INV for invalid enum values

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -243,7 +243,11 @@ class BaseVariable(pr.Node):
         try:
             #print('{}.genDisp(read={}) disp={} value={}'.format(self.path, read, self.disp, value))
             if self.disp == 'enum':
-                ret = self.enum[value]
+                if value in self.enum:
+                    ret = self.enum[value]
+                else:
+                    self._log.error("Invalid enum value {} in variable '{}'".format(value,self.path))
+                    ret = 'INV'
             else:
                 if value == '' or value is None:
                     ret = value

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -247,7 +247,7 @@ class BaseVariable(pr.Node):
                     ret = self.enum[value]
                 else:
                     self._log.error("Invalid enum value {} in variable '{}'".format(value,self.path))
-                    ret = 'INV'
+                    ret = 'INVALID: {:#x}'.format(value)
             else:
                 if value == '' or value is None:
                     ret = value

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -141,8 +141,12 @@ class VariableLink(QObject):
             self._swSet = True
 
             if isinstance(self._widget, QComboBox):
-                if self._widget.currentIndex() != self._widget.findText(disp):
-                    self.updateGui.emit(self._widget.findText(disp))
+                i = self._widget.findText(disp)
+
+                if i < 0: i = 0
+
+                if self._widget.currentIndex() != i:
+                    self.updateGui.emit(i)
             elif isinstance(self._widget, QSpinBox):
                 if self._widget.value != value:
                     self.updateGui.emit(value)


### PR DESCRIPTION
This PR will generate the string 'INV' if the integer value received from hardware does no match a known ENUM key.