### PR TITLE
Allow sub-transactions on large blocks

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -241,20 +241,20 @@ class RemoteBlock(BaseBlock, rim.Master):
         self._setSlave(variables[0].parent)
         
         BaseBlock.__init__(self, path=variables[0].path, mode=variables[0].mode, device=variables[0].parent)
-        self._verifyEn  = False
-        self._bulkEn    = False
-        self._doVerify  = False
-        self._verifyWr  = False
-        self._sData     = bytearray(size)  # Set data
-        self._sDataMask = bytearray(size)  # Set data mask
-        self._bData     = bytearray(size)  # Block data
-        self._vData     = bytearray(size)  # Verify data
-        self._vDataMask = bytearray(size)  # Verify data mask
-        self._size      = size
-        self._offset    = offset
-        self._minSize   = self._reqMinAccess()
-        self._maxSize   = self._reqMaxAccess()
-        self._variables = variables
+        self._verifyEn    = False
+        self._bulkEn      = False
+        self._verifyRange = None
+        self._verifyWr    = False
+        self._sData       = bytearray(size)  # Set data
+        self._sDataMask   = bytearray(size)  # Set data mask
+        self._bData       = bytearray(size)  # Block data
+        self._vData       = bytearray(size)  # Verify data
+        self._vDataMask   = bytearray(size)  # Verify data mask
+        self._size        = size
+        self._offset      = offset
+        self._minSize     = self._reqMinAccess()
+        self._maxSize     = self._reqMaxAccess()
+        self._variables   = variables
 
         if self._minSize == 0 or self._maxSize == 0:
             raise MemoryError(name=self.path, address=self.address, msg="Invalid min/max size")
@@ -438,17 +438,17 @@ class RemoteBlock(BaseBlock, rim.Master):
             # Only verify blocks that have been written since last verify
             if type == rim.Write:
                 self._verifyWr = self._verifyEn
-                  
-            # Setup transaction
-            self._doVerify = (type == rim.Verify)
-            self._doUpdate = True
-
-            # Set data pointer
-            tData = self._vData if self._doVerify else self._bData
 
             # Derive offset and size based upon min transaction size
             offset = math.floor(lowByte / self._minSize) * self._minSize
             size   = math.ceil((highByte-lowByte+1) / self._minSize) * self._minSize
+
+            # Setup transaction
+            self._verifyRange = [offset,offset+size] if  (type == rim.Verify) else None
+            self._doUpdate = True
+
+            # Set data pointer
+            tData = self._vData if self._verifyRange is not None else self._bData
 
             # Start transaction
             self._reqTransaction(self.offset,tData,size,offset,type)
@@ -475,10 +475,10 @@ class RemoteBlock(BaseBlock, rim.Master):
             if err != "":
                 raise MemoryError(name=self.path, address=self.address, msg=err, size=self._size)
 
-            if self._doVerify:
+            if self._verifyRange is not None:
                 self._verifyWr = False
 
-                for x in range(self._size):
+                for x in range(self._verifyRange[0],self._verifyRange[1]):
                     if (self._vData[x] & self._vDataMask[x]) != (self._bData[x] & self._vDataMask[x]):
                         msg  = "Verify Error: "
                         msg += ('Local='    + ''.join(f'{x:#02x}' for x in self._bData))

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -301,8 +301,7 @@ class Device(pr.Node,rim.Hub):
         # Process local blocks.
         if variable is not None:
             for b,v in self._getBlocks(variable).items():
-                if (force or b.stale):
-                    b.startTransaction(rim.Verify, check=checkEach, lowByte=v[0], highByte=v[1])
+                b.startTransaction(rim.Verify, check=checkEach, lowByte=v[0], highByte=v[1])
 
         else:
             for block in self._blocks:
@@ -325,8 +324,7 @@ class Device(pr.Node,rim.Hub):
         # Process local blocks. 
         if variable is not None:
             for b,v in self._getBlocks(variable).items():
-                if (force or b.stale):
-                    b.startTransaction(rim.Read, check=checkEach, lowByte=v[0], highByte=v[1])
+                b.startTransaction(rim.Read, check=checkEach, lowByte=v[0], highByte=v[1])
 
         else:
             for block in self._blocks:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -277,9 +277,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in self._getBlocks(variable):
