### PR TITLE
Update array storage to a dictionary

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -200,9 +200,9 @@ class Node(object):
         if name in self._nodes:
             return self._nodes[name]
 
-        # Node matches name in node array list
-        elif name in self._anodes:
-            return self._anodes[name]
+        # Node matches name in node dictionary list
+        elif name in self._dnodes:
+            return self._dnodes[name]
 
         else:
             raise AttributeError('{} has no attribute {}'.format(self, name))
@@ -295,22 +295,23 @@ class Node(object):
         if aname in self.__dir__():
             raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
 
-        # Create list if it does not exist
+        # Create list and dictionary containers if they do not exist
         if not aname in self._anodes:
-            self._anodes[aname] = []
+            self._anodes[aname] = {'l':[], 'd':{}}
 
         # Start at primary list
-        lst = self._anodes[aname]
+        lst = self._anodes[aname]['l']
+        dic = self._anodes[aname]['d']
 
         # Iterate through keys
         for i in range(len(keys)):
             k = int(keys[i])
 
-            # Fill in empy array locations
+            # Fill in empy list locations
             if len(lst) <= k:
                 lst.extend([None for _ in range(k-len(lst) + 1)])
 
-            # Last key, set node, check if location already has an array
+            # Last key, set node, check for overlaps
             if i == (len(keys)-1): 
                 if lst[k] is not None:
                     raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -201,8 +201,8 @@ class Node(object):
             return self._nodes[name]
 
         # Node matches name in node dictionary list
-        elif name in self._dnodes:
-            return self._dnodes[name]
+        elif name in self._anodes:
+            return self._anodes[name]
 
         else:
             raise AttributeError('{} has no attribute {}'.format(self, name))
@@ -295,33 +295,34 @@ class Node(object):
         if aname in self.__dir__():
             raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
 
-        # Create list and dictionary containers if they do not exist
+        # Create dictionary containers
         if not aname in self._anodes:
-            self._anodes[aname] = {'l':[], 'd':{}}
+            self._anodes[aname] = {}
 
         # Start at primary list
-        lst = self._anodes[aname]['l']
-        dic = self._anodes[aname]['d']
+        sub = self._anodes[aname]
 
         # Iterate through keys
         for i in range(len(keys)):
             k = int(keys[i])
 
-            # Fill in empy list locations
-            if len(lst) <= k:
-                lst.extend([None for _ in range(k-len(lst) + 1)])
-
             # Last key, set node, check for overlaps
             if i == (len(keys)-1): 
-                if lst[k] is not None:
+                if k in sub:
                     raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
 
-                lst[k] = node
+                sub[k] = node
+                return
 
-            # Add next level array and update pointer
-            else:
-                if lst[k] is None: lst[k] = []
-                lst = lst[k]
+            # Next level is empty
+            if not k in sub:
+                sub[k] = {}
+
+            # check for overlaps
+            elif isinstance(sub[k],Node):
+                raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
+            
+            sub = sub[k]
 
 
     def addNode(self, nodeClass, **kwargs):
@@ -590,21 +591,31 @@ class Node(object):
 
             # Name not in list
             if aname is None or aname not in self._anodes or len(keys) == 0:
-                return None
+                return []
 
-            return _iterateList(self._anodes[aname],keys)
+            return _iterateDict(self._anodes[aname],keys)
 
 
-def _iterateList(lst, keys):
+def _iterateDict(d, keys):
     retList = []
 
+    # Wildcard, full list
     if keys[0] == '*' or keys[0] == ':':
-        subList = lst
+        subList = list(d.values())
+
+    # Single item
     elif keys[0].isdigit():
-        subList = [lst[int(keys[0])]]
+        subList = [d[int(keys[0])]]
+
+    # Slice
     else:
+
+        # Form sliceable list
+        tmpList = [None] * max(d.keys())
+        for k,v in d.items(): tmpList[k] = v
+
         try:
-            subList = eval(f'lst[{keys[0]}]')
+            subList = eval(f'tmpList[{keys[0]}]')
         except:
             subList = []
 
@@ -615,8 +626,8 @@ def _iterateList(lst, keys):
             retList.append(e)
 
         # Don't go deeper in tree than the keys provided to avoid over-matching nodes
-        elif len(keys) > 1 and isinstance(e,list):
-            retList.extend(_iterateList(e,keys[1:]))
+        elif len(keys) > 1 and isinstance(e,dict):
+            retList.extend(_iterateDict(e,keys[1:]))
 
     return retList
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -257,6 +257,8 @@ class AxiVersion(pr.Device):
 
         self.BuildStamp.addListener(parseBuildStamp)        
 
+        #self.add(pr.LocalVariable(name = 'TestArray[2]',value=0))
+
         for i in range(4):
             for j in range(4):
                 for k in range(4):
@@ -265,15 +267,7 @@ class AxiVersion(pr.Device):
         self.add(pr.LocalVariable(name = 'TestArray[4][5]',value=0))
         self.add(pr.LocalVariable(name = 'TestArray[6]',value=0))
 
-        #self.add(pr.RemoteVariable(
-        #    name         = 'TestArray[5]',
-        #    description  = 'Array Test Field',
-        #    offset       = 0x2900 + a,
-        #    bitSize      = 32,
-        #    bitOffset    = 0,
-        #    base         = pr.UInt,
-        #    mode         = 'RW',
-        #))
+        #self.add(pr.LocalVariable(name = 'TestArray[2]',value=0))
 
         self.add(pr.RemoteVariable(
             name         = 'TestSpareArray[5][5]',


### PR DESCRIPTION
Array variables are now stored as a dictionary, which is returned when the user accesses the variable via direction lookup, allowing the following calls:

````
for v in dummyTree.AxiVersion.TestArray.values():
    v.setDisp('0')

or

for k,v in dummyTree.AxiVersion.TestArray.values():
    print(f"Item {k} = {v}")
````

nodeMatch will still return the matched nodes as an array. A list generation performance penalty is created when slicing arrays in a configuration file. 
