### PR TITLE
Make error messages more clear

### DIFF
--- a/docs/src/interfaces/memory/hub.rst
+++ b/docs/src/interfaces/memory/hub.rst
@@ -67,8 +67,8 @@ transctions in Python.
                    self._waitTransaction(id)
 
                    # Check transaction result, forward error to incoming transaction
-                   if self._getError() != 0:
-                       transaction.done(self._getError())
+                   if self._getError() != "":
+                       transaction.error(self._getError())
                        return False
 
                    # Handle write or post
@@ -86,12 +86,12 @@ transctions in Python.
                       self._waitTransaction(id)
 
                       # Check transaction result, forward error to incoming transaction
-                      if self._getError() != 0:
-                          transaction.done(self._getError())
+                      if self._getError() != "":
+                          transaction.error(self._getError())
                           return False
 
                       # Success
-                      transaction.done(0)
+                      transaction.done()
 
                    # Handle read or verify read
                    else:
@@ -106,13 +106,13 @@ transctions in Python.
                       self._waitTransaction(id)
 
                       # Check transaction result, forward error to incoming transaction
-                      if self._getError() != 0:
-                          transaction->done(self._getError())
+                      if self._getError() != "":
+                          transaction.error(self._getError())
                           return False
 
                       # Copy data into original transaction and complete
                       transaction.setData(data,0)
-                      transaction.done(0)
+                      transaction.done()
 
 
 Python Device Hub Example
@@ -237,8 +237,8 @@ transctions in C++.
             this->waitTransaction(id);
 
             // Check transaction result, forward error to incoming transaction
-            if ( this->getError() != 0 ) {
-               transaction->done(this->getError());
+            if ( this->getError() != "" ) {
+               transaction->error(this->getError());
                return false
             }
 
@@ -255,11 +255,11 @@ transctions in C++.
                this->waitTransaction(id);
 
                // Check transaction result, forward error to incoming transaction
-               if ( this->getError() != 0 ) {
-                  transaction->done(this->getError());
+               if ( this->getError() != "" ) {
+                  transaction->error(this->getError());
                   return false
                }
-               else transaction->done(0);
+               else transaction->done();
             }
 
             // Handle read or verify read
@@ -274,11 +274,11 @@ transctions in C++.
                this->waitTransaction(id);
 
                // Check transaction result, forward error to incoming transaction
-               if ( this->getError() != 0 ) {
-                  transaction->done(this->getError());
+               if ( this->getError() != "" ) {
+                  transaction->error(this->getError());
                   return false
                }
-               else transaction->done(0);
+               else transaction->done();
             }
 
    };

--- a/docs/src/interfaces/memory/slave.rst
+++ b/docs/src/interfaces/memory/slave.rst
@@ -93,11 +93,11 @@ See :ref:`interfaces_memory_slave` for more detail on the Slave class.
 
                 # If an error occured, complete result with bus fail
                 if not result:
-                    tran.done(rogue.interfaces.memory.BusFail)
+                    tran.error(f"Got a bad result: {result}")
                
                 # Otherwise complete transaction with success 
                 else: 
-                    tran.done(0)
+                    tran.done()
 
         # Protocol callback for read complete
         def protocolReadDone(self,id,data,result):
@@ -118,13 +118,13 @@ See :ref:`interfaces_memory_slave` for more detail on the Slave class.
 
                 # If an error occured, complete result with bus fail
                 if not result:
-                    tran.done(rogue.interfaces.memory.BusFail)
+                    tran.error(f"Got a bad result: {result}")
                
                 # Otherwise set the read data back to the transaction
                 # and complete without error
                 else: 
                     tran.setData(data,0)
-                    tran.done(0)
+                    tran.done()
 
 The equivelent code in C++ is show below:
 
@@ -197,10 +197,10 @@ The equivelent code in C++ is show below:
             if ( tran->expired() ) return;
 
             // If an error occured, complete result with bus fail
-            if ( ! result ) tran->done(rogue::interfaces::memory::BusFail);
+            if ( ! result ) tran->error("Got a bad protocol result %i",result);
                
             // Otherwise complete transaction with success 
-            else tran->done(0);
+            else tran->done();
          }
 
          // Protocol callback for read complete
@@ -217,13 +217,13 @@ The equivelent code in C++ is show below:
             if ( tran->expired() ) return;
 
             // If an error occured, complete result with bus fail
-            if ( ! result ) tran->done(rogue::interfaces::memory::BusFail);
+            if ( ! result ) tran->error("Got a bad protocol result %i",result);
                
             // Otherwise set the read data back to the transaction
             // and complete without error
             else {
                std::copy(data,data+tran->size(),tran->begin());
-               tran->done(0);
+               tran->done();
             }
          }
    };

