### PR TITLE
Fix error message when dma mapping fails & buffer mapping > 4GB

### DIFF
--- a/include/rogue/hardware/drivers/DmaDriver.h
+++ b/include/rogue/hardware/drivers/DmaDriver.h
@@ -293,6 +293,7 @@ static inline void ** dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
    uint32_t bCount;
    uint32_t gCount;
    uint32_t bSize;
+   off_t    offset;
 
    bSize  = ioctl(fd,DMA_Get_Buff_Size,0);
    bCount = ioctl(fd,DMA_Get_Buff_Count,0);
@@ -304,9 +305,9 @@ static inline void ** dmaMapDma(int32_t fd, uint32_t *count, uint32_t *size) {
 
    // Attempt to map
    while ( gCount < bCount ) {
-      if ( (temp = mmap (0, bSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, (bSize*gCount))) == MAP_FAILED) {
-         break;
-      }
+      offset = (off_t)bSize * (off_t)gCount;
+
+      if ( (temp = mmap (0, bSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, offset)) == MAP_FAILED) break;
       ret[gCount++] = temp;
    }
 

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -71,6 +71,9 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
 
    // Result may be that rawBuff_ = NULL
    rawBuff_ = dmaMapDma(fd_,&bCount_,&bSize_);
+   if ( rawBuff_ == NULL ) {
+      throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Failed to map dma buffers. Increase vm map limit: sysctl -w vm.max_map_count=262144"));
+   }
 
    // Start read thread
    thread_ = new boost::thread(boost::bind(&rha::AxiStreamDma::runThread, this));


### PR DESCRIPTION
This PR properly detects when a virtual mapping limit has been reached and displays a helpful error message indicating how to address the issue.

This also fixes an error with mapping buffers above the 4GB boundary.