### PR TITLE
Fix config load issue

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -377,7 +377,7 @@ class RemoteBlock(BaseBlock, rim.Master):
             srcBit = 0
             for x in range(len(var.bitOffset)):
                 self._copyBits(self._sData, var.bitOffset[x], ba, srcBit, var.bitSize[x])
-                self._setBits( self._sDataMask, var.bitOffset[x], var.bitSize[x])
+                self._setBits(self._sDataMask, var.bitOffset[x], var.bitSize[x])
                 srcBit += var.bitSize[x]
 
     def get(self, var):

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -273,6 +273,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
 
       // Not aligned
       else {
+         dstData[dstByte] &= ((0x1 << dstBit) ^ 0xFF);
          dstData[dstByte] |= ((srcData[srcByte] >> srcBit) & 0x1) << dstBit;
          srcByte += (++srcBit / 8);
          dstByte += (++dstBit / 8);


### PR DESCRIPTION
This fixes an issue where a memory block bit is first set to 1 using a configuration file wildcard and then later set to zero. The current code would not clear the bit.