### PR TITLE
Allow process device to be called with an arg

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -82,8 +82,7 @@ class BaseCommand(pr.BaseVariable):
     def retTypeStr(self):
         return self._retTypeStr
 
-    @pr.expose
-    def call(self,arg=None):
+    def __call__(self,arg=None):
         if self._background:
             with self._lock:
                 if self._thread is not None and self._thread.isAlive():
@@ -118,8 +117,9 @@ class BaseCommand(pr.BaseVariable):
         except Exception as e:
             self._log.exception(e)
 
-    def __call__(self,arg=None):
-        return self.call(arg)
+    @pr.expose
+    def call(self,arg=None):
+        return self.__call__(arg)
 
     @staticmethod
     def nothing():

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -49,6 +49,7 @@ class Process(pr.Device):
             name='Running',
             mode='RO',
             value=False,
+            pollInterval=1.0,
             description='Operation is running.'))
 
         self.add(pr.LocalVariable(
@@ -56,12 +57,14 @@ class Process(pr.Device):
             mode='RO',
             units='Pct',
             value=0.0,
+            pollInterval=1.0,
             description='Percent complete: 0.0 - 1.0.'))
 
         self.add(pr.LocalVariable(
             name='Message',
             mode='RO',
             value='',
+            pollInterval=1.0,
             description='Process status message. Prefix with Error: if an error occured.'))
 
     def _start(self):

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -71,8 +71,7 @@ class Process(pr.Device):
         with self._lock:
             self._runEn  = False
 
-    @pr.expose
-    def call(self,arg=None):
+    def __call__(self,arg=None):
         with self._lock:
             if self.Running.value() is False:
                 if arg is not None and self._argVar is not None:
@@ -85,9 +84,6 @@ class Process(pr.Device):
                 self._log.warning("Process already running!")
 
         return None
-
-    def __call__(self,arg=None):
-        return self.call(arg)
 
     def _run(self):
         self.Running.set(True)

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -56,7 +56,13 @@ class Process(pr.Device):
             mode='RO',
             units='Pct',
             value=0.0,
-            description='Percent complete.'))
+            description='Percent complete: 0.0 - 1.0.'))
+
+        self.add(pr.LocalVariable(
+            name='Message',
+            mode='RO',
+            value='',
+            description='Process status message. Prefix with Error: if an error occured.'))
 
     def _start(self):
         with self._lock:
@@ -96,10 +102,12 @@ class Process(pr.Device):
         self.Running.set(False)
 
     def _process(self):
+        self.Message.setDisp("Started")
         for i in range(101):
             if self._runEn is False:
                 break
             time.sleep(1)
             self.Progress.set(i)
-
+            self.Message.setDisp(f"Running for {i} seconds.")
+        self.Message.setDisp("Done")
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -294,7 +294,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     @pr.expose
     def exec(self,path,arg):
         obj = self.getNode(path)
-        return obj.call(arg)
+        return obj(arg)
 
     def setVisibility(self, visibility, nodes):
         """ Set visibility for a list of Node names"""

--- a/python/pyrogue/_Virtual.py
+++ b/python/pyrogue/_Virtual.py
@@ -69,8 +69,8 @@ def VirtualFactory(data):
         for k in data['props']:
             setattr(self.__class__,k,VirtualProperty(self,k))
 
-        # Add __call__ if command
-        if str(pr.BaseCommand) in data['bases']:
+        # Add __call__ if command or Process
+        if str(pr.BaseCommand) in data['bases'] or str(pr.Process) in data['bases']:
             setattr(self.__class__,'__call__',self._call)
         
         # Add getNode and addVarListener if root

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -132,11 +132,11 @@ class CommandLink(QObject):
 
         if self._command.arg:
             try:
-                self._command.call(self._command.parseDisp(value))
+                self._command(self._command.parseDisp(value))
             except Exception:
                 pass
         else:
-            self._command.call()
+            self._command()
 
 class CommandWidget(QWidget):
     def __init__(self, *, parent=None):

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -67,9 +67,9 @@ class EpicsPvHandler(p4p.server.thread.Handler):
             val = op.value().query
 
             if 'arg' in val:
-                ret = self._var.call(val.arg)
+                ret = self._var(val.arg)
             else:
-                ret = self._var.call()
+                ret = self._var()
 
             if ret is None: ret = 'None'
 


### PR DESCRIPTION
This adds the call() and __call__ methods to the Process device to allow it to be treated as a command. The creator now includes the argVariable arg which indicates which sub-variable to update with the value passed in the call. This could be used to replace the "LoadConfig" Command with a Process.

LoadConfig(argVariable='FileName')

LoadConfig.Start.call("config.yaml")
LoadConfig.Start("config.yaml")
LoadConfig.call("config.yaml")
LoadConfig("config.yaml")

all can be used to start the process.
