### PR TITLE
v3.6.1 release candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
       script:
         # Run tests with coverage
         - cd $TRAVIS_BUILD_DIR
-        - python3 -m pytest --cov
+        - python3 -m pytest -s --cov
 
       after_success:
         # Upload coverage report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,24 +138,48 @@ if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
 
    if(APPLE)
 
-      set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
-                            ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                            ${EPICSV3_BASE_DIR}/include/os/Darwin)
+      if(EPICS_PCAS_ROOT)
+         set(EPICSV3_INCLUDES  ${EPICS_PCAS_ROOT}/include
+                               ${EPICSV3_BASE_DIR}/include
+                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                               ${EPICSV3_BASE_DIR}/include/os/Darwin)
 
-      set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.dylib 
-                            ${EPICSV3_LIB_DIR}/libca.dylib 
-                            ${EPICSV3_LIB_DIR}/libCom.dylib 
-                            ${EPICSV3_LIB_DIR}/libgdd.dylib)
+         set(EPICSV3_LIBRARIES ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libcas.dylib 
+                               ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libgdd.dylib
+                               ${EPICSV3_LIB_DIR}/libca.dylib 
+                               ${EPICSV3_LIB_DIR}/libCom.dylib )
+      else()
+         set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
+                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                               ${EPICSV3_BASE_DIR}/include/os/Darwin)
+
+         set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.dylib 
+                               ${EPICSV3_LIB_DIR}/libca.dylib
+                               ${EPICSV3_LIB_DIR}/libCom.dylib
+                               ${EPICSV3_LIB_DIR}/libgdd.dylib )
+      endif()
    else()
 
-      set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
-                            ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                            ${EPICSV3_BASE_DIR}/include/os/Linux)
+      if(EPICS_PCAS_ROOT)
+         set(EPICSV3_INCLUDES  ${EPICS_PCAS_ROOT}/include
+                               ${EPICSV3_BASE_DIR}/include
+                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                               ${EPICSV3_BASE_DIR}/include/os/Linux)
 
-      set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.so 
-                            ${EPICSV3_LIB_DIR}/libca.so 
-                            ${EPICSV3_LIB_DIR}/libCom.so 
-                            ${EPICSV3_LIB_DIR}/libgdd.so )
+         set(EPICSV3_LIBRARIES ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libcas.so 
+                               ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libgdd.so
+                               ${EPICSV3_LIB_DIR}/libca.so 
+                               ${EPICSV3_LIB_DIR}/libCom.so )
+      else()
+         set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
+                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                               ${EPICSV3_BASE_DIR}/include/os/Linux)
+
+         set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.so 
+                               ${EPICSV3_LIB_DIR}/libca.so
+                               ${EPICSV3_LIB_DIR}/libCom.so
+                               ${EPICSV3_LIB_DIR}/libgdd.so )
+      endif()
    endif()
 else()
    set(DO_EPICS_V3 0)
@@ -383,7 +407,10 @@ endif()
 message("")
 
 if (DO_EPICS_V3)
-   message("-- Found EPICS V3: ${EPICSV3_BASE_DIR}")
+   message("-- Found EPICS: ${EPICSV3_BASE_DIR}")
+   if (EPICS_PCAS_ROOT)
+      message("-- EPICS_PCAS_ROOT: ${EPICS_PCAS_ROOT}")
+   endif()
 else()
    message("-- EPICS V3 not included!")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
    if (NOT ZeroMQ_FOUND)
       
       # Convert LD_LIBRARY PATH for search
-      if(ENV{LD_LIBRARY_PATH})
+      if(DEFINED ENV{LD_LIBRARY_PATH})
          string(REPLACE ":" ";" HINT_PATHS $ENV{LD_LIBRARY_PATH})
       else()
          set(HINT_PATHS, "")
@@ -110,10 +110,12 @@ endif()
                  NAMES zmq.h
                  PATHS ${ZMQ_LIBDIR}/../include
                  )
