### PR TITLE
Command interface fixes

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -74,12 +74,14 @@ class BaseCommand(pr.BaseVariable):
             with self._lock:
                 if self._thread is not None and self._thread.isAlive():
                     self._log.warning('Command execution is already in progress!')
-                    return
+                    return None
                 else:
                     self._thread = threading.Thread(target=self._doFunc, args=(arg,))
                     self._thread.start()
+
+            return None
         else:
-            self._doFunc(arg)
+            return self._doFunc(arg)
 
     def _doFunc(self,arg):
         """Execute command: TODO: Update comments"""
@@ -103,7 +105,7 @@ class BaseCommand(pr.BaseVariable):
             self._log.exception(e)
 
     def __call__(self,arg=None):
-        self.call(arg)
+        return self.call(arg)
 
     @staticmethod
     def nothing():

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -398,7 +398,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self.checkBlocks(recurse=True)
             except Exception as e:
                 self._log.exception(e)
+                return False
+
         self._log.info("Done root write")
+        return True
 
     def _read(self):
         """Read all blocks"""
@@ -410,7 +413,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self.checkBlocks(recurse=True)
             except Exception as e:
                 self._log.exception(e)
+                return False
+
         self._log.info("Done root read")
+        return True
 
     def _saveState(self,arg):
         """Save YAML configuration/status to a file. Called from command"""
@@ -424,6 +430,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 f.write(self._getYaml(True,modes=['RW','RO','WO']))
         except Exception as e:
             self._log.exception(e)
+            return False
+
+        return True
 
     def _saveConfig(self,arg):
         """Save YAML configuration to a file. Called from command"""
@@ -437,6 +446,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 f.write(self._getYaml(True,modes=['RW','WO']))
         except Exception as e:
             self._log.exception(e)
+            return False
+
+        return True
 
     def _loadConfig(self,arg):
         """Load YAML configuration from a file. Called from command"""
@@ -445,6 +457,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._setYaml(f.read(),False,['RW','WO'])
         except Exception as e:
             self._log.exception(e)
+            return False
+
+        return True
 
     def _getYaml(self,readFirst,modes=['RW']):
         """
@@ -452,15 +467,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         modes is a list of variable modes to include.
         If readFirst=True a full read from hardware is performed.
         """
-        ret = ""
 
         if readFirst: self._read()
         try:
-            ret = dictToYaml({self.name:self._getDict(modes)},default_flow_style=False)
+            return  dictToYaml({self.name:self._getDict(modes)},default_flow_style=False)
         except Exception as e:
             self._log.exception(e)
-
-        return ret
+            return ""
 
     def _setYaml(self,yml,writeEach,modes=['RW','WO']):
         """
@@ -683,7 +696,7 @@ def keyValueUpdate(old, key, value):
     d = old
     parts = key.split('.')
     for part in parts[:-1]:
-        d = d[part]
+        d = d.get(part, {})
     d[parts[-1]] = value
 
 def dictUpdate(old, new):


### PR DESCRIPTION
This PR fixes the chain of command calls to ensure the return value is propagated.

It also adds return values to various Root commands to allow proper error detection in scripts.

It also adds a fix that Ben had applied locally in the hps space.