### PR TITLE
Docker fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,32 +108,32 @@ jobs:
         - doctr deploy . --built-docs docs/build/html --deploy-branch-name gh-pages --branch-whitelist doc_updates
 
     # Deploy development version stage (deploy_dev)
-    #- &deploy-docker-stage      # Docker
-    #  stage: deploy_dev
-    #  name: "Deploy Docker"
-    #  env: DOCKER_REPO=rogue-dev
-    #  before_install:
-    #    # Prepare enviroment
-    #    - export DOCKER_TAG=`git describe --tags`
-    #    - export DOCKER_IMAGE_NAME=$DOCKER_ORG_NAME/$DOCKER_REPO
-    #    # Bring all the tags
-    #    - git pull --unshallow
-    #    - git pull
-    #
-    #  before_script:
-    #    # Login to docker
-    #    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
-    #
-    #  script:
-    #    # Build docker image
-    #    - travis_wait docker build -q --build-arg branch=$TRAVIS_BRANCH -t $DOCKER_IMAGE_NAME .;
-    #
-    #  after_success:
-    #    # Upload docker image (as tagged and latest version)
-    #    - docker push $DOCKER_IMAGE_NAME;
-    #    - docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$DOCKER_TAG;
-    #    - docker push $DOCKER_IMAGE_NAME:$DOCKER_TAG;
-    
+    - &deploy-docker-stage      # Docker
+     stage: deploy_dev
+     name: "Deploy Docker"
+     env: DOCKER_REPO=rogue-dev
+     before_install:
+       # Prepare enviroment
+       - export DOCKER_TAG=`git describe --tags`
+       - export DOCKER_IMAGE_NAME=$DOCKER_ORG_NAME/$DOCKER_REPO
+       # Bring all the tags
+       - git pull --unshallow
+       - git pull
+
+     before_script:
+       # Login to docker
+       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin;
+
+     script:
+       # Build docker image
+       - travis_wait docker build -q --build-arg branch=$TRAVIS_BRANCH -t $DOCKER_IMAGE_NAME .;
+
+     after_success:
+       # Upload docker image (as tagged and latest version)
+       - docker push $DOCKER_IMAGE_NAME;
+       - docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$DOCKER_TAG;
+       - docker push $DOCKER_IMAGE_NAME:$DOCKER_TAG;
+
     - &deploy-conda-stage       # Conda for linux
       stage: deploy_dev
       name: "Deploy Conda"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,7 @@ jobs:
         - cd $TRAVIS_BUILD_DIR
         - mkdir build; cd build
         - cmake .. -DROGUE_INSTALL=local -DPYTHON_LIBRARY=$PY_PATH/lib/python3.6 -DPYTHON_INCLUDE_DIR=$PY_PATH/include
-        - make
-        - make install
+        - make -j4 install
 
         # Build Docs
         - cd $TRAVIS_BUILD_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,8 @@
-FROM ubuntu:18.04
-
-# Install system tools
-RUN apt-get update && apt-get -y    install wget git \
-                                    cmake python3 python3-dev libboost-all-dev \
-                                    libbz2-dev python3-pip libzmq3-dev python3-pyqt5 \
-                                    libreadline6-dev
-
-# Install EPICS
-RUN mkdir -p /usr/src/epics/base-3.15.5
-WORKDIR /usr/src/epics/base-3.15.5
-RUN wget -O base-3.15.5.tar.gz https://github.com/epics-base/epics-base/archive/R3.15.5.tar.gz
-RUN tar xzf base-3.15.5.tar.gz --strip 1
-RUN make clean && make && make install
-ENV EPICS_BASE /usr/src/epics/base-3.15.5
-
-# PIP Packages
-RUN pip3 install PyYAML Pyro4 parse click ipython pyzmq packaging matplotlib numpy pyepics
+FROM tidair/rogue-base:v1.0.0
 
 # Install Rogue
 ARG branch
-WORKDIR /usr/src
+WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/rogue.git -b $branch
 WORKDIR rogue
 RUN mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR rogue
 RUN mkdir build
 WORKDIR build
 RUN cmake .. -DROGUE_INSTALL=system
-RUN make install
+RUN make -j4 install


### PR DESCRIPTION
- Use `rogue-base` as base to build the rogue docker image.
- Restore the docker image build in travis
- Use 4 jobs to build rogue