### PR TITLE
Poller Enhancements

### DIFF
--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -104,7 +104,7 @@ class PollQueue(object):
         while True:
             now = datetime.datetime.now()
 
-            if self.empty() or self.paused()
+            if self.empty() or self.paused():
                 # Sleep until woken
                 with self._update:
                     self._update.wait()

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -152,7 +152,6 @@ class PollQueue(object):
                         except Exception as e:
                             self._log.exception(e)
 
-                    print(f'Polled {len(blockEntries)} blocks')
 
     def _expiredEntries(self, time=None):
         """An iterator of all entries that expire by a given time. 


### PR DESCRIPTION
Allows the poller to be started and stopped (actually paused) via a new `PollEn` Variable available in every `Root`.

Under the hood, the PollQueue is now created in every Root, but will be immediately paused depending on the value of `Root.start(pollEn=)`. The `Root.PollEn` variable can then be used to start and stop polling at runtime.

There is also a bug fix in the PollQueue that sets the next readout time for each polled Variable based on the current time. This way the poller wont fall behind and poll constantly to catch up.