### PR TITLE
Add generic data reader class

### DIFF
--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -132,40 +132,45 @@ class FileHeader(object):
 
 class FileReader(object):
 
-    def __init__(self, filename, configChan=None, dtype={}):
+    def __init__(self, filename, configChan=None):
         self._filename   = filename
-
-        # Dtype is a dictionary
-        self._dtype = dtype
-
-        # ConfigChan can be a single channel or list
-        if isinstance(configChan,list):
-            self._configChan = configChane
-        elif configChan is not None:
-            self._configChane = [configChan]
-        else:
-            self._configChane = []
-
-        # Update data types for config
-        for chan in configChan:
-            dtype[chan] = str
+        self._configChan = configChan
 
         # Config tracking dictionary
         self._config = {}
 
-    def _checkConfig(self):
-
-        fh = FileHeader
-
-
-    def config(self):
-        return self._config
+        # Open file and get size
+        self._fdata = open(filename,'rb')
+        self._fdata.seek(0,2)
+        self._size = self._fdata.tell()
+        self._fdata.seek(0,0)
 
     @property
     def next(self):
+        pos = self._fdata.tell()
 
-        
+        while pos != self._fdata._size:
 
+            if (self._size - pos) < 8:
+                raise pyrogue.GeneralException("Header Underrun in {}".format(self._filename))
 
+            head = FileHeader(self._fdata)
+            pos = self._fdata.tell()
 
+            if pos + (head.size-4)  > self._size:
+                raise pyrogue.GeneralException("Data Underrun in {}".format(self._filename))
+
+            data = numpy.fromfile(self._fdata,dtype=numpy.uint8,h.size-4)
+            pos = self._fdata.tell()
+       
+            if h.channel == self._configChan:
+                cfg = pyrogue.yamlToData(data.decode('utf-8'))
+                self._config.update(cfg)
+            else:
+                return head, data
+
+        return None, None
+
+    def config(self):
+        return self._config
 

--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -21,6 +21,7 @@
 import rogue.utilities
 import rogue.utilities.fileio
 import pyrogue
+import numpy
 
 class StreamWriter(pyrogue.DataWriter):
     """Stream Writer Wrapper"""
@@ -103,4 +104,68 @@ class StreamReader(pyrogue.Device):
 
     def _getStreamMaster(self):
         return self._reader
+
+
+class FileHeader(object):
+    def __init__(self, fdata):
+        self._size    = numpy.fromfile(fdata,dtype=numpy.uint32,1)
+        self._flags   = numpy.fromfile(fdata,dtype=numpy.uint16,1)
+        self._error   = numpy.fromfile(fdata,dtype=numpy.uint8,1)
+        self._channel = numpy.fromfile(fdata,dtype=numpy.uint8,1)
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def flags(self):
+        return self._flags
+
+    @property
+    def error(self):
+        return self._error
+
+    @property
+    def channel(self):
+        return self._channel
+
+
+class FileReader(object):
+
+    def __init__(self, filename, configChan=None, dtype={}):
+        self._filename   = filename
+
+        # Dtype is a dictionary
+        self._dtype = dtype
+
+        # ConfigChan can be a single channel or list
+        if isinstance(configChan,list):
+            self._configChan = configChane
+        elif configChan is not None:
+            self._configChane = [configChan]
+        else:
+            self._configChane = []
+
+        # Update data types for config
+        for chan in configChan:
+            dtype[chan] = str
+
+        # Config tracking dictionary
+        self._config = {}
+
+    def _checkConfig(self):
+
+        fh = FileHeader
+
+
+    def config(self):
+        return self._config
+
+    @property
+    def next(self):
+
+        
+
+
+
 

--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -159,7 +159,7 @@ class FileReader(object):
 
             if fd.channel == self._configChan:
                 try:
-                    self._config.update(pyrogue.yamlToData(fd.data.decode('utf-8')))
+                    pyrogue.dictUpdate(self._config,pyrogue.yamlToData(fd.data.decode('utf-8')))
                 except:
                     raise rogue.GeneralError("filio.FileReader","Failed to read config from {}".format(self._filename))
             else:


### PR DESCRIPTION
Allows for non streaming read of Rogue data files. Two new classes are created:

pyrogue.utilties.fileio.FileReader
pyrogue.utilties.fileio.FileData

FileReader.next reads the next frame from the file returning a structure containing header and data. A config channel can be passed and the configuration will be cached in the FileReader structure for access.

To read a file:

fread = pyrogue.utilities.fileio.Filereader('data.dat',configChan=100)
head = fread.next
np_data = numpy.frombuffer(head.data,numpy.uint32)
