### PR TITLE
Variable.get() returns staged data if the underlying Block is stale

### DIFF
--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -120,6 +120,9 @@ namespace rogue {
                //! Set all bits in dest with lbs and size
                static void setBits(boost::python::object dst, uint32_t lsb, uint32_t size);
 
+               //! Return true if any bits are set in range
+               static bool anyBits(boost::python::object dst, uint32_t lsb, uint32_t size);
+
 #endif
 
             protected:

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -391,7 +391,7 @@ class RemoteBlock(BaseBlock, rim.Master):
 
             dstBit = 0
             for x in range(len(var.bitOffset)):
-                if self._anyBits(self._sDataMask, var.bitOffset[x], bar.bitSize[x]):
+                if self._anyBits(self._sDataMask, var.bitOffset[x], var.bitSize[x]):
                     self._copyBits(ba, dstBit, self._sData, var.bitOffset[x], var.bitSize[x])
                 else:
                     self._copyBits(ba, dstBit, self._bData, var.bitOffset[x], var.bitSize[x])

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -391,7 +391,10 @@ class RemoteBlock(BaseBlock, rim.Master):
 
             dstBit = 0
             for x in range(len(var.bitOffset)):
-                self._copyBits(ba, dstBit, self._bData, var.bitOffset[x], var.bitSize[x])
+                if self._anyBits(self._sDataMask, var.bitOffset[x], bar.bitSize[x]):
+                    self._copyBits(ba, dstBit, self._sData, var.bitOffset[x], var.bitSize[x])
+                else:
+                    self._copyBits(ba, dstBit, self._bData, var.bitOffset[x], var.bitSize[x])
                 dstBit += var.bitSize[x]
 
             return var._base.fromBytes(ba,sum(var.bitSize))

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -58,6 +58,8 @@ void rim::Master::setup_python() {
       .staticmethod("_copyBits")
       .def("_setBits",            &rim::Master::setBits)
       .staticmethod("_setBits")
+      .def("_anyBits",            &rim::Master::anyBits)
+      .staticmethod("_anyBits")
    ;
 #endif
 }


### PR DESCRIPTION
During a bulk configuration write, it is necessary for `LinkVariables` to see the staged values of any dependent `Variables` that have already been modified. This change allows that by checking the staged data mask in the underlying block and returning the staged data if any exists.