### PR TITLE
Add method to wait for update queue to be complete

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -365,6 +365,12 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             # After with is done
             self._updateQueue.put(False)
 
+    def waitOnUpdate(self):
+        """
+        Wait until all update queue items have been processed.
+        """
+        self._updateQueue.join()
+
     def _rootAttached(self):
         self._parent = self
         self._root   = self


### PR DESCRIPTION
The method root.waitOnUpdate() will block until the update queue has completed.

-Ryan