### PR TITLE
Allow Hub to be root to a virtual address space

### DIFF
--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -48,6 +48,10 @@ namespace rogue {
           * transactions to the next level. This can be usefull to hide complex windows memory 
           * spaces or transactions that require multipled steps be performed in hardware.
           *
+          * If a non zero min and max transaction size are passed at creation this Hub will
+          * behave as if it is a new root Slave memory device in the tree. This is usefull in
+          * cases where this Hub will master a paged address or other virtual address space.
+          *
           * A pyrogue.Device instance is the most typical Hub used in Rogue.
           */
          class Hub : public Master, public Slave {
@@ -55,14 +59,19 @@ namespace rogue {
                //! Offset address of hub
                uint64_t offset_;
 
+               //! Flag if this is a base slave
+               bool root_;
+
             public:
 
                //! Class factory which returns a pointer to a Hub (HubPtr)
                /**Not exposed to Python
                 *
                 * @param offset The offset of this Hub device
+                * @param min The min transaction size, 0 if not a virtual memory space root
+                * @param min The max transaction size, 0 if not a virtual memory space root
                 */
-               static boost::shared_ptr<rogue::interfaces::memory::Hub> create (uint64_t offset);
+               static boost::shared_ptr<rogue::interfaces::memory::Hub> create (uint64_t offset, uint32_t min, uint32_t max);
 
                //! Setup class for use in python
                /* Not exposed to Python
@@ -75,7 +84,7 @@ namespace rogue {
                 * Do not call directly. Only called from the Master class.
                 * @param offset The offset of this Hub device
                 */
-               Hub(uint64_t offset);
+               Hub(uint64_t offset, uint32_t min, uint32_t max);
 
                //! Destroy the Hub
                ~Hub();
@@ -87,6 +96,14 @@ namespace rogue {
                 * @return 64-bit address offset
                 */
                uint64_t getOffset();
+
+               //! Get full address of this Hub
+               /** Return the full address of this Hub
+                *
+                * Exposted as _getAddress() to Python
+                * @return 64-bit address
+                */
+               uint64_t getAddress();
 
                //! Interface to service the getSlaveId request from an attached master
                /** This Hub will foward this request to the next level device.
@@ -148,7 +165,7 @@ namespace rogue {
             public:
 
                // Constructor
-               HubWrap(uint64_t offset);
+               HubWrap(uint64_t offset, uint32_t min, uint32_t max);
 
                // Post a transaction. Master will call this method with the access attributes.
                void doTransaction(boost::shared_ptr<rogue::interfaces::memory::Transaction> transaction);

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -341,9 +341,9 @@ class Device(pr.Node,rim.Hub):
                 ldata = bytearray(numWords*stride)
             
         with self._memLock:
-            for i in range(offset, offset+len(ldata), self._reqMaxAccess):
+            for i in range(offset, offset+len(ldata), self._reqMaxAccess()):
                 sliceOffset = i | self.offset
-                txnSize = min(self._reqMaxAccess, len(ldata)-(i-offset))
+                txnSize = min(self._reqMaxAccess(), len(ldata)-(i-offset))
                 #print(f'sliceOffset: {sliceOffset:#x}, ldata: {ldata}, txnSize: {txnSize}, buffOffset: {i-offset}')
                 self._reqTransaction(sliceOffset, ldata, txnSize, i-offset, txnType)
 
@@ -407,11 +407,11 @@ class Device(pr.Node,rim.Hub):
     def _buildBlocks(self):
         remVars = []
 
-        blkSize = self._blkMinAccess
+        blkSize = self._blkMinAccess()
 
         if self._blockSize is not None:
-            if self._blockSize > self._blkMaxAccess:
-                blkSize = self._blkMaxAccess
+            if self._blockSize > self._blkMaxAccess():
+                blkSize = self._blkMaxAccess()
             else:
                 blkSize = self._blockSize
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -107,7 +107,9 @@ class Device(pr.Node,rim.Hub):
                  expand=True,
                  enabled=True,
                  defaults=None,
-                 enableDeps=None):
+                 enableDeps=None,
+                 hubMin=0,
+                 hubMax=0):
 
         
         """Initialize device class"""
@@ -115,7 +117,7 @@ class Device(pr.Node,rim.Hub):
             name = self.__class__.__name__
 
         # Hub.__init__ must be called first for _setSlave to work below
-        rim.Hub.__init__(self,offset)
+        rim.Hub.__init__(self,offset,hubMin,hubMax)
 
         # Blocks
         self._blocks    = []
@@ -339,9 +341,9 @@ class Device(pr.Node,rim.Hub):
                 ldata = bytearray(numWords*stride)
             
         with self._memLock:
-            for i in range(offset, offset+len(ldata), self._maxTxnSize):
+            for i in range(offset, offset+len(ldata), self._reqMaxAccess):
                 sliceOffset = i | self.offset
-                txnSize = min(self._maxTxnSize, len(ldata)-(i-offset))
+                txnSize = min(self._reqMaxAccess, len(ldata)-(i-offset))
                 #print(f'sliceOffset: {sliceOffset:#x}, ldata: {ldata}, txnSize: {txnSize}, buffOffset: {i-offset}')
                 self._reqTransaction(sliceOffset, ldata, txnSize, i-offset, txnType)
 
@@ -405,11 +407,11 @@ class Device(pr.Node,rim.Hub):
     def _buildBlocks(self):
         remVars = []
 
-        blkSize = self._minTxnSize
+        blkSize = self._blkMinAccess
 
         if self._blockSize is not None:
-            if self._blockSize > self._maxTxnSize:
-                blkSize = self._maxTxnSize
+            if self._blockSize > self._blkMaxAccess:
+                blkSize = self._blkMaxAccess
             else:
                 blkSize = self._blockSize
 
@@ -450,9 +452,6 @@ class Device(pr.Node,rim.Hub):
 
     def _rootAttached(self, parent, root):
         pr.Node._rootAttached(self, parent, root)
-
-        self._maxTxnSize = self._doMaxAccess()
-        self._minTxnSize = self._doMinAccess()
 
         for key,value in self._nodes.items():
             value._rootAttached(self,root)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -370,9 +370,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._root   = self
         self._path   = self.name
 
-        self._maxTxnSize = 4
-        self._minTxnSize = 4
-
         for key,value in self._nodes.items():
             value._rootAttached(self,self)
 

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -35,14 +35,15 @@ namespace bp  = boost::python;
 #endif
 
 //! Create a block, class creator
-rim::HubPtr rim::Hub::create (uint64_t offset) {
-   rim::HubPtr b = boost::make_shared<rim::Hub>(offset);
+rim::HubPtr rim::Hub::create (uint64_t offset, uint32_t min, uint32_t max) {
+   rim::HubPtr b = boost::make_shared<rim::Hub>(offset,min,max);
    return(b);
 }
 
 //! Create an block
-rim::Hub::Hub(uint64_t offset) : Master (), Slave(0,0) { 
+rim::Hub::Hub(uint64_t offset, uint32_t min, uint32_t max) : Master (), Slave(min,max) { 
    offset_ = offset;
+   root_   = (min != 0 && max != 0);
 }
 
 //! Destroy a block
@@ -53,24 +54,33 @@ uint64_t rim::Hub::getOffset() {
    return offset_;
 }
 
+//! Get address
+uint64_t rim::Hub::getAddress() {
+   return(reqAddress() | offset_);
+}
+
 //! Return id to requesting master
 uint32_t rim::Hub::doSlaveId() {
-   return(reqSlaveId());
+   if ( root_ ) return(doSlaveId());
+   else return(reqSlaveId());
 }
 
 //! Return min access size to requesting master
 uint32_t rim::Hub::doMinAccess() {
-   return(reqMinAccess());
+   if ( root_ ) return(doMinAccess());
+   else return(reqMinAccess());
 }
 
 //! Return max access size to requesting master
 uint32_t rim::Hub::doMaxAccess() {
-   return(reqMaxAccess());
+   if ( root_ ) return(doMaxAccess());
+   else return(reqMaxAccess());
 }
 
-//! Return offset
+//! Return address
 uint64_t rim::Hub::doAddress() {
-   return(reqAddress() | offset_);
+   if ( root_ ) return(0);
+   else return(reqAddress() | offset_);
 }
 
 //! Post a transaction. Master will call this method with the access attributes.
@@ -86,8 +96,10 @@ void rim::Hub::doTransaction(rim::TransactionPtr tran) {
 void rim::Hub::setup_python() {
 
 #ifndef NO_PYTHON
-   bp::class_<rim::HubWrap, rim::HubWrapPtr, bp::bases<rim::Master,rim::Slave>, boost::noncopyable>("Hub",bp::init<uint64_t>())
-       .def("_getAddress",    &rim::Hub::doAddress)
+   bp::class_<rim::HubWrap, rim::HubWrapPtr, bp::bases<rim::Master,rim::Slave>, boost::noncopyable>("Hub",bp::init<uint64_t,uint32_t,uint32_t>())
+       .def("_blkMinAccess",  &rim::Hub::doMinAccess)
+       .def("_blkMaxAccess",  &rim::Hub::doMaxAccess)
+       .def("_getAddress",    &rim::Hub::getAddress)
        .def("_getOffset",     &rim::Hub::getOffset)
        .def("_doTransaction", &rim::Hub::doTransaction, &rim::HubWrap::defDoTransaction)
    ;
@@ -99,7 +111,7 @@ void rim::Hub::setup_python() {
 #ifndef NO_PYTHON
 
 //! Constructor
-rim::HubWrap::HubWrap(uint64_t offset) : rim::Hub(offset) {}
+rim::HubWrap::HubWrap(uint64_t offset, uint32_t min, uint32_t max) : rim::Hub(offset,min,max) {}
 
 //! Post a transaction. Master will call this method with the access attributes.
 void rim::HubWrap::doTransaction(rim::TransactionPtr transaction) {

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -61,19 +61,19 @@ uint64_t rim::Hub::getAddress() {
 
 //! Return id to requesting master
 uint32_t rim::Hub::doSlaveId() {
-   if ( root_ ) return(doSlaveId());
+   if ( root_ ) return(rim::Slave::doSlaveId());
    else return(reqSlaveId());
 }
 
 //! Return min access size to requesting master
 uint32_t rim::Hub::doMinAccess() {
-   if ( root_ ) return(doMinAccess());
+   if ( root_ ) return(rim::Slave::doMinAccess());
    else return(reqMinAccess());
 }
 
 //! Return max access size to requesting master
 uint32_t rim::Hub::doMaxAccess() {
-   if ( root_ ) return(doMaxAccess());
+   if ( root_ ) return(rim::Slave::doMaxAccess());
    else return(reqMaxAccess());
 }
 


### PR DESCRIPTION
This PR changed the Hub behavior to better handle how it will behave when mastering a virtual address space. The Slave min and max transaction sizes are now exposed to the Hub class creator. If both of these values are non zero the Hub will be considered the master of a new virtual address space. This means:

* Upstream memory devices will see a new base address of zero
* Upstream memory devices will see the local min and max sizes

The Device which wraps the hub will still know its relative address space to the downstream slaves. raw transactions will also still see the downstream address and min/max sizes. Upstream blocks will see the min/max size of the virtual space. 