### PR TITLE
Fixes for Atlas use. Adds CMake flag to link a static librogue-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ endif()
 find_package(Git QUIET)
 if (GIT_FOUND)
    execute_process (
-      COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
+      COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_SOURCE_DIR}/.git  describe --tags --dirty
       OUTPUT_VARIABLE ROGUE_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -233,8 +233,14 @@ else()
    SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
 endif()
 
+if(STATIC_LIB) 
+set(LINK_MODE STATIC)
+else()
+set(LINK_MODE SHARED)
+endif()
+
 # Create rogue core library
-add_library(rogue-core SHARED "")
+add_library(rogue-core ${LINK_MODE} "")
 
 # Find rogue core sources
 add_subdirectory(src/rogue)
@@ -317,7 +323,7 @@ configure_file(${PROJECT_SOURCE_DIR}/templates/setup.py.in
 #####################################
 
 # Always install core libraries and config files
-install(TARGETS rogue-core LIBRARY DESTINATION ${ROGUE_DIR}/lib)
+install(TARGETS rogue-core LIBRARY DESTINATION ${ROGUE_DIR}/lib ARCHIVE DESTINATION ${ROGUE_DIR}/lib)
 install(FILES   ${PROJECT_BINARY_DIR}/RogueConfig.cmake DESTINATION ${ROGUE_DIR}/lib)
 
 # Copy setup files for local or custom
@@ -400,6 +406,11 @@ if (NO_BZIP)
 else()
 message("-- Found Bzip2: ${BZIP2_INCLUDE_DIR}")
 endif()
+
+if (STATIC_LIB)
+   message("-- Link static rogue library!")
+endif()
+
 
 message("----------------------------------------------------------------------")
 message("")

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#include <string.h>
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -21,6 +21,7 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#include <string.h>
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
+#include <string.h>
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>


### PR DESCRIPTION
### Description
Fixes ESROGUE-357, ESROGUE-355. adds CMake flag to link a static librogue-core

### JIRA
[ESROGUE-355](https://jira.slac.stanford.edu/browse/ESROGUE-355)
[ESROGUE-357](https://jira.slac.stanford.edu/browse/ESROGUE-357)