-      endif()
-
-      # Failed to find it
-      if (NOT ZeroMQ_INCLUDE_DIR)
+         if (NOT ZeroMQ_INCLUDE_DIR)
+            message("")
+            message(FATAL_ERROR "Failed to find ZeroMQ_INCLUDE_DIR!")
+         endif()
+      else()
+         # Failed to find it
          message("")
          message(FATAL_ERROR "Failed to find zeroMQ!")
       endif()

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -59,7 +59,7 @@ namespace rogue {
 
                ~Variable ();
 
-               void varUpdated(std::string path, boost::python::object value, boost::python::object disp);
+               void varUpdated(std::string path, boost::python::object value);
 
                // Lock held when called
                void valueGet();

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -391,7 +391,7 @@ class RemoteBlock(BaseBlock, rim.Master):
             srcBit = 0
             for x in range(len(var.bitOffset)):
                 self._copyBits(self._sData, var.bitOffset[x], ba, srcBit, var.bitSize[x])
-                self._setBits( self._sDataMask, var.bitOffset[x], var.bitSize[x])
+                self._setBits(self._sDataMask, var.bitOffset[x], var.bitSize[x])
                 srcBit += var.bitSize[x]
 
     def get(self, var):

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -313,8 +313,10 @@ class RemoteBlock(BaseBlock, rim.Master):
                 if var._overlapEn:
                     self._setBits(oleMask,var.bitOffset[x],var.bitSize[x])
 
-                # Otherwise add to exclusive mask
+                # Otherwise add to exclusive mask and check for existing mapping
                 else:
+                    if self._anyBits(excMask,var.bitOffset[x],var.bitSize[x]):
+                        raise MemoryError(name=self.path, address=self.address, msg="Variable bit overlap detected.")
                     self._setBits(excMask,var.bitOffset[x],var.bitSize[x])
 
                 # update verify mask

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -119,7 +119,7 @@ class Device(pr.Node,rim.Hub):
                  size=0,
                  hidden=False,
                  blockSize=None,
-                 expand=True,
+                 expand=False,
                  enabled=True,
                  defaults=None,
                  enableDeps=None,

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -254,7 +254,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def addVarListener(self,func):
         """
         Add a variable update listener function.
-        The variable, value and display string will be passed as an arg: func(path,value,disp)
+        The variable and value structure will be passed as args: func(path,varValue)
         """
         with self._varListenLock:
             self._varListeners.append(func)
@@ -554,7 +554,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                         # Call listener functions,
                         with self._varListenLock:
                             for func in self._varListeners:
-                                func(p,val.value.val,valueDisp)
+                                func(p,val)
                     except Exception as e:
                         self._log.exception(e)
                         

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -308,6 +308,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             # After with is done
             self._updateQueue.put(False)
 
+    @pr.expose
     def waitOnUpdate(self):
         """
         Wait until all update queue items have been processed.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -155,7 +155,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='Exit', function=self._exit, hidden=False,
                                  description='Exit the server application'))
 
-    def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, zmqPort=9099):
+    def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, zmqPort=None):
         """Setup the tree. Start the polling thread."""
 
         if self._running:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -61,7 +61,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Root exit."""
         self.stop()
 
-    def __init__(self, *, name=None, description=''):
+    def __init__(self, *, name=None, description='', expand=True):
         """Init the node with passed attributes"""
 
         rogue.interfaces.stream.Master.__init__(self)
@@ -93,7 +93,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._updateThread = None
 
         # Init 
-        pr.Device.__init__(self, name=name, description=description)
+        pr.Device.__init__(self, name=name, description=description, expand=expand)
 
         # Variables
         self.add(pr.LocalVariable(name='SystemLog', value='', mode='RO', hidden=True,

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -166,7 +166,7 @@ class BaseVariable(pr.Node):
         """
         Add a listener Variable or function to call when variable changes. 
         This is usefull when chaining variables together. (adc conversions, etc)
-        The variable, value and display string will be passed as an arg: func(path,value,disp)
+        The variable and value class are passed as an arg: func(path,varValue)
         """
         if isinstance(listener, BaseVariable):
             self.__listeners.append(listener)
@@ -344,10 +344,7 @@ class BaseVariable(pr.Node):
         val = VariableValue(self)
 
         for func in self.__functions:
-            if hasattr(func,'varListener'):
-                func.varListener(self.path,val.value,val.valueDisp)
-            else:
-                func(self.path,val.value,val.valueDisp)
+            func(self.path,val)
 
         return val
 

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -159,10 +159,7 @@ class VirtualNode(pr.Node):
 
     def _doUpdate(self, val):
         for func in self._functions:
-            if hasattr(func,'varListener'):
-                func.varListener(self.path,val.value,val.valueDisp)
-            else:
-                func(self.path,val.value,val.valueDisp)
+            func(self.path,val)
 
     def _virtAttached(self,parent,root,client):
         """Called once the root node is attached."""
@@ -232,7 +229,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
             # Call listener functions,
             for func in self._varListeners:
-                func(k,val.value.val,valueDisp)
+                func(k,val)
 
     @property
     def root(self):

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -43,8 +43,11 @@ class GuiTop(QWidget):
     newRoot = pyqtSignal(pyrogue.Root)
     newVirt = pyqtSignal(pyrogue.VirtualNode)
 
-    def __init__(self,*, group="Servers", parent=None):
+    def __init__(self,*, parent=None, group=None):
         super(GuiTop,self).__init__(parent)
+
+        if group is not None:
+            print("The GuiTop group attribute is now deprecated. Please remove it.")
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -52,10 +55,10 @@ class GuiTop(QWidget):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        self.var = pyrogue.gui.variables.VariableWidget(group=group,parent=self.tab)
+        self.var = pyrogue.gui.variables.VariableWidget(parent=self.tab)
         self.tab.addTab(self.var,'Variables')
 
-        self.cmd = pyrogue.gui.commands.CommandWidget(group=group,parent=self.tab)
+        self.cmd = pyrogue.gui.commands.CommandWidget(parent=self.tab)
         self.tab.addTab(self.cmd,'Commands')
         self.show()
 

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -29,7 +29,7 @@ except ImportError:
 import pyrogue
 
 class CommandDev(QObject):
-    def __init__(self,*,tree,parent,dev,noExpand):
+    def __init__(self,*,tree,parent,dev,noExpand,top):
         QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
@@ -38,6 +38,9 @@ class CommandDev(QObject):
 
         self._widget = QTreeWidgetItem(parent)
         self._widget.setText(0,self._dev.name)
+
+        if top:
+            self._parent.addTopLevelItem(self._widget)
 
         if (not noExpand) and self._dev.expand:
             self._dummy = None
@@ -67,7 +70,7 @@ class CommandDev(QObject):
 
         # Then create devices
         for key,val in self._dev.visableDevices.items():
-            self._children.append(CommandDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand))
+            self._children.append(CommandDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand,top=False))
 
         for i in range(0,4):
             self._tree.resizeColumnToContents(i)
@@ -128,11 +131,11 @@ class CommandLink(QObject):
             self._command.call()
 
 class CommandWidget(QWidget):
-    def __init__(self, *, group, parent=None):
+    def __init__(self, *, parent=None):
         super(CommandWidget, self).__init__(parent)
 
         self.roots = []
-        self.commands = []
+        self._children = []
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -141,11 +144,6 @@ class CommandWidget(QWidget):
 
         self.tree.setColumnCount(2)
         self.tree.setHeaderLabels(['Command','Base','Execute','Arg'])
-
-        self.top = QTreeWidgetItem(self.tree)
-        self.top.setText(0,group)
-        self.tree.addTopLevelItem(self.top)
-        self.top.setExpanded(True)
 
         hb = QHBoxLayout()
         vb.addLayout(hb)
@@ -156,5 +154,5 @@ class CommandWidget(QWidget):
     @pyqtSlot(pyrogue.VirtualNode)
     def addTree(self,root):
         self.roots.append(root)
-        self._devTop = CommandDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)
+        self._children.append(CommandDev(tree=self.tree,parent=self.tree,dev=root,noExpand=False,top=True))
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -55,7 +55,7 @@ class DataLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         vb.addLayout(fl)
 
