### PR TITLE
Add begin and end iterators to Batcher Data and Core. Adds container reservation.

### DIFF
--- a/include/rogue/protocols/batcher/CoreV1.h
+++ b/include/rogue/protocols/batcher/CoreV1.h
@@ -68,20 +68,29 @@ namespace rogue {
                //! Deconstructor
                ~CoreV1();
 
+               //! Init size for internal containers
+               void initSize(uint32_t size);
+
                //! Record count
                uint32_t count();
 
                //! Get header size
                uint32_t headerSize();
 
-               //! Get header iterator
-               rogue::interfaces::stream::FrameIterator header();
+               //! Get begining of header iterator
+               rogue::interfaces::stream::FrameIterator beginHeader();
+
+               //! Get end of header iterator
+               rogue::interfaces::stream::FrameIterator endHeader();
 
                //! Get tail size
                uint32_t tailSize();
 
-               //! Get tail iterator
-               rogue::interfaces::stream::FrameIterator & tail(uint32_t index);
+               //! Get beginning of tail iterator
+               rogue::interfaces::stream::FrameIterator beginTail(uint32_t index);
+
+               //! Get end of tail iterator
+               rogue::interfaces::stream::FrameIterator endTail(uint32_t index);
 
                //! Get data
                std::shared_ptr<rogue::protocols::batcher::Data> & record(uint32_t index);

--- a/include/rogue/protocols/batcher/Data.h
+++ b/include/rogue/protocols/batcher/Data.h
@@ -64,8 +64,11 @@ namespace rogue {
                //! Deconstructor
                ~Data();
 
-               //! Return Data Iterator
-               rogue::interfaces::stream::FrameIterator & iterator();
+               //! Return Begin Data Iterator
+               rogue::interfaces::stream::FrameIterator begin();
+
+               //! Return End Data Iterator
+               rogue::interfaces::stream::FrameIterator end();
 
                //! Return Data Size
                uint32_t size();

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -76,6 +76,12 @@ rpb::CoreV1::CoreV1() {
 //! Deconstructor
 rpb::CoreV1::~CoreV1() {}
 
+//! Init size for internal containers
+void rpb::CoreV1::initSize(uint32_t size) {
+   list_.reserve(size);
+   tails_.reserve(size);
+}
+
 //! Record count
 uint32_t rpb::CoreV1::count() {
    return list_.size();
@@ -86,9 +92,14 @@ uint32_t rpb::CoreV1::headerSize() {
    return headerSize_;
 }
 
-//! Get header iterator
-ris::FrameIterator rpb::CoreV1::header() {
+//! Get beginning of header iterator
+ris::FrameIterator rpb::CoreV1::beginHeader() {
    return frame_->beginRead();
+}
+
+//! Get end of header iterator
+ris::FrameIterator rpb::CoreV1::endHeader() {
+   return frame_->beginRead() + headerSize_;
 }
 
 //! Get tail size
@@ -96,13 +107,22 @@ uint32_t rpb::CoreV1::tailSize() {
    return tailSize_;
 }
 
-//! Get tail iterator
-ris::FrameIterator & rpb::CoreV1::tail(uint32_t index) {
+//! Get beginning of tail iterator
+ris::FrameIterator rpb::CoreV1::beginTail(uint32_t index) {
    if ( index >= tails_.size() ) 
       throw rogue::GeneralError::boundary("batcher::CoreV1::tail", index, tails_.size());
 
    // Invert order on return
    return tails_[(tails_.size()-1) - index];
+}
+
+//! Get end of tail iterator
+ris::FrameIterator rpb::CoreV1::endTail(uint32_t index) {
+   if ( index >= tails_.size() ) 
+      throw rogue::GeneralError::boundary("batcher::CoreV1::tail", index, tails_.size());
+
+   // Invert order on return
+   return tails_[(tails_.size()-1) - index] + tailSize_;
 }
 
 //! Get data

--- a/src/rogue/protocols/batcher/Data.cpp
+++ b/src/rogue/protocols/batcher/Data.cpp
@@ -46,9 +46,14 @@ rpb::Data::Data(ris::FrameIterator it, uint32_t size, uint8_t dest, uint8_t fUse
 //! Deconstructor
 rpb::Data::~Data() {}
 
-//! Return Data Iterator
-ris::FrameIterator & rpb::Data::iterator() {
+//! Return Begin Data Iterator
+ris::FrameIterator rpb::Data::begin() {
    return it_;
+}
+
+//! Return End Data Iterator
+ris::FrameIterator rpb::Data::end() {
+   return it_ + size_;
 }
 
 //! Return Data Size

--- a/src/rogue/protocols/batcher/InverterV1.cpp
+++ b/src/rogue/protocols/batcher/InverterV1.cpp
@@ -73,11 +73,11 @@ void rpb::InverterV1::acceptFrame ( ris::FramePtr frame ) {
    if ( (core.headerSize() != core.tailSize()) || (core.count() == 0) ) return;
 
    // Copy first tail to head
-   std::copy(core.tail(0), core.tail(0)+core.headerSize(), core.header());
+   std::copy(core.beginTail(0), core.endTail(0), core.beginHeader());
 
    // Copy remaining tails
    for (x=1; x < core.count(); x++) 
-      std::copy(core.tail(x), core.tail(x)+core.headerSize(), core.tail(x-1));
+      std::copy(core.beginTail(x), core.endTail(x), core.beginTail(x-1));
 
    // Remove last tail from frame
    frame->adjustPayload(-1 * core.headerSize());

--- a/src/rogue/protocols/batcher/SplitterV1.cpp
+++ b/src/rogue/protocols/batcher/SplitterV1.cpp
@@ -75,7 +75,7 @@ void rpb::SplitterV1::acceptFrame ( ris::FramePtr frame ) {
 
       // Create a new frame
       nFrame = reqFrame(data->size(),true);
-      std::copy(data->iterator(), data->iterator()+data->size(), nFrame->beginWrite());
+      std::copy(data->begin(), data->end(), nFrame->beginWrite());
       nFrame->setPayload(data->size());
 
       // Set flags


### PR DESCRIPTION
Changes Data::iterator() to Data::begin() and adds Data::end().

Changes CoreV1::header to CoreV1::beginheader() and adds CoreV1::endHeader()
Changes CoreV1::tail to CoreV1::beginTail() and adds CoreV1::endTail()

This changes also ensure that returned iterators are copies, not references.

The CoreV1 class also now has an initSize() call which reserves memory for the internal vectors used to track the records.