### PR TITLE
Add ability to define command return type

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -227,6 +227,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         BaseCommand.__init__(
             self,
             name=name,
+            retValue=retValue,
             function=function)
 
         pr.RemoteVariable.__init__(
@@ -235,7 +236,6 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             description=description,
             mode='WO',
             value=value,
-            retValue=retValue,
             enum=enum,
             hidden=hidden,
             minimum=minimum,

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -58,9 +58,9 @@ class BaseCommand(pr.BaseVariable):
         if retValue is None:
             self._retTypeStr = None
         elif isinstance(retValue, list):
-            self._typeStr = f'List[{retValue[0].__class__.__name__}]'
+            self._retTypeStr = f'List[{retValue[0].__class__.__name__}]'
         else:
-            self._typeStr = retValue.__class__.__name__
+            self._retTypeStr = retValue.__class__.__name__
 
         # args flag
         try:

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -31,6 +31,7 @@ class BaseCommand(pr.BaseVariable):
                  name=None,
                  description="",
                  value=0,
+                 retValue=None,
                  enum=None,
                  hidden=False,                 
                  minimum=None,
@@ -54,6 +55,13 @@ class BaseCommand(pr.BaseVariable):
         self._lock = threading.Lock()
         self._background = background
 
+        if retValue is None:
+            self._retTypeStr = None
+        elif isinstance(retValue, list):
+            self._typeStr = f'List[{retValue[0].__class__.__name__}]'
+        else:
+            self._typeStr = value.__class__.__name__
+
         # args flag
         try:
             self._arg = 'arg' in inspect.getfullargspec(self._function).args
@@ -66,6 +74,11 @@ class BaseCommand(pr.BaseVariable):
     @property
     def arg(self):
         return self._arg
+
+    @pr.expose
+    @property
+    def retTypeStr(self):
+        return self._retTypeStr
 
     @pr.expose
     def call(self,arg=None):
@@ -198,6 +211,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
                  name,
                  description='',
                  value=None,
+                 retValue=None,
                  enum=None,
                  hidden=False,
                  minimum=None,
@@ -221,6 +235,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             description=description,
             mode='WO',
             value=value,
+            retValue=retValue,
             enum=enum,
             hidden=hidden,
             minimum=minimum,

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -60,7 +60,7 @@ class BaseCommand(pr.BaseVariable):
         elif isinstance(retValue, list):
             self._typeStr = f'List[{retValue[0].__class__.__name__}]'
         else:
-            self._typeStr = value.__class__.__name__
+            self._typeStr = retValue.__class__.__name__
 
         # args flag
         try:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -147,10 +147,12 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='SetYamlConfig', value='', function=lambda arg: self._setYaml(arg,False,['RW','WO']), hidden=True,
                                  description='Set configuration from passed YAML string'))
 
-        self.add(pr.LocalCommand(name='GetYamlConfig', value=True, function=lambda arg: self._getYaml(arg,['RW','WO']), hidden=True,
+        self.add(pr.LocalCommand(name='GetYamlConfig', value=True, retValue='',
+                                 function=lambda arg: self._getYaml(arg,['RW','WO']), hidden=True,
                                  description='Get current configuration as YAML string. Pass read first arg.'))
 
-        self.add(pr.LocalCommand(name='GetYamlState', value=True, function=lambda arg: self._getYaml(arg,['RW','RO','WO']), hidden=True,
+        self.add(pr.LocalCommand(name='GetYamlState', value=True, retValue='',
+                                 function=lambda arg: self._getYaml(arg,['RW','RO','WO']), hidden=True,
                                  description='Get current state as YAML string. Pass read first arg.'))
 
         self.add(pr.LocalCommand(name='Restart', function=self._restart, hidden=False,


### PR DESCRIPTION
This adds a retType= arg to command creation in order to identify the return type value for commands which return values. This adds the accompanying property to the command:

self.retTypeStr

which returns None for commands that do no return a value.