### PR TITLE
Fix config load issue

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -391,7 +391,7 @@ class RemoteBlock(BaseBlock, rim.Master):
             srcBit = 0
             for x in range(len(var.bitOffset)):
                 self._copyBits(self._sData, var.bitOffset[x], ba, srcBit, var.bitSize[x])
-                self._setBits( self._sDataMask, var.bitOffset[x], var.bitSize[x])
+                self._setBits(self._sDataMask, var.bitOffset[x], var.bitSize[x])
                 srcBit += var.bitSize[x]
 
     def get(self, var):

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -273,6 +273,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
 
       // Not aligned
       else {
+         dstData[dstByte] &= ((0x1 << dstBit) ^ 0xFF);
          dstData[dstByte] |= ((srcData[srcByte] >> srcBit) & 0x1) << dstBit;
          srcByte += (++srcBit / 8);
          dstByte += (++dstBit / 8);

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -252,7 +252,20 @@ class AxiVersion(pr.Device):
             value = ''))
 
         self.BuildStamp.addListener(parseBuildStamp)        
-       
+      
+        for i in range(128):
+            remap = divmod(i,32)
+
+            self.add(pr.RemoteVariable(
+                name         = 'TestArray[{:d}]'.format(i),
+                description  = 'Array Test Field',
+                offset       = 0x1000 + remap[0]<<2,
+                bitSize      = 1,
+                bitOffset    = remap[1],
+                base         = pr.UInt,
+                mode         = 'RW',
+                hidden       = False,
+            ))
 
     def hardReset(self):
         print('AxiVersion hard reset called')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,8 +20,13 @@ import test_device
 import time
 import rogue
 import pyrogue.protocols.epics
+import logging
 
 #rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+
+#logger = logging.getLogger('pyrogue')
+#logger.setLevel(logging.DEBUG)
 
 class DummyTree(pyrogue.Root):
 


### PR DESCRIPTION
This fixes an issue where a memory block bit is first set to 1 using a configuration file wildcard and then later set to zero. The current code would not clear the bit.