### PR TITLE
Add gui run helper; Remove syslog error loops

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -62,14 +62,14 @@ class RootLogHandler(logging.Handler):
                 with self._root.SystemLog.lock:
                     msg =  self._root.SystemLog.value()[:-1]
 
-                    # Only add a comma if list is not empty
+                    # Only add a comma and return if list is not empty
                     if len(msg) > 1:
                         msg += ',\n'
 
                     msg += jsonpickle.encode(se) + ']'
                     self._root.SystemLog.set(msg)
 
-                # Log to database, placeholder waiting for other PR
+                # Log to database
                 if self._root._sqlLog is not None:
                     self._root._sqlLog.logSyslog(se)
 
@@ -736,7 +736,12 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             self._sqlLog.logVariable(p, val)
 
                     except Exception as e:
-                        pr.logException(self._log,e)
+                        if v == self.SystemLog:
+                            print("------- Error Executing Syslog Listeners -------")
+                            print("Error: {}".format(e))
+                            print("------------------------------------------------")
+                        else:
+                            pr.logException(self._log,e)
                         
                 self._log.debug(F"Done update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}")
 

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -35,6 +35,12 @@ import pyrogue.gui.system
 import threading
 import sys
 
+def runGui(root,incGroups=None,excGroups=None):
+    appTop = QApplication(sys.argv)
+    guiTop = pyrogue.gui.GuiTop(incGroups=incGroups,excGroups=excGroups)
+    guiTop.setWindowTitle("Rogue Local Client")
+    guiTop.addTree(root)
+    appTop.exec_()
 
 def application(argv):
     return QApplication(argv)

--- a/python/pyrogue/interfaces/_SqlLogging.py
+++ b/python/pyrogue/interfaces/_SqlLogging.py
@@ -66,8 +66,8 @@ class SqlLogger(object):
                                                  status=varValue.status)
             self._conn.execute(ins)
         except:
-            self._log.error("Lost database connection to {}".format(self._url))
             self._conn = None
+            self._log.error("Lost database connection to {}".format(self._url))
 
     def logSyslog(self, syslogData):
         if self._conn is None:
@@ -82,7 +82,9 @@ class SqlLogger(object):
             self._conn.execute(ins)
 
         except:
-            self._log.error("Lost database connection to {}".format(self._url))
+            print("-----------Error Storing Syslog To DB ----------")
+            print("Lost database connection to {}".format(self._url))
+            print("------------------------------------------------")
             self._conn = None
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,7 @@ import test_device
 import time
 import rogue
 import pyrogue.protocols.epics
+import pyrogue.gui
 #import pyrogue.protocols.epicsV4
 import logging
 
@@ -63,5 +64,6 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
+        pyrogue.gui.runGui(dummyTree)
 


### PR DESCRIPTION
This adds a helper function for starting a gui:
pyrogue.gui.runGui(root)

It also removes error handling loops when an exception occurs while adding a systemlog entry.