### PR TITLE
Pass VariableValue class to update functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
       script:
         # Run tests with coverage
         - cd $TRAVIS_BUILD_DIR
-        - python3 -m pytest --cov
+        - python3 -m pytest -s --cov
 
       after_success:
         # Upload coverage report

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -59,7 +59,7 @@ namespace rogue {
 
                ~Variable ();
 
-               void varUpdated(std::string path, boost::python::object value, boost::python::object disp);
+               void varUpdated(std::string path, boost::python::object value);
 
                // Lock held when called
                void valueGet();

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -254,7 +254,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def addVarListener(self,func):
         """
         Add a variable update listener function.
-        The variable, value and display string will be passed as an arg: func(path,value,disp)
+        The variable and value structure will be passed as args: func(path,varValue)
         """
         with self._varListenLock:
             self._varListeners.append(func)
@@ -553,7 +553,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                         # Call listener functions,
                         with self._varListenLock:
                             for func in self._varListeners:
-                                func(p,val.value.val,valueDisp)
+                                func(p,val)
                     except Exception as e:
                         self._log.exception(e)
                         

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -166,7 +166,7 @@ class BaseVariable(pr.Node):
         """
         Add a listener Variable or function to call when variable changes. 
         This is usefull when chaining variables together. (adc conversions, etc)
-        The variable, value and display string will be passed as an arg: func(path,value,disp)
+        The variable and value class are passed as an arg: func(path,varValue)
         """
         if isinstance(listener, BaseVariable):
             self.__listeners.append(listener)
@@ -344,10 +344,7 @@ class BaseVariable(pr.Node):
         val = VariableValue(self)
 
         for func in self.__functions:
-            if hasattr(func,'varListener'):
-                func.varListener(self.path,val.value,val.valueDisp)
-            else:
-                func(self.path,val.value,val.valueDisp)
+            func(self.path,val)
 
         return val
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -159,10 +159,7 @@ class VirtualNode(pr.Node):
 
     def _doUpdate(self, val):
         for func in self._functions:
-            if hasattr(func,'varListener'):
-                func.varListener(self.path,val.value,val.valueDisp)
-            else:
-                func(self.path,val.value,val.valueDisp)
+            func(self.path,val)
 
     def _virtAttached(self,parent,root,client):
         """Called once the root node is attached."""
@@ -232,7 +229,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
             # Call listener functions,
             for func in self._varListeners:
-                func(k,val.value.val,valueDisp)
+                func(k,val)
 
     @property
     def root(self):

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -55,7 +55,7 @@ class DataLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         vb.addLayout(fl)
 
-        self.writer.dataFile.addListener(self)
+        self.writer.dataFile.addListener(self.varListener)
         self.dataFile = QLineEdit()
         self.dataFile.setText(self.writer.dataFile.valueDisp())
         self.dataFile.textEdited.connect(self.dataFileEdited)
@@ -74,7 +74,7 @@ class DataLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.writer.open.addListener(self)
+        self.writer.open.addListener(self.varListener)
         self.openState = QComboBox()
         self.openState.addItem('False')
         self.openState.addItem('True')
@@ -85,7 +85,7 @@ class DataLink(QObject):
 
         fl.addRow('File Open:',self.openState)
 
-        self.writer.bufferSize.addListener(self)
+        self.writer.bufferSize.addListener(self.varListener)
         self.bufferSize = QLineEdit()
         self.bufferSize.setText(self.writer.bufferSize.valueDisp())
         self.bufferSize.textEdited.connect(self.bufferSizeEdited)
@@ -95,7 +95,7 @@ class DataLink(QObject):
 
         fl.addRow('Buffer Size:',self.bufferSize)
 
-        self.writer.fileSize.addListener(self)
+        self.writer.fileSize.addListener(self.varListener)
         self.totSize = QLineEdit()
         self.totSize.setText(self.writer.fileSize.valueDisp())
         self.totSize.setReadOnly(True)
@@ -117,7 +117,7 @@ class DataLink(QObject):
         pb2.clicked.connect(self._genName)
         fl.addRow(pb1,pb2)
 
-        self.writer.maxFileSize.addListener(self)
+        self.writer.maxFileSize.addListener(self.varListener)
         self.maxSize = QLineEdit()
         self.maxSize.setText(self.writer.maxFileSize.valueDisp())
         self.maxSize.textEdited.connect(self.maxSizeEdited)
@@ -127,7 +127,7 @@ class DataLink(QObject):
 
         fl.addRow('Max Size:',self.maxSize)
 
-        self.writer.frameCount.addListener(self)
+        self.writer.frameCount.addListener(self.varListener)
         self.frameCount = QLineEdit()
         self.frameCount.setText(self.writer.frameCount.valueDisp())
         self.frameCount.setReadOnly(True)
@@ -153,28 +153,28 @@ class DataLink(QObject):
         self.writer.autoName()
         pass
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         if self.block: return
 
         name = path.split('.')[-1]
 
         if name == 'dataFile':
-            self.updateDataFile.emit(disp)
+            self.updateDataFile.emit(value.valueDisp)
 
         elif name == 'open':
-            self.updateOpenState.emit(self.openState.findText(disp))
+            self.updateOpenState.emit(self.openState.findText(value.valueDisp))
 
         elif name == 'bufferSize':
-            self.updateBufferSize.emit(disp)
+            self.updateBufferSize.emit(value.valueDisp)
 
         elif name == 'maxFileSize':
-            self.updateMaxSize.emit(disp)
+            self.updateMaxSize.emit(value.valueDisp)
 
         elif name == 'fileSize':
-            self.updateFileSize.emit(disp)
+            self.updateFileSize.emit(value.valueDisp)
 
         elif name == 'frameCount':
-            self.updateFrameCount.emit(disp)
+            self.updateFrameCount.emit(value.valueDisp)
 
     @pyqtSlot()
     def dataFileEdited(self):
@@ -254,7 +254,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         vb.addLayout(fl)
 
-        self.control.runRate.addListener(self)
+        self.control.runRate.addListener(self.varListener)
         self.runRate = QComboBox()
         self.runRate.activated.connect(self.runRateChanged)
         self.updateRate.connect(self.runRate.setCurrentIndex)
@@ -273,7 +273,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.control.runState.addListener(self)
+        self.control.runState.addListener(self.varListener)
         self.runState = QComboBox()
         self.runState.activated.connect(self.runStateChanged)
         self.updateState.connect(self.runState.setCurrentIndex)
@@ -289,7 +289,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.control.runCount.addListener(self)
+        self.control.runCount.addListener(self.varListener)
         self.runCount = QLineEdit()
         self.runCount.setText(self.control.runCount.valueDisp())
         self.runCount.setReadOnly(True)
@@ -297,19 +297,19 @@ class ControlLink(QObject):
 
         fl.addRow('Run Count:',self.runCount)
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         if self.block: return
 
         name = path.split('.')[-1]
 
         if name == 'runState':
-            self.updateState.emit(self.runState.findText(disp))
+            self.updateState.emit(self.runState.findText(value.valueDisp))
 
         elif name == 'runRate':
-            self.updateRate.emit(self.runRate.findText(disp))
+            self.updateRate.emit(self.runRate.findText(value.valueDisp))
 
         elif name == 'runCount':
-            self.updateCount.emit(disp)
+            self.updateCount.emit(value.valueDisp)
 
     @pyqtSlot(int)
     def runStateChanged(self,value):
@@ -401,7 +401,7 @@ class SystemWidget(QWidget):
         self.systemLog.setReadOnly(True)
         vb.addWidget(self.systemLog)
 
-        root.SystemLog.addListener(self)
+        root.SystemLog.addListener(self.varListener)
         self.updateLog.connect(self.systemLog.setText)
         self.systemLog.setText(root.SystemLog.valueDisp())
         
@@ -415,11 +415,11 @@ class SystemWidget(QWidget):
     def resetLog(self):
         self.root.ClearLog()
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         name = path.split('.')[-1]
 
         if name == 'SystemLog':
-            self.updateLog.emit(disp)
+            self.updateLog.emit(value.valueDisp)
 
     @pyqtSlot()
     def hardReset(self):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -128,9 +128,9 @@ class VariableLink(QObject):
             self._widget.setReadOnly(True)
 
         self._tree.setItemWidget(self._item,3,self._widget)
-        self.varListener(None,self._variable.value(),self._variable.valueDisp())
+        self.varListener(None,pyrogue.VariableValue(self._variable))
 
-        variable.addListener(self)
+        variable.addListener(self.varListener)
 
     def openMenu(self, event):
         menu = QMenu()
@@ -167,7 +167,7 @@ class VariableLink(QObject):
             else:
                 self._variable.setDisp(self._widget.text())
 
-    def varListener(self, path, value, disp):
+    def varListener(self, path, value):
         with self._lock:
             if self._widget is None or self._inEdit is True:
                 return
@@ -175,18 +175,18 @@ class VariableLink(QObject):
             self._swSet = True
 
             if isinstance(self._widget, QComboBox):
-                i = self._widget.findText(disp)
+                i = self._widget.findText(value.valueDisp)
 
                 if i < 0: i = 0
 
                 if self._widget.currentIndex() != i:
                     self.updateGui.emit(i)
             elif isinstance(self._widget, QSpinBox):
-                if self._widget.value != value:
+                if self._widget.value != value.value:
                     self.updateGui.emit(value)
             else:
-                if self._widget.text() != disp:
-                    self.updateGui[str].emit(disp)
+                if self._widget.text() != value.valueDisp:
+                    self.updateGui[str].emit(value.valueDisp)
 
             self._swSet = False
 

--- a/python/pyrogue/interfaces/mysql.py
+++ b/python/pyrogue/interfaces/mysql.py
@@ -193,7 +193,7 @@ class MysqlGw(object):
         self._varSer[variable.path] = 0
         variable.addListener(self._updateVariables)
 
-    def _updateVariables (self, path, value, disp):
+    def _updateVariables (self, path, val):
         with self._dbLock:
             if self._db is None:
                 #self._log.error("Not connected to Mysql server " + self._host)
@@ -201,8 +201,8 @@ class MysqlGw(object):
 
             try:
                 cursor = self._db.cursor(MySQLdb.cursors.DictCursor)
-                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(disp))
-                sql += "server_ser = (server_ser + 1) where name='{}'".format(path)
+                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(val.valueDisp))
+                sql += "server_ser = (server_ser + 1) where name='{}'".format(val.path)
                 cursor.execute(sql)
                 self._db.commit()
             except:

