### PR TITLE
Add memory and stream interface bridges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
         - export BOOST_ROOT=$BOOST_DIR
         - export EPICS_BASE=$EPICS_DIR
         - export EPICS_CA_ADDR_LIST=127.0.0.1
+        # Install zeromq
+        - sudo apt-get install -qq libzmq3-dev
         # Prepare folders
         - mkdir -p $BOOST_DIR
         - mkdir -p $EPICS_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ add_subdirectory(src/rogue)
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${Boost_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC ${EPICSV3_LIBRARIES})
 TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC bz2)
+TARGET_LINK_LIBRARIES(rogue-core LINK_PUBLIC zmq)
 
 # Do not link directly against python in macos
 if (APPLE)

--- a/include/rogue/interfaces/memory/BridgeMaster.h
+++ b/include/rogue/interfaces/memory/BridgeMaster.h
@@ -29,26 +29,22 @@ namespace rogue {
       namespace memory {
 
          //! PGP Card class
-         class BridgeMaster : public rogue::interfaces::stream::Master, 
-                        public rogue::interfaces::stream::Slave {
+         class BridgeMaster : public rogue::interfaces::memory::Master {
 
                //! Inbound Address
-               std::string pullAddr_;
+               std::string reqAddr_;
 
                //! Outbound Address
-               std::string pushAddr_;
-
-               //! Server mode
-               bool server_;
+               std::string respAddr_;
 
                //! Zeromq Context
                void * zmqCtx_;
 
                //! Zeromq inbound port
-               void * zmqPull_;
+               void * zmqReq_;
 
                //! Zeromq outbound port
-               void * zmqPush_;
+               void * zmqResp_;
 
                //! Thread background
                void runThread();
@@ -59,30 +55,25 @@ namespace rogue {
                //! Thread
                boost::thread * thread_;
 
-               //! Lock
-               boost::mutex bridgeMtx_;
-
             public:
 
                //! Class creation
-               static boost::shared_ptr<rogue::interfaces::stream::BridgeMaster> 
-                  create (std::string addr, uint16_t port, bool server);
+               static boost::shared_ptr<rogue::interfaces::memory::BridgeMaster> 
+                      create (std::string addr, uint16_t port);
 
                //! Setup class in python
                static void setup_python();
 
                //! Creator
-               BridgeMaster(std::string addr, uint16_t port, bool server);
+               BridgeMaster(std::string addr, uint16_t port);
 
                //! Destructor
                ~BridgeMaster();
 
-               //! Accept a frame from master
-               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
          };
 
          // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::stream::BridgeMaster> BridgeMasterPtr;
+         typedef boost::shared_ptr<rogue::interfaces::memory::BridgeMaster> BridgeMasterPtr;
 
       }
    }

--- a/include/rogue/interfaces/memory/BridgeMaster.h
+++ b/include/rogue/interfaces/memory/BridgeMaster.h
@@ -1,0 +1,92 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Master Network Bridge
+ * ----------------------------------------------------------------------------
+ * File       : BridgeMaster.h
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Master Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_MEMORY_BRIDGE_MASTER_H__
+#define __ROGUE_INTERFACES_MEMORY_BRIDGE_MASTER_H__
+#include <rogue/interfaces/memory/Master.h>
+#include <rogue/Logging.h>
+#include <boost/thread.hpp>
+#include <stdint.h>
+
+namespace rogue {
+   namespace interfaces {
+      namespace memory {
+
+         //! PGP Card class
+         class BridgeMaster : public rogue::interfaces::stream::Master, 
+                        public rogue::interfaces::stream::Slave {
+
+               //! Inbound Address
+               std::string pullAddr_;
+
+               //! Outbound Address
+               std::string pushAddr_;
+
+               //! Server mode
+               bool server_;
+
+               //! Zeromq Context
+               void * zmqCtx_;
+
+               //! Zeromq inbound port
+               void * zmqPull_;
+
+               //! Zeromq outbound port
+               void * zmqPush_;
+
+               //! Thread background
+               void runThread();
+
+               //! Log
+               rogue::LoggingPtr bridgeLog_;
+
+               //! Thread
+               boost::thread * thread_;
+
+               //! Lock
+               boost::mutex bridgeMtx_;
+
+            public:
+
+               //! Class creation
+               static boost::shared_ptr<rogue::interfaces::stream::BridgeMaster> 
+                  create (std::string addr, uint16_t port, bool server);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Creator
+               BridgeMaster(std::string addr, uint16_t port, bool server);
+
+               //! Destructor
+               ~BridgeMaster();
+
+               //! Accept a frame from master
+               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::BridgeMaster> BridgeMasterPtr;
+
+      }
+   }
+};
+
+#endif
+

--- a/include/rogue/interfaces/memory/BridgeSlave.h
+++ b/include/rogue/interfaces/memory/BridgeSlave.h
@@ -61,7 +61,7 @@ namespace rogue {
             public:
 
                //! Class creation
-               static boost::shared_ptr<rogue::interfaces::master::BridgeSlave> 
+               static boost::shared_ptr<rogue::interfaces::memory::BridgeSlave> 
                       create (std::string addr, uint16_t port);
 
                //! Setup class in python
@@ -78,7 +78,7 @@ namespace rogue {
          };
 
          // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::master::BridgeSlave> BridgeSlavePtr;
+         typedef boost::shared_ptr<rogue::interfaces::memory::BridgeSlave> BridgeSlavePtr;
 
       }
    }

--- a/include/rogue/interfaces/memory/BridgeSlave.h
+++ b/include/rogue/interfaces/memory/BridgeSlave.h
@@ -29,26 +29,22 @@ namespace rogue {
       namespace memory {
 
          //! PGP Card class
-         class BridgeSlave : public rogue::interfaces::stream::Master, 
-                        public rogue::interfaces::stream::Slave {
+         class BridgeSlave : public rogue::interfaces::memory::Slave {
 
                //! Inbound Address
-               std::string pullAddr_;
+               std::string reqAddr_;
 
                //! Outbound Address
-               std::string pushAddr_;
-
-               //! Server mode
-               bool server_;
+               std::string respAddr_;
 
                //! Zeromq Context
                void * zmqCtx_;
 
                //! Zeromq inbound port
-               void * zmqPull_;
+               void * zmqReq_;
 
                //! Zeromq outbound port
-               void * zmqPush_;
+               void * zmqResp_;
 
                //! Thread background
                void runThread();
@@ -65,24 +61,24 @@ namespace rogue {
             public:
 
                //! Class creation
-               static boost::shared_ptr<rogue::interfaces::stream::BridgeSlave> 
-                  create (std::string addr, uint16_t port, bool server);
+               static boost::shared_ptr<rogue::interfaces::master::BridgeSlave> 
+                      create (std::string addr, uint16_t port);
 
                //! Setup class in python
                static void setup_python();
 
                //! Creator
-               BridgeSlave(std::string addr, uint16_t port, bool server);
+               BridgeSlave(std::string addr, uint16_t port);
 
                //! Destructor
                ~BridgeSlave();
 
-               //! Accept a frame from master
-               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
+               //! Post a transaction. Master will call this method with the access attributes.
+               void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> tran);
          };
 
          // Convienence
-         typedef boost::shared_ptr<rogue::interfaces::stream::BridgeSlave> BridgeSlavePtr;
+         typedef boost::shared_ptr<rogue::interfaces::master::BridgeSlave> BridgeSlavePtr;
 
       }
    }

--- a/include/rogue/interfaces/memory/BridgeSlave.h
+++ b/include/rogue/interfaces/memory/BridgeSlave.h
@@ -1,0 +1,92 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Slave Network Bridge
+ * ----------------------------------------------------------------------------
+ * File       : BridgeSlave.h
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Slave Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_MEMORY_BRIDGE_SLAVE_H__
+#define __ROGUE_INTERFACES_MEMORY_BRIDGE_SLAVE_H__
+#include <rogue/interfaces/memory/Slave.h>
+#include <rogue/Logging.h>
+#include <boost/thread.hpp>
+#include <stdint.h>
+
+namespace rogue {
+   namespace interfaces {
+      namespace memory {
+
+         //! PGP Card class
+         class BridgeSlave : public rogue::interfaces::stream::Master, 
+                        public rogue::interfaces::stream::Slave {
+
+               //! Inbound Address
+               std::string pullAddr_;
+
+               //! Outbound Address
+               std::string pushAddr_;
+
+               //! Server mode
+               bool server_;
+
+               //! Zeromq Context
+               void * zmqCtx_;
+
+               //! Zeromq inbound port
+               void * zmqPull_;
+
+               //! Zeromq outbound port
+               void * zmqPush_;
+
+               //! Thread background
+               void runThread();
+
+               //! Log
+               rogue::LoggingPtr bridgeLog_;
+
+               //! Thread
+               boost::thread * thread_;
+
+               //! Lock
+               boost::mutex bridgeMtx_;
+
+            public:
+
+               //! Class creation
+               static boost::shared_ptr<rogue::interfaces::stream::BridgeSlave> 
+                  create (std::string addr, uint16_t port, bool server);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Creator
+               BridgeSlave(std::string addr, uint16_t port, bool server);
+
+               //! Destructor
+               ~BridgeSlave();
+
+               //! Accept a frame from master
+               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::BridgeSlave> BridgeSlavePtr;
+
+      }
+   }
+};
+
+#endif
+

--- a/include/rogue/interfaces/stream/Bridge.h
+++ b/include/rogue/interfaces/stream/Bridge.h
@@ -40,9 +40,6 @@ namespace rogue {
                //! Outbound Address
                std::string pushAddr_;
 
-               //! Server mode
-               bool server_;
-
                //! Zeromq Context
                void * zmqCtx_;
 

--- a/include/rogue/interfaces/stream/Bridge.h
+++ b/include/rogue/interfaces/stream/Bridge.h
@@ -1,0 +1,94 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Stream Network Bridge Class
+ * ----------------------------------------------------------------------------
+ * File       : Bridge.h
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Stream Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_INTERFACES_STREAM_BRIDGE_H__
+#define __ROGUE_INTERFACES_STREAM_BRIDGE_H__
+#include <rogue/interfaces/stream/Master.h>
+#include <rogue/interfaces/stream/Slave.h>
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/Logging.h>
+#include <boost/thread.hpp>
+#include <stdint.h>
+
+namespace rogue {
+   namespace interfaces {
+      namespace stream {
+
+         //! PGP Card class
+         class Bridge : public rogue::interfaces::stream::Master, 
+                        public rogue::interfaces::stream::Slave {
+
+               //! Inbound Address
+               std::string pullAddr_;
+
+               //! Outbound Address
+               std::string pushAddr_;
+
+               //! Server mode
+               bool server_;
+
+               //! Zeromq Context
+               void * zmqCtx_;
+
+               //! Zeromq inbound port
+               void * zmqPull_;
+
+               //! Zeromq outbound port
+               void * zmqPush_;
+
+               //! Thread background
+               void runThread();
+
+               //! Log
+               rogue::LoggingPtr bridgeLog_;
+
+               //! Thread
+               boost::thread * thread_;
+
+               //! Lock
+               boost::mutex bridgeMtx_;
+
+            public:
+
+               //! Class creation
+               static boost::shared_ptr<rogue::interfaces::stream::Bridge> 
+                  create (std::string addr, uint16_t port, bool server);
+
+               //! Setup class in python
+               static void setup_python();
+
+               //! Creator
+               Bridge(std::string addr, uint16_t port, bool server);
+
+               //! Destructor
+               ~Bridge();
+
+               //! Accept a frame from master
+               void acceptFrame ( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
+         };
+
+         // Convienence
+         typedef boost::shared_ptr<rogue::interfaces::stream::Bridge> BridgePtr;
+
+      }
+   }
+};
+
+#endif
+

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -7,3 +7,4 @@ codecov
 pytest>=3.6
 pytest-cov
 pyepics
+pyzmq

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -106,13 +106,13 @@ def busConnect(source,dest):
     """
 
     # Is object a native master or wrapped?
-    if isinstance(source,rogue.interfaces.stream.Master):
+    if isinstance(source,rogue.interfaces.memory.Master):
         master = source
     else:
         master = source._getMemoryMaster()
 
     # Is object a native slave or wrapped?
-    if isinstance(dest,rogue.interfaces.stream.Slave):
+    if isinstance(dest,rogue.interfaces.memory.Slave):
         slave = dest
     else:
         slave = dest._getMemorySlave()

--- a/src/rogue/interfaces/memory/BridgeMaster.cpp
+++ b/src/rogue/interfaces/memory/BridgeMaster.cpp
@@ -1,0 +1,180 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Master Network Bridge
+ * ----------------------------------------------------------------------------
+ * File       : BridgeMaster.cpp
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Master Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/BridgeMaster.h>
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
+#include <rogue/interfaces/stream/FrameLock.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/GeneralError.h>
+#include <boost/make_shared.hpp>
+#include <rogue/GilRelease.h>
+#include <rogue/Logging.h>
+#include <zmq.h>
+
+namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
+
+//! Class creation
+ris::BridgeMasterPtr ris::BridgeMaster::create (std::string addr, uint16_t port, bool server) {
+   ris::BridgeMasterPtr r = boost::make_shared<ris::BridgeMaster>(addr,port,server);
+   return(r);
+}
+
+//! Creator
+ris::BridgeMaster::BridgeMaster (std::string addr, uint16_t port, bool server) {
+   uint32_t to;
+
+   this->server_ = server;
+
+   this->bridgeLog_ = rogue::Logging::create("stream.BridgeMaster");
+
+   // Format address
+   this->pullAddr_ = "tcp://";
+   this->pullAddr_.append(addr);
+   this->pullAddr_.append(":");
+   this->pushAddr_ = this->pullAddr_;
+
+   this->zmqCtx_  = zmq_ctx_new();
+   this->zmqPull_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
+   this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
+
+   // Receive timeout
+   to = 10;
+   zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &to, sizeof(to));
+
+   // Server mode
+   if (server) {
+      this->pullAddr_.append(std::to_string(port));
+      this->pushAddr_.append(std::to_string(port+1));
+
+      this->bridgeLog_->debug("Creating pull server port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeMaster::BridgeMaster",addr,port));
+
+      this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeMaster::BridgeMaster",addr,port+1));
+   }
+
+   // Client mode
+   else {
+      this->pullAddr_.append(std::to_string(port+1));
+      this->pushAddr_.append(std::to_string(port));
+
+      if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeMaster::BridgeMaster",addr,port+1));
+
+      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeMaster::BridgeMaster",addr,port));
+
+      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
+   }
+
+   // Start rx thread
+   this->thread_ = new boost::thread(boost::bind(&ris::BridgeMaster::runThread, this));
+}
+
+//! Destructor
+ris::BridgeMaster::~BridgeMaster() {
+   thread_->interrupt();
+   thread_->join();
+
+   zmq_close(this->zmqPull_);
+   zmq_close(this->zmqPush_);
+   zmq_term(this->zmqCtx_);
+}
+
+//! Accept a frame from master
+void ris::BridgeMaster::acceptFrame ( ris::FramePtr frame ) {
+   uint8_t * data;
+   zmq_msg_t msg;
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr frLock = frame->lock();
+   boost::lock_guard<boost::mutex> lock(bridgeMtx_);
+
+   if ( zmq_msg_init_size (&msg, frame->getPayload()) < 0 ) {
+      bridgeLog_->warning("Failed to init message with size %i",frame->getPayload());
+      return;
+   }
+
+   // Copy data
+   data = (uint8_t *)zmq_msg_data(&msg);
+   std::copy(frame->beginRead(), frame->endRead(), data);
+    
+   // Send data
+   if ( zmq_sendmsg(this->zmqPush_,&msg,0) < 0 )
+      bridgeLog_->warning("Failed to send message with size %i",frame->getPayload());
+}
+
+//! Run thread
+void ris::BridgeMaster::runThread() {
+   ris::FramePtr frame;
+   uint8_t * data;
+   uint32_t  size;
+   zmq_msg_t msg;
+
+   bridgeLog_->logThreadId();
+
+   try {
+
+      while(1) {
+         zmq_msg_init(&msg);
+
+         if ( zmq_recvmsg(this->zmqPull_,&msg,0) > 0 ) {
+
+            // Get message info
+            data = (uint8_t *)zmq_msg_data(&msg);
+            size = zmq_msg_size(&msg);
+
+            // Generate frame
+            frame = ris::Pool::acceptReq(size,false);
+
+            // Copy data
+            std::copy(data,data+size,frame->beginWrite());
+            zmq_msg_close(&msg);
+
+            // Set frame size and send
+            frame->setPayload(size);
+            sendFrame(frame);
+         }
+         boost::this_thread::interruption_point();
+      }
+   } catch (boost::thread_interrupted&) { }
+}
+
+void ris::BridgeMaster::setup_python () {
+#ifndef NO_PYTHON
+
+   bp::class_<ris::BridgeMaster, ris::BridgeMasterPtr, bp::bases<ris::Master,ris::Master>, boost::noncopyable >("BridgeMaster",bp::init<std::string,uint16_t,bool>());
+
+   bp::implicitly_convertible<ris::BridgeMasterPtr, ris::MasterPtr>();
+   bp::implicitly_convertible<ris::BridgeMasterPtr, ris::MasterPtr>();
+#endif
+}
+

--- a/src/rogue/interfaces/memory/BridgeSlave.cpp
+++ b/src/rogue/interfaces/memory/BridgeSlave.cpp
@@ -1,0 +1,180 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Memory Slave Network Bridge
+ * ----------------------------------------------------------------------------
+ * File       : BridgeSlave.cpp
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Memory Slave Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/BridgeSlave.h>
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
+#include <rogue/interfaces/stream/FrameLock.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/GeneralError.h>
+#include <boost/make_shared.hpp>
+#include <rogue/GilRelease.h>
+#include <rogue/Logging.h>
+#include <zmq.h>
+
+namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
+
+//! Class creation
+ris::BridgeSlavePtr ris::BridgeSlave::create (std::string addr, uint16_t port, bool server) {
+   ris::BridgeSlavePtr r = boost::make_shared<ris::BridgeSlave>(addr,port,server);
+   return(r);
+}
+
+//! Creator
+ris::BridgeSlave::BridgeSlave (std::string addr, uint16_t port, bool server) {
+   uint32_t to;
+
+   this->server_ = server;
+
+   this->bridgeLog_ = rogue::Logging::create("stream.BridgeSlave");
+
+   // Format address
+   this->pullAddr_ = "tcp://";
+   this->pullAddr_.append(addr);
+   this->pullAddr_.append(":");
+   this->pushAddr_ = this->pullAddr_;
+
+   this->zmqCtx_  = zmq_ctx_new();
+   this->zmqPull_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
+   this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
+
+   // Receive timeout
+   to = 10;
+   zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &to, sizeof(to));
+
+   // Server mode
+   if (server) {
+      this->pullAddr_.append(std::to_string(port));
+      this->pushAddr_.append(std::to_string(port+1));
+
+      this->bridgeLog_->debug("Creating pull server port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port));
+
+      this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port+1));
+   }
+
+   // Client mode
+   else {
+      this->pullAddr_.append(std::to_string(port+1));
+      this->pushAddr_.append(std::to_string(port));
+
+      if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port+1));
+
+      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port));
+
+      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
+   }
+
+   // Start rx thread
+   this->thread_ = new boost::thread(boost::bind(&ris::BridgeSlave::runThread, this));
+}
+
+//! Destructor
+ris::BridgeSlave::~BridgeSlave() {
+   thread_->interrupt();
+   thread_->join();
+
+   zmq_close(this->zmqPull_);
+   zmq_close(this->zmqPush_);
+   zmq_term(this->zmqCtx_);
+}
+
+//! Accept a frame from master
+void ris::BridgeSlave::acceptFrame ( ris::FramePtr frame ) {
+   uint8_t * data;
+   zmq_msg_t msg;
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr frLock = frame->lock();
+   boost::lock_guard<boost::mutex> lock(bridgeMtx_);
+
+   if ( zmq_msg_init_size (&msg, frame->getPayload()) < 0 ) {
+      bridgeLog_->warning("Failed to init message with size %i",frame->getPayload());
+      return;
+   }
+
+   // Copy data
+   data = (uint8_t *)zmq_msg_data(&msg);
+   std::copy(frame->beginRead(), frame->endRead(), data);
+    
+   // Send data
+   if ( zmq_sendmsg(this->zmqPush_,&msg,0) < 0 )
+      bridgeLog_->warning("Failed to send message with size %i",frame->getPayload());
+}
+
+//! Run thread
+void ris::BridgeSlave::runThread() {
+   ris::FramePtr frame;
+   uint8_t * data;
+   uint32_t  size;
+   zmq_msg_t msg;
+
+   bridgeLog_->logThreadId();
+
+   try {
+
+      while(1) {
+         zmq_msg_init(&msg);
+
+         if ( zmq_recvmsg(this->zmqPull_,&msg,0) > 0 ) {
+
+            // Get message info
+            data = (uint8_t *)zmq_msg_data(&msg);
+            size = zmq_msg_size(&msg);
+
+            // Generate frame
+            frame = ris::Pool::acceptReq(size,false);
+
+            // Copy data
+            std::copy(data,data+size,frame->beginWrite());
+            zmq_msg_close(&msg);
+
+            // Set frame size and send
+            frame->setPayload(size);
+            sendFrame(frame);
+         }
+         boost::this_thread::interruption_point();
+      }
+   } catch (boost::thread_interrupted&) { }
+}
+
+void ris::BridgeSlave::setup_python () {
+#ifndef NO_PYTHON
+
+   bp::class_<ris::BridgeSlave, ris::BridgeSlavePtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("BridgeSlave",bp::init<std::string,uint16_t,bool>());
+
+   bp::implicitly_convertible<ris::BridgeSlavePtr, ris::MasterPtr>();
+   bp::implicitly_convertible<ris::BridgeSlavePtr, ris::SlavePtr>();
+#endif
+}
+

--- a/src/rogue/interfaces/memory/BridgeSlave.cpp
+++ b/src/rogue/interfaces/memory/BridgeSlave.cpp
@@ -17,18 +17,17 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
-#include <rogue/interfaces/stream/BridgeSlave.h>
-#include <rogue/interfaces/stream/Frame.h>
-#include <rogue/interfaces/stream/FrameIterator.h>
-#include <rogue/interfaces/stream/FrameLock.h>
-#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/interfaces/memory/BridgeSlave.h>
+#include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
+#include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
 #include <boost/make_shared.hpp>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
 #include <zmq.h>
 
-namespace ris = rogue::interfaces::stream;
+namespace rim = rogue::interfaces::memory;
 
 #ifndef NO_PYTHON
 #include <boost/python.hpp>
@@ -36,145 +35,206 @@ namespace bp  = boost::python;
 #endif
 
 //! Class creation
-ris::BridgeSlavePtr ris::BridgeSlave::create (std::string addr, uint16_t port, bool server) {
-   ris::BridgeSlavePtr r = boost::make_shared<ris::BridgeSlave>(addr,port,server);
+rim::BridgeSlavePtr rim::BridgeSlave::create (std::string addr, uint16_t port) {
+   rim::BridgeSlavePtr r = boost::make_shared<rim::BridgeSlave>(addr,port);
    return(r);
 }
 
 //! Creator
-ris::BridgeSlave::BridgeSlave (std::string addr, uint16_t port, bool server) {
+rim::BridgeSlave::BridgeSlave (std::string addr, uint16_t port) : rim::Slave(4,0xFFFFFFFF) {
    uint32_t to;
 
-   this->server_ = server;
-
-   this->bridgeLog_ = rogue::Logging::create("stream.BridgeSlave");
+   this->bridgeLog_ = rogue::Logging::create("memory.BridgeSlave");
 
    // Format address
-   this->pullAddr_ = "tcp://";
-   this->pullAddr_.append(addr);
-   this->pullAddr_.append(":");
-   this->pushAddr_ = this->pullAddr_;
+   this->respAddr_ = "tcp://";
+   this->respAddr_.append(addr);
+   this->respAddr_.append(":");
+   this->reqAddr_ = this->respAddr_;
 
    this->zmqCtx_  = zmq_ctx_new();
-   this->zmqPull_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
-   this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
+   this->zmqResp_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
+   this->zmqReq_  = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
 
    // Receive timeout
    to = 10;
-   zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &to, sizeof(to));
+   zmq_setsockopt (this->zmqResp_, ZMQ_RCVTIMEO, &to, sizeof(to));
 
-   // Server mode
-   if (server) {
-      this->pullAddr_.append(std::to_string(port));
-      this->pushAddr_.append(std::to_string(port+1));
+   this->respAddr_.append(std::to_string(port+1));
+   this->reqAddr_.append(std::to_string(port));
 
-      this->bridgeLog_->debug("Creating pull server port: %s",this->pullAddr_.c_str());
+   this->bridgeLog_->debug("Creating response client port: %s",this->respAddr_.c_str());
 
-      if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port));
+   if ( zmq_connect(this->zmqResp_,this->respAddr_.c_str()) < 0 ) 
+      throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port+1));
 
-      this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
+   this->bridgeLog_->debug("Creating request client port: %s",this->reqAddr_.c_str());
 
-      if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port+1));
-   }
-
-   // Client mode
-   else {
-      this->pullAddr_.append(std::to_string(port+1));
-      this->pushAddr_.append(std::to_string(port));
-
-      if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port+1));
-
-      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
-
-      if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port));
-
-      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
-   }
+   if ( zmq_connect(this->zmqReq_,this->reqAddr_.c_str()) < 0 ) 
+      throw(rogue::GeneralError::network("BridgeSlave::BridgeSlave",addr,port));
 
    // Start rx thread
-   this->thread_ = new boost::thread(boost::bind(&ris::BridgeSlave::runThread, this));
+   this->thread_ = new boost::thread(boost::bind(&rim::BridgeSlave::runThread, this));
 }
 
 //! Destructor
-ris::BridgeSlave::~BridgeSlave() {
+rim::BridgeSlave::~BridgeSlave() {
    thread_->interrupt();
    thread_->join();
 
-   zmq_close(this->zmqPull_);
-   zmq_close(this->zmqPush_);
+   zmq_close(this->zmqResp_);
+   zmq_close(this->zmqReq_);
    zmq_term(this->zmqCtx_);
 }
 
-//! Accept a frame from master
-void ris::BridgeSlave::acceptFrame ( ris::FramePtr frame ) {
+//! Post a transaction
+void rim::BridgeSlave::doTransaction(rim::TransactionPtr tran) {
    uint8_t * data;
-   zmq_msg_t msg;
+   uint32_t  x;
+   uint32_t  msgCnt;
+   zmq_msg_t msg[5];
+   uint32_t  id;
+   uint64_t  addr;
+   uint32_t  size;
+   uint32_t  type;
+
+   rim::Transaction::iterator tIter;
 
    rogue::GilRelease noGil;
-   ris::FrameLockPtr frLock = frame->lock();
-   boost::lock_guard<boost::mutex> lock(bridgeMtx_);
+   boost::lock_guard<boost::mutex> block(bridgeMtx_);
+   rim::TransactionLockPtr lock = tran->lock();
 
-   if ( zmq_msg_init_size (&msg, frame->getPayload()) < 0 ) {
-      bridgeLog_->warning("Failed to init message with size %i",frame->getPayload());
-      return;
+   // ID message
+   id = tran->id();
+   zmq_msg_init_size(&(msg[0]),4);
+   memcpy(zmq_msg_data(&(msg[0])), &id, 4);
+
+   // Addr message
+   addr = tran->address();
+   zmq_msg_init_size(&(msg[1]),8);
+   memcpy(zmq_msg_data(&(msg[1])), &addr, 8);
+
+   // Size message
+   size = tran->size();
+   zmq_msg_init_size(&(msg[2]),4);
+   memcpy(zmq_msg_data(&(msg[2])), &size, 4);
+
+   // Type message
+   type = tran->type();
+   zmq_msg_init_size(&(msg[3]),4);
+   memcpy(zmq_msg_data(&(msg[3])), &type, 4);
+
+   // Write transaction
+   if ( type == rim::Write && type == rim::Post ) {
+      msgCnt = 5;
+      zmq_msg_init_size(&(msg[4]),size);
+      data = (uint8_t *) zmq_msg_data(&(msg[4]));
+      std::copy(tran->begin(), tran->end(), data);
    }
 
-   // Copy data
-   data = (uint8_t *)zmq_msg_data(&msg);
-   std::copy(frame->beginRead(), frame->endRead(), data);
-    
-   // Send data
-   if ( zmq_sendmsg(this->zmqPush_,&msg,0) < 0 )
-      bridgeLog_->warning("Failed to send message with size %i",frame->getPayload());
+   // Read transaction
+   else msgCnt = 4;
+
+   // Send message
+   for (x=0; x < msgCnt; x++) 
+      zmq_sendmsg(this->zmqReq_,&(msg[x]),(x==(msgCnt-1)?0:ZMQ_SNDMORE));
+
+   // Add transaction
+   if ( type == rim::Post ) tran->done(0);
+   else addTransaction(tran);
 }
 
 //! Run thread
-void ris::BridgeSlave::runThread() {
-   ris::FramePtr frame;
+void rim::BridgeSlave::runThread() {
+   rim::Transaction::iterator tIter;
+   rim::TransactionPtr tran;
    uint8_t * data;
+   bool      err;
+   uint64_t  more;
+   size_t    moreSize;
+   uint32_t  x;
+   uint32_t  msgCnt;
+   zmq_msg_t msg[5];
+   uint32_t  id;
+   uint64_t  addr;
    uint32_t  size;
-   zmq_msg_t msg;
+   uint32_t  type;
 
    bridgeLog_->logThreadId();
 
    try {
 
       while(1) {
-         zmq_msg_init(&msg);
 
-         if ( zmq_recvmsg(this->zmqPull_,&msg,0) > 0 ) {
+         for (x=0; x < 6; x++) zmq_msg_init(&(msg[x]));
 
-            // Get message info
-            data = (uint8_t *)zmq_msg_data(&msg);
-            size = zmq_msg_size(&msg);
+         // Get first part of message
+         if ( zmq_recvmsg(this->zmqResp_,&(msg[0]),0) > 0 ) {
+            msgCnt = 1;
 
-            // Generate frame
-            frame = ris::Pool::acceptReq(size,false);
+            // Get rest of message
+            while ( msgCnt < 5 ) {
 
-            // Copy data
-            std::copy(data,data+size,frame->beginWrite());
-            zmq_msg_close(&msg);
+               // Make sure more flag matches where we are
+               moreSize = 8;
+               zmq_getsockopt(this->zmqResp_, ZMQ_RCVMORE, &more, &moreSize);
+               if ( ((more == 1) && (msgCnt != 5)) || ((more == 0) && (msgCnt == 5)) ) {
+                  if ( zmq_recvmsg(this->zmqResp_,&(msg[msgCnt]),0) <= 0 ) break; // while ( msgCnt < 5 )
+                  ++msgCnt;
+               } else break; // while ( msgCnt < 5 )
+            }
 
-            // Set frame size and send
-            frame->setPayload(size);
-            sendFrame(frame);
+            // Proper message received
+            if ( msgCnt == 5 ) {
+
+               // Get return fields
+               memcpy(&id,   zmq_msg_data(&(msg[0])), 4);
+               memcpy(&addr, zmq_msg_data(&(msg[1])), 8);
+               memcpy(&size, zmq_msg_data(&(msg[2])), 4);
+               memcpy(&type, zmq_msg_data(&(msg[3])), 4);
+
+               // Find Transaction
+               if ( (tran = getTransaction(id)) == NULL ) {
+                  bridgeLog_->warning("Failed to find transaction id=%i",id);
+                  continue; // while (1)
+               }
+
+               // Lock transaction
+               rim::TransactionLockPtr lock = tran->lock();
+
+               // Transaction expired
+               if ( tran->expired() ) {
+                  bridgeLog_->warning("Transaction expired. Id=%i",id);
+                  continue; // while (1)
+               }
+               tIter = tran->begin();
+
+               // Double check transaction
+               if ( (addr != tran->address()) || (size != tran->size()) || (type != tran->type()) ) {
+                  bridgeLog_->warning("Transaction data mistmatch. Id=%i",id);
+                  tran->done(rim::ProtocolError);
+                  continue; // while (1)
+               }
+
+               // Copy data if read
+               if ( type != rim::Write ) {
+                  data = (uint8_t *)zmq_msg_data(&(msg[4]));
+                  std::copy(data,data+size,tIter);
+                  tran->done(0);
+               }
+            }
          }
          boost::this_thread::interruption_point();
       }
    } catch (boost::thread_interrupted&) { }
 }
 
-void ris::BridgeSlave::setup_python () {
+void rim::BridgeSlave::setup_python () {
 #ifndef NO_PYTHON
 
-   bp::class_<ris::BridgeSlave, ris::BridgeSlavePtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("BridgeSlave",bp::init<std::string,uint16_t,bool>());
+   bp::class_<rim::BridgeSlave, rim::BridgeSlavePtr, bp::bases<rim::Slave>, boost::noncopyable >("BridgeSlave",bp::init<std::string,uint16_t>());
 
-   bp::implicitly_convertible<ris::BridgeSlavePtr, ris::MasterPtr>();
-   bp::implicitly_convertible<ris::BridgeSlavePtr, ris::SlavePtr>();
+   bp::implicitly_convertible<rim::BridgeSlavePtr, rim::SlavePtr>();
 #endif
 }
 

--- a/src/rogue/interfaces/memory/CMakeLists.txt
+++ b/src/rogue/interfaces/memory/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Master.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Transaction.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/TransactionLock.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/BridgeSlave.cpp")
 
 if (DO_PYTHON)
    target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")

--- a/src/rogue/interfaces/memory/CMakeLists.txt
+++ b/src/rogue/interfaces/memory/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Transaction.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/TransactionLock.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/BridgeSlave.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/BridgeMaster.cpp")
 
 if (DO_PYTHON)
    target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -25,8 +25,8 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/interfaces/memory/TransactionLock.h>
-#include <rogue/interfaces/memory/BridgeMaster.h>
-#include <rogue/interfaces/memory/BridgeSlave.h>
+//#include <rogue/interfaces/memory/BridgeMaster.h>
+//#include <rogue/interfaces/memory/BridgeSlave.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -64,8 +64,8 @@ void rim::setup_module() {
    rim::Hub::setup_python(); 
    rim::Transaction::setup_python(); 
    rim::TransactionLock::setup_python(); 
-   rim::BridgeMaster::setup_python(); 
-   rim::BridgeSlave::setup_python(); 
+   //rim::BridgeMaster::setup_python(); 
+   //rim::BridgeSlave::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -26,7 +26,7 @@
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/interfaces/memory/TransactionLock.h>
 #include <rogue/interfaces/memory/BridgeSlave.h>
-//#include <rogue/interfaces/memory/BridgeMaster.h>
+#include <rogue/interfaces/memory/BridgeMaster.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -65,7 +65,7 @@ void rim::setup_module() {
    rim::Transaction::setup_python(); 
    rim::TransactionLock::setup_python(); 
    rim::BridgeSlave::setup_python(); 
-   //rim::BridgeMaster::setup_python(); 
+   rim::BridgeMaster::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -25,8 +25,8 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/interfaces/memory/TransactionLock.h>
+#include <rogue/interfaces/memory/BridgeSlave.h>
 //#include <rogue/interfaces/memory/BridgeMaster.h>
-//#include <rogue/interfaces/memory/BridgeSlave.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -64,8 +64,8 @@ void rim::setup_module() {
    rim::Hub::setup_python(); 
    rim::Transaction::setup_python(); 
    rim::TransactionLock::setup_python(); 
+   rim::BridgeSlave::setup_python(); 
    //rim::BridgeMaster::setup_python(); 
-   //rim::BridgeSlave::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -25,6 +25,8 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/interfaces/memory/TransactionLock.h>
+#include <rogue/interfaces/memory/BridgeMaster.h>
+#include <rogue/interfaces/memory/BridgeSlave.h>
 #include <boost/python.hpp>
 
 namespace bp  = boost::python;
@@ -62,6 +64,8 @@ void rim::setup_module() {
    rim::Hub::setup_python(); 
    rim::Transaction::setup_python(); 
    rim::TransactionLock::setup_python(); 
+   rim::BridgeMaster::setup_python(); 
+   rim::BridgeSlave::setup_python(); 
 
 }
 

--- a/src/rogue/interfaces/stream/Bridge.cpp
+++ b/src/rogue/interfaces/stream/Bridge.cpp
@@ -1,0 +1,180 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Stream Network Bridge Class
+ * ----------------------------------------------------------------------------
+ * File       : Bridge.h
+ * Created    : 2019-01-30
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Stream Network Bridge
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/interfaces/stream/Bridge.h>
+#include <rogue/interfaces/stream/Frame.h>
+#include <rogue/interfaces/stream/FrameIterator.h>
+#include <rogue/interfaces/stream/FrameLock.h>
+#include <rogue/interfaces/stream/Buffer.h>
+#include <rogue/GeneralError.h>
+#include <boost/make_shared.hpp>
+#include <rogue/GilRelease.h>
+#include <rogue/Logging.h>
+#include <zmq.h>
+
+namespace ris = rogue::interfaces::stream;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
+
+//! Class creation
+ris::BridgePtr ris::Bridge::create (std::string addr, uint16_t port, bool server) {
+   ris::BridgePtr r = boost::make_shared<ris::Bridge>(addr,port,server);
+   return(r);
+}
+
+//! Creator
+ris::Bridge::Bridge (std::string addr, uint16_t port, bool server) {
+   uint32_t to;
+
+   this->server_ = server;
+
+   this->bridgeLog_ = rogue::Logging::create("stream.Bridge");
+
+   // Format address
+   this->pullAddr_ = "tcp://";
+   this->pullAddr_.append(addr);
+   this->pullAddr_.append(":");
+   this->pushAddr_ = this->pullAddr_;
+
+   this->zmqCtx_  = zmq_ctx_new();
+   this->zmqPull_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
+   this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
+
+   // Receive timeout
+   to = 10;
+   zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &to, sizeof(to));
+
+   // Server mode
+   if (server) {
+      this->pullAddr_.append(std::to_string(port));
+      this->pushAddr_.append(std::to_string(port+1));
+
+      this->bridgeLog_->debug("Creating pull server port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("Bridge::Bridge",addr,port));
+
+      this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
+
+      if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("Bridge::Bridge",addr,port+1));
+   }
+
+   // Client mode
+   else {
+      this->pullAddr_.append(std::to_string(port+1));
+      this->pushAddr_.append(std::to_string(port));
+
+      if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("Bridge::Bridge",addr,port+1));
+
+      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
+
+      if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
+         throw(rogue::GeneralError::network("Bridge::Bridge",addr,port));
+
+      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
+   }
+
+   // Start rx thread
+   this->thread_ = new boost::thread(boost::bind(&ris::Bridge::runThread, this));
+}
+
+//! Destructor
+ris::Bridge::~Bridge() {
+   thread_->interrupt();
+   thread_->join();
+
+   zmq_close(this->zmqPull_);
+   zmq_close(this->zmqPush_);
+   zmq_term(this->zmqCtx_);
+}
+
+//! Accept a frame from master
+void ris::Bridge::acceptFrame ( ris::FramePtr frame ) {
+   uint8_t * data;
+   zmq_msg_t msg;
+
+   rogue::GilRelease noGil;
+   ris::FrameLockPtr frLock = frame->lock();
+   boost::lock_guard<boost::mutex> lock(bridgeMtx_);
+
+   if ( zmq_msg_init_size (&msg, frame->getPayload()) < 0 ) {
+      bridgeLog_->warning("Failed to init message with size %i",frame->getPayload());
+      return;
+   }
+
+   // Copy data
+   data = (uint8_t *)zmq_msg_data(&msg);
+   std::copy(frame->beginRead(), frame->endRead(), data);
+    
+   // Send data
+   if ( zmq_sendmsg(this->zmqPush_,&msg,0) < 0 )
+      bridgeLog_->warning("Failed to send message with size %i",frame->getPayload());
+}
+
+//! Run thread
+void ris::Bridge::runThread() {
+   ris::FramePtr frame;
+   uint8_t * data;
+   uint32_t  size;
+   zmq_msg_t msg;
+
+   bridgeLog_->logThreadId();
+
+   try {
+
+      while(1) {
+         zmq_msg_init(&msg);
+
+         if ( zmq_recvmsg(this->zmqPull_,&msg,0) > 0 ) {
+
+            // Get message info
+            data = (uint8_t *)zmq_msg_data(&msg);
+            size = zmq_msg_size(&msg);
+
+            // Generate frame
+            frame = ris::Pool::acceptReq(size,false);
+
+            // Copy data
+            std::copy(data,data+size,frame->beginWrite());
+            zmq_msg_close(&msg);
+
+            // Set frame size and send
+            frame->setPayload(size);
+            sendFrame(frame);
+         }
+         boost::this_thread::interruption_point();
+      }
+   } catch (boost::thread_interrupted&) { }
+}
+
+void ris::Bridge::setup_python () {
+#ifndef NO_PYTHON
+
+   bp::class_<ris::Bridge, ris::BridgePtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Bridge",bp::init<std::string,uint16_t,bool>());
+
+   bp::implicitly_convertible<ris::BridgePtr, ris::MasterPtr>();
+   bp::implicitly_convertible<ris::BridgePtr, ris::SlavePtr>();
+#endif
+}
+

--- a/src/rogue/interfaces/stream/Bridge.cpp
+++ b/src/rogue/interfaces/stream/Bridge.cpp
@@ -45,8 +45,6 @@ ris::BridgePtr ris::Bridge::create (std::string addr, uint16_t port, bool server
 ris::Bridge::Bridge (std::string addr, uint16_t port, bool server) {
    uint32_t to;
 
-   this->server_ = server;
-
    this->bridgeLog_ = rogue::Logging::create("stream.Bridge");
 
    // Format address
@@ -84,15 +82,15 @@ ris::Bridge::Bridge (std::string addr, uint16_t port, bool server) {
       this->pullAddr_.append(std::to_string(port+1));
       this->pushAddr_.append(std::to_string(port));
 
+      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
+
       if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
          throw(rogue::GeneralError::network("Bridge::Bridge",addr,port+1));
 
-      this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
+      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
 
       if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
          throw(rogue::GeneralError::network("Bridge::Bridge",addr,port));
-
-      this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
    }
 
    // Start rx thread

--- a/src/rogue/interfaces/stream/CMakeLists.txt
+++ b/src/rogue/interfaces/stream/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Master.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Pool.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Slave.cpp")
 target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Filter.cpp")
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/Bridge.cpp")
 
 if (DO_PYTHON)
    target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")

--- a/src/rogue/interfaces/stream/module.cpp
+++ b/src/rogue/interfaces/stream/module.cpp
@@ -27,6 +27,7 @@
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Fifo.h>
 #include <rogue/interfaces/stream/Filter.h>
+#include <rogue/interfaces/stream/Bridge.h>
 #include <rogue/interfaces/stream/module.h>
 #include <boost/python.hpp>
 
@@ -51,6 +52,6 @@ void ris::setup_module() {
    ris::Pool::setup_python();
    ris::Fifo::setup_python();
    ris::Filter::setup_python();
-
+   ris::Bridge::setup_python();
 }
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+# Comment added by rherbst for demonstration purposes.
+import datetime
+import parse
+import pyrogue as pr
+import pyrogue.interfaces.simulation
+import rogue.interfaces.memory
+import time
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+#import logging
+#logger = logging.getLogger('pyrogue')
+#logger.setLevel(logging.DEBUG)
+
+class AxiVersion(pr.Device):
+
+    # Last comment added by rherbst for demonstration.
+    def __init__(
+            self,       
+            name             = 'AxiVersion',
+            description      = 'AXI-Lite Version Module',
+            numUserConstants = 0,
+            **kwargs):
+        
+        super().__init__(
+            name        = name,
+            description = description,
+            **kwargs)
+
+        ##############################
+        # Variables
+        ##############################
+
+        self.add(pr.RemoteVariable(   
+            name         = 'ScratchPad',
+            description  = 'Register to test reads and writes',
+            offset       = 0x04,
+            bitSize      = 32,
+            bitOffset    = 0x00,
+            base         = pr.UInt,
+            mode         = 'RW',
+            disp         = '{:#08x}'            
+        ))
+
+        self.add(pr.RemoteVariable(   
+            name         = 'UpTimeCnt',
+            description  = 'Number of seconds since last reset',
+            hidden       = True,
+            offset       = 0x08,
+            bitSize      = 32,
+            bitOffset    = 0x00,
+            base         = pr.UInt,
+            mode         = 'RO',
+            disp         = '{:d}',
+            units        = 'seconds',
+            pollInterval = 1
+        ))
+
+class DummyTree(pr.Root):
+
+    def __init__(self):
+        pr.Root.__init__(self,name='dummyTree',description="Dummy tree for example")
+
+        # Use a memory space emulator
+        self.sim = pr.interfaces.simulation.MemEmulate()
+
+        # Create a memory gateway
+        self.mbm = rogue.interfaces.memory.BridgeMaster("127.0.0.1",9020);
+        pr.busConnect(self.mbm,self.sim)
+
+        # Create a memory gateway
+        self.mbs = rogue.interfaces.memory.BridgeSlave("127.0.0.1",9020);
+
+        # Add Device
+        self.add(AxiVersion(memBase=self.mbs,offset=0x0))
+
+        # Start the tree with pyrogue server, internal nameserver, default interface
+        # Set pyroHost to the address of a network interface to specify which nework to run on
+        # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
+        self.start(timeout=2.0, pyroGroup='testGroup', pyroAddr=None, pyroNsAddr=None)
+
+
+def test_memory():
+
+    with DummyTree() as root:
+        time.sleep(5)
+
+        print("Writing 0x50 to scratchpad")
+        root.AxiVersion.ScratchPad.set(0x50)
+
+        ret = root.AxiVersion.ScratchPad.get()
+        print("Read {:#x} from scratchpad".format(ret))
+
+        time.sleep(5)
+
+        if ret != 0x50:
+            raise AssertionError('Scratchpad Mismatch')
+
+if __name__ == "__main__":
+    test_memory()
+

--- a/tests/test_streamBridge.py
+++ b/tests/test_streamBridge.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Data over stream bridge test script
+#-----------------------------------------------------------------------------
+# File       : test_streamBridge.py
+# Created    : 2019-01-30
+#-----------------------------------------------------------------------------
+# This file is part of the rogue_example software. It is subject to 
+# the license terms in the LICENSE.txt file found in the top-level directory 
+# of this distribution and at: 
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+# No part of the rogue_example software, including this file, may be 
+# copied, modified, propagated, or distributed except according to the terms 
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import rogue.interfaces.stream
+import rogue
+import pyrogue
+import time
+
+rogue.Logging.setLevel(rogue.Logging.Debug)
+
+FrameCount = 10000
+FrameSize  = 10000
+
+def data_path():
+
+    # Bridge server
+    serv = rogue.interfaces.stream.Bridge("127.0.0.1",9000,True)
+
+    # Bridge client
+    client = rogue.interfaces.stream.Bridge("127.0.0.1",9000,False)
+
+    # PRBS
+    prbsTx = rogue.utilities.Prbs()
+    prbsRx = rogue.utilities.Prbs()
+
+    # Client stream
+    pyrogue.streamConnect(prbsTx,serv)
+
+    # Server stream
+    pyrogue.streamConnect(client,prbsRx)
+
+    time.sleep(5)
+
+    print("Generating Frames")
+    for _ in range(FrameCount):
+        prbsTx.genFrame(FrameSize)
+    time.sleep(5)
+
+    if prbsRx.getRxCount() != FrameCount:
+        raise AssertionError('Frame count error. Got = {} expected = {}'.format(prbsRx.getRxCount(),FrameCount))
+
+    if prbsRx.getRxErrors() != 0:
+        raise AssertionError('PRBS Frame errors detected! Errors = {}'.format(prbsRx.getRxErrors()))
+
+    print("Done testing")
+
+def test_data_path():
+    data_path()
+
+if __name__ == "__main__":
+    test_data_path()
+


### PR DESCRIPTION
This new feature allows both memory and stream interfaces to be bridged over a TCP network connection. 

The stream interface is a bi-directional bridge with one end acting as a TCP server and the other as a TCP client. To create a stream bridge the following code is called:

On Server:
serv = rogue.interfaces.stream.Bridge("127.0.0.1",9000,True)

The passed address determines which interface is used. Pass "*" to listen on all interfaces. Two ports are required with the base port passed. The above example will use ports 9000 and 9001.

On Client:
client = rogue.interfaces.stream.Bridge("127.0.0.1",9000,False)

The memory interface assumes that the server will host the remote master with the client hosting the local memory slave. This bridge will forward memory requests from memory master(s) on the client to a memory slave on the server. The "Slave" side of the bridge on the client will be connected to memory master(s). The "Master" side of the bridge on the server will be connected to a memory slave.

On Server:
self.mbm = rogue.interfaces.memory.BridgeMaster("127.0.0.1",9020)

The passed address determines which interface is used. Pass "*" to listen on all interfaces. Two ports are required with the base port passed. The above example will use ports 9020 and 9021.

On Client:
self.mbs = rogue.interfaces.memory.BridgeSlave("127.0.0.1",9020);