-        self.writer.dataFile.addListener(self)
+        self.writer.dataFile.addListener(self.varListener)
         self.dataFile = QLineEdit()
         self.dataFile.setText(self.writer.dataFile.valueDisp())
         self.dataFile.textEdited.connect(self.dataFileEdited)
@@ -74,7 +74,7 @@ class DataLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.writer.open.addListener(self)
+        self.writer.open.addListener(self.varListener)
         self.openState = QComboBox()
         self.openState.addItem('False')
         self.openState.addItem('True')
@@ -85,7 +85,7 @@ class DataLink(QObject):
 
         fl.addRow('File Open:',self.openState)
 
-        self.writer.bufferSize.addListener(self)
+        self.writer.bufferSize.addListener(self.varListener)
         self.bufferSize = QLineEdit()
         self.bufferSize.setText(self.writer.bufferSize.valueDisp())
         self.bufferSize.textEdited.connect(self.bufferSizeEdited)
@@ -95,7 +95,7 @@ class DataLink(QObject):
 
         fl.addRow('Buffer Size:',self.bufferSize)
 
-        self.writer.fileSize.addListener(self)
+        self.writer.fileSize.addListener(self.varListener)
         self.totSize = QLineEdit()
         self.totSize.setText(self.writer.fileSize.valueDisp())
         self.totSize.setReadOnly(True)
