### PR TITLE
Change combo box display

### DIFF
--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -105,7 +105,8 @@ class VariableLink(QObject):
             for i in self._variable.enum:
                 self._widget.addItem(self._variable.enum[i])
 
-        elif self._variable.minimum is not None and self._variable.maximum is not None:
+        elif self._variable.minimum is not None and self._variable.maximum is not None and \
+             self._variable.disp == '{}' and self._variable.mode != 'RO':
             self._widget = QSpinBox();
             self._widget.setMinimum(self._variable.minimum)
             self._widget.setMaximum(self._variable.maximum)


### PR DESCRIPTION
A combo box will only be created in the GUI if both min and max are not None, the variable is not read only and the display value is the default of {}.