### PR TITLE
Add VariableWait function to wait for values in one or more variables

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -88,7 +88,7 @@ class VariableWait(object):
             # Check current state of all met flags
             ret = all([v['met'] for k,v in self._clist.items()])
 
-            # Run until timeout of all conditions have been met
+            # Run until timeout or all conditions have been met
             while (not ret) and ((timeout == 0) or ((time.time()-start) < timeout)):
                 self._cv.wait(0.5)
                 ret = all([v['met'] for k,v in self._clist.items()])

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -36,8 +36,6 @@ class VariableWait(object):
     i.e. w = VariableWait({root.device.var1: lambda varVal: varVal.value >= 10,
                            root.device.var2: lambda varVal: varVal.value >= 20})
     w.wait()
-
-    This object can only be used once.
     """
     def __init__(self,varConditions=None):
         self._clist = {}

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -75,8 +75,8 @@ class VariableWait(object):
     def wait(self,timeout=0):
         """ 
         Wait for the defined conditions to be true. Returns True when all conditions have been
-        meet. False if the wait times out. This routines cleans up the conditions list before exiting
-        and new conditions need to be defined before the wait call is used again. Otherwise it will return
+        meet. False if the wait times out. This routine cleans up the conditions list before exiting
+        and new conditions need to be defined before the wait call is used again, otherwise it will return
         True immediatly.
         """
         ret   = False

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -36,8 +36,8 @@ def VariableWait(varList, testFunction, timeout=0):
     The test function is passed a dictionary containing the current
     variableValue state index by variable path
     i.e. w = VariableWait([root.device.var1,root.device.var2], 
-                          lambda varList: varList['root.device.var1'].value >= 10 and \
-                                          varList['root.device.var1'].value >= 20)
+                          lambda varValues: varValues['root.device.var1'].value >= 10 and \
+                                            varValues['root.device.var1'].value >= 20)
     """
 
     # Container class

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -68,6 +68,8 @@ class VariableWait(object):
 
             # Add to listener for variable
             var.addListener(self._varUpdate)
+
+            # Get current state
             self._clist[var.path] = {'var':var, 'cond':condition, 'met':condition(var.getVariableValue(read=False))}
 
     def wait(self,timeout=0):

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -81,6 +81,7 @@ def VirtualFactory(data):
         # Add addListener if Variable
         if str(pr.BaseVariable) in data['bases']:
             setattr(self.__class__,'addListener',self._addListener)
+            setattr(self.__class__,'delListener',self._delListener)
 
         VirtualNode.__init__(self,data)
 
@@ -120,6 +121,10 @@ class VirtualNode(pr.Node):
 
     def _addListener(self, listener):
         self._functions.append(listener)
+
+    def _delListener(self, listener):
+        if listener in self._functions:
+            self._functions.remove(listener)
 
     def _addVarListener(self,func):
         self._client._addVarListener(func)
@@ -198,6 +203,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         # Update tree
         r._virtAttached(r,r,self)
         self._root = r
+
+        setattr(self,self._root.name,self._root)
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
         snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -120,7 +120,8 @@ class VirtualNode(pr.Node):
         return self._client._remoteAttr(self._path, '__call__', *args, **kwargs)
 
     def _addListener(self, listener):
-        self._functions.append(listener)
+        if listener not in self._functions:
+            self._functions.append(listener)
 
     def _delListener(self, listener):
         if listener in self._functions:
@@ -219,7 +220,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         return ret
 
     def _addVarListener(self,func):
-        self._varListeners.append(func)
+        if func not in self._varListeners:
+            self._varListeners.append(func)
 
     def _doUpdate(self,data):
         if self._root is None:


### PR DESCRIPTION
This adds a VariableWait function which can be used to wait for one or more variables to pass a condition test. 

Example Usage:
pyrogue.VariableWait([client.dummyTree.AxiVersion.ScratchPad],lambda varValues: varValues['dummyTree.AxiVersion.Scratchpad'].value > 10)

This PR also adds a hook into the Virtual client to be able to access the root device immediately by name:

client = pyrogue.VirtualClient()  
client.dummyTree.AxiVersion.ScratchPad.get()
