### PR TITLE
Eliminate boost::dynamic_bitset for PRBS computation

### DIFF
--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -23,7 +23,6 @@
 #define __ROGUE_UTILITIES_PRBS_H__
 #include <stdint.h>
 #include <boost/thread.hpp>
-#include <boost/dynamic_bitset.hpp>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 
@@ -115,7 +114,7 @@ namespace rogue {
             boost::thread* txThread_;
 
             //! Internal computation 
-            void flfsr(boost::dynamic_bitset<uint8_t> & data);
+            void flfsr(uint8_t * data);
 
             //! Thread background
             void runThread();
@@ -204,8 +203,6 @@ namespace rogue {
 
       // Convienence
       typedef boost::shared_ptr<rogue::utilities::Prbs> PrbsPtr;
-
-      typedef boost::dynamic_bitset<uint8_t> PrbsData;
 
    }
 }

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -346,7 +346,7 @@ void ru::Prbs::genFrame (uint32_t size) {
    if ( genPl_ ) {
 
       // Init data
-      memcpy(data,frSeq,byteWidth);
+      memcpy(data,frSeq,byteWidth_);
 
       // Generate payload
       while ( frIter != frEnd ) {
@@ -354,7 +354,7 @@ void ru::Prbs::genFrame (uint32_t size) {
          if ( sendCount_ ) ris::toFrame(frIter,byteWidth_,wCount);
          else {
             flfsr(data);
-            frIter = std::copy(data,data+byteWidth,frIter);
+            frIter = std::copy(data,data+byteWidth_,frIter);
          }
          ++wCount[0];
       }
@@ -430,7 +430,7 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    if ( checkPl_ ) {
 
       // Init data
-      memcpy(expData,frSeq,byteWidth);
+      memcpy(expData,frSeq,byteWidth_);
       pos = 0;
 
       // Read payload

--- a/tests/test_streamBridge.py
+++ b/tests/test_streamBridge.py
@@ -18,7 +18,7 @@ import rogue
 import pyrogue
 import time
 
-rogue.Logging.setLevel(rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Debug)
 
 FrameCount = 10000
 FrameSize  = 10000


### PR DESCRIPTION
This change eliminates the need for the boost:: dynamic_bitset when doing the PRBS computation.

I tested sw-sw transmission against the previous version of Rogue.