### PR TITLE
Fix order of arguments for find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ add_definitions(-D__STDC_FORMAT_MACROS)
 # Boost + Python
 #####################################
 if ( NOT NO_PYTHON ) 
-   find_package(PythonInterp QUIET REQUIRED 3.6)
-   find_package(PythonLibs QUIET REQUIRED 3.6)
+   find_package(PythonInterp 3.6 QUIET REQUIRED)
+   find_package(PythonLibs 3.6 QUIET REQUIRED)
 
    set(Boost_USE_MULTITHREADED ON)
 


### PR DESCRIPTION
Having the package version at the end made cmake to fail locating python3.6. It was selecting python2.7 instead. In cmake documentation the package version is in front of the other options, so maybe the order matters. 

With this modification cmake successfully find python3.6 in the docker environment (cmake 3.10.2)