### PR TITLE
Update toFrame and fromFrame to be buffer boundary aware

### DIFF
--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -236,12 +236,13 @@ namespace rogue {
             uint8_t * ptr = (uint8_t *)src;
             uint32_t  csize;
 
-            while ( size > 0 ) {
+            do {
                csize = (size > iter.remBuffer())?iter.remBuffer():size;
-               iter = std::copy(ptr, ptr+csize, iter);
+               std::memcpy(iter.ptr(), ptr, csize);
                ptr  += csize;
+               iter += csize;
                size -= csize;
-            }
+            } while ( size > 0 && csize > 0 );
          }
 
          //! Inline helper function to copy values from a frame iterator
@@ -252,14 +253,38 @@ namespace rogue {
           * @param dst Pointer to data destination
           */
          inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
-            uint32_t csize;
+            uint8_t * ptr = (uint8_t *)dst;
+            uint32_t  csize;
 
-            while ( size > 0 ) {
+            do {
                csize = (size > iter.remBuffer())?iter.remBuffer():size;
-               dst = std::copy(iter,iter+csize,(uint8_t*)dst);
+               std::memcpy(ptr, iter.ptr(), csize);
+               ptr  += csize;
                iter += csize;
                size -= csize;
-            }
+            } while ( size > 0 && csize > 0 );
+         }
+
+         //! Inline helper function to copy frame data between frames
+         /** This helper function copies data from the source Frame at the iterator 
+          * location into the dest frame at the iterator location. Both iterators are 
+          * updated by tye copy size.
+          * @param srcIter FrameIterator at position to copy the data from
+          * @param size The number of bytes to copy
+          * @param dstIter FrameIterator at position to copy the data to
+          */
+         inline void copyFrame ( rogue::interfaces::stream::FrameIterator & srcIter, uint32_t size, 
+                                 rogue::interfaces::stream::FrameIterator & dstIter ) {
+            uint32_t  csize;
+
+            do {
+               csize = (size  > srcIter.remBuffer())?srcIter.remBuffer():size;
+               csize = (csize > dstIter.remBuffer())?dstIter.remBuffer():csize;
+               std::memcpy(dstIter.ptr(), srcIter.ptr(), csize);
+               srcIter += csize;
+               dstIter += csize;
+               size    -= csize;
+            } while ( size > 0 && csize > 0 );
          }
       }
    }

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -233,7 +233,7 @@ namespace rogue {
           * @param src Pointer to data source
           */
          inline void toFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * src) {
-            (uint8_t *) ptr = reinterpret_cst(<uint8_t>(src);
+            uint8_t * ptr = reinterpret_cast<uint8_t *>(src);
             uint32_t  csize;
 
             do {
@@ -253,7 +253,7 @@ namespace rogue {
           * @param dst Pointer to data destination
           */
          inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
-            (uint8_t *) ptr = reinterpret_cst(<uint8_t>(dst);
+            uint8_t * ptr = reinterpret_cast<uint8_t *>(dst);
             uint32_t  csize;
 
             do {

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -21,6 +21,7 @@
 #define __ROGUE_INTERFACES_STREAM_FRAME_ITERATOR_H__
 #include <stdint.h>
 #include <vector>
+#include <cstring>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -233,7 +233,7 @@ namespace rogue {
           * @param src Pointer to data source
           */
          inline void toFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * src) {
-            uint8_t * ptr = (uint8_t *)src;
+            (uint8_t *) ptr = reinterpret_cst(<uint8_t>(src);
             uint32_t  csize;
 
             do {
@@ -253,7 +253,7 @@ namespace rogue {
           * @param dst Pointer to data destination
           */
          inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
-            uint8_t * ptr = (uint8_t *)dst;
+            (uint8_t *) ptr = reinterpret_cst(<uint8_t>(dst);
             uint32_t  csize;
 
             do {

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -233,7 +233,15 @@ namespace rogue {
           * @param src Pointer to data source
           */
          inline void toFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * src) {
-            iter = std::copy((uint8_t*)src, ((uint8_t*)src)+size, iter);
+            uint8_t * ptr = (uint8_t *)src;
+            uint32_t  csize;
+
+            while ( size > 0 ) {
+               csize = (size > iter.remBuffer())?iter.remBuffer():size;
+               iter = std::copy(ptr, ptr+csize, iter);
+               ptr  += csize;
+               size -= csize;
+            }
          }
 
          //! Inline helper function to copy values from a frame iterator
@@ -244,8 +252,14 @@ namespace rogue {
           * @param dst Pointer to data destination
           */
          inline void fromFrame ( rogue::interfaces::stream::FrameIterator & iter, uint32_t size, void * dst) {
-            std::copy(iter,iter+size,(uint8_t*)dst);
-            iter += size;
+            uint32_t csize;
+
+            while ( size > 0 ) {
+               csize = (size > iter.remBuffer())?iter.remBuffer():size;
+               dst = std::copy(iter,iter+csize,(uint8_t*)dst);
+               iter += csize;
+               size -= csize;
+            }
          }
       }
    }

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -80,12 +80,14 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
 
    while ( (ret == 0) && (count != tran->size()) ) {
       if (tran->type() == rim::Write || tran->type() == rim::Post) {
-         std::copy(it,it+dataSize,ptr);
+
+         // Assume transaction has a contigous memory block
+         std::memcpy(ptr,it,dataSize);
          ret = dmaWriteRegister(fd_,tran->address()+count,data);
       }
       else {
          ret = dmaReadRegister(fd_,tran->address()+count,&data);
-         std::copy(ptr,ptr+dataSize,it);
+         std::memcpy(it,ptr,dataSize);
       }
       count += dataSize;
       it += dataSize;

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -22,6 +22,7 @@
 #include <rogue/GeneralError.h>
 #include <rogue/GilRelease.h>
 #include <memory>
+#include <cstring>
 #include <thread>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -265,7 +265,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
 
       // Aligned
       if ( (srcBit == 0) && (dstBit == 0) && (bytes > 0) ) {
-         memcpy(&(dstData[dstByte]),&(srcData[srcByte]),bytes);
+         std::memcpy(&(dstData[dstByte]),&(srcData[srcByte]),bytes);
          dstByte += bytes;
          srcByte += bytes;
          rem -= (bytes * 8);

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
 #include <string.h>
+#include <cstring>
 #include <memory>
 #include <string.h>
 #include <inttypes.h>

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -103,7 +103,6 @@ void rim::TcpClient::close() {
 
 //! Post a transaction
 void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
-   uint8_t * data;
    uint32_t  x;
    uint32_t  msgCnt;
    zmq_msg_t msg[5];
@@ -112,8 +111,6 @@ void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
    uint32_t  size;
    uint32_t  type;
 
-   rim::Transaction::iterator tIter;
-
    rogue::GilRelease noGil;
    std::lock_guard<std::mutex> block(bridgeMtx_);
    rim::TransactionLockPtr lock = tran->lock();
@@ -121,29 +118,28 @@ void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
    // ID message
    id = tran->id();
    zmq_msg_init_size(&(msg[0]),4);
-   memcpy(zmq_msg_data(&(msg[0])), &id, 4);
+   std::memcpy(zmq_msg_data(&(msg[0])), &id, 4);
 
    // Addr message
    addr = tran->address();
    zmq_msg_init_size(&(msg[1]),8);
-   memcpy(zmq_msg_data(&(msg[1])), &addr, 8);
+   std::memcpy(zmq_msg_data(&(msg[1])), &addr, 8);
 
    // Size message
    size = tran->size();
    zmq_msg_init_size(&(msg[2]),4);
-   memcpy(zmq_msg_data(&(msg[2])), &size, 4);
+   std::memcpy(zmq_msg_data(&(msg[2])), &size, 4);
 
    // Type message
    type = tran->type();
    zmq_msg_init_size(&(msg[3]),4);
-   memcpy(zmq_msg_data(&(msg[3])), &type, 4);
+   std::memcpy(zmq_msg_data(&(msg[3])), &type, 4);
 
    // Write transaction
    if ( type == rim::Write || type == rim::Post ) {
       msgCnt = 5;
       zmq_msg_init_size(&(msg[4]),size);
-      data = (uint8_t *) zmq_msg_data(&(msg[4]));
-      std::copy(tran->begin(), tran->end(), data);
+      std::memcpy(zmq_msg_data(&(msg[4])), tran->begin(), size);
    }
 
    // Read transaction
@@ -167,9 +163,7 @@ void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
 
 //! Run thread
 void rim::TcpClient::runThread() {
-   rim::Transaction::iterator tIter;
    rim::TransactionPtr tran;
-   uint8_t * data;
    bool      err;
    uint64_t  more;
    size_t    moreSize;
@@ -218,11 +212,11 @@ void rim::TcpClient::runThread() {
             }
 
             // Get return fields
-            memcpy(&id,     zmq_msg_data(&(msg[0])), 4);
-            memcpy(&addr,   zmq_msg_data(&(msg[1])), 8);
-            memcpy(&size,   zmq_msg_data(&(msg[2])), 4);
-            memcpy(&type,   zmq_msg_data(&(msg[3])), 4);
-            memcpy(&result, zmq_msg_data(&(msg[5])), 4);
+            std::memcpy(&id,     zmq_msg_data(&(msg[0])), 4);
+            std::memcpy(&addr,   zmq_msg_data(&(msg[1])), 8);
+            std::memcpy(&size,   zmq_msg_data(&(msg[2])), 4);
+            std::memcpy(&type,   zmq_msg_data(&(msg[3])), 4);
+            std::memcpy(&result, zmq_msg_data(&(msg[5])), 4);
 
             // Find Transaction
             if ( (tran = getTransaction(id)) == NULL ) {
@@ -240,7 +234,6 @@ void rim::TcpClient::runThread() {
                for (x=0; x < msgCnt; x++) zmq_msg_close(&(msg[x]));
                continue; // while (1)
             }
-            tIter = tran->begin();
 
             // Double check transaction
             if ( (addr != tran->address()) || (size != tran->size()) || (type != tran->type()) ) {
@@ -258,8 +251,7 @@ void rim::TcpClient::runThread() {
                   for (x=0; x < msgCnt; x++) zmq_msg_close(&(msg[x]));
                   continue; // while (1)
                }
-               data = (uint8_t *)zmq_msg_data(&(msg[4]));
-               std::copy(data,data+size,tIter);
+               std::memcpy(tran->begin(),zmq_msg_data(&(msg[4])), size);
             }
             tran->done(result);
             bridgeLog_->debug("Response for transaction id=%" PRIu32 ", addr=0x%" PRIx64

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -21,6 +21,7 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/GeneralError.h>
 #include <string.h>
+#include <cstring>
 #include <memory>
 #include <string.h>
 #include <inttypes.h>

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -142,10 +142,10 @@ void rim::TcpServer::runThread() {
             }
 
             // Get return fields
-            memcpy(&id,   zmq_msg_data(&(msg[0])), 4);
-            memcpy(&addr, zmq_msg_data(&(msg[1])), 8);
-            memcpy(&size, zmq_msg_data(&(msg[2])), 4);
-            memcpy(&type, zmq_msg_data(&(msg[3])), 4);
+            std::memcpy(&id,   zmq_msg_data(&(msg[0])), 4);
+            std::memcpy(&addr, zmq_msg_data(&(msg[1])), 8);
+            std::memcpy(&size, zmq_msg_data(&(msg[2])), 4);
+            std::memcpy(&type, zmq_msg_data(&(msg[3])), 4);
 
             // Write data is expected
             if ( (type == rim::Write) || (type == rim::Post) ) {
@@ -172,7 +172,7 @@ void rim::TcpServer::runThread() {
 
             // Result message
             zmq_msg_init_size(&(msg[5]),4);
-            memcpy(zmq_msg_data(&(msg[5])),&result, 4);
+            std::memcpy(zmq_msg_data(&(msg[5])),&result, 4);
 
             // Send message
             for (x=0; x < 6; x++) 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -179,7 +179,6 @@ rim::Transaction::iterator rim::Transaction::end() {
 //! Set transaction data from python
 void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
-   uint8_t *  data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
       throw(rogue::GeneralError("Transaction::writePy","Python Buffer Error In Frame"));
@@ -191,15 +190,13 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
       throw(rogue::GeneralError::boundary("Frame::write",offset+count,size_));
    }
 
-   data = (uint8_t *)pyBuf.buf;
-   std::copy(data,data+count,begin()+offset);
+   std::memcpy(begin()+offset, (uint8_t *)puBuf.buf, count);
    PyBuffer_Release(&pyBuf);
 }
 
 //! Get transaction data from python
 void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    Py_buffer  pyBuf;
-   uint8_t *  data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 
       throw(rogue::GeneralError("Transaction::readPy","Python Buffer Error In Frame"));
@@ -211,8 +208,7 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
       throw(rogue::GeneralError::boundary("Frame::readPy",offset+count,size_));
    }
 
-   data = (uint8_t *)pyBuf.buf;
-   std::copy(begin()+offset,begin()+offset+count,data);
+   std::memcpy((uint8_t *)puBuf.buf, begin()+offset, count);
    PyBuffer_Release(&pyBuf);
 }
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -190,7 +190,7 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
       throw(rogue::GeneralError::boundary("Frame::write",offset+count,size_));
    }
 
-   std::memcpy(begin()+offset, (uint8_t *)puBuf.buf, count);
+   std::memcpy(begin()+offset, (uint8_t *)pyBuf.buf, count);
    PyBuffer_Release(&pyBuf);
 }
 
@@ -208,7 +208,7 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
       throw(rogue::GeneralError::boundary("Frame::readPy",offset+count,size_));
    }
 
-   std::memcpy((uint8_t *)puBuf.buf, begin()+offset, count);
+   std::memcpy((uint8_t *)pyBuf.buf, begin()+offset, count);
    PyBuffer_Release(&pyBuf);
 }
 

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -81,7 +81,7 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    ris::Frame::iterator dst;
 
    // FIFO is full, drop frame
-   if ( queue_.busy()  ) return;
+   if ( queue_.busy() ) return;
 
    rogue::GilRelease noGil;
    ris::FrameLockPtr lock = frame->lock();
@@ -116,7 +116,7 @@ void ris::Fifo::runThread() {
    log_->logThreadId();
 
    while(threadEn_) {
-      if ( (frame = queue_.pop()) != NULL ) sendFrame(queue_.pop());
+      if ( (frame = queue_.pop()) != NULL ) sendFrame(frame);
    }
 }
 

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -76,9 +76,8 @@ ris::Fifo::~Fifo() {
 //! Accept a frame from master
 void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    uint32_t       size;
-   ris::BufferPtr buff;
    ris::FramePtr  nFrame;
-   ris::Frame::BufferIterator src;
+   ris::Frame::iterator src;
    ris::Frame::iterator dst;
 
    // FIFO is full, drop frame
@@ -99,12 +98,11 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
       nFrame = reqFrame(size,true);
 
       // Get destination pointer
+      src = frame->beginRead();
       dst = nFrame->beginWrite();
 
-      // Copy the frame, attempt to be effecient by iterating through source buffers
-      for (src=frame->beginBuffer(); src != frame->endBuffer(); ++src) 
-         dst = std::copy((*src)->begin(), (*src)->endPayload(), dst);
-
+      // Copy the frame
+      ris::copyFrame(src, size, dst);
       nFrame->setPayload(size);
    }
 

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -327,7 +327,6 @@ ris::Frame::iterator ris::Frame::endWrite() {
 //! Read up to count bytes from frame, starting from offset. Python version.
 void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    Py_buffer pyBuf;
-   uint8_t * data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_SIMPLE) < 0 ) 
       throw(rogue::GeneralError("Frame::readPy","Python Buffer Error In Frame"));
@@ -341,17 +340,13 @@ void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    }
 
    ris::Frame::iterator beg = this->beginRead() + offset;
-   ris::Frame::iterator end = this->beginRead() + (offset + count);
-
-   data = (uint8_t *)pyBuf.buf;
-   std::copy(beg,end,data);
+   ris::fromFrame(beg, count, (uint8_t *)pyBuf.buf);
    PyBuffer_Release(&pyBuf);
 }
 
 //! Write python buffer to frame, starting at offset. Python Version
 void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
    Py_buffer pyBuf;
-   uint8_t * data;
 
    if ( PyObject_GetBuffer(p.ptr(),&pyBuf,PyBUF_CONTIG) < 0 )
       throw(rogue::GeneralError("Frame::writePy","Python Buffer Error In Frame"));
@@ -365,10 +360,7 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
    }
 
    ris::Frame::iterator beg = this->beginWrite() + offset;
-
-   data = (uint8_t *)pyBuf.buf;
-   std::copy(data,data+count,beg);
-
+   ris::toFrame(beg, count, (uint8_t *)pyBuf.buf); 
    minPayload(offset+count);
    PyBuffer_Release(&pyBuf);
 }

--- a/src/rogue/protocols/batcher/InverterV1.cpp
+++ b/src/rogue/protocols/batcher/InverterV1.cpp
@@ -73,11 +73,11 @@ void rpb::InverterV1::acceptFrame ( ris::FramePtr frame ) {
    if ( (core.headerSize() != core.tailSize()) || (core.count() == 0) ) return;
 
    // Copy first tail to head
-   std::copy(core.beginTail(0), core.endTail(0), core.beginHeader());
+   std::memcpy(core.beginHeader().ptr(), core.beginTail(0).ptr(), core.headerSize());
 
    // Copy remaining tails
    for (x=1; x < core.count(); x++) 
-      std::copy(core.beginTail(x), core.endTail(x), core.beginTail(x-1));
+      std::memcpy(core.beginTail(x-1).ptr(), core.beginTail(x).ptr(), core.headerSize());
 
    // Remove last tail from frame
    frame->adjustPayload(-1 * core.headerSize());

--- a/src/rogue/protocols/batcher/SplitterV1.cpp
+++ b/src/rogue/protocols/batcher/SplitterV1.cpp
@@ -75,8 +75,9 @@ void rpb::SplitterV1::acceptFrame ( ris::FramePtr frame ) {
 
       // Create a new frame
       nFrame = reqFrame(data->size(),true);
-      ris::FrameIterator iter = nFrame->beginWrite();
-      ris::toFrame(iter, data->begin(), data->size());
+      ris::FrameIterator fIter = nFrame->beginWrite();
+      ris::FrameIterator dIter = data->begin();
+      ris::copyFrame(fIter, data->size(), dIter);
       nFrame->setPayload(data->size());
 
       // Set flags

--- a/src/rogue/protocols/batcher/SplitterV1.cpp
+++ b/src/rogue/protocols/batcher/SplitterV1.cpp
@@ -75,7 +75,8 @@ void rpb::SplitterV1::acceptFrame ( ris::FramePtr frame ) {
 
       // Create a new frame
       nFrame = reqFrame(data->size(),true);
-      std::copy(data->begin(), data->end(), nFrame->beginWrite());
+      ris::FrameIterator iter = nFrame->beginWrite();
+      ris::toFrame(iter, data->begin(), data->size());
       nFrame->setPayload(data->size());
 
       // Set flags

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -134,10 +134,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    ris::toFrame(fIter,headerLen,header); 
 
    // Write data
-   if ( doWrite ) {
-      std::copy(tIter,tIter+tran->size(),fIter);
-      fIter += tran->size();
-   }
+   if ( doWrite ) ris::toFrame(fIter, tran->size(), tIter);
 
    // Last field is zero
    tail[0] = 0;
@@ -233,7 +230,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    // Copy data if read
    if ( ! doWrite ) {
       fIter = frame->beginRead() + RxHeadLen;
-      std::copy(fIter,fIter+tran->size(),tIter);
+      ri::fromFrame(tIter, tran->size, tIter);
    }
 
    // Done

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -230,7 +230,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    // Copy data if read
    if ( ! doWrite ) {
       fIter = frame->beginRead() + RxHeadLen;
-      ri::fromFrame(tIter, tran->size, tIter);
+      ris::fromFrame(fIter, tran->size(), tIter);
    }
 
    // Done

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -153,7 +153,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    ris::toFrame(fIter,HeadLen,header);
 
    // Write data
-   if ( doWrite ) std::copy(tIter,tIter+tran->size(),fIter);
+   if ( doWrite ) ris::toFrame(fIter, tran->size(), tIter);
 
    if ( tran->type() == rim::Post ) tran->done(0);
    else addTransaction(tran);
@@ -245,7 +245,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Copy data if read
-   if ( ! doWrite ) std::copy(fIter,fIter+tran->size(),tIter);
+   if ( ! doWrite ) ris::fromFrame(fIter, tran->size(), tIter);
 
    tran->done(0);
 }

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -346,7 +346,7 @@ void ru::Prbs::genFrame (uint32_t size) {
    if ( genPl_ ) {
 
       // Init data
-      memcpy(data,frSeq,byteWidth_);
+      std::memcpy(data,frSeq,byteWidth_);
 
       // Generate payload
       while ( frIter != frEnd ) {
@@ -354,7 +354,7 @@ void ru::Prbs::genFrame (uint32_t size) {
          if ( sendCount_ ) ris::toFrame(frIter,byteWidth_,wCount);
          else {
             flfsr(data);
-            frIter = std::copy(data,data+byteWidth_,frIter);
+            ris::toFrame(frIter, byteWidth_, data);
          }
          ++wCount[0];
       }
@@ -430,7 +430,7 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    if ( checkPl_ ) {
 
       // Init data
-      memcpy(expData,frSeq,byteWidth_);
+      std::memcpy(expData,frSeq,byteWidth_);
       pos = 0;
 
       // Read payload

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -46,6 +46,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <string.h>
+#include <cstring>
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -283,7 +283,7 @@ void ruf::StreamWriter::intWrite(void *data, uint32_t size) {
 
    // Append to buffer if non zero
    else if ( buffSize_ > 0 && size > 0 ) {
-      memcpy(buffer_ + currBuffer_, data, size);
+      std::memcpy(buffer_ + currBuffer_, data, size);
       currBuffer_ += size;
    }
 }

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Data over stream bridge test script
+#-----------------------------------------------------------------------------
+# File       : test_streamBridge.py
+# Created    : 2019-01-30
+#-----------------------------------------------------------------------------
+# This file is part of the rogue_example software. It is subject to 
+# the license terms in the LICENSE.txt file found in the top-level directory 
+# of this distribution and at: 
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+# No part of the rogue_example software, including this file, may be 
+# copied, modified, propagated, or distributed except according to the terms 
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import rogue.interfaces.stream
+import rogue
+import pyrogue
+import time
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+
+FrameCount = 10000
+FrameSize  = 10000
+
+def fifo_path():
+
+    # PRBS
+    prbsTx = rogue.utilities.Prbs()
+    prbsRx = rogue.utilities.Prbs()
+
+    # FIFO
+    fifo = rogue.interfaces.stream.Fifo(0,0,False);
+
+    # Client stream
+    pyrogue.streamConnect(prbsTx,fifo)
+
+    # Server stream
+    pyrogue.streamConnect(fifo,prbsRx)
+
+    print("Generating Frames")
+    for _ in range(FrameCount):
+        prbsTx.genFrame(FrameSize)
+    time.sleep(5)
+
+    if prbsRx.getRxErrors() != 0:
+        raise AssertionError('PRBS Frame errors detected! Errors = {}'.format(prbsRx.getRxErrors()))
+
+    if prbsRx.getRxCount() != FrameCount:
+        raise AssertionError('Frame count error. Got = {} expected = {}'.format(prbsRx.getRxCount(),FrameCount))
+
+    print("Done testing")
+
+def test_fifo_path():
+    fifo_path()
+
+if __name__ == "__main__":
+    test_fifo_path()
+

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -41,7 +41,7 @@ def fifo_path():
     print("Generating Frames")
     for _ in range(FrameCount):
         prbsTx.genFrame(FrameSize)
-    time.sleep(20)
+    time.sleep(30)
 
     if prbsRx.getRxErrors() != 0:
         raise AssertionError('PRBS Frame errors detected! Errors = {}'.format(prbsRx.getRxErrors()))

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -41,7 +41,7 @@ def fifo_path():
     print("Generating Frames")
     for _ in range(FrameCount):
         prbsTx.genFrame(FrameSize)
-    time.sleep(5)
+    time.sleep(20)
 
     if prbsRx.getRxErrors() != 0:
         raise AssertionError('PRBS Frame errors detected! Errors = {}'.format(prbsRx.getRxErrors()))

--- a/tests/test_streamBridge.py
+++ b/tests/test_streamBridge.py
@@ -46,7 +46,7 @@ def data_path():
     print("Generating Frames")
     for _ in range(FrameCount):
         prbsTx.genFrame(FrameSize)
-    time.sleep(5)
+    time.sleep(20)
 
     if prbsRx.getRxCount() != FrameCount:
         raise AssertionError('Frame count error. Got = {} expected = {}'.format(prbsRx.getRxCount(),FrameCount))


### PR DESCRIPTION
This PR eliminates all instances of std::copy and replaces them with std::memcpy. The toFrame and fromFrame methods can now handle bulk data across buffer boundaries. copyFrame has been added as a help function of deal with data copies between frames.