### PR TITLE
Make pickle operation recursive, Use JSON for ZMQ Interface

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
      - epics-base=3.14.12.8
      - zeromq
      - pyyaml
+     - jsonpickle
      - pyzmq
      - parse
      - click

--- a/conda.yml
+++ b/conda.yml
@@ -12,6 +12,7 @@ dependencies:
   - ipython
   - cmake
   - pyyaml
+  - jsonpickle
   - pyzmq
   - parse
   - click

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -12,6 +12,7 @@ dependencies:
   - make
   - cmake
   - pyyaml
+  - jsonpickle
   - pyzmq
   - parse
   - click

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,4 +1,5 @@
 PyYAML
+jsonpickle
 parse
 click
 coverage

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -95,7 +95,7 @@ class EnableVariable(pr.BaseVariable):
             if oldEn != newEn:
                 self.parent.enableChanged(newEn)
 
-        super()._doUpdate()
+        return super()._doUpdate()
 
     def _rootAttached(self,parent,root):
         pr.Node._rootAttached(self,parent,root)

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -155,7 +155,6 @@ class Node(object):
     def __reduce__(self):
         attr = {}
 
-        # Sub-nodes
         attr['name']        = self._name
         attr['class']       = self.__class__.__name__
         attr['bases']       = pr.genBaseList(self.__class__)

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -163,7 +163,7 @@ class Node(object):
         attr['hidden']      = self._hidden
         attr['path']        = self._path
         attr['expand']      = self._expand
-        attr['nodes']       = [k for k,v in self._nodes.items()]
+        attr['nodes']       = self._nodes
         attr['props']       = []
         attr['funcs']       = {}
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -164,9 +164,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         # Call special root level rootAttached
         self._rootAttached()
 
-        # Encode structure
-        self._structure = jsonpickle.encode(self)
-
         # Get full list of Devices and Blocks
         tmpList = []
         for d in self.deviceList:
@@ -210,6 +207,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Start ZMQ server if enabled
         if zmqPort is not None:
+            self._structure = jsonpickle.encode(self)
             self._zmqServer = pr.interfaces.ZmqServer(root=self,addr="*",port=zmqPort)
 
         # Read current state

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -243,9 +243,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def running(self):
         return self._running
 
