### PR TITLE
Update To Reset Behavior, Change SoftReset to Initialize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,8 @@ jobs:
 
       script:
         # Build conda package
-        - conda build -q conda-recipe --output-folder bld-dir -c defaults -c conda-forge -c paulscherrerinstitute
+        - conda build --debug conda-recipe --output-folder bld-dir -c defaults -c conda-forge -c paulscherrerinstitute
+        #- conda build -q conda-recipe --output-folder bld-dir -c defaults -c conda-forge -c paulscherrerinstitute
 
       after_success:
         # Upload conda package

--- a/docs/src/hardware/axi/features.rst
+++ b/docs/src/hardware/axi/features.rst
@@ -30,7 +30,8 @@ In C++:
 
 The debug messages can then be viewed using the dmesg command in linux:
 
-.. code-block::
+.. code::
+
    $ dmesg
 
 ZeroCopy Enable

--- a/docs/src/hardware/axi/memory.rst
+++ b/docs/src/hardware/axi/memory.rst
@@ -13,7 +13,7 @@ The set of hardware which use this include but are not limited to:
 - Zynq7000 FPGA with TID-AIRs RCe core firmware
 
 The following example assumes a single card is being accessed by a single master,
-with the master being the device created in the :ref:`interface_memory_master_ex`.
+with the master being the device created in the :ref:`interfaces_memory_master_ex`.
 
 See :ref:`hardware_axi_axi_mem_map` for more information about the AxiMemMap class methods.
 