-                if (force or b.stale):                
-                    b.startTransaction(rim.Write, check=checkEach)
+            for b,v in self._getBlocks(variable).items():
+                if (force or b.stale):
+                    b.startTransaction(rim.Write, check=checkEach, lowByte=v[0], highByte=v[1])
 
         else:
             for block in self._blocks:
@@ -300,8 +300,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks.
         if variable is not None:
-            for b in self._getBlocks(variable):
-                b.startTransaction(rim.Verify, check=checkEach)
+            for b,v in self._getBlocks(variable).items():
+                if (force or b.stale):
+                    b.startTransaction(rim.Verify, check=checkEach, lowByte=v[0], highByte=v[1])
 
         else:
             for block in self._blocks:
@@ -323,8 +324,9 @@ class Device(pr.Node,rim.Hub):
 
         # Process local blocks. 
         if variable is not None:
-            for b in self._getBlocks(variable):
-                b.startTransaction(rim.Read, check=checkEach)
+            for b,v in self._getBlocks(variable).items():
+                if (force or b.stale):
+                    b.startTransaction(rim.Read, check=checkEach, lowByte=v[0], highByte=v[1])
 
         else:
             for block in self._blocks:
@@ -343,7 +345,7 @@ class Device(pr.Node,rim.Hub):
 
             # Process local blocks
             if variable is not None:
-                for b in self._getBlocks(variable):
+                for b,v in self._getBlocks(variable).items():
                     b._checkTransaction()
 
             else:
@@ -436,20 +438,35 @@ class Device(pr.Node,rim.Hub):
     def _getBlocks(self, variables):
         """
         Get a list of unique blocks from a list of Variables. 
+        The returned dictionary has the block as the key with each block assocaited
+        with a list. The first list item is the low byte associated with the variable list,
+        the second is the high byte associated with the variable list.
         Variables must belong to this device!
         """
         if isinstance(variables, pr.BaseVariable):
             variables = [variables]
 
-        blocks = []
+        blocks = {}
+
         for v in variables:
             if v.parent is not self:
                 raise DeviceError(
                     f'Variable {v.path} passed to {self.path}._getBlocks() is not a member of {self.path}')
-            else:
-                if v._block not in blocks and v._block is not None:
-                    blocks.append(v._block)
-                
+            elif v._block is not None:
+
+                if isinstance(v._block,pr.RemoteBlock):
+                    lowByte  = math.floor(v.bitOffset[0] / 8)
+                    highByte = math.floor((v.bitOffset[-1] + v.bitSize[-1] - 1) / 8)
+                else:
+                    lowByte  = None
+                    highByte = None
+
+                if v._block not in blocks:
+                    blocks[v._block] = [lowByte, highByte]
+                elif lsb is not None:
+                    if lowByte  < blocks[v._block][0]: blocks[v._block][0] = lowByte
+                    if highByte > blocks[v._block][1]: blocks[v._block][1] = highByte
+
         return blocks
 
     def _buildBlocks(self):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -452,7 +452,7 @@ class Device(pr.Node,rim.Hub):
                     f'Variable {v.path} passed to {self.path}._getBlocks() is not a member of {self.path}')
             elif v._block is not None:
 
-                if isinstance(v._block,pr.RemoteBlock):
+                if isinstance(v,pr.RemoteVariable):
                     lowByte  = math.floor(v.bitOffset[0] / 8)
                     highByte = math.floor((v.bitOffset[-1] + v.bitSize[-1] - 1) / 8)
                 else:
@@ -461,7 +461,7 @@ class Device(pr.Node,rim.Hub):
 
                 if v._block not in blocks:
                     blocks[v._block] = [lowByte, highByte]
-                elif lsb is not None:
+                elif lowByte is not None and highByte is not None:
                     if lowByte  < blocks[v._block][0]: blocks[v._block][0] = lowByte
                     if highByte > blocks[v._block][1]: blocks[v._block][1] = highByte
 


### PR DESCRIPTION
This PR allows the user to setup a device with a large block size, allowing both large bulk memory transactions and individual sub-block transactions. 

Calling writeBlocks, readBlocks, verifyBlocks without a variable list will generate a burst transaction on the entire block. Calling the above functions with a variable list will only access the range of the block overlapped by the passed variables. Single get() and set() transactions will only generate transactions on the range of the block covered by the accessed variable.