### PR TITLE
Supress stack trace for memory errors

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -118,7 +118,7 @@ class BaseCommand(pr.BaseVariable):
             return pr.varFuncHelper(self._function,pargs, self._log,self.path)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
 
     @pr.expose
     def call(self,arg=None):
@@ -264,7 +264,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
                 self._block.startTransaction(rogue.interfaces.memory.Write, check=True)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
 
  
     def get(self, read=True):
@@ -275,7 +275,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             ret = self._block.get(self)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             return None
 
         return ret

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -23,6 +23,12 @@ import functools as ft
 import parse
 import collections
 
+def logException(log,e):
+    if isinstance(e,pr.MemoryError):
+        log.error(e)
+    else:
+        log.exception(e)
+
 def logInit(cls=None,name=None,path=None):
 
     # Support base class in order of precedence

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -150,7 +150,7 @@ class PollQueue(object):
                         try:
                             entry.block._checkTransaction()
                         except Exception as e:
-                            self._log.prException(e)
+                            pr.logException(self._log,e)
 
 
     def _expiredEntries(self, time=None):

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -138,7 +138,7 @@ class PollQueue(object):
                         try:
                             entry.block.startTransaction(rogue.interfaces.memory.Read, check=False)
                         except Exception as e:
-                            self._log.exception(e)
+                            pr.logException(self._log,e)
 
                         # Update the entry with new read time
                         entry.readTime = now + entry.interval
@@ -150,7 +150,7 @@ class PollQueue(object):
                         try:
                             entry.block._checkTransaction()
                         except Exception as e:
-                            self._log.exception(e)
+                            self._log.prException(e)
 
 
     def _expiredEntries(self, time=None):

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -100,7 +100,7 @@ class Process(pr.Device):
         try:
             self._process()
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
 
         self.Running.set(False)
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -450,7 +450,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.info("Check root read")
                 self.checkBlocks(recurse=True)
             except Exception as e:
-                self._log.prException(e)
+                pr.logException(self._log,e)
                 return False
 
         self._log.info("Done root write")
@@ -465,7 +465,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.info("Check root read")
                 self.checkBlocks(recurse=True)
             except Exception as e:
-                self._log.prException(e)
+                pr.logException(self._log,e)
                 return False
 
         self._log.info("Done root read")
@@ -482,7 +482,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             with open(name,'w') as f:
                 f.write(self._getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups,varEncode=True))
         except Exception as e:
-            self._log.prException(e)
+            pr.logException(self._log,e)
             return False
 
         return True
@@ -493,7 +493,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             with open(name,'r') as f:
                 self._setYaml(yml=f.read(),writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
         except Exception as e:
-            self._log.prException(e)
+            pr.logException(self._log,e)
             return False
 
         return True
@@ -509,7 +509,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         try:
             return dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)},varEncode)
         except Exception as e:
-            self._log.prException(e)
+            pr.logException(self._log,e)
             return ""
 
     def _setYaml(self,yml,writeEach,modes,incGroups,excGroups):
@@ -594,7 +594,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             for func in self._varListeners:
                                 func(p,val)
                     except Exception as e:
-                        self._log.prException(e)
+                        pr.logException(self._log,e)
                         
                 self._log.debug(F"Done update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}")
 
@@ -603,7 +603,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 try:
                     self._sendYamlFrame(dataToYaml(d,varEncode=False))
                 except Exception as e:
-                    self._log.prException(e)
+                    pr.logException(self._log,e)
 
                 # Send over zmq link
                 if self._zmqServer is not None:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -388,7 +388,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                         f.write("{}\n".format(v.description))
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
 
     def _exit(self):
         print("Stopping Rogue root")
@@ -450,7 +450,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.info("Check root read")
                 self.checkBlocks(recurse=True)
             except Exception as e:
-                self._log.exception(e)
+                self._log.prException(e)
                 return False
 
         self._log.info("Done root write")