--- a/docs/src/hardware/axi/stream.rst
+++ b/docs/src/hardware/axi/stream.rst
@@ -21,7 +21,7 @@ hardware. One which will be associated with a register protocol (SRPV3 in this c
 and the other will be a bi-directional data channel. This channel will be connected to
 the custom sender and receiver described in :ref:`interfaces_stream_sending` and
 :ref:`interfaces_stream_receiving`. The example also uses the memory master 
-created in :ref:`interface_memory_master_ex`.
+created in :ref:`interfaces_memory_master_ex`.
 
 See :ref:`hardware_axi_axi_stream_dma` for more information about the AxiStreamDma class methods.
 

--- a/docs/src/installing/application.rst
+++ b/docs/src/installing/application.rst
@@ -22,7 +22,7 @@ compile the applications:
    $ cmake ..
    $ make
 
-The outputs will be placed in a **bin* sub-directory.
+The outputs will be placed in a **bin** sub-directory.
 
 .. code:: cmake
 

--- a/docs/src/installing/index.rst
+++ b/docs/src/installing/index.rst
@@ -18,4 +18,5 @@ This section describes how to obtain and install Rogue.
    build
    application
    firewall
+   windows
 

--- a/docs/src/interfaces/stream/classes/buffer.rst
+++ b/docs/src/interfaces/stream/classes/buffer.rst
@@ -6,11 +6,11 @@ Buffer
 
 The list of Buffer objects in a Frame is iterated using a the following typedef:
 
-.. doxygentypedef:: rogue::interfaces::stream::Frame::BufferIterator
+   rogue::interfaces::stream::Frame::BufferIterator
 
 The uint8_t data within a Buffer is iterated using a the following typedef:
 
-.. doxygentypedef:: rogue::interfaces::stream::Buffer::iterator
+   rogue::interfaces::stream::Buffer::iterator
 
 Buffer objects in C++ are referenced by the following shared pointer typedef:
 
@@ -20,3 +20,4 @@ The Buffer class description is shown below:
 
 .. doxygenclass:: rogue::interfaces::stream::Buffer
    :members:
+

--- a/docs/src/interfaces/stream/classes/frameIterator.rst
+++ b/docs/src/interfaces/stream/classes/frameIterator.rst
@@ -6,7 +6,7 @@ Frame Iterator
 
 The FrameIterator class is also aliased as a Frame::iterator
 
-.. doxygentypedef:: rogue::interfaces::stream::Frame::iterator
+   rogue::interfaces::stream::Frame::iterator
 
 The class description is shown below:
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -330,12 +330,18 @@ class RemoteBlock(BaseBlock, rim.Master):
         # Set exclusive flag
         self._overlapEn = all (excMask[i] == 0 for i in range(size))
 
+        # Force block to be stale at startup
+        self.setStale()
+
     def __repr__(self):
         return repr(self._variables)
 
     @property
     def stale(self):
         return any([b != 0 for b in self._sDataMask])
+
+    def setStale(self):
+        for b in self._sDataMask: b = 0xFF
 
     @property
     def offset(self):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -331,7 +331,7 @@ class RemoteBlock(BaseBlock, rim.Master):
         self._overlapEn = all (excMask[i] == 0 for i in range(size))
 
         # Force block to be stale at startup
-        self.setStale()
+        self._forceStale()
 
     def __repr__(self):
         return repr(self._variables)
@@ -339,9 +339,6 @@ class RemoteBlock(BaseBlock, rim.Master):
     @property
     def stale(self):
         return any([b != 0 for b in self._sDataMask])
-
-    def setStale(self):
-        for b in self._sDataMask: b = 0xFF
 
     @property
     def offset(self):
@@ -471,6 +468,8 @@ class RemoteBlock(BaseBlock, rim.Master):
             #print(f'Checking {self.name}.startTransaction(check={check})')
             self._checkTransaction()
 
+    def _forceStale(self):
+        for b in self._sDataMask: b = 0xFF
 
     def _checkTransaction(self):
         

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -226,14 +226,17 @@ class Device(pr.Node,rim.Hub):
             elif isinstance(variables[0], str):
                 self.variables[v]._hidden = hidden
 
-    def softReset(self):
-        pass
+    def initialize(self):
+        for key,value in self.devices.items():
+            value.initialize()
 
     def hardReset(self):
-        pass
+        for key,value in self.devices.items():
+            value.hardReset()
 
     def countReset(self):
-        pass
+        for key,value in self.devices.items():
+            value.countReset()
 
     def enableChanged(self,value):
         pass # Do nothing

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -231,6 +231,8 @@ class Device(pr.Node,rim.Hub):
             value.initialize()
 
     def hardReset(self):
+        for block in self._blocks:
+            block._forceStale()
         for key,value in self.devices.items():
             value.hardReset()
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -98,10 +98,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             description='String containing newline seperated system logic entries'))
 
         self.add(pr.LocalVariable(name='ForceWrite', value=False, mode='RW', hidden=True,
-            description='Configuration Flag To Always Write Non Stale Blocks For WriteAll, ReadConfig and setYaml'))
+            description='Configuration Flag To Always Write Non Stale Blocks For WriteAll, LoadConfig and setYaml'))
 
         self.add(pr.LocalVariable(name='InitAfterConfig', value=False, mode='RW', hidden=True,
-            description='Configuration Flag To Execute Initialize after ReadConfig or setYaml'))
+            description='Configuration Flag To Execute Initialize after LoadConfig or setYaml'))
 
         self.add(pr.LocalVariable(name='Time', value=0.0, mode='RO', hidden=True,
                  localGet=lambda: time.time(), pollInterval=1.0, description='Current Time In Seconds Since EPOCH UTC'))
@@ -117,13 +117,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name="ReadAll", function=self._read,
                                  description='Read all values from the hardware'))
 
-        self.add(pr.LocalCommand(name='WriteState', value='', function=self._writeState,
-                                 description='Write state to passed filename in YAML format'))
+        self.add(pr.LocalCommand(name='SaveState', value='', function=self._saveState,
+                                 description='Save state to passed filename in YAML format'))
 
-        self.add(pr.LocalCommand(name='WriteConfig', value='', function=self._writeConfig,
-                                 description='Write configuration to passed filename in YAML format'))
+        self.add(pr.LocalCommand(name='SaveConfig', value='', function=self._saveConfig,
+                                 description='Save configuration to passed filename in YAML format'))
 
