### PR TITLE
Add gui client to pyrogue.gui module

### DIFF
--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -165,18 +165,16 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def __init__(self, addr, port):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
+        self._root = None
+        self._varListeners = []
+        self._nodes = {}
 
-        # Get root entity
-        self._root = self._remoteAttr(None, None)
+        # Try to connect to root entity
+        while self._root is None:
+            self._root = self._remoteAttr(None, None)
 
         # Walk the tree
         self._setupClass(self._root,self._root)
-
-        # Node lists
-        self._nodes = {}
-
-        # Variable listeners
-        self._varListeners = []
 
     def _setupClass(self, root, cls):
         cls._root   = root

--- a/python/pyrogue/gui/__main__.py
+++ b/python/pyrogue/gui/__main__.py
@@ -1,0 +1,33 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to 
+# the license terms in the LICENSE.txt file found in the top-level directory 
+# of this distribution and at: 
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+# No part of the rogue software platform, including this file, may be 
+# copied, modified, propagated, or distributed except according to the terms 
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import argparse
+import pyrogue
+import pyrogue.gui
+import sys
+
+parser = argparse.ArgumentParser('Pyrogue GUI Client')
+parser.add_argument('--host', type=str, help='Server host name or address',default='localhost')
+parser.add_argument('--port', type=int, help='Server port number',default=9099)
+args = parser.parse_args()
+
+print("Connecting to host {} port {}".format(args.host,args.port))
+
+# Connect to the server
+client = pyrogue.VirtualClient(args.host,args.port)
+
+# Create GUI
+appTop = pyrogue.gui.application(sys.argv)
+guiTop = pyrogue.gui.GuiTop()
+guiTop.addTree(client.root)
+
+# Run gui
+appTop.exec_()
+

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -43,7 +43,7 @@ class GuiTop(QWidget):
     newRoot = pyqtSignal(pyrogue.Root)
     newVirt = pyqtSignal(pyrogue.VirtualNode)
 
-    def __init__(self,*, group,parent=None):
+    def __init__(self,*, group="Servers", parent=None):
         super(GuiTop,self).__init__(parent)
 
         vb = QVBoxLayout()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 #-----------------------------------------------------------------------------
-# Title      : PyRogue AXI-Lite Version Module
+# Title      : PyRogue AXI-Lite Version Module Test
 #-----------------------------------------------------------------------------
-# File       : AxiVersion.py
+# File       : test_device.py
 # Created    : 2017-04-12
 #-----------------------------------------------------------------------------
 # Description:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Server only test script
+#-----------------------------------------------------------------------------
+# File       : test_server.py
+# Created    : 2018-02-28
+#-----------------------------------------------------------------------------
+# This file is part of the rogue_example software. It is subject to 
+# the license terms in the LICENSE.txt file found in the top-level directory 
+# of this distribution and at: 
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+# No part of the rogue_example software, including this file, may be 
+# copied, modified, propagated, or distributed except according to the terms 
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import pyrogue
+import pyrogue.interfaces.simulation
+import rogue.interfaces.stream
+import test_device
+import time
+import rogue
+
+class DummyTree(pyrogue.Root):
+
+    def __init__(self):
+
+        pyrogue.Root.__init__(self,name='dummyTree',description="Dummy tree for example")
+
+        # Use a memory space emulator
+        sim = pyrogue.interfaces.simulation.MemEmulate()
+        
+        # Add Device
+        self.add(test_device.AxiVersion(memBase=sim,offset=0x0))
+
+        # Start the tree with pyrogue server, internal nameserver, default interface
+        # Set pyroHost to the address of a network interface to specify which nework to run on
+        # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
+        self.start(timeout=2.0, pollEn=True, zmqPort=9099)
+
+if __name__ == "__main__":
+
+    with DummyTree() as dummyTree:
+
+        print("Running in python main")
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            exit()
+


### PR DESCRIPTION
A gui client can now be started with:

python -m pyrogue.gui

or

python -m pyrogue.gui --host=somehost --port=9099

Also fixes some bugs in the virtual client and adds server test scripts.