@@ -117,7 +117,7 @@ class DataLink(QObject):
         pb2.clicked.connect(self._genName)
         fl.addRow(pb1,pb2)
 
-        self.writer.maxFileSize.addListener(self)
+        self.writer.maxFileSize.addListener(self.varListener)
         self.maxSize = QLineEdit()
         self.maxSize.setText(self.writer.maxFileSize.valueDisp())
         self.maxSize.textEdited.connect(self.maxSizeEdited)
@@ -127,7 +127,7 @@ class DataLink(QObject):
 
         fl.addRow('Max Size:',self.maxSize)
 
-        self.writer.frameCount.addListener(self)
+        self.writer.frameCount.addListener(self.varListener)
         self.frameCount = QLineEdit()
         self.frameCount.setText(self.writer.frameCount.valueDisp())
         self.frameCount.setReadOnly(True)
@@ -153,28 +153,28 @@ class DataLink(QObject):
         self.writer.autoName()
         pass
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         if self.block: return
 
         name = path.split('.')[-1]
 
         if name == 'dataFile':
-            self.updateDataFile.emit(disp)
+            self.updateDataFile.emit(value.valueDisp)
 
         elif name == 'open':
-            self.updateOpenState.emit(self.openState.findText(disp))
+            self.updateOpenState.emit(self.openState.findText(value.valueDisp))
 
         elif name == 'bufferSize':
-            self.updateBufferSize.emit(disp)
+            self.updateBufferSize.emit(value.valueDisp)
 
         elif name == 'maxFileSize':
-            self.updateMaxSize.emit(disp)
+            self.updateMaxSize.emit(value.valueDisp)
 
         elif name == 'fileSize':
-            self.updateFileSize.emit(disp)
+            self.updateFileSize.emit(value.valueDisp)
 
         elif name == 'frameCount':
-            self.updateFrameCount.emit(disp)
+            self.updateFrameCount.emit(value.valueDisp)
 
     @pyqtSlot()
     def dataFileEdited(self):
@@ -254,7 +254,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         vb.addLayout(fl)
 
-        self.control.runRate.addListener(self)
+        self.control.runRate.addListener(self.varListener)
         self.runRate = QComboBox()
         self.runRate.activated.connect(self.runRateChanged)
         self.updateRate.connect(self.runRate.setCurrentIndex)
@@ -273,7 +273,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.control.runState.addListener(self)
+        self.control.runState.addListener(self.varListener)
         self.runState = QComboBox()
         self.runState.activated.connect(self.runStateChanged)
         self.updateState.connect(self.runState.setCurrentIndex)
@@ -289,7 +289,7 @@ class ControlLink(QObject):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        self.control.runCount.addListener(self)
+        self.control.runCount.addListener(self.varListener)
         self.runCount = QLineEdit()
         self.runCount.setText(self.control.runCount.valueDisp())
         self.runCount.setReadOnly(True)
