### PR TITLE
Allow user to specify typeStr for LocalVariables

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -535,6 +535,7 @@ class DataWriter(Device):
             name='bufferSize',
             mode='RW',
             value=0,
+            typeStr='UInt32',
             localSet=self._setBufferSize,
             description='File buffering size. Enables caching of data before call to file system.'))
 
@@ -542,6 +543,7 @@ class DataWriter(Device):
             name='maxFileSize',
             mode='RW',
             value=0,
+            typeStr='UInt64',
             localSet=self._setMaxFileSize,
             description='Maximum size for an individual file. Setting to a non zero splits the run data into multiple files.'))
 
@@ -549,6 +551,7 @@ class DataWriter(Device):
             name='fileSize',
             mode='RO',
             value=0,
+            typeStr='UInt64',
             pollInterval=1,
             localGet=self._getFileSize,
             description='Size of data files(s) for current open session in bytes.'))
@@ -557,6 +560,7 @@ class DataWriter(Device):
             name='frameCount',
             mode='RO',
             value=0,
+            typeStr='UInt32',
             pollInterval=1,
             localGet=self._getFrameCount,
             description='Frame in data file(s) for current open session in bytes.'))
@@ -640,6 +644,7 @@ class RunControl(Device):
         self.add(pr.LocalVariable(
             name='runCount',
             value=0,
+            typeStr='UInt32',
             mode='RO',
             pollInterval=1,
             description='Run Counter updated by run thread.'))

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -49,6 +49,7 @@ class BaseVariable(pr.Node):
                  hidden=False,
                  minimum=None,
                  maximum=None,
+                 typeStr='Unknown',
                  pollInterval=0
                 ):
 
@@ -82,13 +83,11 @@ class BaseVariable(pr.Node):
             self._disp = 'enum'
 
         # Determine typeStr from value type
-        if value is not None:
+        if typeStr == 'Unknown' and value is not None:
             if isinstance(value, list):
                 self._typeStr = f'List[{value[0].__class__.__name__}]'
             else:
                 self._typeStr = value.__class__.__name__
-        else:
-            self._typeStr = 'Unknown'
 
         # Create inverted enum
         self._revEnum = None
@@ -492,6 +491,7 @@ class LocalVariable(BaseVariable):
                  maximum=None,
                  localSet=None,
                  localGet=None,
+                 typeStr='Unknown',
                  pollInterval=0):
 
         if value is None and localGet is None:
@@ -582,7 +582,6 @@ class LinkVariable(BaseVariable):
             self._linkedGet = linkedGet if linkedGet else variable.value
             self._linkedSet = linkedSet if linkedSet else variable.set
 
-            
             # Search the kwargs for overridden properties, otherwise the properties from the linked variable will be used
             args = ['disp', 'enum', 'units', 'minimum', 'maximum']
             for arg in args:
@@ -590,10 +589,7 @@ class LinkVariable(BaseVariable):
                     kwargs[arg] = getattr(variable, arg)
 
         # Call super constructor
-        BaseVariable.__init__(self, name=name, **kwargs)
-
-        # Must be done after super cunstructor to override it
-        self._typeStr = typeStr        
+        BaseVariable.__init__(self, name=name, typeStr=typeStr, **kwargs)
 
         # Dependency tracking
         if variable is not None:

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -66,6 +66,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiOpen',
             mode        = 'RO', 
+            value       = False,
             localGet    = lambda: self._rssi.getOpen(),
             pollInterval= pollInterval, 
         ))
@@ -73,6 +74,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiDownCount',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getDownCount(),
             pollInterval= pollInterval, 
         )) 
@@ -80,6 +83,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiDropCount',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getDropCount(),
             pollInterval= pollInterval, 
         ))  
@@ -87,6 +92,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'rssiRetranCount',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getRetranCount(),
             pollInterval= pollInterval, 
         ))  
@@ -94,6 +101,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locBusy',
             mode        = 'RO', 
+            value       = False,
             localGet    = lambda: self._rssi.getLocBusy(),
             hidden      = True,
             pollInterval= pollInterval, 
@@ -102,6 +110,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locBusyCnt',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getLocBusyCnt(),
             pollInterval= pollInterval, 
         ))         
@@ -109,6 +119,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'remBusy',
             mode        = 'RO', 
+            value       = False,
             localGet    = lambda: self._rssi.getRemBusy(),
             hidden      = True,
             pollInterval= pollInterval, 
@@ -117,6 +128,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'remBusyCnt',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getRemBusyCnt(),
             pollInterval= pollInterval, 
         ))                 
@@ -124,6 +137,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locTryPeriod',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getLocTryPeriod(),
             localSet    = lambda value: self._rssi.setLocTryPeriod(value)
         ))                 
@@ -131,6 +146,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxBuffers',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxBuffers(),
             localSet    = lambda value: self._rssi.setLocMaxBuffers(value)
         ))                 
@@ -138,6 +155,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxSegment',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocMaxSegment(),
             localSet    = lambda value: self._rssi.setLocMaxSegment(value)
         ))                 
@@ -145,6 +164,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locCumAckTout',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocCumAckTout(),
             localSet    = lambda value: self._rssi.setLocCumAckTout(value)
         ))                 
@@ -152,6 +173,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locRetranTout',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocRetranTout(),
             localSet    = lambda value: self._rssi.setLocRetranTout(value)
         ))                 
@@ -159,6 +182,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locNullTout',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocNullTout(),
             localSet    = lambda value: self._rssi.setLocNullTout(value)
         ))                 
