### PR TITLE
Remove PCAS support from MACOS, properly detect existence of PCAS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,64 +126,48 @@ endif()
 #####################################
 if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
    set(DO_EPICS_V3 1)
-   set(EPICSV3_BASE_DIR  $ENV{EPICS_BASE})
+   set(EPICSV3_BASE_DIR $ENV{EPICS_BASE})
    if(DEFINED ENV{EPICS_HOST_ARCH})
-       set(EPICSV3_ARCH      $ENV{EPICS_HOST_ARCH})
+       set(EPICSV3_ARCH $ENV{EPICS_HOST_ARCH})
    else()
        execute_process(COMMAND ${EPICSV3_BASE_DIR}/startup/EpicsHostArch 
                        OUTPUT_VARIABLE EPICSV3_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
        string(REGEX REPLACE "\n$" "" EPICSV3_ARCH "${EPICSV3_ARCH}")
    endif()
-   set(EPICSV3_LIB_DIR   ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH} )
 
+   # PCAS is part of epics before version 4
    if(DEFINED ENV{EPICS_PCAS_ROOT})
-      set(EPICS_PCAS_ROOT $ENV{EPICS_PCAS_ROOT})
+      set(EPICSV3_PCAS_DIR $ENV{EPICS_PCAS_ROOT})
+   else()
+      set(EPICSV3_PCAS_DIR $ENV{EPICS_BASE})
    endif()
 
-   if(APPLE)
+   # See if we can find the pcas header, may not exist if epics 7 without pcas is installed
+   find_path(E3_TEST_INCLUDE_DIR NAMES casdef.h PATHS ${EPICSV3_PCAS_DIR}/include)
+   if (NOT E3_TEST_INCLUDE_DIR)
+      set(DO_EPICS_V3 0)
+   elseif(APPLE)
 
-      if(EPICS_PCAS_ROOT)
-         set(EPICSV3_INCLUDES  ${EPICS_PCAS_ROOT}/include
-                               ${EPICSV3_BASE_DIR}/include
-                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                               ${EPICSV3_BASE_DIR}/include/os/Darwin)
+      set(EPICSV3_INCLUDES  ${EPICSV3_PCAS_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                            ${EPICSV3_BASE_DIR}/include/os/Darwin)
 
-         set(EPICSV3_LIBRARIES ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libcas.dylib 
-                               ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libgdd.dylib
-                               ${EPICSV3_LIB_DIR}/libca.dylib 
-                               ${EPICSV3_LIB_DIR}/libCom.dylib )
-      else()
-         set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
-                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                               ${EPICSV3_BASE_DIR}/include/os/Darwin)
-
-         set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.dylib 
-                               ${EPICSV3_LIB_DIR}/libca.dylib
-                               ${EPICSV3_LIB_DIR}/libCom.dylib
-                               ${EPICSV3_LIB_DIR}/libgdd.dylib )
-      endif()
+      set(EPICSV3_LIBRARIES ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libcas.dylib 
+                            ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libgdd.dylib
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libca.dylib 
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libCom.dylib )
    else()
 
-      if(EPICS_PCAS_ROOT)
-         set(EPICSV3_INCLUDES  ${EPICS_PCAS_ROOT}/include
-                               ${EPICSV3_BASE_DIR}/include
-                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                               ${EPICSV3_BASE_DIR}/include/os/Linux)
+      set(EPICSV3_INCLUDES  ${EPICSV3_PCAS_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include/compiler/gcc 
+                            ${EPICSV3_BASE_DIR}/include/os/Linux)
 
-         set(EPICSV3_LIBRARIES ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libcas.so 
-                               ${EPICS_PCAS_ROOT}/lib/${EPICSV3_ARCH}/libgdd.so
-                               ${EPICSV3_LIB_DIR}/libca.so 
-                               ${EPICSV3_LIB_DIR}/libCom.so )
-      else()
-         set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
-                               ${EPICSV3_BASE_DIR}/include/compiler/gcc 
-                               ${EPICSV3_BASE_DIR}/include/os/Linux)
-
-         set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.so 
-                               ${EPICSV3_LIB_DIR}/libca.so
-                               ${EPICSV3_LIB_DIR}/libCom.so
-                               ${EPICSV3_LIB_DIR}/libgdd.so )
-      endif()
+      set(EPICSV3_LIBRARIES ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libcas.so 
+                            ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libgdd.so
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV#_ARCH}/libca.so 
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV#_ARCH}/libCom.so )
    endif()
 else()
    set(DO_EPICS_V3 0)
@@ -411,11 +395,7 @@ endif()
 message("")
 
 if (DO_EPICS_V3)
-   if (EPICS_PCAS_ROOT)
-      message("-- Found EPICS: ${EPICS_PCAS_ROOT}")
-   else()
-      message("-- Found EPICS: ${EPICSV3_BASE_DIR}")
-   endif()
+   message("-- Found EPICS: ${EPICSV3_PCAS_DIR}")
 else()
    message("-- EPICS V3 not included!")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,8 @@ if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
 
       set(EPICSV3_LIBRARIES ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libcas.so 
                             ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libgdd.so
-                            ${EPICSV3_BASE_DIR}/lib/${EPICSV#_ARCH}/libca.so 
-                            ${EPICSV3_BASE_DIR}/lib/${EPICSV#_ARCH}/libCom.so )
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libca.so 
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libCom.so )
    endif()
 else()
    set(DO_EPICS_V3 0)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
      - bzip2
      - zeromq
      - epics-base
-     - pcas
+     - pcas       [linux]
      - git
 
    run:
@@ -33,9 +33,9 @@ requirements:
      - cmake
      - make
      - bzip2
-     - epics-base
-     - pcas
-     - p4p
+     - epics-base 
+     - pcas       [linux]
+     - p4p        
      - zeromq
      - pyyaml
      - jsonpickle

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -24,5 +24,4 @@ dependencies:
   - bzip2
   - zeromq
   - epics-base
-  - pcas
   - p4p


### PR DESCRIPTION
This PR changes the CMakelists file to properly detect situations where epics-base is installed without pcas. It also removes pcas support from MACOS Anaconda builds. 