@@ -297,19 +297,19 @@ class ControlLink(QObject):
 
         fl.addRow('Run Count:',self.runCount)
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         if self.block: return
 
         name = path.split('.')[-1]
 
         if name == 'runState':
-            self.updateState.emit(self.runState.findText(disp))
+            self.updateState.emit(self.runState.findText(value.valueDisp))
 
         elif name == 'runRate':
-            self.updateRate.emit(self.runRate.findText(disp))
+            self.updateRate.emit(self.runRate.findText(value.valueDisp))
 
         elif name == 'runCount':
-            self.updateCount.emit(disp)
+            self.updateCount.emit(value.valueDisp)
 
     @pyqtSlot(int)
     def runStateChanged(self,value):
@@ -401,7 +401,7 @@ class SystemWidget(QWidget):
         self.systemLog.setReadOnly(True)
         vb.addWidget(self.systemLog)
 
-        root.SystemLog.addListener(self)
+        root.SystemLog.addListener(self.varListener)
         self.updateLog.connect(self.systemLog.setText)
         self.systemLog.setText(root.SystemLog.valueDisp())
         
@@ -415,11 +415,11 @@ class SystemWidget(QWidget):
     def resetLog(self):
         self.root.ClearLog()
 
-    def varListener(self,path,value,disp):
+    def varListener(self,path,value):
         name = path.split('.')[-1]
 
         if name == 'SystemLog':
-            self.updateLog.emit(disp)
+            self.updateLog.emit(value.valueDisp)
 
     @pyqtSlot()
     def hardReset(self):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -31,7 +31,7 @@ import threading
 
 class VariableDev(QObject):
 
-    def __init__(self,*,tree,parent,dev,noExpand):
+    def __init__(self,*,tree,parent,dev,noExpand,top):
         QObject.__init__(self)
         self._parent   = parent
         self._tree     = tree
@@ -40,6 +40,9 @@ class VariableDev(QObject):
 
         self._widget = QTreeWidgetItem(parent)
         self._widget.setText(0,self._dev.name)
+
+        if top:
+            self._parent.addTopLevelItem(self._widget)
 
         if (not noExpand) and self._dev.expand:
             self._dummy = None
@@ -68,7 +71,7 @@ class VariableDev(QObject):
 
         # Then create devices
         for key,val in self._dev.visableDevices.items():
-            self._children.append(VariableDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand))
+            self._children.append(VariableDev(tree=self._tree,parent=self._widget,dev=val,noExpand=noExpand,top=False))
 
         for i in range(0,4):
             self._tree.resizeColumnToContents(i)
@@ -225,10 +228,11 @@ class VariableLink(QObject):
 
 
 class VariableWidget(QWidget):
-    def __init__(self, *, group, parent=None):
+    def __init__(self, *, parent=None):
         super(VariableWidget, self).__init__(parent)
 
         self.roots = []
+        self._children = []
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -237,11 +241,6 @@ class VariableWidget(QWidget):
 
         self.tree.setColumnCount(2)
         self.tree.setHeaderLabels(['Variable','Mode','Base','Value','Units'])
-
-        self.top = QTreeWidgetItem(self.tree)
-        self.top.setText(0,group)
-        self.tree.addTopLevelItem(self.top)
-        self.top.setExpanded(True)
 
         hb = QHBoxLayout()
         vb.addLayout(hb)
@@ -256,7 +255,7 @@ class VariableWidget(QWidget):
     @pyqtSlot(pyrogue.VirtualNode)
     def addTree(self,root):
         self.roots.append(root)
-        self.devTop = VariableDev(tree=self.tree,parent=self.top,dev=root,noExpand=False)
+        self._children.append(VariableDev(tree=self.tree,parent=self.tree,dev=root,noExpand=False,top=True))
 
     @pyqtSlot()
     def readPressed(self):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -105,7 +105,8 @@ class VariableLink(QObject):
             for i in self._variable.enum:
                 self._widget.addItem(self._variable.enum[i])
 
