### PR TITLE
Move VirtualClient to interfaces

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -196,7 +196,7 @@ class Node(object):
                 attr['funcs'][k] = {'args'   : [a for a in inspect.getfullargspec(v).args if a != 'self'],
                                     'kwargs' : inspect.getfullargspec(v).kwonlyargs}
 
-        return (pr.VirtualFactory, (attr,))
+        return (pr.interfaces.VirtualFactory, (attr,))
 
     def __contains__(self, item):
         return item in self._nodes.values()
@@ -538,4 +538,12 @@ def nodeMatch(nodes,name):
         else:
             return [r]
 
+def genBaseList(cls):
+    ret = [str(cls)]
+
+    for l in cls.__bases__:
+        if l is not object:
+            ret += genBaseList(l)
+
+    return ret
 

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -23,7 +23,6 @@ from pyrogue._Device    import *
 from pyrogue._Memory    import *
 from pyrogue._Root      import *
 from pyrogue._PollQueue import *
-from pyrogue._Virtual   import *
 from pyrogue._Process   import *
 from pyrogue._DataWriter import *
 from pyrogue._RunControl import *

--- a/python/pyrogue/gui/__main__.py
+++ b/python/pyrogue/gui/__main__.py
@@ -10,6 +10,7 @@
 
 import argparse
 import pyrogue
+import pyrogue.interfaces
 import pyrogue.gui
 import sys
 
@@ -22,7 +23,7 @@ args = parser.parse_args()
 print("Connecting to host {} port {}".format(args.host,args.port))
 
 # Connect to the server
-client = pyrogue.VirtualClient(args.host,args.port)
+client = pyrogue.interfaces.VirtualClient(args.host,args.port)
 
 # Create GUI
 appTop = pyrogue.gui.application(sys.argv)

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -27,6 +27,7 @@ except ImportError:
     from PyQt4.QtGui     import *
 
 import pyrogue
+import pyrogue.interfaces
 import pyrogue.gui
 import pyrogue.gui.variables
 import pyrogue.gui.commands
@@ -41,7 +42,7 @@ def application(argv):
 class GuiTop(QWidget):
 
     newRoot = pyqtSignal(pyrogue.Root,int)
-    newVirt = pyqtSignal(pyrogue.VirtualNode,int)
+    newVirt = pyqtSignal(pyrogue.interfaces.VirtualNode,int)
 
     def __init__(self,*, parent=None, minVisibility=25, group=None):
         super(GuiTop,self).__init__(parent)
@@ -78,13 +79,13 @@ class GuiTop(QWidget):
         if not root.running:
             raise Exception("GUI can not be attached to a tree which is not started")
 
-        if isinstance(root,pyrogue.VirtualNode):
+        if isinstance(root,pyrogue.interfaces.VirtualNode):
             self.newVirt.emit(root,self._minVisibility)
         else:
             self.newRoot.emit(root,self._minVisibility)
 
     @pyqtSlot(pyrogue.Root,int)
-    @pyqtSlot(pyrogue.VirtualNode,int)
+    @pyqtSlot(pyrogue.interfaces.VirtualNode,int)
     def _addTree(self,root,minVisibility):
         self.sys = pyrogue.gui.system.SystemWidget(root=root,parent=self.tab)
         self.tab.addTab(self.sys,root.name)

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -159,7 +159,7 @@ class CommandWidget(QWidget):
         self.devTop = None
 
     @pyqtSlot(pyrogue.Root,int)
-    @pyqtSlot(pyrogue.VirtualNode,int)
+    @pyqtSlot(pyrogue.interfaces.VirtualNode,int)
     def addTree(self,root,minVisibility):
         self.roots.append(root)
         self._children.append(CommandDev(tree=self.tree,

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -27,6 +27,7 @@ except ImportError:
     from PyQt4.QtGui     import *
 
 import pyrogue
+import pyrogue.interfaces
 import threading
 
 class VariableDev(QObject):
@@ -333,7 +334,7 @@ class VariableWidget(QWidget):
         self.devTop = None
 
     @pyqtSlot(pyrogue.Root,int)
-    @pyqtSlot(pyrogue.VirtualNode,int)
+    @pyqtSlot(pyrogue.interfaces.VirtualNode,int)
     def addTree(self,root, minVisibility):
         self.roots.append(root)
         self._children.append(VariableDev(tree=self.tree,

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -24,15 +24,6 @@ import functools as ft
 import jsonpickle
 
 
-def genBaseList(cls):
-    ret = [str(cls)]
-
-    for l in cls.__bases__:
-        if l is not object:
-            ret += genBaseList(l)
-
-    return ret
-
 
 class VirtualProperty(object):
     def __init__(self, node, attr):

--- a/python/pyrogue/interfaces/__init__.py
+++ b/python/pyrogue/interfaces/__init__.py
@@ -9,4 +9,5 @@
 #-----------------------------------------------------------------------------
 
 from pyrogue.interfaces._ZmqServer import *
+from pyrogue.interfaces._Virtual   import *
 


### PR DESCRIPTION
This moves the VirtualClient class from pyrogue.VirtualClient to pyrogue.interfaces.VirtualClient to be consistent with other itnterfaces.