### PR TITLE
Support zip file archives for libraries and config files

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -26,6 +26,7 @@ import functools as ft
 import time
 import queue
 import jsonpickle
+import zipfile
 from contextlib import contextmanager
 
 class RootLogHandler(logging.Handler):
@@ -463,9 +464,21 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     def _loadConfig(self,arg):
         """Load YAML configuration from a file. Called from command"""
-        try:
-            with open(arg,'r') as f:
-                self._setYaml(f.read(),False,['RW','WO'])
+        try: 
+
+            # File in a Zip archive
+            if '.zip/' in arg:
+                base = np[:np.find['.zip/']+4]
+                sub  = np[np.find['.zip/']+5:]
+
+                with zipfile.ZipFile(base) as zf:
+                    with zf.open(sub,'r') as f:
+                        self._setYaml(f.read(),False,['RW','WO'])
+              
+            # Standard file
+            else:
+                with open(arg,'r') as f:
+                    self._setYaml(f.read(),False,['RW','WO'])
         except Exception as e:
             self._log.exception(e)
             return False

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -53,11 +53,15 @@ def addLibraryPath(path):
         else:
             np = base + '/' + p
         
-        # Verify directory exists and is readable
-        if not os.access(np,os.R_OK):
-            raise Exception("Library path {} does not exist or is not readable".format(np))
-        sys.path.append(np)
+        # Verify directory or archive exists and is readable
+        if '.zip/' in np:
+            tst = np[:np.find['.zip/']+4]
+        else:
+            tst = np
 
+        if not os.access(tst,os.R_OK):
+            raise Exception("Library path {} does not exist or is not readable".format(tst))
+        sys.path.append(np)
 
 def streamConnect(source, dest):
     """


### PR DESCRIPTION
This adds support for adding library paths in zip files with the following command:

pyrogue.addLibraryPath('/my/path/to/archive.zip/python/')

It also allows config files to be loaded from similar archives:

root.LoadConfig('/my/path/to/archive.zip/config/defaults.yml')