### PR TITLE
Allow for read of configuration directory containing multiple files

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -528,8 +528,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Passed path is a directory
         if os.path.isdir(name):
-            lst = glob.glob('{}/*.yml'.format(name))
-            lst.extend(glob.glob('{}/*.yaml'.format(name)))
+            dlst = glob.glob('{}/*.yml'.format(name))
+            dlst.extend(glob.glob('{}/*.yaml'.format(name)))
+            lst = sorted(dlst)
 
         # Add file to list
         else:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -528,8 +528,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Passed path is a directory
         if os.path.isdir(name):
-            lst = glob.glob('{}/*.yml'.format(args.path))
-            lst.extend(glob.glob('{}/*.yaml'.format(args.path)))
+            lst = glob.glob('{}/*.yml'.format(name))
+            lst.extend(glob.glob('{}/*.yaml'.format(name)))
 
         # Add file to list
         else:
@@ -596,8 +596,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             node = self.getNode(key)
 
             # Call setDict on node
-            if node is not None
-                node._setDict(d=node,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
+            if node is not None:
+                node._setDict(d=value,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
             else:
                 self._log.error("Entry {} not found".format(key))
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -540,9 +540,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 for fn in lst:
                     with open(fn,'r') as f:
                         d = yamlToData(f.read())
-
-                        with self.pollBlock(), self.updateGroup():
-                            self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
+                        self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
                 if not writeEach: self._write()
 
@@ -552,7 +550,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         except Exception as e:
             pr.logException(self._log,e)
             return False
-            
+
         return True
 
     def _getYaml(self,readFirst,modes,incGroups,excGroups):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -552,21 +552,31 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Pass arg is a python list
         if isinstance(name,list):
-            lst = name
+            rawlst = name
 
         # Passed arg is a comma seperated list of files
         elif ',' in name:
-            lst = name.split(',')
+            rawlst = name.split(',')
 
-        # Passed path is a directory
-        elif os.path.isdir(name):
-            dlst = glob.glob('{}/*.yml'.format(name))
-            dlst.extend(glob.glob('{}/*.yaml'.format(name)))
-            lst = sorted(dlst)
-
-        # Add file to list
+        # Not a list
         else:
-            lst = [name]
+            rawlst = [name]
+
+        # Init final list
+        lst = []
+
+        # Iterate through raw list and look for directories
+        for rl in rawlst:
+
+            # Entry is a directory
+            if os.path.isdir(rl):
+                dlst = glob.glob('{}/*.yml'.format(rl))
+                dlst.extend(glob.glob('{}/*.yaml'.format(rl)))
+                lst.extend(sorted(dlst))
+
+            # Otherise assume it is a file
+            else:
+                lst.append(rl)
 
         try:
             with self.pollBlock(), self.updateGroup():

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -550,8 +550,16 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def loadYaml(self,name,writeEach,modes,incGroups,excGroups):
         """Load YAML configuration from a file. Called from command"""
 
+        # Pass arg is a python list
+        if isinstance(name,list):
+            lst = name
+
+        # Passed arg is a comma seperated list of files
+        elif ',' in name:
+            lst = name.split(',')
+
         # Passed path is a directory
-        if os.path.isdir(name):
+        elif os.path.isdir(name):
             dlst = glob.glob('{}/*.yml'.format(name))
             dlst.extend(glob.glob('{}/*.yaml'.format(name)))
             lst = sorted(dlst)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -571,6 +571,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         try:
             with self.pollBlock(), self.updateGroup():
                 for fn in lst:
+                    self._log.debug("loadYaml: loading {}".format(fn))
                     with open(fn,'r') as f:
                         d = yamlToData(f.read())
                         self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -456,7 +456,7 @@ class SystemWidget(QWidget):
     def loadSettings(self):
         dlg = QFileDialog()
 
-        loadFile = dlg.getOpenFileName(caption='Read config file', filter='Config Files(*.yml);;All Files(*.*)')
+        loadFile = dlg.getOpenFileNames(caption='Read config file', filter='Config Files(*.yml);;All Files(*.*)')
 
         # Detect QT5 return
         if isinstance(loadFile,tuple):


### PR DESCRIPTION
This PR allows the loading of multiple configuration files when a directory is passed as an arg to LoadConfig.

Any .yml or .yaml files in the passed directory will be loaded in sorted order. Each file is parsed and applied to the management tree individually with the write() call generated after all configuration files have been loaded. 

This PR also allows the root node to be aliased with the name 'root'.