### PR TITLE
Add save enable flag to variables

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -182,7 +182,7 @@ class BaseCommand(pr.BaseVariable):
     def _setDict(self,d,writeEach,modes):
         pass
 
-    def _getDict(self,modes):
+    def _getDict(self,modes, saveEnFilt):
         return None
 
     def get(self,read=True):

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -72,7 +72,7 @@ class MemoryDevice(pr.Device):
             for offset, values in d.items():
                 self._setValues[offset] = [self._base.fromString(s, self._wordBitSize) for s in values.split(',')]
 
-    def _getDict(self,modes):
+    def _getDict(self,modes, saveEnFilt):
         return None
 
     def writeBlocks(self, force=False, recurse=True, variable=None, checkEach=False):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -404,7 +404,7 @@ class Node(object):
             daemon.register(n)
             n._exportNodes(daemon)
 
-    def _getDict(self,modes):
+    def _getDict(self,modes, saveEnFilt):
         """
         Get variable values in a dictionary starting from this level.
         Attributes that are Nodes are recursed.
@@ -412,7 +412,7 @@ class Node(object):
         """
         data = odict()
         for key,value in self._nodes.items():
-            nv = value._getDict(modes)
+            nv = value._getDict(modes,saveEnFilt)
             if nv is not None:
                 data[key] = nv
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -41,6 +41,7 @@ class BaseVariable(pr.Node):
                  name,
                  description='',
                  mode='RW',
+                 saveEn=True,
                  value=None,
                  disp='{}',
                  enum=None,
@@ -48,7 +49,6 @@ class BaseVariable(pr.Node):
                  hidden=False,
                  minimum=None,
                  maximum=None,
-                 saveEn=True,
                  pollInterval=0,
                  typeStr='Unknown',
                  offset=0
@@ -363,6 +363,7 @@ class RemoteVariable(BaseVariable):
                  name,
                  description='',
                  mode='RW',
+                 saveEn=True,
                  value=None,
                  disp=None,
                  enum=None,
@@ -382,7 +383,7 @@ class RemoteVariable(BaseVariable):
             disp = base.defaultdisp
 
         BaseVariable.__init__(self, name=name, description=description, 
-                              mode=mode, value=value, disp=disp, 
+                              mode=mode, saveEn=SaveEn, value=value, disp=disp, 
                               enum=enum, units=units, hidden=hidden,
                               minimum=minimum, maximum=maximum,
                               pollInterval=pollInterval)
@@ -493,6 +494,7 @@ class LocalVariable(BaseVariable):
                  name,
                  description='',
                  mode='RW',
+                 saveEn=True,
                  value=None,
                  disp='{}',
                  enum=None,
@@ -509,7 +511,7 @@ class LocalVariable(BaseVariable):
             raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
 
         BaseVariable.__init__(self, name=name, description=description, 
-                              mode=mode, value=value, disp=disp, 
+                              mode=mode, saveEn=saveEn, value=value, disp=disp, 
                               enum=enum, units=units, hidden=hidden,
                               minimum=minimum, maximum=maximum, typeStr=typeStr,
                               pollInterval=pollInterval)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -48,6 +48,7 @@ class BaseVariable(pr.Node):
                  hidden=False,
                  minimum=None,
                  maximum=None,
+                 saveEn=True,
                  pollInterval=0,
                  typeStr='Unknown',
                  offset=0
@@ -55,6 +56,7 @@ class BaseVariable(pr.Node):
 
         # Public Attributes
         self._mode          = mode
+        self._saveEn        = saveEn
         self._units         = units
         self._minimum       = minimum # For base='range'
         self._maximum       = maximum # For base='range'
@@ -128,6 +130,11 @@ class BaseVariable(pr.Node):
     @property
     def mode(self):
         return self._mode
+
+    @pr.expose
+    @property
+    def saveEn(self):
+        return self._saveEn
 
     @pr.expose
     @property
@@ -328,8 +335,8 @@ class BaseVariable(pr.Node):
         if self._mode in modes:
             self.setDisp(d,writeEach)
 
-    def _getDict(self,modes):
-        if self._mode in modes:
+    def _getDict(self,modes, saveEnFilt):
+        if self._mode in modes and (self._saveEn or (not saveEnFilt)):
             return VariableValue(self)
         else:
             return None

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -383,7 +383,7 @@ class RemoteVariable(BaseVariable):
             disp = base.defaultdisp
 
         BaseVariable.__init__(self, name=name, description=description, 
-                              mode=mode, saveEn=SaveEn, value=value, disp=disp, 
+                              mode=mode, saveEn=saveEn, value=value, disp=disp, 
                               enum=enum, units=units, hidden=hidden,
                               minimum=minimum, maximum=maximum,
                               pollInterval=pollInterval)

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -151,7 +151,7 @@ class VirtualNode(pr.Node):
     def _rootAttached(self,parent,root):
         raise pr.NodeError('_rootAttached not supported in VirtualNode')
 
-    def _getDict(self,modes):
+    def _getDict(self,modes, saveEnFilt):
         raise pr.NodeError('_getDict not supported in VirtualNode')
 
     def _setDict(self,d,writeEach,modes=['RW']):


### PR DESCRIPTION
This adds the saveEn attribute to variables with a default value of True. If saveEn is set to false the variable will not be included in the configuration save. It will still be included in state dumps and dumps to the data file. This only applies to the SaveConfig and GetYamlConfig commands.