### PR TITLE
Properly handle variables that return None in dataToYaml

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -607,13 +607,10 @@ def dataToYaml(data,varEncode=True):
         else:
             enc = 'tag:yaml.org,2002:str'
 
-        try:
-            ret = dumper.represent_scalar(enc, data.valueDisp)
-        except Exception as e:
-            print("Failed to process: {}".format(data))
-            raise e
-
-        return ret
+        if data.valueDisp is None:
+            return dumper.represent_scalar('tag:yaml.org,2002:null',u'null')
+        else:
+            return dumper.represent_scalar(enc, data.valueDisp)
 
     def _dict_representer(dumper, data):
         return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())


### PR DESCRIPTION
This also moves the exception catches to a place where the error will make more sense.