-        elif self._variable.minimum is not None and self._variable.maximum is not None:
+        elif self._variable.minimum is not None and self._variable.maximum is not None and \
+             self._variable.disp == '{}' and self._variable.mode != 'RO':
             self._widget = QSpinBox();
             self._widget.setMinimum(self._variable.minimum)
             self._widget.setMaximum(self._variable.maximum)

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -132,9 +132,9 @@ class VariableLink(QObject):
             self._widget.setReadOnly(True)
 
         self._tree.setItemWidget(self._item,3,self._widget)
-        self.varListener(None,self._variable.value(),self._variable.valueDisp())
+        self.varListener(None,pyrogue.VariableValue(self._variable))
 
-        variable.addListener(self)
+        variable.addListener(self.varListener)
 
     def openMenu(self, event):
         menu = QMenu()
@@ -171,7 +171,7 @@ class VariableLink(QObject):
             else:
                 self._variable.setDisp(self._widget.text())
 
-    def varListener(self, path, value, disp):
+    def varListener(self, path, value):
         with self._lock:
             if self._widget is None or self._inEdit is True:
                 return
@@ -179,18 +179,18 @@ class VariableLink(QObject):
             self._swSet = True
 
             if isinstance(self._widget, QComboBox):
-                i = self._widget.findText(disp)
+                i = self._widget.findText(value.valueDisp)
 
                 if i < 0: i = 0
 
                 if self._widget.currentIndex() != i:
                     self.updateGui.emit(i)
             elif isinstance(self._widget, QSpinBox):
-                if self._widget.value != value:
+                if self._widget.value != value.value:
                     self.updateGui.emit(value)
             else:
-                if self._widget.text() != disp:
-                    self.updateGui[str].emit(disp)
+                if self._widget.text() != value.valueDisp:
+                    self.updateGui[str].emit(value.valueDisp)
 
             self._swSet = False
 

--- a/python/pyrogue/interfaces/mysql.py
+++ b/python/pyrogue/interfaces/mysql.py
@@ -193,7 +193,7 @@ class MysqlGw(object):
         self._varSer[variable.path] = 0
         variable.addListener(self._updateVariables)
 
-    def _updateVariables (self, path, value, disp):
+    def _updateVariables (self, path, val):
         with self._dbLock:
             if self._db is None:
                 #self._log.error("Not connected to Mysql server " + self._host)
@@ -201,7 +201,7 @@ class MysqlGw(object):
 
             try:
                 cursor = self._db.cursor(MySQLdb.cursors.DictCursor)
