### PR TITLE
Handle File Write Errors With Log Error Instead Of Exception

### DIFF
--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -39,6 +39,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <stdint.h>
 #include <boost/thread.hpp>
+#include <rogue/Logging.h>
 #include <map>
 
 namespace rogue {

--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -52,6 +52,10 @@ namespace rogue {
             friend class StreamWriterChannel;
             
             protected:
+
+               // Log
+               boost::shared_ptr<rogue::Logging> log_;
+
                //! File descriptor
                int32_t fd_;
 

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -89,7 +89,7 @@ ruf::StreamWriter::StreamWriter() {
    currBuffer_ = 0;
    dropErrors_ = false;
 
-   this->log_ = rogue::Logging::create("fileio.StreamWriter");
+   log_ = rogue::Logging::create("fileio.StreamWriter");
 }
 
 //! Deconstructor
@@ -249,7 +249,7 @@ void ruf::StreamWriter::intWrite(void *data, uint32_t size) {
       if (write(fd_,data,size) != (int32_t)size) {
          ::close(fd_);
          fd_ = -1;
-         this->log_->error("Write failed, closing file!");
+         log_->error("Write failed, closing file!");
          return;
       }
       currSize_ += size;
@@ -298,7 +298,7 @@ void ruf::StreamWriter::flush() {
       if ( write(fd_,buffer_,currBuffer_) != (int32_t)currBuffer_ ) {
          ::close(fd_);
          fd_ = -1;
-         this->log_->error("Write failed, closing file!");
+         log_->error("Write failed, closing file!");
          currBuffer_ = 0;
          return;
       }

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -88,6 +88,8 @@ ruf::StreamWriter::StreamWriter() {
    frameCount_ = 0;
    currBuffer_ = 0;
    dropErrors_ = false;
+
+   this->log_ = rogue::Logging::create("fileio.StreamWriter");
 }
 
 //! Deconstructor
@@ -244,8 +246,12 @@ void ruf::StreamWriter::intWrite(void *data, uint32_t size) {
    // Attempted write is larger than buffer, raw write
    // This is called if bufer is disabled
    if ( size > buffSize_ ) {
-      if (write(fd_,data,size) != (int32_t)size) 
-         throw(rogue::GeneralError("StreamWriter::intWrite","Write failed"));
+      if (write(fd_,data,size) != (int32_t)size) {
+         ::close(fd_);
+         fd_ = -1;
+         this->log_->error("Write failed, closing file!");
+         return;
+      }
       currSize_ += size;
       totSize_  += size;
    }
@@ -289,8 +295,13 @@ void ruf::StreamWriter::checkSize(uint32_t size) {
 //! Flush file
 void ruf::StreamWriter::flush() {
    if ( currBuffer_ > 0 ) {
-      if ( write(fd_,buffer_,currBuffer_) != (int32_t)currBuffer_ )
-         throw(rogue::GeneralError("StreamWriter::flush","Write failed"));
+      if ( write(fd_,buffer_,currBuffer_) != (int32_t)currBuffer_ ) {
+         ::close(fd_);
+         fd_ = -1;
+         this->log_->error("Write failed, closing file!");
+         currBuffer_ = 0;
+         return;
+      }
       currSize_ += currBuffer_;
       totSize_  += currBuffer_;
       currBuffer_ = 0;


### PR DESCRIPTION
Do not allow write errors to crash the application.