### PR TITLE
Fix shared memory interface errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ add_subdirectory(src/rogue)
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${Boost_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${EPICSV3_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC bz2)
+TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC rt)
 
 # Do not link directly against python in macos
 if (APPLE)

--- a/src/rogue/SMemControl.cpp
+++ b/src/rogue/SMemControl.cpp
@@ -82,7 +82,11 @@ std::string rogue::SMemControlWrap::doRequest ( uint8_t type, std::string path, 
 
       if (bp::override f = this->get_override("_doRequest")) {
          try {
-            return(f(type,path,arg));
+            if ( type == ROGUE_CMD_GET || type == ROGUE_CMD_VALUE ) 
+               return(f(type,path,arg));
+            else
+               f(type,path,arg);
+               return std::string("");
          } catch (...) {
             PyErr_Print();
          }

--- a/src/rogue/SMemControl.cpp
+++ b/src/rogue/SMemControl.cpp
@@ -84,9 +84,10 @@ std::string rogue::SMemControlWrap::doRequest ( uint8_t type, std::string path, 
          try {
             if ( type == ROGUE_CMD_GET || type == ROGUE_CMD_VALUE ) 
                return(f(type,path,arg));
-            else
+            else {
                f(type,path,arg);
                return std::string("");
+            }
          } catch (...) {
             PyErr_Print();
          }

--- a/templates/RogueConfig.cmake.in
+++ b/templates/RogueConfig.cmake.in
@@ -121,7 +121,8 @@ set(ROGUE_LIBRARIES @CONF_LIBRARIES@
                     ${Boost_LIBRARIES}
                     ${PYTHON_LIBRARIES}
                     ${EPICSV3_LIBRARIES}
-                    LINK_PUBLIC bz2)
+                    LINK_PUBLIC bz2
+                    LINK_PUBLIC rt)
 
 # Set Version
 set(ROGUE_VERSION @ROGUE_VERSION@)


### PR DESCRIPTION
Only expect an return value when command is a get or value type.

Also adds librt to library list in cmake rules.