### PR TITLE
Remove group from gui

### DIFF
--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -43,8 +43,11 @@ class GuiTop(QWidget):
     newRoot = pyqtSignal(pyrogue.Root)
     newVirt = pyqtSignal(pyrogue.VirtualNode)
 
-    def __init__(self,*, parent=None):
+    def __init__(self,*, parent=None, group=None):
         super(GuiTop,self).__init__(parent)
+
+        if group:
+            print("The GuiTop group attribute is now deprecated. Please remove it.")
 
         vb = QVBoxLayout()
         self.setLayout(vb)

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -43,7 +43,7 @@ class GuiTop(QWidget):
     newRoot = pyqtSignal(pyrogue.Root)
     newVirt = pyqtSignal(pyrogue.VirtualNode)
 
-    def __init__(self,*, group="Servers", parent=None):
+    def __init__(self,*, parent=None):
         super(GuiTop,self).__init__(parent)
 
         vb = QVBoxLayout()
@@ -52,10 +52,10 @@ class GuiTop(QWidget):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        self.var = pyrogue.gui.variables.VariableWidget(group=group,parent=self.tab)
+        self.var = pyrogue.gui.variables.VariableWidget(parent=self.tab)
         self.tab.addTab(self.var,'Variables')
 
-        self.cmd = pyrogue.gui.commands.CommandWidget(group=group,parent=self.tab)
+        self.cmd = pyrogue.gui.commands.CommandWidget(parent=self.tab)
         self.tab.addTab(self.cmd,'Commands')
         self.show()
 

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -46,7 +46,7 @@ class GuiTop(QWidget):
     def __init__(self,*, parent=None, group=None):
         super(GuiTop,self).__init__(parent)
 
-        if group:
+        if group is not None:
             print("The GuiTop group attribute is now deprecated. Please remove it.")
 
         vb = QVBoxLayout()

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -29,7 +29,7 @@ except ImportError:
 import pyrogue
 
 class CommandDev(QObject):
-    def __init__(self,*,tree,parent,dev,noExpand):
+    def __init__(self,*,tree,parent,dev,noExpand,top):
         QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
@@ -38,6 +38,9 @@ class CommandDev(QObject):
 
         self._widget = QTreeWidgetItem(parent)
         self._widget.setText(0,self._dev.name)
+
+        if top:
+            self._parent.addTopLevelItem(self._widget)
 
         if (not noExpand) and self._dev.expand:
             self._dummy = None
@@ -67,7 +70,7 @@ class CommandDev(QObject):
 
         # Then create devices
         for key,val in self._dev.visableDevices.items():
-            self._children.append(CommandDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand))
+            self._children.append(CommandDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand,top=False))
 
         for i in range(0,4):
             self._tree.resizeColumnToContents(i)
@@ -128,11 +131,11 @@ class CommandLink(QObject):
             self._command.call()
 
 class CommandWidget(QWidget):
-    def __init__(self, *, group, parent=None):
+    def __init__(self, *, parent=None):
         super(CommandWidget, self).__init__(parent)
 
         self.roots = []
-        self.commands = []
+        self._children = []
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -141,11 +144,6 @@ class CommandWidget(QWidget):
 
         self.tree.setColumnCount(2)
         self.tree.setHeaderLabels(['Command','Base','Execute','Arg'])
-
-        self.top = QTreeWidgetItem(self.tree)
-        self.top.setText(0,group)
-        self.tree.addTopLevelItem(self.top)
-        self.top.setExpanded(True)
 
         hb = QHBoxLayout()
         vb.addLayout(hb)
@@ -156,5 +154,5 @@ class CommandWidget(QWidget):
     @pyqtSlot(pyrogue.VirtualNode)
     def addTree(self,root):
         self.roots.append(root)
-        self._devTop = CommandDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)
+        self._children.append(CommandDev(tree=self.tree,parent=self.tree,dev=root,noExpand=False,top=True))
 

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -31,7 +31,7 @@ import threading
 
 class VariableDev(QObject):
 
-    def __init__(self,*,tree,parent,dev,noExpand):
+    def __init__(self,*,tree,parent,dev,noExpand,top):
         QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
@@ -40,6 +40,9 @@ class VariableDev(QObject):
 
         self._widget = QTreeWidgetItem(parent)
         self._widget.setText(0,self._dev.name)
+
+        if top:
+            self._parent.addTopLevelItem(self._widget)
 
         if (not noExpand) and self._dev.expand:
             self._dummy = None
@@ -68,7 +71,7 @@ class VariableDev(QObject):
 
         # Then create devices
         for key,val in self._dev.visableDevices.items():
-            self._children.append(VariableDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand))
+            self._children.append(VariableDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand,top=False))
 
         for i in range(0,4):
             self._tree.resizeColumnToContents(i)
@@ -225,10 +228,11 @@ class VariableLink(QObject):
 
 
 class VariableWidget(QWidget):
-    def __init__(self, *, group, parent=None):
+    def __init__(self, *, parent=None):
         super(VariableWidget, self).__init__(parent)
 
         self.roots = []
+        self._children = []
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -237,11 +241,6 @@ class VariableWidget(QWidget):
 
         self.tree.setColumnCount(2)
         self.tree.setHeaderLabels(['Variable','Mode','Base','Value','Units'])
-
-        self.top = QTreeWidgetItem(self.tree)
-        self.top.setText(0,group)
-        self.tree.addTopLevelItem(self.top)
-        self.top.setExpanded(True)
 
         hb = QHBoxLayout()
         vb.addLayout(hb)
@@ -256,7 +255,7 @@ class VariableWidget(QWidget):
     @pyqtSlot(pyrogue.VirtualNode)
     def addTree(self,root):
         self.roots.append(root)
-        self.devTop = VariableDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)
+        self._children.append(VariableDev(tree=self.tree,parent=self.tree,dev=root,noExpand=False,top=True))
 
     @pyqtSlot()
     def readPressed(self):


### PR DESCRIPTION
This removes the concept of a "group" from the gui. Instead the roots are added right at the top level of the tree, removing an unnecessary level of indent.