--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -48,14 +48,10 @@ namespace rogue {
          GeneralError (std::string src,std::string text);
 
          static GeneralError create(std::string src, const char * fmt, ...);
-         static GeneralError timeout(std::string src, struct timeval & tout);
-         static GeneralError timeout(std::string src, uint32_t tout);
          static GeneralError open(std::string src, std::string file);
          static GeneralError dest(std::string src, std::string file, uint32_t dest);
-         static GeneralError boundary(std::string src, uint32_t position, uint32_t limit);
          static GeneralError allocation(std::string src, uint32_t size);
          static GeneralError network(std::string src, std::string host, uint16_t port);
-         static GeneralError ret(std::string src, std::string text, int32_t ret);
 
          char const * what() const throw();
          static void setup_python();

--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -27,16 +27,11 @@
 #include <boost/python.hpp>
 #endif
 
-#define DEFAULT_TIMEOUT 1000000
-
 namespace rogue {
 
 #ifndef NO_PYTHON
    extern PyObject * generalErrorObj;
 #endif
-
-   // Set default timeout value
-   void defaultTimeout(struct timeval &tout);
 
    //! General exception 
    /*

--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -48,10 +48,6 @@ namespace rogue {
          GeneralError (std::string src,std::string text);
 
          static GeneralError create(std::string src, const char * fmt, ...);
-         static GeneralError open(std::string src, std::string file);
-         static GeneralError dest(std::string src, std::string file, uint32_t dest);
-         static GeneralError allocation(std::string src, uint32_t size);
-         static GeneralError network(std::string src, std::string host, uint16_t port);
 
          char const * what() const throw();
          static void setup_python();

--- a/include/rogue/Helpers.h
+++ b/include/rogue/Helpers.h
@@ -34,5 +34,20 @@
 // Connect memory bus
 #define busConnect(src,dst) src->setSlave(dst);
 
+// Global default timeout value
+#define DEFAULT_TIMEOUT 1000000
+
+namespace rogue {
+
+   // Return default timeout value
+   inline void defaultTimeout(struct timeval &tout) {
+      div_t divResult = div(DEFAULT_TIMEOUT,1000000);
+      tout.tv_sec  = divResult.quot;
+      tout.tv_usec = divResult.rem;
+   }
+}
+
+
+
 #endif
 

--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -85,9 +85,6 @@ namespace rogue {
          void info(const char * fmt, ...);
          void debug(const char * fmt, ...);
 
-         void timeout(const char *txt, struct timeval & tout);
-         void timeout(const char *txt, uint32_t tout);
-
          void logThreadId();
 
          static void setup_python();

--- a/include/rogue/interfaces/memory/Constants.h
+++ b/include/rogue/interfaces/memory/Constants.h
@@ -25,66 +25,6 @@ namespace rogue {
    namespace interfaces {
       namespace memory {
 
-         ///////////////////////////
-         // Memory Error Constants
-         ///////////////////////////
-
-         /** This is a software level timeout that is triggered
-          * if the memory Slave never completed the transaction.
-          *
-          * Exposted to python as rogue.interfaces.memory.TimeoutError
-          */
-         static const uint32_t TimeoutError = 0x01000000;
-
-         /** The readback verify value did not match the written value.
-          *
-          * Exposted to python as rogue.interfaces.memory.VerifyError
-          */
-         static const uint32_t VerifyError = 0x02000000;
-
-         /** The Slave has declared an address error.
-          * This can occur if the address is at an alignment not
-          * support by the memory Slave
-          *
-          * Exposted to python as rogue.interfaces.memory.AddressError
-          */
-         static const uint32_t AddressError = 0x03000000;
-
-         /** A bus timeout is declared at the hardware level
-          * indicating the bus transaction has timed out.
-          *
-          * Exposted to python as rogue.interfaces.memory.BusTimeout
-          */
-         static const uint32_t BusTimeout = 0x04000000;
-
-         /** A bus failure is declared at the hardware level.
-          *
-          * Exposted to python as rogue.interfaces.memory.BusFail
-          */
-         static const uint32_t BusFail = 0x05000000;
-
-         /** The transaction is not unsupported.
-          *
-          * Exposted to python as rogue.interfaces.memory.Unsupported
-          */
-         static const uint32_t Unsupported = 0x06000000;
-
-         /** The Slave has declared a size violation. This can 
-          * occur when the requested transaction size exceeds 
-          * the maximum transaction supported by the Slave.
-          *
-          * Exposted to python as rogue.interfaces.memory.SizeError
-          */
-         static const uint32_t SizeError = 0x07000000;
-
-         /** The Slave has declared a protocol error. This can 
-          * occur if the transaction data was corrupted while the 
-          * transaction was in progress. 
-          *
-          * Exposted to python as rogue.interfaces.memory.ProtocolError
-          */
-         static const uint32_t ProtocolError = 0x08000000;
-
          //////////////////////////////
          // Transaction Type Constants
          //////////////////////////////

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -64,7 +64,7 @@ namespace rogue {
                std::mutex mastMtx_;
 
                //! Error status
-               uint32_t error_;
+               std::string error_;
 
                //! Log
                std::shared_ptr<rogue::Logging> log_;
@@ -144,21 +144,21 @@ namespace rogue {
                //! Get error of last Transaction
                /** This method returns the error value of the last set of transactions initiated
                 * by this master. If more than one transaction was initiated, the result is the
-                * logical of the transaction error values.
+                * concatenation the transaction error values.
                 *
                 * Exposted to python as _getError()
                 * @return Error value
                 */
-               uint32_t getError();
+               std::string getError();
 
                //! Set the error value
                /** This method sets the error value for this master. Set to
-                * zero to clear the error state.
+                * "" to clear the error state.
                 *
                 * Exposted to python as _setError()
                 * @param error New error value
                 */
-               void setError(uint32_t error);
+               void setError(std::string error);
 
                //! Set timeout value for transactions
                /** Sets the timeout value for future transactions. THis is the amount of time

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -151,14 +151,12 @@ namespace rogue {
                 */
                std::string getError();
 
-               //! Set the error value
-               /** This method sets the error value for this master. Set to
-                * "" to clear the error state.
+               //! Clear the error value
+               /** This method clears the error value for this master.
                 *
-                * Exposted to python as _setError()
-                * @param error New error value
+                * Exposted to python as _clearError()
                 */
-               void setError(std::string error);
+               void clearError();
 
                //! Set timeout value for transactions
                /** Sets the timeout value for future transactions. THis is the amount of time

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -143,8 +143,7 @@ namespace rogue {
 
                //! Get error of last Transaction
                /** This method returns the error value of the last set of transactions initiated
-                * by this master. If more than one transaction was initiated, the result is the
-                * concatenation the transaction error values.
+                * by this master. 
                 *
                 * Exposted to python as _getError()
                 * @return Error value

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -182,7 +182,6 @@ namespace rogue {
                 * error types are defined in Constants.
                 *
                 * Exposted as done() to Python
-                * @param error Transaction error message or "" for no error.
                 */
                void done();
 

--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -98,7 +98,7 @@ namespace rogue {
                uint32_t type_;
 
                // Transaction error
-               uint32_t error_;
+               std::string error_;
 
                // Transaction id
                uint32_t id_;
@@ -113,7 +113,7 @@ namespace rogue {
                static std::shared_ptr<rogue::interfaces::memory::Transaction> create (struct timeval timeout);
 
                // Wait for the transaction to complete, called by Master
-               uint32_t wait();
+               std::string wait();
 
             public:
 
@@ -177,14 +177,29 @@ namespace rogue {
                 */
                void refreshTimer(std::shared_ptr<rogue::interfaces::memory::Transaction> reference);
 
-               //! Complete transaction with passed error
+               //! Complete transaction without error
                /** Lock must be held before calling this method. The
                 * error types are defined in Constants.
                 *
                 * Exposted as done() to Python
-                * @param error Transaction error value or 0 for no error.
+                * @param error Transaction error message or "" for no error.
                 */
-               void done(uint32_t error);
+               void done();
+
+               //! Complete transaction with passed error, python interface
+               /** Lock must be held before calling this method.
+                *
+                * Exposted as error() to Python
+                * @param error Transaction error message
+                */
+               void errorPy(std::string error);
+
+               //! Complete transaction with passed error
+               /** Lock must be held before calling this method.
+                *
+                * @param error Transaction error message
+                */
+               void error(const char * fmt, ...);
 
                //! Get start iterator for Transaction data
                /** Not exposed to Python

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -27,10 +27,10 @@ class MemoryError(Exception):
 
     def __init__(self, *, name, address, msg=None, size=0):
 
-        self._value = f"Memory Error for {name} at address {address:#08x} "
+        self._value = f"Memory Error for {name} at address {address:#08x}"
 
         if msg is not None:
-            self._value += msg
+            self._value += " " + msg
 
     def __str__(self):
         return repr(self._value)

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -25,39 +25,12 @@ import inspect
 class MemoryError(Exception):
     """ Exception for memory access errors."""
 
-    def __init__(self, *, name, address, error=0, msg=None, size=0):
+    def __init__(self, *, name, address, msg=None, size=0):
 
         self._value = f"Memory Error for {name} at address {address:#08x} "
 
-        if (error & 0xFF000000) == rim.TimeoutError:
-            self._value += "Timeout."
-
-        elif (error & 0xFF000000) == rim.VerifyError:
-            self._value += "Verify error."
-
-        elif (error & 0xFF000000) == rim.AddressError:
-            self._value += "Address error."
-
-        elif (error & 0xFF000000) == rim.SizeError:
-            self._value += f"Size error. Size={size}."
-
-        elif (error & 0xFF000000) == rim.BusTimeout:
-            self._value += "Bus timeout."
-
-        elif (error & 0xFF000000) == rim.BusFail:
-            self._value += "Bus Error: {:#02x}".format(error & 0xFF)
-
-        elif (error & 0xFF000000) == rim.Unsupported:
-            self._value += "Unsupported Transaction."
-
-        elif (error & 0xFF000000) == rim.ProtocolError:
-            self._value += "Protocol Error."
-
-        elif error != 0:
-            self._value += f"Unknown error {error:#02x}."
-
         if msg is not None:
-            self._value += (' ' + msg)
+            self._value += msg
 
     def __str__(self):
         return repr(self._value)
@@ -433,7 +406,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                 return
 
             self._waitTransaction(0)
-            self.error = 0
+            self.error = ""
 
             # Move staged write data to block. Clear stale.
             if type == rim.Write or type == rim.Post:
@@ -483,10 +456,10 @@ class RemoteBlock(BaseBlock, rim.Master):
 
             # Error
             err = self.error
-            self.error = 0
+            self.error = ""
 
-            if err > 0:
-                raise MemoryError(name=self.path, address=self.address, error=err, size=self._size)
+            if err != "":
+                raise MemoryError(name=self.path, address=self.address, msg=err, size=self._size)
 
             if self._doVerify:
                 self._verifyWr = False
@@ -497,7 +470,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                         msg += ('. Verify=' + ''.join(f'{x:#02x}' for x in self._vData))
                         msg += ('. Mask='   + ''.join(f'{x:#02x}' for x in self._vDataMask))
 
-                        raise MemoryError(name=self.path, address=self.address, error=rim.VerifyError, msg=msg, size=self._size)
+                        raise MemoryError(name=self.path, address=self.address, msg=msg, size=self._size)
 
                # Updated
             doUpdate = self._doUpdate

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -343,10 +343,6 @@ class RemoteBlock(BaseBlock, rim.Master):
     def error(self):
         return self._getError()
 
-    @error.setter
-    def error(self,value):
-        self._setError(value)
-
     @property
     def bulkEn(self):
         return self._bulkEn
@@ -406,7 +402,7 @@ class RemoteBlock(BaseBlock, rim.Master):
                 return
 
             self._waitTransaction(0)
-            self.error = ""
+            self._clearError()
 
             # Move staged write data to block. Clear stale.
             if type == rim.Write or type == rim.Post:
@@ -456,7 +452,7 @@ class RemoteBlock(BaseBlock, rim.Master):
 
             # Error
             err = self.error
-            self.error = ""
+            self._clearError()
 
             if err != "":
                 raise MemoryError(name=self.path, address=self.address, msg=err, size=self._size)
@@ -466,7 +462,8 @@ class RemoteBlock(BaseBlock, rim.Master):
 
                 for x in range(self._size):
                     if (self._vData[x] & self._vDataMask[x]) != (self._bData[x] & self._vDataMask[x]):
-                        msg  = ('Local='    + ''.join(f'{x:#02x}' for x in self._bData))
+                        msg  = "Verify Error: "
+                        msg += ('Local='    + ''.join(f'{x:#02x}' for x in self._bData))
                         msg += ('. Verify=' + ''.join(f'{x:#02x}' for x in self._vData))
                         msg += ('. Mask='   + ''.join(f'{x:#02x}' for x in self._vDataMask))
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -412,7 +412,7 @@ class Device(pr.Node,rim.Hub):
             else: txn = rim.Write
 
             for _ in range(tryCount):
-                self._setError(0)
+                self._clearError()
                 self._rawTxnChunker(offset, data, base, stride, wordBitSize, txn)
                 self._waitTransaction(0)
 
@@ -426,7 +426,7 @@ class Device(pr.Node,rim.Hub):
     def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=32, data=None, tryCount=1):
         with self._memLock:
             for _ in range(tryCount):
-                self._setError(0)
+                self._clearError()
                 ldata = self._rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Read, numWords=numWords)
                 self._waitTransaction(0)
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -416,12 +416,12 @@ class Device(pr.Node,rim.Hub):
                 self._rawTxnChunker(offset, data, base, stride, wordBitSize, txn)
                 self._waitTransaction(0)
 
-                if self._getError() == 0: return
+                if self._getError() == "": return
                 elif posted: break
                 self._log.warning("Retrying raw write transaction")
 
             # If we get here an error has occured
-            raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
+            raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
         
     def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=32, data=None, tryCount=1):
         with self._memLock:
@@ -430,7 +430,7 @@ class Device(pr.Node,rim.Hub):
                 ldata = self._rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Read, numWords=numWords)
                 self._waitTransaction(0)
 
-                if self._getError() == 0:
+                if self._getError() == "":
                     if numWords == 1:
                         return base.fromBytes(base.mask(ldata, wordBitSize),wordBitSize)
                     else:
@@ -438,7 +438,7 @@ class Device(pr.Node,rim.Hub):
                 self._log.warning("Retrying raw read transaction")
                 
             # If we get here an error has occured
-            raise pr.MemoryError (name=self.name, address=offset|self.address, error=self._getError())
+            raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
 
 
     def _getBlocks(self, variables):

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -111,7 +111,7 @@ class MemoryDevice(pr.Device):
 
             # Error check?
             error = self._getError()
-            self._setError(0)
+            self._setError("")
 
             # Convert the read verfiy data back to the native type
             # Can't do this until waitTransaction is done
@@ -128,7 +128,7 @@ class MemoryDevice(pr.Device):
                     msg += f'Expected: \n {self._wrValues} \n'
                     msg += f'Got: \n {checkValues}'
                     print(msg)
-                    raise MemoryError(name=self.name, address=self.address, error=rim.VerifyError, msg=msg, size=self._size)
+                    raise MemoryError(name=self.name, address=self.address, msg=msg, size=self._size)
 
 
             # destroy the txn maps when done with verify

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -63,7 +63,7 @@ class MemoryDevice(pr.Device):
             #print(f'get() self._wordBitSize={self._wordBitSize}')
             data = self._rawTxnChunker(offset=offset, data=None, base=self._base, stride=self._stride, wordBitSize=self._wordBitSize, txnType=rim.Read, numWords=numWords)
             self._waitTransaction(0)
-            self._setError(0)
+            self._clearError()
             return [self._base.fromBytes(data[i:i+self._stride], self._wordBitSize)
                     for i in range(0, len(data), self._stride)]
 
@@ -111,7 +111,7 @@ class MemoryDevice(pr.Device):
 
             # Error check?
             error = self._getError()
-            self._setError("")
+            self._clearError()
 
             # Convert the read verfiy data back to the native type
             # Can't do this until waitTransaction is done

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -150,10 +150,10 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         type    = transaction.type()
 
         if (address % self._minWidth) != 0:
-            transaction.done(rogue.interfaces.memory.AddressError)
+            trasnaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")
             return
         elif size > self._maxSize:
-            transaction.done(rogue.interfaces.memory.SizeError)
+            trasnaction.error("Transaction size {size} exceeds max {self._maxSize}")
             return
 
         for i in range (0, size):
@@ -168,12 +168,12 @@ class MemEmulate(rogue.interfaces.memory.Slave):
             for i in range(0, size):
                 self._data[address+i] = ba[i]
 
-            transaction.done(0)
+            transaction.done()
 
         else:
             for i in range(0, size):
                 ba[i] = self._data[address+i]
 
             transaction.setData(ba,0)
-            transaction.done(0)
+            transaction.done()
 

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -150,10 +150,10 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         type    = transaction.type()
 
         if (address % self._minWidth) != 0:
-            trasnaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")
+            transaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")
             return
         elif size > self._maxSize:
-            trasnaction.error("Transaction size {size} exceeds max {self._maxSize}")
+            transaction.error("Transaction size {size} exceeds max {self._maxSize}")
             return
 
         for i in range (0, size):

--- a/src/rogue/GeneralError.cpp
+++ b/src/rogue/GeneralError.cpp
@@ -44,59 +44,10 @@ rogue::GeneralError rogue::GeneralError::create(std::string src, const char * fm
    return(rogue::GeneralError(src,temp));
 }
 
-rogue::GeneralError rogue::GeneralError::timeout(std::string src, struct timeval & tout) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"timeout after %li.%li Seconds",tout.tv_sec, tout.tv_usec);
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::timeout(std::string src, uint32_t tout) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"timeout after %i Microseconds",tout);
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::open(std::string src, std::string file) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"failed to open file %s",file.c_str());
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::dest(std::string src, std::string file, uint32_t dest) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"failed to open file %s with dest 0x%x",file.c_str(),dest);
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::boundary(std::string src, uint32_t position, uint32_t limit) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"boundary error. Position = %i, Limit = %i",position,limit);
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::allocation(std::string src, uint32_t size) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"failed to allocate size = %i",size);
-   return(rogue::GeneralError(src,temp));
-}
-
 rogue::GeneralError rogue::GeneralError::network(std::string src, std::string host, uint16_t port) {
    char temp[BuffSize];
 
    snprintf(temp,BuffSize,"Network connect error. Host = %s, Port = %i",host.c_str(),port);
-   return(rogue::GeneralError(src,temp));
-}
-
-rogue::GeneralError rogue::GeneralError::ret(std::string src, std::string text, int32_t ret) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"%s. Ret=%i",text.c_str(),ret);
    return(rogue::GeneralError(src,temp));
 }
 

--- a/src/rogue/GeneralError.cpp
+++ b/src/rogue/GeneralError.cpp
@@ -44,13 +44,6 @@ rogue::GeneralError rogue::GeneralError::create(std::string src, const char * fm
    return(rogue::GeneralError(src,temp));
 }
 
-rogue::GeneralError rogue::GeneralError::network(std::string src, std::string host, uint16_t port) {
-   char temp[BuffSize];
-
-   snprintf(temp,BuffSize,"Network connect error. Host = %s, Port = %i",host.c_str(),port);
-   return(rogue::GeneralError(src,temp));
-}
-
 char const * rogue::GeneralError::what() const throw() {
    return(text_);
 }

--- a/src/rogue/GeneralError.cpp
+++ b/src/rogue/GeneralError.cpp
@@ -29,13 +29,6 @@ PyObject * rogue::generalErrorObj = 0;
 
 #endif
 
-// Set default timeout value
-void rogue::defaultTimeout(struct timeval &tout) {
-   div_t divResult = div(DEFAULT_TIMEOUT,1000000);
-   tout.tv_sec  = divResult.quot;
-   tout.tv_usec = divResult.rem;
-}
-
 rogue::GeneralError::GeneralError(std::string src,std::string text) {
    snprintf(text_,BuffSize,"%s: General Error: %s",src.c_str(),text.c_str());
 }

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -147,14 +147,6 @@ void rogue::Logging::debug(const char * fmt, ...) {
    va_end(arg);
 }
 
-void rogue::Logging::timeout(const char *txt, struct timeval & tout) {
-   rogue::Logging::critical("%s: Timeout after %li.%li seconds", txt, tout.tv_sec, tout.tv_usec);
-}
-
-void rogue::Logging::timeout(const char *txt, uint32_t tout) {
-   rogue::Logging::critical("%s: Timeout after %i microseconds", txt, tout);
-}
-
 void rogue::Logging::logThreadId() {
    uint32_t tid;
 

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -49,7 +49,8 @@ rha::AxiMemMapPtr rha::AxiMemMap::create (std::string path) {
 rha::AxiMemMap::AxiMemMap(std::string path) : rim::Slave(4,0xFFFFFFFF) {
    fd_ = ::open(path.c_str(), O_RDWR);
    log_ = rogue::Logging::create("axi.AxiMemMap");
-   if ( fd_ < 0 ) throw(rogue::GeneralError::open("AxiMemMap::AxiMemMap",path));
+   if ( fd_ < 0 ) 
+      throw(rogue::GeneralError::create("AxiMemMap::AxiMemMap", "Failed to open device file: %s",path.c_str()));
 }
 
 //! Destructor

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -71,7 +71,8 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
    dataSize = sizeof(uint32_t);
    ptr = (uint8_t *)(&data);
 
-   if ( (tran->size() % dataSize) != 0 ) tran->done(rim::SizeError);
+   if ( (tran->size() % dataSize) != 0 ) 
+      tran->error("Invalid transaction size %i, must be an integer number of %i bytes",tran->size(),dataSize);
 
    count = 0;
    ret = 0;
@@ -96,7 +97,8 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
    }
 
    log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
-   tran->done((ret==0)?0:1);
+   if ( ret != 0 ) tran->error("Memory transaction failed with error code %i, see driver error codes",ret);
+   else tran->done();
 }
 
 void rha::AxiMemMap::setup_python () {

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -161,7 +161,7 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->timeout("AxiStreamDma::acceptReq", timeout_);
+               log_->critical("AxiStreamDma::acceptReq: Timeout waiting for outbound buffer after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -256,7 +256,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
             
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->timeout("AxiStreamDma::acceptFrame", timeout_);
+               log_->critical("AxiStreamDma::acceptFrame: Timeout waiting for outbound write after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -57,7 +57,7 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
    rogue::GilRelease noGil;
 
    if ( (fd_ = ::open(path.c_str(), O_RDWR)) < 0 )
-      throw(rogue::GeneralError::open("AxiStreamDma::AxiStreamDma",path.c_str()));
+      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", "Failed to open device file: %s",path.c_str()));
 
    if ( dmaCheckVersion(fd_) < 0 )
       throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Bad kernel driver version detected. Please re-compile kernel driver"));
@@ -67,7 +67,9 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
 
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
-      throw(rogue::GeneralError::dest("AxiStreamDma::AxiStreamDma",path.c_str(),dest_));
+      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", 
+            "Failed to open device file %s with dest 0x%x",path.c_str(),dest));
+
    }
 
    // Result may be that rawBuff_ = NULL

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -73,7 +73,7 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
 
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
-      throw(rogue::GeneralError::dest("PgpCard::PgpCard",path.c_str(),(lane_*4)+vc_));
+      throw(rogue::GeneralError::create("PgpCard::PgpCard","Failed to acquire destination %i on device %s",(lane*4)+vc,path.c_str()));
    }
 
    // Result may be that rawBuff_ = NULL

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -29,6 +29,7 @@
 #include <rogue/interfaces/stream/FrameLock.h>
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -205,7 +205,7 @@ ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->timeout("PgpCard::acceptReq", timeout_);
+               log_->critical("PgpCard::acceptReq: Timeout waiting for outbound buffer after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -281,7 +281,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->timeout("PgpCard::acceptFrame", timeout_);
+               log_->critical("PgpCard::acceptFrame: Timeout waiting for outbound write after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -63,7 +63,7 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
    log_ = rogue::Logging::create("hardware.PgpCard");
 
    if ( (fd_ = ::open(path.c_str(), O_RDWR)) < 0 ) 
-      throw(rogue::GeneralError::open("PgpCard::PgpCard",path.c_str()));
+      throw(rogue::GeneralError::create("PgpCard::PgpCard", "Failed to open device file: %s",path.c_str()));
 
    if ( dmaCheckVersion(fd_) < 0 )
       throw(rogue::GeneralError("PgpCard::PgpCard","Bad kernel driver version detected. Please re-compile kernel driver"));

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -125,7 +125,7 @@ std::string rogue::interfaces::ZmqClient::send(std::string value) {
    zmq_msg_init(&msg);
 
    if ( zmq_recvmsg(this->zmqReq_,&msg,0) <= 0 )
-      throw rogue::GeneralError::timeout("ZmqClient::send", timeout_*1000);
+      throw rogue::GeneralError::create("ZmqClient::send","Timeout sending message after %i uS",timeout_*1000);
 
    data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
    zmq_msg_close(&msg);

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -69,7 +69,8 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port) {
          throw(rogue::GeneralError("ZmqClient::ZmqClient","Failed to set socket subscribe"));
 
    if ( zmq_connect(this->zmqSub_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("ZmqClient::ZmqClient",addr,port));
+      throw(rogue::GeneralError::create("ZmqClient::ZmqClient",
+               "Failed to connect to port %i at address %s",port,addr.c_str()));
 
    // Setup request port
    temp = "tcp://";
@@ -89,7 +90,8 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port) {
       throw(rogue::GeneralError("ZmqClient::ZmqClient","Failed to set socket relaxed"));
 
    if ( zmq_connect(this->zmqReq_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("ZmqClient::ZmqClient",addr,port+1));
+      throw(rogue::GeneralError::create("ZmqClient::ZmqClient",
+               "Failed to connect to port %i at address %s",port+1,addr.c_str()));
 
    log_->info("Connected to Rogue server at ports %i:%i:",port,port+1);
 

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -59,7 +59,8 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
    temp.append(std::to_string(static_cast<long long>(port)));
 
    if ( zmq_bind(this->zmqPub_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("ZmqServer::ZmqServer",addr,port));
+      throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
+               "Failed to bind server to port %i on interface %i. Another process may be using this port.",port,addr.c_str()));
 
    // Setup response port
    temp = "tcp://";
@@ -68,7 +69,8 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
    temp.append(std::to_string(static_cast<long long>(port+1)));
 
    if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("ZmqServer::ZmqServer",addr,port+1));
+      throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
+               "Failed to bind server to port %i on interface %i. Another process may be using this port.",port+1,addr.c_str()));
 
    log_->info("Started to Rogue server at ports %i:%i:",port,port+1);
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -67,7 +67,7 @@ void rim::Master::setup_python() {
 
 //! Create object
 rim::Master::Master() {
-   error_   = 0;
+   error_   = "";
    slave_   = rim::Slave::create(4,4); // Empty placeholder
 
    rogue::defaultTimeout(sumTime_);
@@ -111,12 +111,12 @@ uint64_t rim::Master::reqAddress() {
 }
 
 //! Get error
-uint32_t rim::Master::getError() {
+std::string rim::Master::getError() {
    return error_;
 }
 
 //! Rst error
-void rim::Master::setError(uint32_t error) {
+void rim::Master::setError(std::string error) {
    rogue::GilRelease noGil;
    std::lock_guard<std::mutex> lock(mastMtx_);
    error_ = error;
@@ -198,7 +198,7 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
 void rim::Master::waitTransaction(uint32_t id) {
    TransactionMap::iterator it;
    rim::TransactionPtr tran;
-   uint32_t error;
+   std::string error;
 
    rogue::GilRelease noGil;
    while (1) {
@@ -216,7 +216,7 @@ void rim::Master::waitTransaction(uint32_t id) {
       }
 
       // Outside of lock
-      if ( (error = tran->wait()) != 0 ) error_ = error;
+      if ( (error = tran->wait()) != "" ) error_ = error;
    }
 }
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -160,7 +160,9 @@ uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p
 
    if ( (tran->size_ + offset) > tran->pyBuf_.len ) {
       PyBuffer_Release(&(tran->pyBuf_));
-      throw(rogue::GeneralError::boundary("Master::reqTransactionPy",(tran->size_+offset),tran->pyBuf_.len));
+      throw(rogue::GeneralError::create("Master::reqTransactionPy",
+               "Attempt to access %i bytes in python buffer with size %i at offset %i",
+               tran->size_,tran->pyBuf_.len,offset));
    }
 
    tran->pyValid_ = true;
@@ -239,7 +241,9 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
 
    if ( (dstLsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
-      throw(rogue::GeneralError::boundary("Master::copyBits",(dstLsb + size),(dstBuf.len*8)));
+      throw(rogue::GeneralError::create("Master::copyBits",
+               "Attempt to copy %i bits starting from bit %i from dest array with bitSize %i",
+               size, dstLsb, dstBuf.len*8));
    }
 
    if ( PyObject_GetBuffer(src.ptr(),&srcBuf,PyBUF_SIMPLE) < 0 ) {
@@ -250,7 +254,9 @@ void rim::Master::copyBits(boost::python::object dst, uint32_t dstLsb, boost::py
    if ( (srcLsb + size) > (srcBuf.len*8) ) {
       PyBuffer_Release(&srcBuf);
       PyBuffer_Release(&dstBuf);
-      throw(rogue::GeneralError::boundary("Master::copyBits",(srcLsb + size),(srcBuf.len*8)));
+      throw(rogue::GeneralError::create("Master::copyBits",
+               "Attempt to copy %i bits starting from bit %i from source array with bitSize %i",
+               size, srcLsb, srcBuf.len*8));
    }
 
    srcByte = srcLsb / 8;
@@ -302,7 +308,9 @@ void rim::Master::setBits(boost::python::object dst, uint32_t lsb, uint32_t size
 
    if ( (lsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
-      throw(rogue::GeneralError::boundary("Master::setBits",(lsb + size),(dstBuf.len*8)));
+      throw(rogue::GeneralError::create("Master::setBits",
+               "Attempt to set %i bits starting from bit %i in array with bitSize %i",
+               size, lsb, dstBuf.len*8));
    }
 
    dstByte = lsb / 8;
@@ -347,7 +355,9 @@ bool rim::Master::anyBits(boost::python::object dst, uint32_t lsb, uint32_t size
 
    if ( (lsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
-      throw(rogue::GeneralError::boundary("Master::anyBits",(lsb + size),(dstBuf.len*8)));
+      throw(rogue::GeneralError::create("Master::anyBits",
+               "Attempt to access %i bits starting from bit %i from array with bitSize %i",
+               size, lsb, dstBuf.len*8));
    }
 
    dstByte = lsb / 8;

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -51,7 +51,7 @@ void rim::Master::setup_python() {
       .def("_reqMaxAccess",       &rim::Master::reqMaxAccess)
       .def("_reqAddress",         &rim::Master::reqAddress)
       .def("_getError",           &rim::Master::getError)
-      .def("_setError",           &rim::Master::setError)
+      .def("_clearError",         &rim::Master::clearError)
       .def("_setTimeout",         &rim::Master::setTimeout)
       .def("_reqTransaction",     &rim::Master::reqTransactionPy)
       .def("_waitTransaction",    &rim::Master::waitTransaction)
@@ -116,10 +116,10 @@ std::string rim::Master::getError() {
 }
 
 //! Rst error
-void rim::Master::setError(std::string error) {
+void rim::Master::clearError() {
    rogue::GilRelease noGil;
    std::lock_guard<std::mutex> lock(mastMtx_);
-   error_ = error;
+   error_ = "";
 }
 
 //! Set timeout

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -22,6 +22,7 @@
 #include <rogue/interfaces/memory/Constants.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -134,7 +134,7 @@ uint64_t rim::Slave::doAddress() {
 
 //! Post a transaction
 void rim::Slave::doTransaction(rim::TransactionPtr transaction) {
-   transaction->done(rim::Unsupported);
+   transaction->error("Unsupported transaction using unconnected memory bus");
 }
 
 void rim::Slave::setup_python() {

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -69,7 +69,7 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
    // Don't buffer when no connection
    opt = 1;
    if ( zmq_setsockopt (this->zmqReq_, ZMQ_IMMEDIATE, &opt, sizeof(int32_t)) != 0 ) 
-         throw(rogue::GeneralError("TcpClient::TcpClient","Failed to set socket immediate"));
+         throw(rogue::GeneralError("memory::TcpClient::TcpClient","Failed to set socket immediate"));
 
    this->respAddr_.append(std::to_string(static_cast<long long>(port+1)));
    this->reqAddr_.append(std::to_string(static_cast<long long>(port)));
@@ -77,12 +77,14 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
    this->bridgeLog_->debug("Creating response client port: %s",this->respAddr_.c_str());
 
    if ( zmq_connect(this->zmqResp_,this->respAddr_.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("TcpClient::TcpClient",addr,port+1));
+      throw(rogue::GeneralError::create("memory::TcpCore::TcpCore",
+               "Failed to connect to remote port %i at address %s",port+1,addr.c_str()));
 
    this->bridgeLog_->debug("Creating request client port: %s",this->reqAddr_.c_str());
 
    if ( zmq_connect(this->zmqReq_,this->reqAddr_.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("TcpClient::TcpClient",addr,port));
+      throw(rogue::GeneralError::create("memory::TcpCore::TcpCore",
+               "Failed to connect to remote port %i at address %s",port,addr.c_str()));
 
    // Start rx thread
    threadEn_ = true;

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -98,17 +98,17 @@ void rim::TcpServer::close() {
 
 //! Run thread
 void rim::TcpServer::runThread() {
-   uint8_t * data;
-   uint64_t  more;
-   size_t    moreSize;
-   uint32_t  x;
-   uint32_t  msgCnt;
-   zmq_msg_t msg[6];
-   uint32_t  id;
-   uint64_t  addr;
-   uint32_t  size;
-   uint32_t  type;
-   uint32_t  result;
+   uint8_t *   data;
+   uint64_t    more;
+   size_t      moreSize;
+   uint32_t    x;
+   uint32_t    msgCnt;
+   zmq_msg_t   msg[6];
+   uint32_t    id;
+   uint64_t    addr;
+   uint32_t    size;
+   uint32_t    type;
+   std::string result;
 
    bridgeLog_->logThreadId();
 
@@ -171,11 +171,11 @@ void rim::TcpServer::runThread() {
             waitTransaction(0);
             result = getError();
 
-            bridgeLog_->debug("Done transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32 ", result=%" PRIu32,id,addr,size,type,result);
+            bridgeLog_->debug("Done transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32 ", result=%s",id,addr,size,type,result.c_str());
 
             // Result message
             zmq_msg_init_size(&(msg[5]),4);
-            std::memcpy(zmq_msg_data(&(msg[5])),&result, 4);
+            std::memcpy(zmq_msg_data(&(msg[5])),result.c_str(), result.length());
 
             // Send message
             for (x=0; x < 6; x++) 

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -69,12 +69,14 @@ rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
    this->bridgeLog_->debug("Creating response client port: %s",this->respAddr_.c_str());
 
    if ( zmq_bind(this->zmqResp_,this->respAddr_.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("TcpServer::TcpServer",addr,port+1));
+      throw(rogue::GeneralError::create("memory::TcpServer::TcpServer",
+               "Failed to bind server to port %i at address %s, another process may be using this port",port+1,addr.c_str()));
 
    this->bridgeLog_->debug("Creating request client port: %s",this->reqAddr_.c_str());
 
    if ( zmq_bind(this->zmqReq_,this->reqAddr_.c_str()) < 0 ) 
-      throw(rogue::GeneralError::network("TcpServer::TcpServer",addr,port));
+      throw(rogue::GeneralError::create("memory::TcpServer::TcpServer",
+               "Failed to bind server to port %i at address %s, another process may be using this port",port,addr.c_str()));
 
    // Start rx thread
    threadEn_ = true;

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -166,7 +166,7 @@ void rim::TcpServer::runThread() {
             bridgeLog_->debug("Starting transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32,id,addr,size,type);
 
             // Execute transaction and wait for result
-            this->setError(0);
+            this->clearError();
             reqTransaction(addr,size,data,type);
             waitTransaction(0);
             result = getError();

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -187,7 +187,9 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
 
    if ( (offset + count) > size_ ) {
       PyBuffer_Release(&pyBuf);
-      throw(rogue::GeneralError::boundary("Frame::write",offset+count,size_));
+      throw(rogue::GeneralError::create("Transaction::setData",
+               "Attempt to set %i bytes at offset %i to python buffer with size %i",
+               count,offset,size_));
    }
 
    std::memcpy(begin()+offset, (uint8_t *)pyBuf.buf, count);
@@ -205,7 +207,9 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
 
    if ( (offset + count) > size_ ) {
       PyBuffer_Release(&pyBuf);
-      throw(rogue::GeneralError::boundary("Frame::readPy",offset+count,size_));
+      throw(rogue::GeneralError::create("Transaction::getData",
+               "Attempt to get %i bytes from offset %i to python buffer with size %i",
+               count,offset,size_));
    }
 
    std::memcpy((uint8_t *)pyBuf.buf, begin()+offset, count);

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -155,7 +155,7 @@ std::string rim::Transaction::wait() {
            timercmp(&currTime,&(endTime_),>) ) {
 
          done_  = true;
-         error_ = "Timeout waiting for register transaction response";
+         error_ = "Timeout waiting for register transaction message response";
       }
       else cond_.wait_for(lock,std::chrono::microseconds(1000));
    }

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -43,16 +43,6 @@ void rim::setup_module() {
    // set the current scope to the new sub-module
    bp::scope io_scope = module;
 
-   // Error constants
-   bp::scope().attr("TimeoutError")  = TimeoutError;
-   bp::scope().attr("VerifyError")   = VerifyError;
-   bp::scope().attr("AddressError")  = AddressError;
-   bp::scope().attr("SizeError")     = SizeError;
-   bp::scope().attr("BusTimeout")    = BusTimeout;
-   bp::scope().attr("BusFail")       = BusFail;
-   bp::scope().attr("ProtocolError") = ProtocolError;
-   bp::scope().attr("Unsupported")   = Unsupported;
-
    // Transaction constants
    bp::scope().attr("Read")   = Read;
    bp::scope().attr("Write")  = Write;

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -82,12 +82,14 @@ void ris::Buffer::adjustHeader(int32_t value) {
 
    // Decreasing header size
    if ( value < 0 && (uint32_t)abs(value) > headRoom_ ) 
-         throw(rogue::GeneralError::boundary("Buffer::adjustHeader",abs(value),headRoom_));
+         throw(rogue::GeneralError::create("Buffer::adjustHeader",
+                  "Attempt to reduce header with size %i by %i",headRoom_,value));
 
    // Increasing header size
    if ( value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)) ) 
-         throw(rogue::GeneralError::boundary("Buffer::adjustHeader",
-               (uint32_t)value, (rawSize_ - (headRoom_ + tailRoom_))));
+         throw(rogue::GeneralError::create("Buffer::adjustHeader",
+                  "Attempt to increase header by %i in buffer with size %i",
+                  value, (rawSize_ - (headRoom_ + tailRoom_))));
 
    // Make adjustment
    headRoom_ += value;
@@ -112,12 +114,14 @@ void ris::Buffer::adjustTail(int32_t value) {
 
    // Decreasing tail size
    if ( value < 0 && (uint32_t)abs(value) > tailRoom_ ) 
-         throw(rogue::GeneralError::boundary("Buffer::adjustTail",abs(value),tailRoom_));
+         throw(rogue::GeneralError::create("Buffer::adjustTail",
+                  "Attempt to reduce tail with size %i by %i",tailRoom_,value));
 
    // Increasing tail size
    if ( value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)) ) 
-         throw(rogue::GeneralError::boundary("Buffer::adjustTail",
-               (uint32_t)value, (rawSize_ - (headRoom_ + tailRoom_))));
+         throw(rogue::GeneralError::create("Buffer::adjustTail",
+                  "Attempt to increase header by %i in buffer with size %i",
+                  value, (rawSize_ - (headRoom_ + tailRoom_))));
 
    // Make adjustment
    tailRoom_ += value;
@@ -198,8 +202,9 @@ uint32_t ris::Buffer::getPayload() {
 //! Set payload size (not including header)
 void ris::Buffer::setPayload(uint32_t size) {
    if ( size > (rawSize_ - (headRoom_ + tailRoom_) ) ) 
-      throw(rogue::GeneralError::boundary("Buffer::setPayload",
-            size, (rawSize_ - (headRoom_ + tailRoom_))));
+      throw(rogue::GeneralError::create("Buffer::setPayload",
+               "Attempt to set payload to size %i in buffer with size %i",
+               size, (rawSize_ - (headRoom_ + tailRoom_))));
 
    payload_ = size + headRoom_;
 
@@ -218,7 +223,10 @@ void ris::Buffer::minPayload(uint32_t size) {
 //! Adjust payload size
 void ris::Buffer::adjustPayload(int32_t value) {
    if ( value < 0 && (uint32_t)abs(value) > getPayload())
-      throw(rogue::GeneralError::boundary("Buffer::adjustPayload", abs(value), (getPayload())));
+      throw(rogue::GeneralError::create("Buffer::adjustPayload",
+               "Attempt to decrease payload by %i in buffer with size %i",
+               value, getPayload()));
+
    setPayload(getPayload() + value);
 }
 

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -191,7 +191,9 @@ void ris::Frame::setPayload(uint32_t pSize) {
    }
 
    if ( lSize != 0 ) 
-      throw(rogue::GeneralError::boundary("Frame::setPayload",pSize,size_));
+      throw(rogue::GeneralError::create("Frame::setPayload",
+               "Attempt to set payload to size %i in frame with size %i",
+               pSize,size_));
 
    // Refresh
    payload_ = pSize;
@@ -212,7 +214,9 @@ void ris::Frame::adjustPayload(int32_t value) {
    uint32_t size = getPayload();
 
    if ( value < 0 && (uint32_t)abs(value) > size)
-      throw(rogue::GeneralError::boundary("Frame::adjustPayload", abs(value), size));
+      throw(rogue::GeneralError::create("Frame::adjustPayload",
+               "Attempt to reduce payload by %i in frame with size %i",
+               value,size));
 
    setPayload(size + value);
 }
@@ -336,7 +340,8 @@ void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
 
    if ( (offset + count) > size ) {
       PyBuffer_Release(&pyBuf);
-      throw(rogue::GeneralError::boundary("Frame::readPy",offset+count,size));
+      throw(rogue::GeneralError::create("Frame::readPy",
+               "Attempt to read %i bytes from frame at offset %i with size %i",count,offset,size));
    }
 
    ris::Frame::iterator beg = this->beginRead() + offset;
@@ -356,7 +361,8 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
 
    if ( (offset + count) > size ) {
       PyBuffer_Release(&pyBuf);
-      throw(rogue::GeneralError::boundary("Frame::writePy",offset+count,size));
+      throw(rogue::GeneralError::create("Frame::writePy",
+               "Attempt to write %i bytes to frame at offset %i with size %i",count,offset,size));
    }
 
    ris::Frame::iterator beg = this->beginWrite() + offset;

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -152,7 +152,7 @@ ris::BufferPtr ris::Pool::allocBuffer ( uint32_t size, uint32_t *total ) {
       dataQ_.pop();
    }
    else if ( (data = (uint8_t *)malloc(bAlloc)) == NULL ) 
-      throw(rogue::GeneralError::allocation("Pool::allocBuffer",bAlloc));
+      throw(rogue::GeneralError::create("Pool::allocBuffer","Failed to allocate buffer with size = %i",bAlloc));
 
    // Only use lower 24 bits of meta. 
    // Upper 8 bits may have special meaning to sub-class

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -79,12 +79,14 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
       this->bridgeLog_->debug("Creating pull server port: %s",this->pullAddr_.c_str());
 
       if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("TcpCore::TcpCore",addr,port));
+         throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
+                  "Failed to bind server to port %i at address %s, another process may be using this port",port,addr.c_str()));
 
       this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
 
       if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("TcpCore::TcpCore",addr,port+1));
+         throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
+                  "Failed to bind server to port %i at address %s, another process may be using this port",port+1,addr.c_str()));
    }
 
    // Client mode
@@ -95,12 +97,14 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
       this->bridgeLog_->debug("Creating pull client port: %s",this->pullAddr_.c_str());
 
       if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("TcpCore::TcpCore",addr,port+1));
+         throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
+                  "Failed to connect to remote port %i at address %s",port+1,addr.c_str()));
 
       this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
 
       if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 ) 
-         throw(rogue::GeneralError::network("TcpCore::TcpCore",addr,port));
+         throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
+                  "Failed to connect to remote port %i at address %s",port,addr.c_str()));
    }
 
    // Start rx thread

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -110,7 +110,8 @@ uint32_t rpb::CoreV1::tailSize() {
 //! Get beginning of tail iterator
 ris::FrameIterator rpb::CoreV1::beginTail(uint32_t index) {
    if ( index >= tails_.size() ) 
-      throw rogue::GeneralError::boundary("batcher::CoreV1::tail", index, tails_.size());
+      throw(rogue::GeneralError::create("bather::CoreV1::beginTail",
+               "Attempt to get tail index %i in message with %i tails",index,tails_.size()));
 
    // Invert order on return
    return tails_[(tails_.size()-1) - index];
@@ -119,7 +120,8 @@ ris::FrameIterator rpb::CoreV1::beginTail(uint32_t index) {
 //! Get end of tail iterator
 ris::FrameIterator rpb::CoreV1::endTail(uint32_t index) {
    if ( index >= tails_.size() ) 
-      throw rogue::GeneralError::boundary("batcher::CoreV1::tail", index, tails_.size());
+      throw rogue::GeneralError::create("batcher::CoreV1::tail", 
+            "Attempt to access tail %i in frame with %i tails", index, tails_.size());
 
    // Invert order on return
    return tails_[(tails_.size()-1) - index] + tailSize_;
@@ -128,7 +130,8 @@ ris::FrameIterator rpb::CoreV1::endTail(uint32_t index) {
 //! Get data
 rpb::DataPtr & rpb::CoreV1::record(uint32_t index) {
    if ( index >= list_.size() ) 
-      throw rogue::GeneralError::boundary("batcher::CoreV1::record", index, list_.size());
+      throw rogue::GeneralError::create("batcher::CoreV1::record", 
+            "Attempt to access record %i in frame with %i records", index, tails_.size());
 
    // Invert order on return
    return list_[(list_.size()-1) - index];

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -25,6 +25,7 @@
 #include <rogue/protocols/packetizer/Transport.h>
 #include <rogue/protocols/packetizer/Application.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <math.h>

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -102,8 +102,9 @@ ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {
   
       // Buffer should support our header/tail plus at least one payload byte 
       if ( buff->getAvailable() < (headSize_ + tailSize_ + 1) )
-         throw(rogue::GeneralError::boundary("packetizer::Controller::reqFrame",
-                  (headSize_ + tailSize_ + 1), buff->getAvailable()));
+         throw(rogue::GeneralError::create("packetizer::Controller::reqFrame",
+                  "Buffer size %i is less than min size required %i",
+                  buff->getAvailable(), (headSize_ + tailSize_ + 1)));
 
       // Add 8 bytes to head and tail reservation
       buff->adjustHeader(headSize_);

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -180,7 +180,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       usleep(10);
       gettimeofday(&currTime,NULL);
       if ( timercmp(&currTime,&endTime,>)) {
-         log_->timeout("ControllerV1::applicationRx",timeout_);
+         log_->critical("ControllerV1::applicationRx: Timeout waiting for outbound queue after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
          gettimeofday(&startTime,NULL);
          timeradd(&startTime,&timeout_,&endTime);
       }

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -228,7 +228,7 @@ void rpp::ControllerV2::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       usleep(10);
       gettimeofday(&currTime,NULL);
       if ( timercmp(&currTime,&endTime,>)) {
-         log_->timeout("ControllerV2::applicationRx",timeout_);
+         log_->critical("ControllerV2::applicationRx: Timeout waiting for outbound queue after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
          gettimeofday(&startTime,NULL);
          timeradd(&startTime,&timeout_,&endTime);
       }

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -27,6 +27,7 @@
 #include <rogue/protocols/rssi/Transport.h>
 #include <rogue/protocols/rssi/Application.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <memory>
 #include <cmath>
 #include <rogue/GilRelease.h>

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -165,9 +165,9 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
 
    // Make sure there is enough room the buffer for our header
    if ( buffer->getAvailable() < rpr::Header::HeaderSize )
-      throw(rogue::GeneralError::boundary("rss::Controller::reqFrame",
-                                          rpr::Header::HeaderSize,
-                                          buffer->getAvailable()));
+      throw(rogue::GeneralError::create("rssi::Controller::reqFrame",
+               "Buffer size %i is less than min header size %i",
+               rpr::Header::HeaderSize,buffer->getAvailable()));
 
    // Update buffer to include our header space.
    buffer->adjustHeader(rpr::Header::HeaderSize);

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -362,7 +362,7 @@ void rpr::Controller::applicationRx ( ris::FramePtr frame ) {
       usleep(10);
       if ( timePassed(startTime,timeout_) ) {
          gettimeofday(&startTime,NULL);
-         log_->timeout("Controller::applicationRx",timeout_);
+         log_->critical("Controller::applicationRx: Timeout waiting for outbound queue after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
       }
    }
 

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -161,7 +161,9 @@ void rpr::Header::update() {
    size = (syn)?SynSize:HeaderSize;
 
    if ( buff->getSize() < size )
-      throw(rogue::GeneralError::boundary("Header::update",size,buff->getSize()));
+      throw(rogue::GeneralError::create("rssi::Header::update",
+               "Buffer size %i is less size indicated in header %i",
+               buff->getSize(), size));
 
    buff->minPayload(size);
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -107,13 +107,18 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
 
    // Size error
    if ((tran->address() % min()) != 0 ) {
-      tran->done(rim::AddressError);
+      tran->error("Transaction address 0x%x is not aligned to min size %i",tran->address(),min());
       return;
    }
 
    // Size error
-   if ((tran->size() % min()) != 0 || tran->size() < min() || tran->size() > max()) {
-      tran->done(rim::SizeError);
+   if ((tran->size() % min()) != 0 || tran->size() < min()) {
+      tran->error("Transaction size 0x%x is not aligned to min size %i",tran->size(),min());
+      return;
+   }
+
+   if (tran->size() > max()) {
+      tran->error("Transaction size 0x%x exceeds max size %i",tran->size(),min());
       return;
    }
 
@@ -140,7 +145,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    tail[0] = 0;
    ris::toFrame(fIter,TailLen,tail); 
 
-   if ( tran->type() == rim::Post ) tran->done(0);
+   if ( tran->type() == rim::Post ) tran->done();
    else addTransaction(tran);
 
    log_->debug("Send frame for id=%i, addr 0x%0.8x. Size=%i, type=%i, doWrite=%i",
@@ -220,9 +225,9 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    fIter = frame->endRead()-TailLen;
    ris::fromFrame(fIter,TailLen,tail);
    if ( tail[0] != 0 ) {
-      if ( tail[0] & 0x20000 ) tran->done(rim::BusTimeout);
-      else if ( tail[0] & 0x10000 ) tran->done(rim::BusFail);
-      else tran->done(tail[0]);
+      if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
+      else if ( tail[0] & 0x10000 ) tran->error("Axi bus retruned fail status in hardware");
+      else tran->error("Non zero status message retruned on axi bus in hardware: 0x%x",tail[0]);
       log_->warning("Error detected for ID id=%i, tail=0x%0.8x",id,tail[0]);
       return;
    }
@@ -234,6 +239,6 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Done
-   tran->done(0);
+   tran->done();
 }
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -227,7 +227,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    if ( tail[0] != 0 ) {
       if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
       else if ( tail[0] & 0x10000 ) tran->error("Axi bus retruned fail status in hardware");
-      else tran->error("Non zero status message retruned on axi bus in hardware: 0x%x",tail[0]);
+      else tran->error("Non zero status message returned on axi bus in hardware: 0x%x",tail[0]);
       log_->warning("Error detected for ID id=%i, tail=0x%0.8x",id,tail[0]);
       return;
    }

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -126,13 +126,18 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
 
    // Size error
    if ((tran->address() % min()) != 0 ) {
-      tran->done(rim::AddressError);
+      tran->error("Transaction address 0x%x is not aligned to min size %i",tran->address(),min());
       return;
    }
 
    // Size error
-   if ((tran->size() % min()) != 0 || tran->size() < min() || tran->size() > max()) {
-      tran->done(rim::SizeError);
+   if ((tran->size() % min()) != 0 || tran->size() < min()) {
+      tran->error("Transaction size 0x%x is not aligned to min size %i",tran->size(),min());
+      return;
+   }
+
+   if (tran->size() > max()) {
+      tran->error("Transaction size 0x%x exceeds max size %i",tran->size(),min());
       return;
    }
 
@@ -155,7 +160,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    // Write data
    if ( doWrite ) ris::toFrame(fIter, tran->size(), tIter);
 
-   if ( tran->type() == rim::Post ) tran->done(0);
+   if ( tran->type() == rim::Post ) tran->done();
    else addTransaction(tran);
 
    log_->debug("Send frame for id=%i, addr 0x%0.8x. Size=%i, type=%i",
@@ -224,15 +229,14 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
          (header[1] != expHeader[1]) || (header[2] != expHeader[2]) ||
          (header[3] != expHeader[3]) || (header[4] != expHeader[4]) ) {
      log_->warning("Bad header for %i",id);
-     tran->done(rim::ProtocolError);
+     tran->error("Received SRPV3 message did not match expected protocol");
      return;
    }
 
    // Check tail
    if ( tail[0] != 0 ) {
-      if ( tail[0] & 0xFF) tran->done(rim::BusFail | (tail[0] & 0xFF));
-      else if ( tail[0] & 0x100 ) tran->done(rim::BusTimeout);
-      else tran->done(tail[0]);
+      if ( tail[0] & 0x100 ) tran->error("Axi bus timeout detected in hardware");
+      else tran->error("Non zero status message retruned on axi bus in hardware: 0x%x",tail[0]);
       log_->warning("Error detected for ID id=%i, tail=0x%0.8x",id,tail[0]);
       return;
    }
@@ -240,13 +244,13 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    // Verify frame size, drop frame
    if ( (fSize != expFrameLen) || (header[4]+1) != tran->size() ) {
       log_->warning("Size mismatch id=%i. fsize=%i, exp=%i, tsize=%i, header=%i",id, fSize, expFrameLen, tran->size(),header[4]+1);
-      tran->done(rim::ProtocolError);
+      tran->error("Received SRPV3 message had a header size mismatch");
       return;
    }
 
    // Copy data if read
    if ( ! doWrite ) ris::fromFrame(fIter, tran->size(), tIter);
 
-   tran->done(0);
+   tran->done();
 }
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -60,7 +60,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
-      throw(rogue::GeneralError::network("Client::Client(socket)",address_.c_str(),port_));
+      throw(rogue::GeneralError::create("Client::Client","Failed to create socket for port %i at address %s",port_,address_.c_str()));
 
    // Lookup host address
    bzero(&aiHints, sizeof(aiHints));
@@ -70,7 +70,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    aiHints.ai_protocol = IPPROTO_UDP;
 
    if ( ::getaddrinfo(address_.c_str(), 0, &aiHints, &aiList) || !aiList)
-      throw(rogue::GeneralError::network("Client::Client(getaddrinfo)",address_.c_str(),port_));
+      throw(rogue::GeneralError::create("Client::Client","Failed to resolve address %s",address_.c_str()));
 
    addr = (const sockaddr_in*)(aiList->ai_addr);
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -140,7 +140,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
          tout = timeout_;
          
          if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-            udpLog_->timeout("Client::acceptFrame",timeout_);
+            udpLog_->critical("Client::acceptFrame: Timeout waiting for outbound transmit after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
             res = 0;
          }
          else if ( (res = sendmsg(fd_,&msg,0)) < 0 )

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -20,6 +20,7 @@
 #include <rogue/protocols/udp/Core.h>
 #include <rogue/Logging.h>
 #include <rogue/GeneralError.h>
+#include <rogue/Helpers.h>
 #include <unistd.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -56,7 +56,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
-      throw(rogue::GeneralError::network("Server::Server","0.0.0.0",port_));
+      throw(rogue::GeneralError::create("Server::Server","Failed to create socket for port %i",port_));
 
    // Setup Remote Address
    memset(&locAddr_,0,sizeof(struct sockaddr_in));
@@ -67,13 +67,13 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    memset(&remAddr_,0,sizeof(struct sockaddr_in));
 
    if (bind(fd_, (struct sockaddr *) &locAddr_, sizeof(locAddr_))<0) 
-      throw(rogue::GeneralError::network("Server::Server","0.0.0.0",port_));
+      throw(rogue::GeneralError::create("Server::Server","Failed to bind to local port %i. Another process may be using it",port_));
 
    // Kernel assigns port
    if ( port_ == 0 ) {
       len = sizeof(locAddr_);
       if (getsockname(fd_, (struct sockaddr *) &locAddr_, &len) < 0 ) 
-         throw(rogue::GeneralError::network("Server::Server","0.0.0.0",port_));
+         throw(rogue::GeneralError::create("Server::Server","Failed to dynamically assign local port"));
       port_ = ntohs(locAddr_.sin_port);
    }
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -143,7 +143,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
          tout = timeout_;
          
          if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-            udpLog_->timeout("Server::acceptFrame",timeout_);
+            udpLog_->critical("Server::acceptFrame: Timeout waiting for outbound transmit after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
             res = 0;
          }
          else if ( (res = sendmsg(fd_,&msg,0)) < 0 )

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -68,7 +68,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
    strm.opaque  = NULL;
 
    if ( (ret = BZ2_bzDecompressInit(&strm,0,0)) != BZ_OK ) 
-      throw(rogue::GeneralError::ret("StreamUnZip::acceptFrame","Error initializing decompressor",ret));
+      throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Error initializing decompressor. ret=%i",ret));
 
    // Setup decompression pointers
    rBuff = frame->beginBuffer();
@@ -85,7 +85,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
       ret = BZ2_bzDecompress(&strm);
 
       if ( (ret != BZ_STREAM_END) && (ret != BZ_OK) ) 
-         throw(rogue::GeneralError::ret("StreamUnZip::acceptFrame","Decompression runtime error",ret));
+         throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Decompression runtime error %i",ret));
 
       if ( ret == BZ_STREAM_END ) break;
 

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -69,7 +69,7 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    strm.opaque  = NULL;
 
    if ( (ret = BZ2_bzCompressInit(&strm,1,0,30)) != BZ_OK ) 
-      throw(rogue::GeneralError::ret("StreamZip::acceptFrame","Error initializing compressor",ret));
+      throw(rogue::GeneralError::create("StreamZip::acceptFrame","Error initializing compressor. ret=%i",ret));
 
    // Setup decompression pointers
    rBuff = frame->beginBuffer();
@@ -85,7 +85,7 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    do {
 
       if ( (ret = BZ2_bzCompress(&strm,(done)?BZ_FINISH:BZ_RUN)) == BZ_SEQUENCE_ERROR )
-         throw(rogue::GeneralError::ret("StreamZip::acceptFrame","Compression runtime error",ret));
+         throw(rogue::GeneralError::create("StreamZip::acceptFrame","Compression runtime error %i",ret));
 
       // Update read buffer if neccessary
       if ( strm.avail_in == 0 && (!done)) {

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -86,7 +86,7 @@ void ruf::LegacyStreamReader::open(std::string file) {
    }
 
    if ( (fd_ = ::open(file.c_str(),O_RDONLY)) < 0 ) 
-      throw(rogue::GeneralError::open("LegacyStreamReader::open",file));
+      throw(rogue::GeneralError::create("LegacyStreamReader::open","Failed to open file %s",file.c_str()));
 
    active_ = true;
    threadEn_ = true;

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -88,7 +88,7 @@ void ruf::StreamReader::open(std::string file) {
    }
 
    if ( (fd_ = ::open(file.c_str(),O_RDONLY)) < 0 ) 
-      throw(rogue::GeneralError::open("StreamReader::open",file));
+      throw(rogue::GeneralError::create("StreamReader::open","Failed to open data file: %s",file.c_str()));
 
    active_ = true;
    threadEn_ = true;

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -121,7 +121,7 @@ void ruf::StreamWriter::open(std::string file) {
    if ( sizeLimit_ > 0 ) name.append(".1");
 
    if ( (fd_ = ::open(name.c_str(),O_RDWR|O_CREAT|O_APPEND,S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)) < 0 )
-      throw(rogue::GeneralError::open("StreamWriter::open",name));
+      throw(rogue::GeneralError::create("StreamWriter::open","Failed to open data file: %s",name.c_str()));
 
    totSize_    = 0;
    currSize_   = 0;
@@ -168,7 +168,7 @@ void ruf::StreamWriter::setBufferSize(uint32_t size) {
 
          // Create new buffer
          if ( (buffer_ = (uint8_t *)malloc(size)) == NULL )
-            throw(rogue::GeneralError::allocation("StreamWriter::setBufferSize",size));
+            throw(rogue::GeneralError::create("StreamWriter::setBufferSize","Failed to allocate buffer with size = %i",size));
          buffSize_ = size;
       }
    }

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -334,7 +334,7 @@ void ruf::StreamWriter::checkSize(uint32_t size) {
 
       // Open new file
       if ( (fd_ = ::open(name.c_str(),O_RDWR|O_CREAT|O_APPEND,S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)) < 0 )
-         throw(rogue::GeneralError::open("StreamWriter::checkSize",name));
+         throw(rogue::GeneralError::create("StreamWriter::checkSize","Failed to open file %s",name.c_str()));
 
       currSize_ = 0;
    }


### PR DESCRIPTION
This PR changes many of the error messages in the system in order to make them more clear to the end user.

In order to accomplish this the error transport for memory transactions is now changed. In the new model the error message is generated at the lowest level, allowing more specific details to be communicated. 

This will break custom memory hubs written in either C++ or Python as the transaction->done() interface changes. Applications which use a memory bridge should re-deploy both sides of the link.