@@ -166,6 +191,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxRetran',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxRetran(),
             localSet    = lambda value: self._rssi.setLocMaxRetran(value)
         ))                 
@@ -173,6 +200,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxCumAck',
             mode        = 'RW', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxCumAck(),
             localSet    = lambda value: self._rssi.setLocMaxCumAck(value)
         ))                 
@@ -180,6 +209,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curMaxBuffers',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.curMaxBuffers(),
             pollInterval= pollInterval 
         ))                 
@@ -187,6 +218,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curMaxSegment',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.curMaxSegment(),
             pollInterval= pollInterval 
         ))                 
@@ -194,6 +227,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curCumAckTout',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.curCumAckTout(),
             pollInterval= pollInterval 
         ))                 
@@ -201,6 +236,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curRetranTout',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.curRetranTout(),
             pollInterval= pollInterval 
         ))                 
@@ -208,6 +245,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curNullTout',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.curNullTout(),
             pollInterval= pollInterval 
         ))                 
@@ -215,6 +254,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curMaxRetran',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.curMaxRetran(),
             pollInterval= pollInterval 
         ))                 
@@ -222,6 +263,8 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'curMaxCumAck',
             mode        = 'RO', 
+            value       = 0,
+            typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.curMaxCumAck(),
             pollInterval= pollInterval 
         ))                 
@@ -242,4 +285,3 @@ class UdpRssiPack(pr.Device):
     def _stop(self):
         self._rssi.stop()
         self.rssiOpen.get()
-

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -36,23 +36,23 @@ class PrbsRx(pyrogue.Device):
             self._prbs.setTaps(taps)
 
         self.add(pyrogue.LocalVariable(name='rxErrors', description='RX Error Count',
-                                       mode='RO', pollInterval=1, value=0,
+                                       mode='RO', pollInterval=1, value=0, typeStr='UInt32',
                                        localGet=self._prbs.getRxErrors))
 
         self.add(pyrogue.LocalVariable(name='rxCount', description='RX Count',
-                                       mode='RO', pollInterval=1, value=0,
+                                       mode='RO', pollInterval=1, value=0, typeStr='UInt32',
                                        localGet=self._prbs.getRxCount))
 
         self.add(pyrogue.LocalVariable(name='rxBytes', description='RX Bytes',
-                                       mode='RO', pollInterval=1, value=0,
+                                       mode='RO', pollInterval=1, value=0, typeStr='UInt32',
                                        localGet=self._prbs.getRxBytes))
 
         self.add(pyrogue.LocalVariable(name='rxRate', description='RX Rate', disp="{:.3e}",
-                                       mode='RO', pollInterval=1, value=0, units='Frames/s',
+                                       mode='RO', pollInterval=1, value=0.0, units='Frames/s',
                                        localGet=self._prbs.getRxRate))
 
         self.add(pyrogue.LocalVariable(name='rxBw', description='RX BW', disp="{:.3e}",
-                                       mode='RO', pollInterval=1, value=0, units='Bytes/s',
+                                       mode='RO', pollInterval=1, value=0.0, units='Bytes/s',
                                        localGet=self._prbs.getRxBw))
 
         self.add(pyrogue.LocalVariable(name='checkPayload', description='Payload Check Enable',
@@ -90,7 +90,7 @@ class PrbsTx(pyrogue.Device):
         self._prbs.sendCount(sendCount)
 
         self.add(pyrogue.LocalVariable(name='txSize', description='PRBS Frame Size', 
-                                       localSet=self._txSize, mode='RW', value=0))
+                                       localSet=self._txSize, mode='RW', value=0, typeStr='UInt32'))
 
         self.add(pyrogue.LocalVariable(name='txEnable', description='PRBS Run Enable', mode='RW',
                                        value=False, localSet=self._txEnable))
@@ -99,23 +99,23 @@ class PrbsTx(pyrogue.Device):
                                       function=self._genFrame))
 
         self.add(pyrogue.LocalVariable(name='txErrors', description='TX Error Count', mode='RO', pollInterval = 1,
-                                       value=0, localGet=self._prbs.getTxErrors))
+                                       value=0, typeStr='UInt32', localGet=self._prbs.getTxErrors))
 
         self.add(pyrogue.LocalVariable(name='txCount', description='TX Count', mode='RO', pollInterval = 1,
-                                       value=0, localGet=self._prbs.getTxCount))
+                                       value=0, typeStr='UInt32', localGet=self._prbs.getTxCount))
 
         self.add(pyrogue.LocalVariable(name='txBytes', description='TX Bytes', mode='RO', pollInterval = 1,
-                                       value=0, localGet=self._prbs.getTxBytes))
+                                       value=0, typeStr='UInt32', localGet=self._prbs.getTxBytes))
 
         self.add(pyrogue.LocalVariable(name='genPayload', description='Payload Generate Enable',
                                        mode='RW', value=True, localSet=self._plEnable))
 
         self.add(pyrogue.LocalVariable(name='txRate', description='TX Rate',  disp="{:.3e}",
-                                       mode='RO', pollInterval=1, value=0, units='Frames/s',
+                                       mode='RO', pollInterval=1, value=0.0, units='Frames/s',
                                        localGet=self._prbs.getTxRate))
 
         self.add(pyrogue.LocalVariable(name='txBw', description='TX BW',  disp="{:.3e}",
-                                       mode='RO', pollInterval=1, value=0, units='Bytes/s',
+                                       mode='RO', pollInterval=1, value=0.0, units='Bytes/s',
                                        localGet=self._prbs.getTxBw))
 
     def _plEnable(self,value,changed):


### PR DESCRIPTION
This is required to properly map variable type to external clients.