### PR TITLE
Add ability to return data from command, use command default, add new root commands

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -89,12 +89,15 @@ class BaseCommand(pr.BaseVariable):
         try:
 
             # Convert arg
-            arg = self.parseDisp(arg)
+            if arg is None:
+                arg = self._default
+            else:
+                arg = self.parseDisp(arg)
 
             # Possible args
             pargs = {'dev' : self.parent, 'cmd' : self, 'arg' : arg}
 
-            pr.varFuncHelper(self._function,pargs, self._log,self.path)
+            return pr.varFuncHelper(self._function,pargs, self._log,self.path)
 
         except Exception as e:
             self._log.exception(e)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -142,7 +142,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  description='Get current configuration as YAML string. Pass read first arg.'))
 
         self.add(pr.LocalCommand(name='GetYamlState', value=True, function=lambda r: self._getYaml(r,['RW','RO','WO']),
-                                 description='Get current configuration as YAML string. Pass read first arg.'))
+                                 description='Get current state as YAML string. Pass read first arg.'))
 
     def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, pyroGroup=None, pyroAddr=None, pyroNsAddr=None):
         """Setup the tree. Start the polling thread."""

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -135,7 +135,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='ClearLog', function=self._clearLog,
                                  description='Clear the message log cntained in the SystemLog variable'))
 
-        self.add(pr.LocalCommand(name='SetYamlConfig', function=lambda s: self._setYaml(s,False,['RW','WO']),
+        self.add(pr.LocalCommand(name='SetYamlConfig', value='', function=lambda s: self._setYaml(s,False,['RW','WO']),
                                  description='Set configuration from passed YAML string'))
 
         self.add(pr.LocalCommand(name='GetYamlConfig', value=True, function=lambda r: self._getYaml(r,['RW','WO']),

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -284,10 +284,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             if isinstance(func,Pyro4.core.Proxy):                                    
                 func._pyroOneway.add("varListener")                                  
 
-
-        if self.InitAfterConfig.value():
-            self.initialize()
-
     @Pyro4.expose
     def get(self,path):
         obj = self.getNode(path)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -135,13 +135,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='ClearLog', function=self._clearLog,
                                  description='Clear the message log cntained in the SystemLog variable'))
 
-        self.add(pr.LocalCommand(name='SetYamlConfig', value='', function=lambda s: self._setYaml(s,False,['RW','WO']),
+        self.add(pr.LocalCommand(name='SetYamlConfig', value='', function=lambda arg: self._setYaml(arg,False,['RW','WO']),
                                  description='Set configuration from passed YAML string'))
 
-        self.add(pr.LocalCommand(name='GetYamlConfig', value=True, function=lambda r: self._getYaml(r,['RW','WO']),
+        self.add(pr.LocalCommand(name='GetYamlConfig', value=True, function=lambda arg: self._getYaml(arg,['RW','WO']),
                                  description='Get current configuration as YAML string. Pass read first arg.'))
 
-        self.add(pr.LocalCommand(name='GetYamlState', value=True, function=lambda r: self._getYaml(r,['RW','RO','WO']),
+        self.add(pr.LocalCommand(name='GetYamlState', value=True, function=lambda arg: self._getYaml(arg,['RW','RO','WO']),
                                  description='Get current state as YAML string. Pass read first arg.'))
 
     def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, pyroGroup=None, pyroAddr=None, pyroNsAddr=None):


### PR DESCRIPTION
This PR update command to add a value to be returned.

Commands will also use the default value if no arg is provided when called.

setYaml and getYaml are now private functions. I added three new root level commands for SetYamlConfig, GetYamlConfig and GetYamlState. GetYamlConfig and GetYamlState take the read first arg.