### PR TITLE
Add simple ZmqClient class

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -161,7 +161,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='Exit', function=self._exit,visibility=50,
                                  description='Exit the server application'))
 
-    def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, zmqPort=None):
+    def start(self, timeout=1.0, initRead=False, initWrite=False, pollEn=True, zmqPort=None, serverPort=None):
         """Setup the tree. Start the polling thread."""
 
         if self._running:
@@ -214,8 +214,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Start ZMQ server if enabled
         if zmqPort is not None:
+            self._log.warning("zmqPort arg is deprecated. Please use serverPort arg instead")
+            serverPort = zmqPort
+
+        # Start server
+        if serverPort is not None:
             self._structure = jsonpickle.encode(self)
-            self._zmqServer = pr.interfaces.ZmqServer(root=self,addr="*",port=zmqPort)
+            self._zmqServer = pr.interfaces.ZmqServer(root=self,addr="*",port=serverPort)
 
         # Read current state
         if initRead:

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -2,7 +2,7 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue base module - ZMQ Client
 #-----------------------------------------------------------------------------
-# File       : pyrogue/interfaces/_ZmqClient.py
+# File       : pyrogue/interfaces/_SimpleClient.py
 # Created    : 2017-05-16
 #-----------------------------------------------------------------------------
 # This file is part of the rogue software platform. It is subject to 
@@ -23,13 +23,13 @@ import rogue.interfaces
 import functools as ft
 import jsonpickle
 
-class ZmqClient(rogue.interfaces.ZmqClient):
+class SimpleClient(rogue.interfaces.ZmqClient):
 
     def __init__(self, addr="localhost", port=9099):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
 
         # Setup logging
-        self._log = pr.logInit(cls=self,name="ZmqClient",path=None)
+        self._log = pr.logInit(cls=self,name="SimpleClient",path=None)
 
         # Get root name as a connection test
         self.setTimeout(1000)

--- a/python/pyrogue/interfaces/_ZmqClient.py
+++ b/python/pyrogue/interfaces/_ZmqClient.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Title      : PyRogue base module - ZMQ Client
+#-----------------------------------------------------------------------------
+# File       : pyrogue/interfaces/_ZmqClient.py
+# Created    : 2017-05-16
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to 
+# the license terms in the LICENSE.txt file found in the top-level directory 
+# of this distribution and at: 
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+# No part of the rogue software platform, including this file, may be 
+# copied, modified, propagated, or distributed except according to the terms 
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import sys
+from collections import OrderedDict as odict
+import logging
+import inspect
+import pyrogue as pr
+import zmq
+import rogue.interfaces
+import functools as ft
+import jsonpickle
+
+class ZmqClient(rogue.interfaces.ZmqClient):
+
+    def __init__(self, addr="localhost", port=9099):
+        rogue.interfaces.ZmqClient.__init__(self,addr,port)
+
+        # Setup logging
+        self._log = pr.logInit(cls=self,name="ZmqClient",path=None)
+
+        # Get root name as a connection test
+        self.setTimeout(1000)
+        rn = None
+        while rn is None:
+            rn = self._remoteAttr('__rootname__',None)
+
+        print("Connected to {} at {}:{}".format(rn,addr,port))
+
+    def _remoteAttr(self, path, attr, *args, **kwargs):
+        snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
+        y = jsonpickle.encode(snd)
+        try:
+            resp = self._send(y)
+            ret = jsonpickle.decode(resp)
+        except Exception as msg:
+            print("got remote exception: {}".format(msg))
+            ret = None
+
+        return ret
+
+    def get(self,path):
+        return self._remoteAttr(path, 'get')
+
+    def getDisp(self,path):
+        return self._remoteAttr(path, 'getDisp')
+
+    def value(self,path):
+        return self._remoteAttr(path, 'value')
+
+    def valueDisp(self,path):
+        return self._remoteAttr(path, 'valueDisp')
+
+    def set(self,path,value):
+        return self._remoteAttr(path, 'set', value)
+
+    def setDisp(self,path,value):
+        return self._remoteAttr(path, 'setDisp', value)
+
+    def exec(self,path,arg):
+        return self._remoteAttr(path, 'exec', arg)
+

--- a/python/pyrogue/interfaces/__init__.py
+++ b/python/pyrogue/interfaces/__init__.py
@@ -9,5 +9,5 @@
 #-----------------------------------------------------------------------------
 
 from pyrogue.interfaces._ZmqServer import *
-from pyrogue.interfaces._ZmqClient import *
+from pyrogue.interfaces._SimpleClient import *
 

--- a/python/pyrogue/interfaces/__init__.py
+++ b/python/pyrogue/interfaces/__init__.py
@@ -9,4 +9,5 @@
 #-----------------------------------------------------------------------------
 
 from pyrogue.interfaces._ZmqServer import *
+from pyrogue.interfaces._ZmqClient import *
 


### PR DESCRIPTION
This adds a thin lightweight, fast to load, SimpleClient. The interface on this client is limited to the following commands:

client.get("path.to.variable")
client.getDisp("path.to.variable")
client.value("path.to.variable")
client.valueDisp("path.to.variable")
client.set("path.to.variable",value)
client.setDisp("path.to.variable",value)
client.exec("path.to.command",arg)

This PR also deprecates the zmqPort= arg for root.Start() and adds serverPort to make sure the interface is protocol agnostic for the future.
