### PR TITLE
Allow user to update a command's function

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -196,6 +196,9 @@ class BaseCommand(pr.BaseVariable):
     @staticmethod
     def postedTouchZero(cmd):
         cmd.post(0)
+
+    def replaceFunction(self, function):
+        self._function = function
         
     def _setDict(self,d,writeEach,modes,incGroups,excGroups):
         pass


### PR DESCRIPTION
This can be used to update the default settings for built in commands. As an example:

````
root.SaveConfig.replaceFunction(lambda arg: self.saveYaml(name=arg,
                                        readFirst=False,
                                        modes=['RW','WO'],
                                        incGroups='MyConfigGroup',
                                         excGroups='NoConfig',
                                         autoPrefix='config')
````