### PR TITLE
Allow sync read/write operation in EPICS interface

### DIFF
--- a/include/rogue/protocols/epicsV3/Server.h
+++ b/include/rogue/protocols/epicsV3/Server.h
@@ -29,6 +29,7 @@
 #include <gddAppFuncTable.h>
 #include <map>
 #include <rogue/Queue.h>
+#include <rogue/Logging.h>
 
 namespace rogue {
    namespace protocols {
@@ -47,7 +48,7 @@ namespace rogue {
                bool threadEn_;
 
                std::thread ** workers_;
-               uint32_t       workCnt_;
+               uint32_t         workCnt_;
                bool workersEn_;
 
                std::mutex mtx_;
@@ -59,6 +60,8 @@ namespace rogue {
                void runThread();
 
                void runWorker();
+
+               std::shared_ptr<rogue::Logging> log_;
 
             public:
 
@@ -77,6 +80,8 @@ namespace rogue {
                void addValue(std::shared_ptr<rogue::protocols::epicsV3::Value> value);
 
                void addWork(std::shared_ptr<rogue::protocols::epicsV3::Work> work);
+
+               bool doAsync();
 
                pvExistReturn pvExistTest (const casCtx &ctx, const char *pvName);
 

--- a/python/pyrogue/protocols/epics.py
+++ b/python/pyrogue/protocols/epics.py
@@ -26,7 +26,7 @@ class EpicsCaServer(object):
     """
     Class to contain an epics ca server
     """
-    def __init__(self,*,base,root,pvMap=None, syncRead=True, threadCount=1):
+    def __init__(self,*,base,root,pvMap=None, syncRead=True, threadCount=0):
         self._root      = root
         self._base      = base 
         self._log       = pyrogue.logInit(cls=self)

--- a/src/rogue/protocols/epicsV3/Pv.cpp
+++ b/src/rogue/protocols/epicsV3/Pv.cpp
@@ -61,24 +61,33 @@ caStatus rpe::Pv::beginTransaction() {
 void rpe::Pv::endTransaction() { }
 
 caStatus rpe::Pv::read(const casCtx &ctx, gdd &value) {
-   casAsyncReadIO * rio = new casAsyncReadIO(ctx);
-   rpe::WorkPtr work = rpe::Work::createRead(value_, value, rio);
-   server_->addWork(work);
-   return S_casApp_asyncCompletion;
+   if (server_->doAsync()) {
+      casAsyncReadIO * rio = new casAsyncReadIO(ctx);
+      rpe::WorkPtr work = rpe::Work::createRead(value_, value, rio);
+      server_->addWork(work);
+      return S_casApp_asyncCompletion;
+   }
+   else return value_->read(value);
 }
 
 caStatus rpe::Pv::write(const casCtx &ctx, const gdd &value) {
-   casAsyncWriteIO * wio = new casAsyncWriteIO(ctx);
-   rpe::WorkPtr work = rpe::Work::createWrite(value_, value, wio);
-   server_->addWork(work);
-   return S_casApp_asyncCompletion;
+   if (server_->doAsync()) {
+      casAsyncWriteIO * wio = new casAsyncWriteIO(ctx);
+      rpe::WorkPtr work = rpe::Work::createWrite(value_, value, wio);
+      server_->addWork(work);
+      return S_casApp_asyncCompletion;
+   }
+   else return value_->write(value);
 }
 
 caStatus rpe::Pv::writeNotify(const casCtx &ctx, const gdd &value) {
-   casAsyncWriteIO * wio = new casAsyncWriteIO(ctx);
-   rpe::WorkPtr work = rpe::Work::createWrite(value_, value, wio);
-   server_->addWork(work);
-   return S_casApp_asyncCompletion;
+   if (server_->doAsync()) {
+      casAsyncWriteIO * wio = new casAsyncWriteIO(ctx);
+      rpe::WorkPtr work = rpe::Work::createWrite(value_, value, wio);
+      server_->addWork(work);
+      return S_casApp_asyncCompletion;
+   }
+   else return value_->write(value);
 }
 
 casChannel * rpe::Pv::createChannel(const casCtx &ctx,

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -80,7 +80,6 @@ void rpe::Server::start() {
       workersEn_ = true;
       for (x=0; x < workCnt_; x++) 
          workers_[x] = new std::thread(boost::bind(&rpe::Server::runWorker, this));
-      }
    }
    running_ = true;
 }

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -76,12 +76,12 @@ void rpe::Server::start() {
    threadEn_ = true;
    thread_ = new std::thread(&rpe::Server::runThread, this);
 
-   if ( workCnt_ > 0 ) {]
+   if ( workCnt_ > 0 ) {
       workersEn_ = true;
       for (x=0; x < workCnt_; x++) 
          workers_[x] = new std::thread(boost::bind(&rpe::Server::runWorker, this));
       }
-
+   }
    running_ = true;
 }
 

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -44,7 +44,13 @@ void rpe::Server::setup_python() {
 //! Class creation
 rpe::Server::Server (uint32_t count) : caServer(), running_(false) { 
    workCnt_ = count;
-   workers_ = (std::thread **)malloc(workCnt_ * sizeof(std::thread *));
+   workersEn_ = false;
+   threadEn_  = false;
+
+   if ( count > 0 ) workers_ = (std::thread **)malloc(workCnt_ * sizeof(std::thread *));
+   else workers_ = NULL;
+
+   log_ = rogue::Logging::create("epicsV3.Server");
 }
 
 rpe::Server::~Server() {
@@ -57,24 +63,32 @@ rpe::Server::~Server() {
       it->second.reset();
    }
    values_.clear();
-   free(workers_);
+
+   if ( workers_ != NULL ) free(workers_);
 }
 
 void rpe::Server::start() {
    uint32_t x;
    //this->setDebugLevel(10);
+
+   log_->info("Starting epics server with %i workers",workCnt_);
+
    threadEn_ = true;
    thread_ = new std::thread(&rpe::Server::runThread, this);
 
-   workersEn_ = true;
-   for (x=0; x < workCnt_; x++) 
-      workers_[x] = new std::thread(&rpe::Server::runWorker, this);
+   if ( workCnt_ > 0 ) {]
+      workersEn_ = true;
+      for (x=0; x < workCnt_; x++) 
+         workers_[x] = new std::thread(boost::bind(&rpe::Server::runWorker, this));
+      }
 
    running_ = true;
 }
 
 void rpe::Server::stop() {
    uint32_t x;
+
+   log_->info("Stopping epics server");
 
    if (running_) {
       rogue::GilRelease noGil;
@@ -105,6 +119,10 @@ void rpe::Server::addValue(rpe::ValuePtr value) {
    else {
       throw rogue::GeneralError("Server::addValue","EPICs name already exists: " + value->epicsName());
    }
+}
+
+bool rpe::Server::doAsync() {
+   return workersEn_;
 }
 
 void rpe::Server::addWork(rpe::WorkPtr work) {
@@ -149,19 +167,35 @@ pvAttachReturn rpe::Server::pvAttach(const casCtx &ctx, const char *pvName) {
 
 //! Run thread
 void rpe::Server::runThread() {
+
+   log_->info("Starting epics server thread");
+   log_->logThreadId();
+
    while(threadEn_) {
-      fileDescriptorManager.process(0.01);
+      try{
+         fileDescriptorManager.process(0.01);
+      } catch (...) {
+         log_->error("Caught exception in server thread");
+      }
    }
+   log_->info("Stopping epics server thread");
 }
 
 //! Work thread
 void rpe::Server::runWorker() {
    rpe::WorkPtr work;
 
+   log_->info("Starting epics worker thread");
+   log_->logThreadId();
+
    while(workersEn_) {
       work = workQueue_.pop();
       if (work == NULL) break;
-      work->execute();
+      try{
+         work->execute();
+      } catch (...) {
+         log_->error("Caught exception in worker thread");
+      }
    }
 }
 


### PR DESCRIPTION
Starting the EPICS interface with threadCount=0 will enable sync read/write operation.

EPICS will run in sync mode by default.