### PR TITLE
Provide mechanism to stop Queue on exit

### DIFF
--- a/include/rogue/Queue.h
+++ b/include/rogue/Queue.h
@@ -42,7 +42,7 @@ namespace rogue {
              max_   = 0; 
              thold_ = 0;
              busy_  = false;
-             run_   = false;
+             run_   = true;
           }
 
           void stop() {

--- a/include/rogue/Queue.h
+++ b/include/rogue/Queue.h
@@ -35,12 +35,22 @@ namespace rogue {
           uint32_t max_;
           uint32_t thold_;
           bool     busy_;
+          bool     run_;
       public:
 
           Queue() { 
              max_   = 0; 
              thold_ = 0;
              busy_  = false;
+             run_   = false;
+          }
+
+          void stop() {
+             boost::mutex::scoped_lock lock(mtx_);
+             run_ = false;
+             lock.unlock();
+             popCond_.notify_all();
+             pushCond_.notify_all();
           }
 
           void setMax(uint32_t max) { max_ = max; }
@@ -50,10 +60,10 @@ namespace rogue {
           void push(T const &data) {
              boost::mutex::scoped_lock lock(mtx_);
    
-             while(max_ > 0 && queue_.size() >= max_) 
+             while(run_ && max_ > 0 && queue_.size() >= max_) 
                 pushCond_.wait(lock);
 
-             queue_.push(data);
+             if ( run_ ) queue_.push(data);
              busy_ = ( thold_ > 0 && queue_.size() > thold_ );
              lock.unlock();
              popCond_.notify_all();
@@ -83,9 +93,11 @@ namespace rogue {
           T pop() {
              T ret;
              boost::mutex::scoped_lock lock(mtx_);
-             while(queue_.empty()) popCond_.wait(lock);
-             ret=queue_.front();
-             queue_.pop();
+             while(run_ && queue_.empty()) popCond_.wait(lock);
+             if ( run_ ) {
+                ret=queue_.front();
+                queue_.pop();
+             }
              busy_ = ( thold_ > 0 && queue_.size() > thold_ );
              lock.unlock();
              pushCond_.notify_all();

--- a/include/rogue/protocols/packetizer/Controller.h
+++ b/include/rogue/protocols/packetizer/Controller.h
@@ -83,6 +83,9 @@ namespace rogue {
                //! Frame received at transport interface
                virtual void transportRx( boost::shared_ptr<rogue::interfaces::stream::Frame> frame );
 
+               //! Stop transmit queue
+               void stopQueue();
+
                //! Interface for transport transmitter thread
                boost::shared_ptr<rogue::interfaces::stream::Frame> transportTx ();
 

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -151,6 +151,9 @@ namespace rogue {
                //! Destructor
                ~Controller();
 
+               //! Stop Queues
+               void stopQueue();
+
                //! Transport frame allocation request
                boost::shared_ptr<rogue::interfaces::stream::Frame> reqFrame ( uint32_t size );
 

--- a/src/rogue/protocols/packetizer/Application.cpp
+++ b/src/rogue/protocols/packetizer/Application.cpp
@@ -60,6 +60,7 @@ rpp::Application::Application (uint8_t id) {
 //! Destructor
 rpp::Application::~Application() { 
    thread_->interrupt();
+   queue_.stop();
    thread_->join();
 }
 
@@ -88,12 +89,13 @@ void rpp::Application::pushFrame( ris::FramePtr frame ) {
 
 //! Thread background
 void rpp::Application::runThread() {
+   ris::FramePtr frame;
    Logging log("packetizer.Application");
    log.logThreadId();
 
    try {
       while(1) {
-         sendFrame(queue_.pop());
+         if ( (frame = queue_.pop()) != NULL ) sendFrame(frame);
          boost::this_thread::interruption_point();
       }
    } catch (boost::thread_interrupted&) { }

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -65,7 +65,7 @@ rpp::Controller::Controller ( rpp::TransportPtr tran, rpp::ApplicationPtr * app,
 rpp::Controller::~Controller() { }
 
 //! Stop TX
-rpp::Controller::stopQueue() { 
+void rpp::Controller::stopQueue() { 
    tranQueue_.stop();
 }
 

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -64,6 +64,11 @@ rpp::Controller::Controller ( rpp::TransportPtr tran, rpp::ApplicationPtr * app,
 //! Destructor
 rpp::Controller::~Controller() { }
 
+//! Stop TX
+rpp::Controller::stopQueue() { 
+   tranQueue_.stop();
+}
+
 //! Transport frame allocation request
 // Needs to be updated to support cascaded packetizers
 ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {

--- a/src/rogue/protocols/packetizer/Transport.cpp
+++ b/src/rogue/protocols/packetizer/Transport.cpp
@@ -57,7 +57,7 @@ rpp::Transport::Transport () { }
 //! Destructor
 rpp::Transport::~Transport() { 
    thread_->interrupt();
-   cntl_->stopTx();
+   cntl_->stopQueue();
    thread_->join();
 }
 

--- a/src/rogue/protocols/packetizer/Transport.cpp
+++ b/src/rogue/protocols/packetizer/Transport.cpp
@@ -57,6 +57,7 @@ rpp::Transport::Transport () { }
 //! Destructor
 rpp::Transport::~Transport() { 
    thread_->interrupt();
+   cntl_->stopTx();
    thread_->join();
 }
 
@@ -75,12 +76,13 @@ void rpp::Transport::acceptFrame ( ris::FramePtr frame ) {
 
 //! Thread background
 void rpp::Transport::runThread() {
+   ris::FramePtr frame;
    Logging log("packetizer.Transport");
    log.logThreadId();
 
    try {
       while(1) {
-         sendFrame(cntl_->transportTx());
+         if ( (frame=cntl_->transportTx()) != NULL ) sendFrame(frame);
          boost::this_thread::interruption_point();
       }
    } catch (boost::thread_interrupted&) { }

--- a/src/rogue/protocols/rssi/Application.cpp
+++ b/src/rogue/protocols/rssi/Application.cpp
@@ -57,6 +57,7 @@ rpr::Application::Application () { }
 //! Destructor
 rpr::Application::~Application() { 
    thread_->interrupt();
+   cntl_->stopQueue();
    thread_->join();
 }
 
@@ -80,12 +81,13 @@ void rpr::Application::acceptFrame ( ris::FramePtr frame ) {
 
 //! Thread background
 void rpr::Application::runThread() {
+   ris::FramePtr frame;
    Logging log("rssi.Application");
    log.logThreadId();
 
    try {
       while(1) {
-         sendFrame(cntl_->applicationTx());
+         if ( (frame=cntl_->applicationTx()) != NULL ) sendFrame(frame);
          boost::this_thread::interruption_point();
       }
    } catch (boost::thread_interrupted&) { }

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -119,7 +119,7 @@ rpr::Controller::~Controller() {
 }
 
 //! Stop queues
-rpr::Controller::stopQueue() {
+void rpr::Controller::stopQueue() {
    appQueue_.stop();
 }
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -118,6 +118,11 @@ rpr::Controller::~Controller() {
    stop();
 }
 
+//! Stop queues
+rpr::Controller::stopQueue() {
+   appQueue_.stop();
+}
+
 //! Close
 void rpr::Controller::stop() {
    if ( thread_ != NULL ) {
@@ -301,7 +306,7 @@ ris::FramePtr rpr::Controller::applicationTx() {
    rogue::GilRelease noGil;
 
    do {
-      head = appQueue_.pop();
+      if ((head = appQueue_.pop()) == NULL) return(frame);
       stCond_.notify_all();
 
       frame = head->getFrame();


### PR DESCRIPTION

This change ensures that threads are allowed to close cleanly when the rogue application exists. In the past threads could be locked waiting on a Queue entry.