@@ -465,7 +465,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 self._log.info("Check root read")
                 self.checkBlocks(recurse=True)
             except Exception as e:
-                self._log.exception(e)
+                self._log.prException(e)
                 return False
 
         self._log.info("Done root read")
@@ -482,7 +482,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             with open(name,'w') as f:
                 f.write(self._getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups,varEncode=True))
         except Exception as e:
-            self._log.exception(e)
+            self._log.prException(e)
             return False
 
         return True
@@ -493,7 +493,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             with open(name,'r') as f:
                 self._setYaml(yml=f.read(),writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
         except Exception as e:
-            self._log.exception(e)
+            self._log.prException(e)
             return False
 
         return True
@@ -509,7 +509,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         try:
             return dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)},varEncode)
         except Exception as e:
-            self._log.exception(e)
+            self._log.prException(e)
             return ""
 
     def _setYaml(self,yml,writeEach,modes,incGroups,excGroups):
@@ -594,7 +594,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             for func in self._varListeners:
                                 func(p,val)
                     except Exception as e:
-                        self._log.exception(e)
+                        self._log.prException(e)
                         
                 self._log.debug(F"Done update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}")
 
@@ -603,7 +603,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 try:
                     self._sendYamlFrame(dataToYaml(d,varEncode=False))
                 except Exception as e:
-                    self._log.exception(e)
+                    self._log.prException(e)
 
                 # Send over zmq link
                 if self._zmqServer is not None:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -320,7 +320,7 @@ class BaseVariable(pr.Node):
                     self._parent.checkBlocks(recurse=False, variable=self)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             self._log.error("Error setting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
 
     @pr.expose
@@ -338,7 +338,7 @@ class BaseVariable(pr.Node):
                 self._block.startTransaction(rogue.interfaces.memory.Post, check=True)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             self._log.error("Error posting value '{}' to variable '{}' with type {}".format(value,self.path,self.typeStr))
 
     @pr.expose
@@ -359,7 +359,7 @@ class BaseVariable(pr.Node):
                 ret = None
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             self._log.error("Error reading value from variable '{}'".format(self.path))
             ret = None
 
@@ -395,7 +395,7 @@ class BaseVariable(pr.Node):
                     ret = self.disp.format(value)
 
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             self._log.error(f"Error generating disp for value {value} in variable {self.path}")
             ret = None
 
@@ -439,7 +439,7 @@ class BaseVariable(pr.Node):
         try:
             self.set(self.parseDisp(sValue), write)
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
             self._log.error("Error setting value '{}' to variable '{}' with type {}".format(sValue,self.path,self.typeStr))
 
     @pr.expose

--- a/python/pyrogue/utilities/fileio.py
+++ b/python/pyrogue/utilities/fileio.py
@@ -35,7 +35,7 @@ class StreamWriter(pyrogue.DataWriter):
         try:
             self._writer.open(self.DataFile.value())
         except Exception as e:
-            self._log.exception(e)
+            pr.logException(self._log,e)
 
         # Dump config/status to file
         if self._configEn: self.root._streamYaml()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -20,6 +20,7 @@
 import datetime
 import parse
 import pyrogue as pr
+import rogue
 
 class AxiVersion(pr.Device):
 
@@ -294,6 +295,14 @@ class AxiVersion(pr.Device):
         @self.command(hidden=False,value='',retValue='')
         def TestCommand(arg):
             return('Got {}'.format(arg))
+
+        @self.command(hidden=False,value='',retValue='')
+        def TestMemoryException(arg):
+            raise pr.MemoryError(name='blah',address=0)
+
+        @self.command(hidden=False,value='',retValue='')
+        def TestGeneralException(arg):
+            raise rogue.GeneralError('blah','test general')
 
     def hardReset(self):
         print('AxiVersion hard reset called')


### PR DESCRIPTION
This PR adds a new wrapper function used when logging exceptions. If the exception is a MemoryError then the stack trace printout will be suppressed. This avoids user confusion when Rogue generates memory errors which are a standard run time error. 