### PR TITLE
Update TCP bridge operating modes

### DIFF
--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -43,7 +43,7 @@ rim::TcpClientPtr rim::TcpClient::create (std::string addr, uint16_t port) {
 
 //! Creator
 rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFFFFFFF) {
-   int32_t to;
+   int32_t opt;
 
    this->bridgeLog_ = rogue::Logging::create("memory.TcpClient");
 
@@ -58,9 +58,14 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
    this->zmqReq_  = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
 
    // Receive timeout
-   to = 100;
-   if ( zmq_setsockopt (this->zmqResp_, ZMQ_RCVTIMEO, &to, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("TcpServer::TcpServer","Failed to set socket timeout"));
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqResp_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("TcpClient::TcpClient","Failed to set socket timeout"));
+
+   // Don't buffer when no connection
+   opt = 1;
+   if ( zmq_setsockopt (this->zmqReq_, ZMQ_IMMEDIATE, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("TcpClient::TcpClient","Failed to set socket immediate"));
 
    this->respAddr_.append(std::to_string(static_cast<long long>(port+1)));
    this->reqAddr_.append(std::to_string(static_cast<long long>(port)));
@@ -141,7 +146,7 @@ void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
 
    // Send message
    for (x=0; x < msgCnt; x++) 
-      zmq_sendmsg(this->zmqReq_,&(msg[x]),(x==(msgCnt-1)?0:ZMQ_SNDMORE));
+      zmq_sendmsg(this->zmqReq_,&(msg[x]),((x==(msgCnt-1)?0:ZMQ_SNDMORE))|ZMQ_DONTWAIT);
 
    // Add transaction
    if ( type == rim::Post ) tran->done(0);

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -41,7 +41,7 @@ rim::TcpServerPtr rim::TcpServer::create (std::string addr, uint16_t port) {
 
 //! Creator
 rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
-   int32_t to;
+   int32_t opt;
 
    this->bridgeLog_ = rogue::Logging::create("memory.TcpServer");
 
@@ -56,8 +56,8 @@ rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
    this->zmqReq_  = zmq_socket(this->zmqCtx_,ZMQ_PULL);
 
    // Receive timeout
-   to = 100;
-   if ( zmq_setsockopt (this->zmqReq_, ZMQ_RCVTIMEO, &to, sizeof(int32_t)) != 0 ) 
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqReq_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("TcpServer::TcpServer","Failed to set socket timeout"));
 
    this->respAddr_.append(std::to_string(static_cast<long long>(port+1)));

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -43,7 +43,7 @@ ris::TcpCorePtr ris::TcpCore::create (std::string addr, uint16_t port, bool serv
 
 //! Creator
 ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
-   int32_t to;
+   int32_t opt;
 
    this->bridgeLog_ = rogue::Logging::create("stream.TcpCore");
 
@@ -58,9 +58,14 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
    this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
 
    // Receive timeout
-   to = 100;
-   if ( zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &to, sizeof(int32_t)) != 0 ) 
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("TcpCore::TcpCore","Failed to set socket timeout"));
+
+   // Don't buffer when no connection
+   opt = 1;
+   if ( zmq_setsockopt (this->zmqPush_, ZMQ_IMMEDIATE, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("TcpCore::TcpCore","Failed to set socket immediate"));
 
    // Server mode
    if (server) {


### PR DESCRIPTION
The stream bridge will no longer queue frames when the connection is lost. It will still block until the connection is restored, but multiple frames will not be buffered.

The memory client will no longer block once the buffer is full and will return immediately when the connection is down.