### PR TITLE
Add GUI pop up menu to enable read/write methods on variables on devices

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -159,12 +159,12 @@ class Device(pr.Node,rim.Hub):
         # Variable interface to enable flag
         self.add(EnableVariable(enabled=enabled, deps=enableDeps))
 
-        self.add(pr.LocalCommand(name='ReadDevice', value='', hidden=True,
-                                 function=lambda : self.readAndCheckBlocks(recurse=False),
+        self.add(pr.LocalCommand(name='ReadDevice', value=False, hidden=True,
+                                 function=lambda arg: self.readAndCheckBlocks(recurse=arg),
                                  description='Force read of device without recursion'))
 
         self.add(pr.LocalCommand(name='WriteDevice', value='', hidden=True,
-                                 function=lambda : self.writeAndVerifyBlocks(force=True,recurse=False),
+                                 function=lambda arg: self.writeAndVerifyBlocks(force=True,recurse=arg),
                                  description='Force write of device without recursion'))
 
     @Pyro4.expose

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -159,6 +159,14 @@ class Device(pr.Node,rim.Hub):
         # Variable interface to enable flag
         self.add(EnableVariable(enabled=enabled, deps=enableDeps))
 
+        self.add(pr.LocalCommand(name='ReadDevice', value='', hidden=True,
+                                 function=lambda : self.readAndCheckBlocks(recurse=False),
+                                 description='Force read of device without recursion'))
+
+        self.add(pr.LocalCommand(name='WriteDevice', value='', hidden=True,
+                                 function=lambda : self.writeAndVerifyBlocks(force=True,recurse=False),
+                                 description='Force write of device without recursion'))
+
     @Pyro4.expose
     @property
     def address(self):
@@ -337,6 +345,11 @@ class Device(pr.Node,rim.Hub):
         """Perform a write, verify and check. Usefull for committing any stale variables"""
         self.writeBlocks(force=force, recurse=recurse, variable=variable, checkEach=checkEach)
         self.verifyBlocks(recurse=recurse, variable=variable, checkEach=checkEach)
+        self.checkBlocks(recurse=recurse, variable=variable)
+
+    def readAndCheckBlocks(self, recurse=True, variable=None, checkEach=False):
+        """Perform a read and check."""
+        self.readBlocks(recurse=recurse, variable=variable, checkEach=checkEach)
         self.checkBlocks(recurse=recurse, variable=variable)
 
     def _rawTxnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -135,12 +135,26 @@ class VariableLink(QObject):
 
     def openMenu(self, event):
         menu = QMenu()
-        read_action  = menu.addAction('Read Now')
-        write_action = menu.addAction('Write Now')
+        read_variable  = None
+        write_variable = None
+
+        read_device = menu.addAction('Read Device')
+        write_device = menu.addAction('Write Device')
+
+        if self._variable.mode != 'WO':
+            read_variable = menu.addAction('Read Variable')
+        if self._variable.mode != 'RO':
+            write_variable = menu.addAction('Write Variable')
+
         action = menu.exec_(self._widget.mapToGlobal(event))
-        if action == read_action:
+
+        if action == read_device:
+            self._variable.parent.ReadDevice()
+        elif action == write_device:
+            self._variable.parent.WriteDevice()
+        elif action == read_variable:
             self._variable.get()
-        elif action == write_action:
+        elif action == write_variable:
             if isinstance(self._widget, QComboBox):
                 self._variable.setDisp(self._widget.currentText())
             elif isinstance(self._widget, QSpinBox):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -138,6 +138,8 @@ class VariableLink(QObject):
         read_variable  = None
         write_variable = None
 
+        read_recurse = menu.addAction('Read Recursive')
+        write_recurse = menu.addAction('Write Recursive')
         read_device = menu.addAction('Read Device')
         write_device = menu.addAction('Write Device')
 
@@ -148,10 +150,14 @@ class VariableLink(QObject):
 
         action = menu.exec_(self._widget.mapToGlobal(event))
 
-        if action == read_device:
-            self._variable.parent.ReadDevice()
+        if action == read_recurse:
+            self._variable.parent.ReadDevice(True)
+        elif action == write_recurse:
+            self._variable.parent.WriteDevice(True)
+        elif action == read_device:
+            self._variable.parent.ReadDevice(False)
         elif action == write_device:
-            self._variable.parent.WriteDevice()
+            self._variable.parent.WriteDevice(False)
         elif action == read_variable:
             self._variable.get()
         elif action == write_variable:

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -100,7 +100,6 @@ class VariableLink(QObject):
         if self._variable.disp == 'enum' and self._variable.enum is not None and self._variable.mode != 'RO':
             self._widget = QComboBox()
             self._widget.activated.connect(self.guiChanged)
-            self._widget.setToolTip(self._variable.description)
 
             self.updateGui.connect(self._widget.setCurrentIndex)
 
@@ -112,7 +111,6 @@ class VariableLink(QObject):
             self._widget.setMinimum(self._variable.minimum)
             self._widget.setMaximum(self._variable.maximum)
             self._widget.valueChanged.connect(self.guiChanged)
-            self._widget.setToolTip(self._variable.description)
 
             self.updateGui.connect(self._widget.setValue)
 
@@ -120,9 +118,12 @@ class VariableLink(QObject):
             self._widget = QLineEdit()
             self._widget.returnPressed.connect(self.returnPressed)
             self._widget.textEdited.connect(self.valueChanged)
-            self._widget.setToolTip(self._variable.description)
 
             self.updateGui[str].connect(self._widget.setText)
+
+        self._widget.setToolTip(self._variable.description)
+        self._widget.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._widget.customContextMenuRequested.connect(self.openMenu)
 
         if self._variable.mode == 'RO':
             self._widget.setReadOnly(True)
@@ -131,6 +132,13 @@ class VariableLink(QObject):
         self.varListener(None,self._variable.value(),self._variable.valueDisp())
 
         variable.addListener(self)
+
+    def openMenu(self, event):
+        menu = QMenu()
+        read_action = menu.addAction('Read Now')
+        action = menu.exec_(self._widget.mapToGlobal(event))
+        if action == read_action:
+            self._variable.get()
 
     @Pyro4.expose
     def varListener(self, path, value, disp):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -135,10 +135,18 @@ class VariableLink(QObject):
 
     def openMenu(self, event):
         menu = QMenu()
-        read_action = menu.addAction('Read Now')
+        read_action  = menu.addAction('Read Now')
+        write_action = menu.addAction('Write Now')
         action = menu.exec_(self._widget.mapToGlobal(event))
         if action == read_action:
             self._variable.get()
+        elif action == write_action:
+            if isinstance(self._widget, QComboBox):
+                self._variable.setDisp(self._widget.currentText())
+            elif isinstance(self._widget, QSpinBox):
+                self._variable.set(self._widget.value())
+            else:
+                self._variable.setDisp(self._widget.text())
 
     @Pyro4.expose
     def varListener(self, path, value, disp):


### PR DESCRIPTION
Right clicking on any variable box will provide a popup menu which will enable the user to read or write the specific variable or the entire containing device. Device read and writes are not recursive. The read variable and write variable options are dependent on the variable mode.