--- a/python/pyrogue/interfaces/mysql.py
+++ b/python/pyrogue/interfaces/mysql.py
@@ -202,7 +202,7 @@ class MysqlGw(object):
             try:
                 cursor = self._db.cursor(MySQLdb.cursors.DictCursor)
                 sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(val.valueDisp))
-                sql += "server_ser = (server_ser + 1) where name='{}'".format(val.path)
+                sql += "server_ser = (server_ser + 1) where name='{}'".format(path)
                 cursor.execute(sql)
                 self._db.commit()
             except:

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -112,14 +112,19 @@ rpe::Variable::~Variable() { }
 
 void rpe::Variable::varUpdated(std::string path, bp::object value) {
    rogue::GilRelease noGil;
+   bp::object convValue;
 
    log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(value.attr("valueDisp")));
    {
       std::lock_guard<std::mutex> lock(mtx_);
       noGil.acquire();
+  
+      printf("\n\n\nHere1\n\n\n"); 
+      if (  isString_ || epicsType_ == aitEnumEnum16 ) convValue = value.attr("valueDisp");
+      else convValue = value.attr("value");
+      printf("\n\n\nHere2\n\n\n"); 
 
-      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(value.attr("valueDisp"));
-      else fromPython(value.attr("value"));
+      fromPython(convValue);
    }
    noGil.release();
    this->updated();

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -111,6 +111,9 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
 rpe::Variable::~Variable() { }
 
 void rpe::Variable::varUpdated(std::string path, bp::object value) {
+
+   return;
+
    rogue::GilRelease noGil;
    bp::object convValue;
 

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -113,12 +113,12 @@ rpe::Variable::~Variable() { }
 void rpe::Variable::varUpdated(std::string path, bp::object value) {
    rogue::GilRelease noGil;
 
-   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(value.attr("disp")));
+   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(value.attr("valueDisp")));
    {
       std::lock_guard<std::mutex> lock(mtx_);
       noGil.acquire();
 
-      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(value.attr("disp"));
+      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(value.attr("valueDisp"));
       else fromPython(value.attr("value"));
    }
    noGil.release();

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -111,21 +111,16 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
 rpe::Variable::~Variable() { }
 
 void rpe::Variable::varUpdated(std::string path, bp::object value) {
-
-   return;
-
    rogue::GilRelease noGil;
    bp::object convValue;
 
-   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(value.attr("valueDisp")));
+   log_->debug("Variable update for %s", epicsName_.c_str());
    {
       std::lock_guard<std::mutex> lock(mtx_);
       noGil.acquire();
   
-      printf("\n\n\nHere1\n\n\n"); 
       if (  isString_ || epicsType_ == aitEnumEnum16 ) convValue = value.attr("valueDisp");
       else convValue = value.attr("value");
-      printf("\n\n\nHere2\n\n\n"); 
 
       fromPython(convValue);
    }

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -110,16 +110,16 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
 
 rpe::Variable::~Variable() { }
 
-void rpe::Variable::varUpdated(std::string path, bp::object value, bp::object disp) {
+void rpe::Variable::varUpdated(std::string path, bp::object value) {
    rogue::GilRelease noGil;
 
-   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(disp));
+   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(value.attr("disp")));
    {
       std::lock_guard<std::mutex> lock(mtx_);
       noGil.acquire();
 
-      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(disp);
-      else fromPython(value);
+      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(value.attr("disp"));
+      else fromPython(value.attr("value"));
    }
    noGil.release();
    this->updated();


### PR DESCRIPTION
This PR changes the API for the variable update functions. The API changes from:

varUpdated(path, value, disp)

to 

varUpdated(path,varValue)

This will impact any application code which uses these callbacks. This will enable more information, such as alarm state, to be passed as part of the update. This also removes the check for varUpdated as part of the passed class. You must now either pass a variable or the function.