### PR TITLE
Add timeout to StreamWriter Frame Count Wait

### DIFF
--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -145,7 +145,7 @@ namespace rogue {
                uint32_t getFrameCount();
 
                //! Block until a frame count is reached
-               void waitFrameCount(uint32_t count);
+               bool waitFrameCount(uint32_t count, uint64_t timeout);
 
          };
 

--- a/include/rogue/utilities/fileio/StreamWriterChannel.h
+++ b/include/rogue/utilities/fileio/StreamWriterChannel.h
@@ -76,7 +76,7 @@ namespace rogue {
                void setFrameCount(uint32_t count);
 
                //! Block until a number of frames have been received
-               void waitFrameCount(uint32_t count);
+               bool waitFrameCount(uint32_t count, uint64_t timeout);
          };
 
          // Convienence

--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -56,10 +56,10 @@ class StreamWriter(pyrogue.DataWriter):
         return self._writer.getFrameCount()
 
     def _waitFrameCount(self, count, timeout=0):
-        self._writer.waitFrameCount(count,timeout*1000000)
+        return self._writer.waitFrameCount(count,timeout*1000000)
 
     def _waitFrameChannelCount(self, chan, count, timeout=0):
-        self._writer.getChannel(chan).waitFrameCount(count,timeout*1000000)
+        return self._writer.getChannel(chan).waitFrameCount(count,timeout*1000000)
 
     def getChannel(self,chan):
         return self._writer.getChannel(chan)

--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -55,8 +55,11 @@ class StreamWriter(pyrogue.DataWriter):
     def _getFrameCount(self,dev,var):
         return self._writer.getFrameCount()
 
-    def _waitFrameCount(self, count):
-        self._writer.waitFrameCount(count)
+    def _waitFrameCount(self, count, timeout=0):
+        self._writer.waitFrameCount(count,timeout*1000000)
+
+    def _waitFrameChannelCount(self, chan, count, timeout=0):
+        self._writer.getChannel(chan).waitFrameCount(count,timeout*1000000)
 
     def getChannel(self,chan):
         return self._writer.getChannel(chan)

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -188,12 +188,20 @@ uint32_t ruf::StreamWriter::getFrameCount() {
    return(frameCount_);
 }
 
-void ruf::StreamWriter::waitFrameCount(uint32_t count) {
+bool ruf::StreamWriter::waitFrameCount(uint32_t count, uint64_t timeout) {
   rogue::GilRelease noGil;
   boost::unique_lock<boost::mutex> lock(mtx_);
   while (frameCount_ < count) {
     cond_.timed_wait(lock, boost::posix_time::microseconds(1000));
   }
+
+
+   //if (timeout != 0 ) {
+      //div_t divResult = div(timeout,1000000);
+      //sumTime_.tv_sec  = divResult.quot;
+      //sumTime_.tv_usec = divResult.rem;       
+   //}
+
 }
 
 //! Write data to file. Called from StreamWriterChannel

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -195,6 +195,7 @@ bool ruf::StreamWriter::waitFrameCount(uint32_t count, uint64_t timeout) {
     cond_.timed_wait(lock, boost::posix_time::microseconds(1000));
   }
 
+  return true;
 
    //if (timeout != 0 ) {
       //div_t divResult = div(timeout,1000000);

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -94,11 +94,17 @@ void ruf::StreamWriterChannel::setFrameCount(uint32_t count) {
   frameCount_ = count;
 }
 
-void ruf::StreamWriterChannel::waitFrameCount(uint32_t count) {
+bool ruf::StreamWriterChannel::waitFrameCount(uint32_t count, uint64_t timeout) {
   rogue::GilRelease noGil;
   boost::unique_lock<boost::mutex> lock(mtx_);
   while (frameCount_ < count) {
     cond_.timed_wait(lock, boost::posix_time::microseconds(1000));
   }
+
+   //if (timeout != 0 ) {
+      //div_t divResult = div(timeout,1000000);
+      //sumTime_.tv_sec  = divResult.quot;
+      //sumTime_.tv_usec = divResult.rem;       
+   //}
 }
 

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -100,6 +100,7 @@ bool ruf::StreamWriterChannel::waitFrameCount(uint32_t count, uint64_t timeout) 
   while (frameCount_ < count) {
     cond_.timed_wait(lock, boost::posix_time::microseconds(1000));
   }
+  return true;
 
    //if (timeout != 0 ) {
       //div_t divResult = div(timeout,1000000);


### PR DESCRIPTION
A timeout value can now be passed to the StreamWriter and StreamWriterChannel waitFrameCount method. The value passed is a value in microseconds. The StreamWrite Python wrapper accepts a float value in seconds. I added a python wrapper method to call the StreamWriterChannel method with a float seconds value. 