### PR TITLE
Assert notify_all while holding conditional lock

### DIFF
--- a/include/rogue/Queue.h
+++ b/include/rogue/Queue.h
@@ -48,7 +48,6 @@ namespace rogue {
           void stop() { 
              std::unique_lock<std::mutex> lock(mtx_);
              run_ = false;
-             lock.unlock();
              pushCond_.notify_all();
              popCond_.notify_all();
           }
@@ -65,7 +64,6 @@ namespace rogue {
 
              if ( run_ ) queue_.push(data);
              busy_ = ( thold_ > 0 && queue_.size() > thold_ );
-             lock.unlock();
              popCond_.notify_all();
           }
 
@@ -86,7 +84,6 @@ namespace rogue {
              std::unique_lock<std::mutex> lock(mtx_);
              while(!queue_.empty()) queue_.pop();
              busy_ = false;
-             lock.unlock();
              pushCond_.notify_all();
           }
 
@@ -99,7 +96,6 @@ namespace rogue {
                 queue_.pop();
              }
              busy_ = ( thold_ > 0 && queue_.size() > thold_ );
-             lock.unlock();
              pushCond_.notify_all();
              return(ret);
           }

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -215,7 +215,6 @@ void ruf::LegacyStreamReader::runThread() {
    if ( fd_ >= 0 ) ::close(fd_);
    fd_ = -1;
    active_ = false;
-   lock.unlock();
    cond_.notify_all();
 }
 

--- a/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
@@ -135,7 +135,6 @@ void ruf::LegacyStreamWriter::writeFile ( uint8_t channel, std::shared_ptr<rogue
      
      // Update counters
      frameCount_ ++;
-     lock.unlock();
      cond_.notify_all();
    }
 }

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -222,7 +222,6 @@ void ruf::StreamReader::runThread() {
    if ( fd_ >= 0 ) ::close(fd_);
    fd_ = -1;
    active_ = false;
-   lock.unlock();
    cond_.notify_all();
 }
 

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -254,7 +254,6 @@ void ruf::StreamWriter::writeFile ( uint8_t channel, std::shared_ptr<rogue::inte
 
       // Update counters
       frameCount_ ++;
-      lock.unlock();
       cond_.notify_all();
    }
 }

--- a/src/rogue/utilities/fileio/StreamWriterChannel.cpp
+++ b/src/rogue/utilities/fileio/StreamWriterChannel.cpp
@@ -81,7 +81,6 @@ void ruf::StreamWriterChannel::acceptFrame ( ris::FramePtr frame ) {
 
    writer_->writeFile (ichan, frame);
    frameCount_++;
-   lock.unlock();
    cond_.notify_all();
 }
 


### PR DESCRIPTION
There is some evidence that calling notify_all when not holding the conditional lock can result in the notify being missed.