### PR TITLE
Add support for multidimensional arrays

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -547,7 +547,7 @@ class Node(object):
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups):
         for key, value in d.items():
-            ret = self._nodeMatch(key)
+            ret = self.nodeMatch(key)
 
             if len(ret) == 0:
                 self._log.error("Entry {} not found".format(key))
@@ -563,7 +563,7 @@ class Node(object):
     def _setTimeout(self,timeout):
         pass
 
-    def _nodeMatch(self,name):
+    def nodeMatch(self,name):
         """
         Return a node or list of nodes which match the given name. The name can either
         be a single value or a list accessor:

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -441,7 +441,10 @@ class Node(object):
         return self._root
 
     def node(self, path):
-        return self._nodeMatch(path)
+        if name in self._nodes:
+            return self._nodes[name]
+        else:
+            return None
 
     @property
     def isDevice(self):
@@ -546,7 +549,7 @@ class Node(object):
         for key, value in d.items():
             ret = self._nodeMatch(key)
 
-            if ret is None:
+            if len(ret) == 0:
                 self._log.error("Entry {} not found".format(key))
             else:
                 if not isistance(ret,list):
@@ -588,14 +591,7 @@ class Node(object):
             if aname is None or aname not in self._anodes:
                 return None
 
-            lst = _iterateList(self._anodes[aname],keys)
-
-            if len(lst) == 0:
-                return None
-            elif len(lst) == 1:
-                return lst[0]
-            else: 
-                return lst
+            return _iterateList(self._anodes[aname],keys)
 
 
 def _iterateList(lst, keys):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -552,9 +552,6 @@ class Node(object):
             if len(ret) == 0:
                 self._log.error("Entry {} not found".format(key))
             else:
-                if not isistance(ret,list):
-                    ret = [ret]
-
                 for n in ret:
                     if n is not None:
                         if n.filterByGroup(incGroups,excGroups):
@@ -578,7 +575,7 @@ class Node(object):
         """
         # Node matches name in node list
         if name in self._nodes:
-            return self._nodes[name]
+            return [self._nodes[name]]
 
         # Otherwise we may need to slice an array
         else:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -256,31 +256,14 @@ class AxiVersion(pr.Device):
             value = ''))
 
         self.BuildStamp.addListener(parseBuildStamp)        
-     
-        a = 0
-        for i in range(8):
-            for j in range(8):
 
-                self.add(pr.RemoteVariable(
-                    name         = 'TestArray[{:d}][{:d}]'.format(i,j),
-                    description  = 'Array Test Field',
-                    offset       = 0x1000 + a,
-                    bitSize      = 32,
-                    bitOffset    = 0,
-                    base         = pr.UInt,
-                    mode         = 'RW',
-                ))
-                a += 4
+        for i in range(4):
+            for j in range(4):
+                for k in range(4):
+                    self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]',value=0)) 
 
-        self.add(pr.RemoteVariable(
-            name         = 'TestArray[10]',
-            description  = 'Array Test Field',
-            offset       = 0x2800 + a,
-            bitSize      = 32,
-            bitOffset    = 0,
-            base         = pr.UInt,
-            mode         = 'RW',
-        ))
+        self.add(pr.LocalVariable(name = 'TestArray[4][5]',value=0))
+        self.add(pr.LocalVariable(name = 'TestArray[6]',value=0))
 
         #self.add(pr.RemoteVariable(
         #    name         = 'TestArray[5]',

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -282,6 +282,16 @@ class AxiVersion(pr.Device):
             mode         = 'RW',
         ))
 
+        #self.add(pr.RemoteVariable(
+        #    name         = 'TestArray[5]',
+        #    description  = 'Array Test Field',
+        #    offset       = 0x2900 + a,
+        #    bitSize      = 32,
+        #    bitOffset    = 0,
+        #    base         = pr.UInt,
+        #    mode         = 'RW',
+        #))
+
         self.add(pr.RemoteVariable(
             name         = 'TestSpareArray[5][5]',
             description  = 'Array Test Field',

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -256,20 +256,51 @@ class AxiVersion(pr.Device):
             value = ''))
 
         self.BuildStamp.addListener(parseBuildStamp)        
-      
-        #for i in range(16):
-        for i in range(1024):
-            remap = divmod(i,32)
+     
+        a = 0
+        for i in range(8):
+            for j in range(8):
 
