### PR TITLE
Call finishInit() for root attached variables

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -144,6 +144,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         for key,value in self._nodes.items():
             value._rootAttached(self,self)
 
+        # Some variable initialization can run until the blocks are built
+        for v in self.variables.values():
+            v._finishInit()
+
         # Look for device overlaps
         tmpDevs = self.deviceList
         tmpDevs.sort(key=lambda x: (x.memBaseId, x.address, x.size))


### PR DESCRIPTION

finishInit() was not being called for the variables attached to the root. This resulting is  root level variables not properly polling.

