### PR TITLE
Allow blocks to overlap Devices in some cases

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -327,8 +327,15 @@ class RemoteBlock(BaseBlock, rim.Master):
                 print("This warning will be replaced with an exception in the next release!!!!!!!!")
                 break;
 
+        # Set exclusive flag
+        self._overlapEn = (not self._anyBits(excMask))
+
     def __repr__(self):
         return repr(self._variables)
+
+    @property
+    def overlapEn(self):
+        return self._overlapEn
 
     @property
     def stale(self):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -334,10 +334,6 @@ class RemoteBlock(BaseBlock, rim.Master):
         return repr(self._variables)
 
     @property
-    def overlapEn(self):
-        return self._overlapEn
-
-    @property
     def stale(self):
         return any([b != 0 for b in self._sDataMask])
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -328,7 +328,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                 break;
 
         # Set exclusive flag
-        self._overlapEn = (not self._anyBits(excMask))
+        self._overlapEn = any (excMask[i] != 0 for i in range(size))
 
     def __repr__(self):
         return repr(self._variables)

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -328,7 +328,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                 break;
 
         # Set exclusive flag
-        self._overlapEn = any (excMask[i] != 0 for i in range(size))
+        self._overlapEn = all (excMask[i] == 0 for i in range(size))
 
     def __repr__(self):
         return repr(self._variables)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -169,7 +169,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                 # Allow overlaps between Devices and Blocks if the block exclusive access bits are not set. 
                 # This would mean that all variables have overlapEn set.
-                if not (isinstance(tmpList[i-1],pr.Device) and isinstance(tmpList[i],pr.Block) and tmpList[i].overlapEn):
+                if not (isinstance(tmpList[i-1],pr.Device) and isinstance(tmpList[i],pr.Block) and \
+                        (tmpList[i] in tmpList[i-1]._blocks) and tmpList[i]._overlapEn):
 
                     print("\n\n\n------------------------ Memory Overlap Warning !!! --------------------------------")
                     print("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -163,18 +163,23 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             tmpList[i].name,  tmpList[i].address,
                             tmpList[i-1].name,tmpList[i-1].address, tmpList[i-1].size))
 
+            # Detect overlaps
             if (tmpList[i].size != 0) and (tmpList[i].memBaseId == tmpList[i-1].memBaseId) and \
                (tmpList[i].address < (tmpList[i-1].address + tmpList[i-1].size)):
 
-                print("\n\n\n------------------------ Memory Overlap Warning !!! --------------------------------")
-                print("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
-                      tmpList[i].name,tmpList[i].address,
-                      tmpList[i-1].name,tmpList[i-1].address,tmpList[i-1].size))
-                print("This warning will be replaced with an exception in the next release!!!!!!!!")
+                # Allow overlaps between Devices and Blocks if the block exclusive access bits are not set. 
+                # This would mean that all variables have overlapEn set.
+                if not (isinstance(tmpList[i-1],pr.Device) and isinstance(tmpList[i],pr.Block) and tmpList[i].overlapEn):
 
-                #raise pr.NodeError("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
-                #                   tmpList[i].name,tmpList[i].address,
-                #                   tmpList[i-1].name,tmpList[i-1].address,tmpList[i-1].size))
+                    print("\n\n\n------------------------ Memory Overlap Warning !!! --------------------------------")
+                    print("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
+                          tmpList[i].name,tmpList[i].address,
+                          tmpList[i-1].name,tmpList[i-1].address,tmpList[i-1].size))
+                    print("This warning will be replaced with an exception in the next release!!!!!!!!")
+
+                    #raise pr.NodeError("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
+                    #                   tmpList[i].name,tmpList[i].address,
+                    #                   tmpList[i-1].name,tmpList[i-1].address,tmpList[i-1].size))
 
         # Set timeout if not default
         if timeout != 1.0:


### PR DESCRIPTION
This will allow a block to overlap a device if the block is part of the Device and all of the variables in the block have the overlapEn flag set.