### PR TITLE
Add __enter__ and __exit__ to locks

### DIFF
--- a/include/rogue/interfaces/memory/TransactionLock.h
+++ b/include/rogue/interfaces/memory/TransactionLock.h
@@ -55,6 +55,11 @@ namespace rogue {
                //! lock
                void unlock();
 
+               //! Enter method for python, do nothing
+               void enter();
+
+               //! Exit method for python, do nothing
+               void exit(void *, void *, void *);
          };
 
          // Convienence

--- a/include/rogue/interfaces/stream/FrameLock.h
+++ b/include/rogue/interfaces/stream/FrameLock.h
@@ -55,6 +55,12 @@ namespace rogue {
                //! lock
                void unlock();
 
+               //! Enter method for python, do nothing
+               void enter();
+
+               //! Exit method for python, do nothing
+               void exit(void *, void *, void *);
+
          };
 
          // Convienence

--- a/src/rogue/interfaces/memory/TransactionLock.cpp
+++ b/src/rogue/interfaces/memory/TransactionLock.cpp
@@ -50,6 +50,8 @@ void rim::TransactionLock::setup_python() {
    bp::class_<rim::TransactionLock, rim::TransactionLockPtr, boost::noncopyable>("TransactionLock",bp::no_init)
       .def("lock",      &rim::TransactionLock::lock)
       .def("unlock",    &rim::TransactionLock::unlock)
+      .def("__enter__", &rim::TransactionLock::enter)
+      .def("__exit__",  &rim::TransactionLock::exit)
    ;
 #endif
 }
@@ -76,4 +78,9 @@ void rim::TransactionLock::unlock() {
    }
 }
 
+//! Enter method for python, do nothing
+void rim::TransactionLock::enter() { }
+
+//! Exit method for python, do nothing
+void rim::TransactionLock::exit(void *, void *, void *) { }
 

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -37,6 +37,7 @@ ris::FrameLockPtr ris::FrameLock::create (ris::FramePtr frame) {
 
 //! Constructor
 ris::FrameLock::FrameLock(ris::FramePtr frame) {
+   rogue::GilRelease noGil;
    frame_ = frame;
    frame_->lock_.lock();
    locked_ = true;
@@ -63,6 +64,7 @@ ris::FrameLock::~FrameLock() {
 //! lock
 void ris::FrameLock::lock() {
    if ( ! locked_ ) {
+      rogue::GilRelease noGil;
       frame_->lock_.lock();
       locked_ = true;
    }

--- a/src/rogue/interfaces/stream/FrameLock.cpp
+++ b/src/rogue/interfaces/stream/FrameLock.cpp
@@ -49,6 +49,8 @@ void ris::FrameLock::setup_python() {
    bp::class_<ris::FrameLock, ris::FrameLockPtr, boost::noncopyable>("FrameLock",bp::no_init)
       .def("lock",      &ris::FrameLock::lock)
       .def("unlock",    &ris::FrameLock::unlock)
+      .def("__enter__", &ris::FrameLock::enter)
+      .def("__exit__",  &ris::FrameLock::exit)
    ;
 #endif
 }
@@ -74,3 +76,8 @@ void ris::FrameLock::unlock() {
    }
 }
 
+//! Enter method for python, do nothing
+void ris::FrameLock::enter() { }
+
+//! Exit method for python, do nothing
+void ris::FrameLock::exit(void *, void *, void *) { }


### PR DESCRIPTION

This will allow the frame and transaction locks to be used in python with blocks:
   with frame.lock():
      access frame data