-    def getNode(self, path):
-        return self._getPath(path)
-
     def addVarListener(self,func):
         """
         Add a variable update listener function.
@@ -318,7 +315,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         return pr.Node.__reduce__(self)
 
     @ft.lru_cache(maxsize=None)
-    def _getPath(self,path):
+    def getNode(self,path):
         obj = self
 
         if '.' in path:
@@ -489,7 +486,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                     self._setDict(value,writeEach,modes)
                 else:
                     try:
-                        self._getPath(key).setDisp(value)
+                        self.getNode(key).setDisp(value)
                     except:
                         self._log.error("Entry {} not found".format(key))
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -187,12 +187,20 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         # Setup logging
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
 
-        # Try to connect to root entity, long timeout
-        self.setTimeout(20000)
-        r = None
-        while r is None:
-            r = self._remoteAttr(None, None)
+        # Get root name as a connection test
+        rn = None
+        while rn is None:
+            rn = self._remoteAttr('__rootname__',None)
 
+        print("Connected to {} at {}:{}".format(rn,addr,port))
+
+        # Try to connect to root entity, long timeout
+        print("Getting structure for {}".format(rn))
+        self.setTimeout(20000)
+        r = self._remoteAttr('__structure__', None)
+        print("Ready to use {}".format(rn))
+
+        # Update tree
         r._virtAttached(r,r,self)
         self._root = r
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -83,8 +83,6 @@ class VirtualNode(pr.Node):
 
         self._path  = attrs['path']
         self._class = attrs['class']
-
-        #self._nodes = odict({k:None for k in attrs['nodes']})
         self._nodes = attrs['nodes']
         self._bases = attrs['bases']
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -21,6 +21,7 @@ import pyrogue as pr
 import zmq
 import rogue.interfaces
 import functools as ft
+import jsonpickle
 
 
 def genBaseList(cls):
@@ -184,10 +185,10 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
-        y = pr.dataToYaml(snd,config=False)
+        y = jsonpickle.encode(snd)
         try:
             resp = self._send(y)
-            ret = pr.yamlToData(resp,config=False)
+            ret = jsonpickle.decode(resp)
         except Exception as msg:
             print("got remote exception: {}".format(msg))
             ret = None
@@ -201,7 +202,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         if not self._ready:
             return
 
-        d = pr.yamlToData(data)
+        d = jsonpickle.decode(data)
 
         for k,val in d.items():
             n = self._root.getNode(k)

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -188,6 +188,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
 
         # Get root name as a connection test
+        self.setTimeout(1000)
         rn = None
         while rn is None:
             rn = self._remoteAttr('__rootname__',None)
@@ -196,16 +197,13 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
         # Try to connect to root entity, long timeout
         print("Getting structure for {}".format(rn))
-        self.setTimeout(20000)
+        self.setTimeout(120000)
         r = self._remoteAttr('__structure__', None)
         print("Ready to use {}".format(rn))
 
         # Update tree
         r._virtAttached(r,r,self)
         self._root = r
-
-        # Update to shorter timeout
-        self.setTimeout(1000)
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -169,19 +169,19 @@ class VirtualClient(rogue.interfaces.ZmqClient):
     def __init__(self, addr="localhost", port=9099):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
         self.setTimeout(20000)
-        self._root = None
         self._varListeners = []
-        self._ready = False
+        self._root = None
 
         # Setup logging
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
 
         # Try to connect to root entity
-        while self._root is None:
-            self._root = self._remoteAttr(None, None)
+        r = None
+        while r is None:
+            r = self._remoteAttr(None, None)
 
-        self._root._virtAttached(self._root,self._root,self)
-        self._ready = True
+        r._virtAttached(r,r,self)
+        self._root = r
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
@@ -199,7 +199,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._varListeners.append(func)
 
     def _doUpdate(self,data):
-        if not self._ready:
+        if self._root is None:
             return
 
         d = jsonpickle.decode(data)

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -69,6 +69,19 @@ def VirtualFactory(data):
         for k in data['props']:
             setattr(self.__class__,k,VirtualProperty(self,k))
 
+        # Add __call__ if command
+        if str(pr.BaseCommand) in data['bases']:
+            setattr(self.__class__,'__call__',self._call)
+        
+        # Add getNode and addVarListener if root
+        if str(pr.Root) in data['bases']:
+            setattr(self.__class__,'getNode',self._getNode)
+            setattr(self.__class__,'addVarListener',self._addVarListener)
+
+        # Add addListener if Variable
+        if str(pr.BaseVariable) in data['bases']:
+            setattr(self.__class__,'addListener',self._addListener)
+
         VirtualNode.__init__(self,data)
 
     newclass = type('Virtual' + data['class'], (VirtualNode,), {"__init__": __init__})
@@ -96,26 +109,26 @@ class VirtualNode(pr.Node):
         # Setup logging
         self._log = pr.logInit(cls=self,name=self.name,path=self._path)
 
-    def __call__(self, *args, **kwargs):
-        return self._client._remoteAttr(self._path, '__call__', *args, **kwargs)
-
     def add(self,node):
-        raise NodeError('add not supported in VirtualNode')
+        raise pr.NodeError('add not supported in VirtualNode')
 
     def find(self, *, recurse=True, typ=None, **kwargs):
-        raise NodeError('find not supported in VirtualNode')
+        raise pr.NodeError('find not supported in VirtualNode')
 
     def callRecursive(self, func, nodeTypes=None, **kwargs):
-        raise NodeError('callRecursive not supported in VirtualNode')
+        raise pr.NodeError('callRecursive not supported in VirtualNode')
 
-    def addListener(self, listener):
+    def _call(self, *args, **kwargs):
+        return self._client._remoteAttr(self._path, '__call__', *args, **kwargs)
+
+    def _addListener(self, listener):
         self._functions.append(listener)
 
-    def addVarListener(self,func):
+    def _addVarListener(self,func):
         self._client._addVarListener(func)
 
     @ft.lru_cache(maxsize=None)
-    def getNode(self,path):
+    def _getNode(self,path):
         obj = self
 
         if '.' in path:
@@ -139,13 +152,13 @@ class VirtualNode(pr.Node):
         return cs in self._bases
 
     def _rootAttached(self,parent,root):
-        raise NodeError('_rootAttached not supported in VirtualNode')
+        raise pr.NodeError('_rootAttached not supported in VirtualNode')
 
     def _getDict(self,modes):
-        raise NodeError('_getDict not supported in VirtualNode')
+        raise pr.NodeError('_getDict not supported in VirtualNode')
 
     def _setDict(self,d,writeEach,modes=['RW']):
-        raise NodeError('_setDict not supported in VirtualNode')
+        raise pr.NodeError('_setDict not supported in VirtualNode')
 
     def _doUpdate(self, val):
         for func in self._functions:

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -167,6 +167,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def __init__(self, addr="localhost", port=9099):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
+        self.setTimeout(20000)
         self._root = None
         self._varListeners = []
         self._ready = False
@@ -183,10 +184,10 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
-        y = pr.dataToYaml(snd) + '\n'
+        y = pr.dataToYaml(snd,config=False)
         try:
             resp = self._send(y)
-            ret = pr.yamlToData(resp)
+            ret = pr.yamlToData(resp,config=False)
         except Exception as msg:
             print("got remote exception: {}".format(msg))
             ret = None

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -142,6 +142,26 @@ class VirtualNode(pr.Node):
         for key,value in self._nodes.items():
             value._virtAttached(self,root,client)
 
+    @ft.lru_cache(maxsize=None)
+    def getNode(self,path):
+        obj = self
+
+        if '.' in path:
+            lst = path.split('.')
+
+            if lst[0] != self.name:
+                return None
+
+            for a in lst[1:]:
+                if not hasattr(obj,'node'):
+                    return None
+                obj = obj.node(a)
+
+        elif path != self.name:
+            return None
+
+        return obj
+
 
 class VirtualClient(rogue.interfaces.ZmqClient):
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -113,6 +113,26 @@ class VirtualNode(pr.Node):
     def addVarListener(self,func):
         self._client._addVarListener(func)
 
+    @ft.lru_cache(maxsize=None)
+    def getNode(self,path):
+        obj = self
+
+        if '.' in path:
+            lst = path.split('.')
+
+            if lst[0] != self.name:
+                return None
+
+            for a in lst[1:]:
+                if not hasattr(obj,'node'):
+                    return None
+                obj = obj.node(a)
+
+        elif path != self.name:
+            return None
+
+        return obj
+
     def _isinstance(self,typ):
         cs = str(typ)
         return cs in self._bases
@@ -141,26 +161,6 @@ class VirtualNode(pr.Node):
 
         for key,value in self._nodes.items():
             value._virtAttached(self,root,client)
-
-    @ft.lru_cache(maxsize=None)
-    def getNode(self,path):
-        obj = self
-
-        if '.' in path:
-            lst = path.split('.')
-
-            if lst[0] != self.name:
-                return None
-
-            for a in lst[1:]:
-                if not hasattr(obj,'node'):
-                    return None
-                obj = obj.node(a)
-
-        elif path != self.name:
-            return None
-
-        return obj
 
 
 class VirtualClient(rogue.interfaces.ZmqClient):

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -168,20 +168,23 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def __init__(self, addr="localhost", port=9099):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
-        self.setTimeout(20000)
         self._varListeners = []
         self._root = None
 
         # Setup logging
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
 
-        # Try to connect to root entity
+        # Try to connect to root entity, long timeout
+        self.setTimeout(20000)
         r = None
         while r is None:
             r = self._remoteAttr(None, None)
 
         r._virtAttached(r,r,self)
         self._root = r
+
+        # Update to shorter timeout
+        self.setTimeout(1000)
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -40,8 +40,12 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             kwargs  = d['kwargs'] if 'kwargs' in d else {}
             rawStr  = d['rawStr'] if 'rawStr' in d else False
 
+            # Special case to get name
+            if path == "__rootname__":
+                return self.encode(self._root.name,rawStr=rawStr)
+
             # Special case to get structure
-            if path is None and attr is None:
+            if path == "__structure__":
                 return self._root._structure
 
             node = self._root.getNode(path)

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -23,7 +23,7 @@ class ZmqServer(rogue.interfaces.ZmqServer):
 
     def _doRequest(self,data):
         try:
-            d = pyrogue.yamlToData(data)
+            d = pyrogue.yamlToData(data,config=False)
 
             path    = d['path']   if 'path'   in d else None
             attr    = d['attr']   if 'attr'   in d else None
@@ -37,16 +37,16 @@ class ZmqServer(rogue.interfaces.ZmqServer):
                 node = self._root.getNode(path)
 
             if attr is None:
-                return pyrogue.dataToYaml(node)
+                return pyrogue.dataToYaml(node,config=False)
             else:
                 nAttr = getattr(node, attr)
 
             if nAttr is None:
-                return pyrogue.dataToYaml(None)
+                return pyrogue.dataToYaml(None,config=False)
             elif callable(nAttr):
-                return pyrogue.dataToYaml(nAttr(*args,**kwargs),rawStr=rawStr)
+                return pyrogue.dataToYaml(nAttr(*args,**kwargs),config=False,rawStr=rawStr)
             else:
-                return pyrogue.dataToYaml(nAttr,rawStr=rawStr)
+                return pyrogue.dataToYaml(nAttr,config=False,rawStr=rawStr)
 
         except Exception as msg:
             print("ZMQ Got Exception: {}".format(msg))

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -49,6 +49,10 @@ class ZmqServer(rogue.interfaces.ZmqServer):
                 return self._root._structure
 
             node = self._root.getNode(path)
+
+            if node is None:
+                return self.encode(None,rawStr=False)
+
             nAttr = getattr(node, attr)
 
             if nAttr is None:

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -38,8 +38,9 @@ void rogue::interfaces::ZmqClient::setup_python() {
 #ifndef NO_PYTHON
 
    bp::class_<rogue::interfaces::ZmqClientWrap, rogue::interfaces::ZmqClientWrapPtr, boost::noncopyable>("ZmqClient",bp::init<std::string, uint16_t>())
-      .def("_doUpdate", &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
-      .def("_send",     &rogue::interfaces::ZmqClient::send)
+      .def("_doUpdate",  &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
+      .def("_send",      &rogue::interfaces::ZmqClient::send)
+      .def("setTimeout", &rogue::interfaces::ZmqClient::setTimeout)
    ;
 #endif
 }

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -38,9 +38,13 @@ void rogue::interfaces::ZmqClient::setup_python() {
 #ifndef NO_PYTHON
 
    bp::class_<rogue::interfaces::ZmqClientWrap, rogue::interfaces::ZmqClientWrapPtr, boost::noncopyable>("ZmqClient",bp::init<std::string, uint16_t>())
-      .def("_doUpdate",  &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
-      .def("_send",      &rogue::interfaces::ZmqClient::send)
-      .def("setTimeout", &rogue::interfaces::ZmqClient::setTimeout)
+      .def("_doUpdate",    &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
+      .def("_send",        &rogue::interfaces::ZmqClient::send)
+      .def("setTimeout",   &rogue::interfaces::ZmqClient::setTimeout)
+      .def("getDisp",      &rogue::interfaces::ZmqClient::getDisp)
+      .def("setDisp",      &rogue::interfaces::ZmqClient::setDisp)
+      .def("exec",         &rogue::interfaces::ZmqClient::exec)
+      .def("valueDisp",    &rogue::interfaces::ZmqClient::valueDisp)
    ;
 #endif
 }
@@ -177,18 +181,19 @@ void rogue::interfaces::ZmqClient::runThread() {
 }
 
 std::string rogue::interfaces::ZmqClient::sendWrapper(std::string path, std::string attr, std::string arg, bool rawStr) {
-   std::string yaml;
+   std::string snd;
    std::string ret;
 
-   yaml  = "args: !!python/tuple [" + arg + "]\n";
-   yaml += "attr: " + attr + "\n";
-   yaml += "path: " + path + "\n";
-   yaml += "kwargs: {}\n";
+   snd  = "{\"attr\": \"" + attr + "\",";
+   snd += "\"path\": \"" + path + "\",";
 
-   if ( rawStr ) yaml += "rawStr: true\n";
-   else yaml += "rawStr: false\n";
+   if (arg != "") 
+      snd += "\"args\": {\"py/tuple\": [\"" + arg + "\"]},";
 
-   return(send(yaml));
+   if ( rawStr ) snd += "\"rawStr\": true}";
+   else snd += "\"rawStr\": false}";
+
+   return(send(snd));
 }
 
 std::string rogue::interfaces::ZmqClient::getDisp(std::string path) {


### PR DESCRIPTION
This change makes the node pickle operation recursive, allowing the full tree to be picked in a single operation.

Also addresses a bug where some sub-nodes were not being setup properly and causing errors when right clicking "ReadDevice" on the GUI.