-        self.add(pr.LocalCommand(name='ReadConfig', value='', function=self._readConfig,
+        self.add(pr.LocalCommand(name='LoadConfig', value='', function=self._loadConfig,
                                  description='Read configuration from passed filename in YAML format'))
 
         self.add(pr.LocalCommand(name='Initialize', function=self.initialize,
@@ -441,8 +441,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.exception(e)
         self._log.info("Done root read")
 
-    def _writeState(self,arg):
-        """Write YAML configuration/status to a file. Called from command"""
+    def _saveState(self,arg):
+        """Save YAML configuration/status to a file. Called from command"""
 
         # Auto generate name if no arg
         if arg is None or arg == '':
@@ -454,8 +454,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         except Exception as e:
             self._log.exception(e)
 
-    def _writeConfig(self,arg):
-        """Write YAML configuration to a file. Called from command"""
+    def _saveConfig(self,arg):
+        """Save YAML configuration to a file. Called from command"""
 
         # Auto generate name if no arg
         if arg is None or arg == '':
@@ -467,8 +467,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         except Exception as e:
             self._log.exception(e)
 
-    def _readConfig(self,arg):
-        """Read YAML configuration from a file. Called from command"""
+    def _loadConfig(self,arg):
+        """Load YAML configuration from a file. Called from command"""
         try:
             with open(arg,'r') as f:
                 self.setYaml(f.read(),False,['RW','WO'])

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -356,8 +356,8 @@ class SystemWidget(QWidget):
         pb.clicked.connect(self.hardReset)
         hb.addWidget(pb)
 
-        pb = QPushButton('Soft Reset')
-        pb.clicked.connect(self.softReset)
+        pb = QPushButton('Initialize')
+        pb.clicked.connect(self.initialize)
         hb.addWidget(pb)
 
         pb = QPushButton('Count Reset')
@@ -430,8 +430,8 @@ class SystemWidget(QWidget):
         self.root.HardReset()
 
     @pyqtSlot()
-    def softReset(self):
-        self.root.SoftReset()
+    def initialzie(self):
+        self.root.Initialize()
 
     @pyqtSlot()
     def countReset(self):

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -448,7 +448,7 @@ class SystemWidget(QWidget):
             loadFile = loadFile[0]
 
         if loadFile != '':
-            self.root.ReadConfig(loadFile)
+            self.root.LoadConfig(loadFile)
 
     @pyqtSlot()
     def saveSettings(self):
@@ -462,7 +462,7 @@ class SystemWidget(QWidget):
             saveFile = saveFile[0]
 
         if saveFile != '':
-            self.root.WriteConfig(saveFile)
+            self.root.SaveConfig(saveFile)
 
     @pyqtSlot()
     def saveState(self):
@@ -476,5 +476,5 @@ class SystemWidget(QWidget):
             stateFile = stateFile[0]
 
         if stateFile != '':
-            self.root.WriteState(stateFile)
+            self.root.SaveState(stateFile)
 

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -63,6 +63,7 @@ class PrbsRx(pyrogue.Device):
 
     def countReset(self):
         self._prbs.resetCount()
+        super().countReset()
 
     def _getStreamSlave(self):
         return self._prbs
@@ -123,6 +124,7 @@ class PrbsTx(pyrogue.Device):
 
     def countReset(self):
         self._prbs.resetCount()
+        super().countReset()
 
     def _genFrame(self):
         self._prbs.genFrame(self.txSize.value())


### PR DESCRIPTION
This PR changes the behavior of the Rogue reset commands and how they are used.

SoftReset now becomes Initialize

The three reset functions, HardReset, CountReset and Initialize are no longer recursed from the top level. Instead the default function in a device will recurse on the child devices. If the user re-implemented the reset function, they must call the super() reset function in order to properly recurse if desired. 

A new variable in root, InitAfterConfig, defines if the Initialize() method should be called after a yaml file is loaded, or after setYaml() is called directly. 

This PR also sets all blocks to stale as a result of HardReset and at startup..

ReadConfig is changed to LoadConfig, WriteConfig is changed to SaveConfig and WriteState is changed to SaveState.