-            self.add(pr.RemoteVariable(
-                name         = 'TestArray[{:d}]'.format(i),
-                description  = 'Array Test Field',
-                offset       = 0x1000 + remap[0]<<2,
-                bitSize      = 1,
-                bitOffset    = remap[1],
-                base         = pr.UInt,
-                mode         = 'RW',
-            ))
+                self.add(pr.RemoteVariable(
+                    name         = 'TestArray[{:d}][{:d}]'.format(i,j),
+                    description  = 'Array Test Field',
+                    offset       = 0x1000 + a,
+                    bitSize      = 32,
+                    bitOffset    = 0,
+                    base         = pr.UInt,
+                    mode         = 'RW',
+                ))
+                a += 4
+
+        self.add(pr.RemoteVariable(
+            name         = 'TestArray[10]',
+            description  = 'Array Test Field',
+            offset       = 0x2800 + a,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
+            mode         = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TestSpareArray[5][5]',
+            description  = 'Array Test Field',
+            offset       = 0x2000,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
+            mode         = 'RW',
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'TestSpareArray[8][8]',
+            description  = 'Array Test Field',
+            offset       = 0x2004,
+            bitSize      = 32,
+            bitOffset    = 0,
+            base         = pr.UInt,
+            mode         = 'RW',
+        ))
 
         self.add(pr.RemoteVariable(
             name         = 'AlarmTest'.format(i),


### PR DESCRIPTION
This PR adds support for multidimensional arrays for Nodes. Non rectangular and sparse arrays are supported. For example:

````
 for i in range(4):
     for j in range(4):
         for j in range(4):              
             self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]', value=0)) 

addVariable(pyrogue.LocalVariable(name='TestArray[4][5]',value=0))
addVariable(pyrogue.LocalVariable(name='TestArray[6]',value=0))
````
Which generates the following configuration file matching:

````
In [3]: a.nodeMatch('TestArray[*][*][*]')                                                                                                                                                                                                                  
Out[3]: 
[dummyTree.AxiVersion.TestArray[0][0][0],
 dummyTree.AxiVersion.TestArray[0][0][1],
 dummyTree.AxiVersion.TestArray[0][0][2],
 dummyTree.AxiVersion.TestArray[0][0][3],
....
 dummyTree.AxiVersion.TestArray[3][3][2],
 dummyTree.AxiVersion.TestArray[3][3][3]]

In [4]: a.nodeMatch('TestArray[*][*]')                                                                                                                                                                                                                     
Out[4]: [dummyTree.AxiVersion.TestArray[4][5]]

In [5]: a.nodeMatch('TestArray[*]')                                                                                                                                                                                                                        
Out[5]: [dummyTree.AxiVersion.TestArray[6]]

In [6]: a.nodeMatch('TestArray[*][0][0]')                                                                                                                                                                                                                  
Out[6]: 
[dummyTree.AxiVersion.TestArray[0][0][0],
 dummyTree.AxiVersion.TestArray[1][0][0],
 dummyTree.AxiVersion.TestArray[2][0][0],
 dummyTree.AxiVersion.TestArray[3][0][0]]

In [7]: a.nodeMatch('TestArray[*][0][*]')                                                                                                                                                                                                                  
Out[7]: 
[dummyTree.AxiVersion.TestArray[0][0][0],
 dummyTree.AxiVersion.TestArray[0][0][1],
 dummyTree.AxiVersion.TestArray[0][0][2],
 dummyTree.AxiVersion.TestArray[0][0][3],
 dummyTree.AxiVersion.TestArray[1][0][0],
 dummyTree.AxiVersion.TestArray[1][0][1],
 dummyTree.AxiVersion.TestArray[1][0][2],
 dummyTree.AxiVersion.TestArray[1][0][3],
 dummyTree.AxiVersion.TestArray[2][0][0],
 dummyTree.AxiVersion.TestArray[2][0][1],
 dummyTree.AxiVersion.TestArray[2][0][2],
 dummyTree.AxiVersion.TestArray[2][0][3],
 dummyTree.AxiVersion.TestArray[3][0][0],
 dummyTree.AxiVersion.TestArray[3][0][1],
 dummyTree.AxiVersion.TestArray[3][0][2],
 dummyTree.AxiVersion.TestArray[3][0][3]]

````