-                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(disp))
+                sql = "update variable set value='{}', server_ts=now(),".format(mysqlString(val.valueDisp))
                 sql += "server_ser = (server_ser + 1) where name='{}'".format(path)
                 cursor.execute(sql)
                 self._db.commit()

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -273,6 +273,7 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
 
       // Not aligned
       else {
+         dstData[dstByte] &= ((0x1 << dstBit) ^ 0xFF);
          dstData[dstByte] |= ((srcData[srcByte] >> srcBit) & 0x1) << dstBit;
          srcByte += (++srcBit / 8);
          dstByte += (++dstBit / 8);

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -136,7 +136,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    else if ( typeStr == "float" or typeStr == "Float32" ) {
       log_->info("Detected 32-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumFloat32;
-      precision_ = 32;
+      precision_ = 4;
       fSize_ = 4;
    }
 
@@ -144,7 +144,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    else if ( typeStr == "Float64" ) {
       log_->info("Detected 64-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumFloat64;
-      precision_ = 64;
+      precision_ = 4;
       fSize_ = 8;
    }
 

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -110,16 +110,19 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
 
 rpe::Variable::~Variable() { }
 
-void rpe::Variable::varUpdated(std::string path, bp::object value, bp::object disp) {
+void rpe::Variable::varUpdated(std::string path, bp::object value) {
    rogue::GilRelease noGil;
+   bp::object convValue;
 
-   log_->debug("Variable update for %s: Disp=%s", epicsName_.c_str(),(char *)bp::extract<char *>(disp));
+   log_->debug("Variable update for %s", epicsName_.c_str());
    {
       std::lock_guard<std::mutex> lock(mtx_);
       noGil.acquire();
+  
+      if (  isString_ || epicsType_ == aitEnumEnum16 ) convValue = value.attr("valueDisp");
+      else convValue = value.attr("value");
 
-      if (  isString_ || epicsType_ == aitEnumEnum16 ) fromPython(disp);
-      else fromPython(value);
+      fromPython(convValue);
    }
    noGil.release();
    this->updated();

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -252,7 +252,20 @@ class AxiVersion(pr.Device):
             value = ''))
 
         self.BuildStamp.addListener(parseBuildStamp)        
-       
+      
+        for i in range(128):
+            remap = divmod(i,32)
+
+            self.add(pr.RemoteVariable(
+                name         = 'TestArray[{:d}]'.format(i),
+                description  = 'Array Test Field',
+                offset       = 0x1000 + remap[0]<<2,
+                bitSize      = 1,
+                bitOffset    = remap[1],
+                base         = pr.UInt,
+                mode         = 'RW',
+                hidden       = False,
+            ))
 
     def hardReset(self):
         print('AxiVersion hard reset called')

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -203,6 +203,22 @@ class AxiVersion(pr.Device):
             hidden       = True,
         ))
 
+        self.add(pr.RemoteVariable(   
+            name         = 'TestEnum',
+            description  = 'ENUM Test Field',
+            offset       = 0x900,
+            bitSize      = 3,
+            bitOffset    = 0x00,
+            enum         = {0: 'Test0',
+                            1: 'Test1',
+                            2: 'Test2',
+                            3: 'Test3',
+                            4: 'Test4'},
+            base         = pr.UInt,
+            mode         = 'RW',
+            hidden       = False,
+        ))
+
         
         def parseBuildStamp(var, value, disp):
             p = parse.parse("{ImageName}: {BuildEnv}, {BuildServer}, Built {BuildDate} by {Builder}", value.strip())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,6 +19,9 @@ import rogue.interfaces.stream
 import test_device
 import time
 import rogue
+import pyrogue.protocols.epics
+
+#rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
 
 class DummyTree(pyrogue.Root):
 
@@ -36,6 +39,9 @@ class DummyTree(pyrogue.Root):
         # Set pyroHost to the address of a network interface to specify which nework to run on
         # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
         self.start(timeout=2.0, pollEn=True, zmqPort=9099)
+
+        self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
+        self.epics.start()
 
 if __name__ == "__main__":
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,8 +20,13 @@ import test_device
 import time
 import rogue
 import pyrogue.protocols.epics
+import logging
 
 #rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+
+#logger = logging.getLogger('pyrogue')
+#logger.setLevel(logging.DEBUG)
 
 class DummyTree(pyrogue.Root):
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,6 +15,7 @@
 #-----------------------------------------------------------------------------
 import pyrogue
 import pyrogue.interfaces.simulation
+import pyrogue.utilities.fileio
 import rogue.interfaces.stream
 import test_device
 import time
@@ -39,6 +40,9 @@ class DummyTree(pyrogue.Root):
         
         # Add Device
         self.add(test_device.AxiVersion(memBase=sim,offset=0x0))
+
+        # Add Data Writer
+        self.add(pyrogue.utilities.fileio.StreamWriter())
 
         # Start the tree with pyrogue server, internal nameserver, default interface
         # Set pyroHost to the address of a network interface to specify which nework to run on


### PR DESCRIPTION
### Description
- Set root's default to zmqPort=None
- Change default of `expand` from True to False #423
- Fix epics enum interface #424
- Poller Enhancements #425
- Build fix for EPICS 7 which moves pcas to a separate package. #427
- Fix build error deriving zeromq location from LD_LIBRARY_PATH. #426
- Build fix for EPICS 7 which moves pcas to a separate package. #427
- Root needs to expand by default #432
- Expose Root.waitOnUpdate() on ZMQ Server #433
- Change combo box display #429
- Remove group from gui #436
- Fix config load issue #434
- Pass VariableValue class to update functions #428
- Fix missing bit overlap check when adding variables to a block. #438