### PR TITLE
Remove unnecessary ZMQ timeout setting

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -21,6 +21,7 @@ import threading
 from collections import OrderedDict as odict
 import logging
 import pyrogue as pr
+import pyrogue.interfaces
 import functools as ft
 import time
 import queue

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -60,10 +60,6 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port) {
    temp.append(":");
    temp.append(std::to_string(static_cast<long long>(port)));
 
-   timeout_ = 1000; // 1 second
-   if ( zmq_setsockopt (this->zmqSub_, ZMQ_RCVTIMEO, &timeout_, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("ZmqClient::ZmqClient","Failed to set socket timeout"));
-
    if ( zmq_setsockopt (this->zmqSub_, ZMQ_SUBSCRIBE, "", 0) != 0 )
          throw(rogue::GeneralError("ZmqClient::ZmqClient","Failed to set socket subscribe"));
 
@@ -98,12 +94,14 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port) {
 
 rogue::interfaces::ZmqClient::~ZmqClient() {
    rogue::GilRelease noGil;
-   threadEn_ = false;
-   thread_->join();
+   //threadEn_ = false;
+   //thread_->join();
 
+   threadEn_ = false;
    zmq_close(this->zmqSub_);
    zmq_close(this->zmqReq_);
    zmq_term(this->zmqCtx_);
+   thread_->join();
 }
 
 void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs) {

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -45,7 +45,6 @@ void rogue::interfaces::ZmqServer::setup_python() {
 
 rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
    std::string temp;
-   int32_t opt;
 
    log_ = rogue::Logging::create("ZmqServer");
 
@@ -68,10 +67,6 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
    temp.append(":");
    temp.append(std::to_string(static_cast<long long>(port+1)));
 
-   opt = 1000; // 1 second
-   if ( zmq_setsockopt (this->zmqRep_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("ZmqServer::ZmqServer","Failed to set socket timeout"));
-
    if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) 
       throw(rogue::GeneralError::network("ZmqServer::ZmqServer",addr,port+1));
 
@@ -84,11 +79,10 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
 rogue::interfaces::ZmqServer::~ZmqServer() {
    rogue::GilRelease noGil;
    threadEn_ = false;
-   thread_->join();
-
    zmq_close(this->zmqPub_);
    zmq_close(this->zmqRep_);
    zmq_term(this->zmqCtx_);
+   thread_->join();
 }
 
 void rogue::interfaces::ZmqServer::publish(std::string value) {

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -65,11 +65,6 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
    this->zmqResp_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
    this->zmqReq_  = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
 
-   // Receive timeout
-   opt = 1000; // 1 second
-   if ( zmq_setsockopt (this->zmqResp_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("TcpClient::TcpClient","Failed to set socket timeout"));
-
    // Don't buffer when no connection
    opt = 1;
    if ( zmq_setsockopt (this->zmqReq_, ZMQ_IMMEDIATE, &opt, sizeof(int32_t)) != 0 ) 
@@ -100,11 +95,10 @@ rim::TcpClient::~TcpClient() {
 
 void rim::TcpClient::close() {
    threadEn_ = false;
-   thread_->join();
-
    zmq_close(this->zmqResp_);
    zmq_close(this->zmqReq_);
    zmq_term(this->zmqCtx_);
+   thread_->join();
 }  
 
 //! Post a transaction

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -43,7 +43,6 @@ rim::TcpServerPtr rim::TcpServer::create (std::string addr, uint16_t port) {
 
 //! Creator
 rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
-   int32_t opt;
    std::string logstr;
 
    logstr = "memory.TcpServer.";
@@ -62,11 +61,6 @@ rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
    this->zmqCtx_  = zmq_ctx_new();
    this->zmqResp_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
    this->zmqReq_  = zmq_socket(this->zmqCtx_,ZMQ_PULL);
-
-   // Receive timeout
-   opt = 1000; // 1 second
-   if ( zmq_setsockopt (this->zmqReq_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("TcpServer::TcpServer","Failed to set socket timeout"));
 
    this->respAddr_.append(std::to_string(static_cast<long long>(port+1)));
    this->reqAddr_.append(std::to_string(static_cast<long long>(port)));
@@ -93,11 +87,10 @@ rim::TcpServer::~TcpServer() {
 
 void rim::TcpServer::close() {
    threadEn_ = false;
-   thread_->join();
-
    zmq_close(this->zmqResp_);
    zmq_close(this->zmqReq_);
    zmq_term(this->zmqCtx_);
+   thread_->join();
 }
 
 //! Run thread

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -66,11 +66,6 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
    this->zmqPull_ = zmq_socket(this->zmqCtx_,ZMQ_PULL);
    this->zmqPush_ = zmq_socket(this->zmqCtx_,ZMQ_PUSH);
 
-   // Receive timeout
-   opt = 1000; // 1 second
-   if ( zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("TcpCore::TcpCore","Failed to set socket timeout"));
-
    // Don't buffer when no connection
    opt = 1;
    if ( zmq_setsockopt (this->zmqPush_, ZMQ_IMMEDIATE, &opt, sizeof(int32_t)) != 0 ) 
@@ -120,11 +115,10 @@ ris::TcpCore::~TcpCore() {
 
 void ris::TcpCore::close() {
    threadEn_ = false;
-   thread_->join();
-
    zmq_close(this->zmqPull_);
    zmq_close(this->zmqPush_);
    zmq_term(this->zmqCtx_);
+   thread_->join();
 }
 
 //! Accept a frame from master

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -26,7 +26,7 @@ class LocalRoot(pyrogue.Root):
         pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
         my_device=myDevice()
         self.add(my_device)
-        self.start()
+        self.start(zmqPort=None)
 
 class LocalRootWithEpics(LocalRoot):
     def __init__(self, use_map=False):


### PR DESCRIPTION
It is not necessary to have a timeout setting on the zmq sockets serviced by threads. Closing the socket will allow the thread to exit.