### PR TITLE
Enable heartbeat outside of poll, gui state indication

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -30,6 +30,7 @@ import jsonpickle
 import zipfile
 import traceback
 import gzip
+import datetime
 from contextlib import contextmanager
 
 SystemLogInit = '[]'

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -195,8 +195,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
         self._varListeners = []
         self._monitors = []
-        self._root = None
-        self._link = False
+        self._root  = None
+        self._link  = False
         self._ltime = time.time()
 
         # Setup logging
@@ -226,11 +226,16 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._link  = True
         self._root.Time.addListener(self._monListener)
         self._ltime = self._root.Time.value()
-        self._monWorker()
-
 
     def addLinkMonitor(self, function):
-        self._monitors.append(function)
+        if not function in self._monitors:
+            self._monitors.append(function)
+        self._monWorker()
+
+    def remLinkMonitor(self, function):
+        if function in self._monitors:
+            self._monitors.remove(function)
+        self._monWorker()
 
     @property
     def linked(self):
@@ -240,6 +245,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._ltime = val.value
 
     def _monWorker(self):
+        if len(self._monitors) == 0: return
+
         threading.Timer(1.0,self._monWorker).start()
 
         if self._link and (time.time() - self._ltime) > 1.5:

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -23,6 +23,8 @@ import rogue.interfaces
 import functools as ft
 import jsonpickle
 import re
+import time
+import threading
 
 
 
@@ -192,30 +194,65 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
         rogue.interfaces.ZmqClient.__init__(self,addr,port)
         self._varListeners = []
+        self._monitors = []
         self._root = None
+        self._link = False
+        self._ltime = time.time()
 
         # Setup logging
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
 
         # Get root name as a connection test
         self.setTimeout(1000)
-        rn = None
-        while rn is None:
-            rn = self._remoteAttr('__rootname__',None)
+        self._rn = None
+        while self._rn is None:
+            self._rn = self._remoteAttr('__rootname__',None)
 
-        print("Connected to {} at {}:{}".format(rn,addr,port))
+        print("Connected to {} at {}:{}".format(self._rn,addr,port))
 
         # Try to connect to root entity, long timeout
-        print("Getting structure for {}".format(rn))
+        print("Getting structure for {}".format(self._rn))
         self.setTimeout(120000)
         r = self._remoteAttr('__structure__', None)
-        print("Ready to use {}".format(rn))
+        print("Ready to use {}".format(self._rn))
 
         # Update tree
         r._virtAttached(r,r,self)
         self._root = r
 
         setattr(self,self._root.name,self._root)
+
+        # Link tracking
+        self._link  = True
+        self._root.Time.addListener(self._monListener)
+        self._ltime = self._root.Time.value()
+        self._monWorker()
+
+
+    def addLinkMonitor(self, function):
+        self._monitors.append(function)
+
+    @property
+    def linked(self):
+        return self._link
+
+    def _monListener(self,path,val):
+        self._ltime = val.value
+
+    def _monWorker(self):
+        threading.Timer(1.0,self._monWorker).start()
+
+        if self._link and (time.time() - self._ltime) > 1.5:
+            self._link = False
+            print(f"Link to {self._rn} lost!")
+            for mon in self._monitors:
+                mon(self._link)
+
+        elif (not self._link) and (time.time() - self._ltime) < 1.5:
+            self._link = True
+            print(f"Link to {self._rn} restored!")
+            for mon in self._monitors:
+                mon(self._link)
 
 
     def _remoteAttr(self, path, attr, *args, **kwargs):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -81,6 +81,7 @@ class RogueConnection(PyDMConnection):
         self._node   = None
         self._enum   = None
         self._notDev = False
+        self._address = address
 
         if utilities.is_pydm_app():
             self._client = pyrogue.interfaces.VirtualClient(self._host, self._port)
@@ -101,6 +102,7 @@ class RogueConnection(PyDMConnection):
 
         self.add_listener(channel)
         self._client.addLinkMonitor(self.linkState)
+        print("Adding monitor for {}".format(self._address))
 
     def linkState(self, state):
         if state:
@@ -203,6 +205,8 @@ class RogueConnection(PyDMConnection):
             self.new_value_signal[str].emit(self._node.name)
 
     def remove_listener(self, channel, destroying):
+        print("Removing monitor for {}".format(self._address))
+        self._client.remLinkMonitor(self.linkState)
         #if channel.value_signal is not None:
         #    #try:
         #    #    channel.value_signal[str].disconnect(self.put_value)

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -102,7 +102,6 @@ class RogueConnection(PyDMConnection):
 
         self.add_listener(channel)
         self._client.addLinkMonitor(self.linkState)
-        print("Adding monitor for {}".format(self._address))
 
     def linkState(self, state):
         if state:
@@ -205,7 +204,6 @@ class RogueConnection(PyDMConnection):
             self.new_value_signal[str].emit(self._node.name)
 
     def remove_listener(self, channel, destroying):
-        print("Removing monitor for {}".format(self._address))
         self._client.remLinkMonitor(self.linkState)
         #if channel.value_signal is not None:
         #    #try:

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -100,6 +100,14 @@ class RogueConnection(PyDMConnection):
                 self._int = True
 
         self.add_listener(channel)
+        self._client.addLinkMonitor(self.linkState)
+
+    def linkState(self, state):
+        if state:
+            self.connection_state_signal.emit(True)
+        else:
+            self.connection_state_signal.emit(False)
+
 
     def _updateVariable(self,path,varValue):
         if self._mode == 'name':

--- a/python/pyrogue/pydm/widgets/command.py
+++ b/python/pyrogue/pydm/widgets/command.py
@@ -28,9 +28,10 @@ class Command(PyDMFrame):
 
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(Command, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/command.py
+++ b/python/pyrogue/pydm/widgets/command.py
@@ -68,6 +68,9 @@ class Command(PyDMFrame):
 
             hb.addWidget(self._widget)
 
+        # This needs to be changed when pydm is updated. In the future the primary
+        # channel interface will be the input widget, with the button generating a
+        # update of the channel.
         self._btn = PyDMPushButton(label='Exec',
                                    pressValue=self._value,
                                    init_channel=self._path + '/disp')

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -157,7 +157,7 @@ class CommandTree(PyDMFrame):
         self._children  = []
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(CommandTree, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -108,6 +108,9 @@ class CommandHolder(QTreeWidgetItem):
 
         self.setText(1,self._cmd.typeStr)
 
+        # This needs to be changed when pydm is updated. In the future the primary
+        # channel interface will be the input widget, with the button generating a
+        # update of the channel.
         self._btn = PyDMPushButton(label='Exec',
                                    pressValue=self._value,
                                    init_channel=self._path + '/disp')

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -26,9 +26,10 @@ import datetime
 class DataWriter(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(DataWriter, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/process.py
+++ b/python/pyrogue/pydm/widgets/process.py
@@ -25,9 +25,10 @@ from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
 class Process(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(Process, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -19,7 +19,7 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLineEdit, PyDMPushButton
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt, Property, Slot
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, QGroupBox
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, QGroupBox, QLineEdit, QLabel
 import datetime
 
 class RootControl(PyDMFrame):
@@ -57,28 +57,73 @@ class RootControl(PyDMFrame):
         w = PyDMPushButton(label='Count Reset',pressValue=1,init_channel=self._path + '.CountReset')
         hb.addWidget(w)
 
+        # Load Config
+        # This needs to be changed to the new pydm command interface with the push
+        # button commiting the line edit value
         hb = QHBoxLayout()
         vb.addLayout(hb)
 
-        # Hidden boxes which are updated by file browse for now
-        self._loadSettingsCmd = PyDMLineEdit(parent=None, init_channel=self._path + '.LoadConfig')
-        self._saveSettingsCmd = PyDMLineEdit(parent=None, init_channel=self._path + '.SaveConfig')
-        self._saveStateCmd    = PyDMLineEdit(parent=None, init_channel=self._path + '.SaveState')
+        self._loadConfigCmd = PyDMPushButton(label='Load Config',
+                                             pressValue='',
+                                             init_channel=self._path + '.LoadConfig')
 
-        pb = QPushButton('Load Settings')
-        pb.clicked.connect(self._loadSettings)
+        hb.addWidget(self._loadConfigCmd)
+
+        self._loadConfigValue = QLineEdit()
+        self._loadConfigValue.textChanged.connect(self._loadConfigChanged)
+        hb.addWidget(self._loadConfigValue)
+
+        pb = QPushButton('Browse')
+        pb.clicked.connect(self._loadConfigBrowse)
         hb.addWidget(pb)
 
-        pb = QPushButton('Save Settings')
-        pb.clicked.connect(self._saveSettings)
+        # Save Config
+        # This needs to be changed to the new pydm command interface with the push
+        # button commiting the line edit value
+        hb = QHBoxLayout()
+        vb.addLayout(hb)
+
+        self._saveConfigCmd = PyDMPushButton(label='Save Config',
+                                             pressValue='',
+                                             init_channel=self._path + '.SaveConfig')
+
+        hb.addWidget(self._saveConfigCmd)
+
+        self._saveConfigValue = QLineEdit()
+        self._saveConfigValue.textChanged.connect(self._saveConfigChanged)
+        hb.addWidget(self._saveConfigValue)
+
+        pb = QPushButton('Browse')
+        pb.clicked.connect(self._saveConfigBrowse)
         hb.addWidget(pb)
 
-        pb = QPushButton('Save State')
-        pb.clicked.connect(self._saveState)
+        # Save State
+        # This needs to be changed to the new pydm command interface with the push
+        # button commiting the line edit value
+        hb = QHBoxLayout()
+        vb.addLayout(hb)
+
+        self._saveStateCmd = PyDMPushButton(label='Save State ',
+                                            pressValue='',
+                                            init_channel=self._path + '.SaveState')
+
+        hb.addWidget(self._saveStateCmd)
+
+        self._saveStateValue = QLineEdit()
+        self._saveStateValue.textChanged.connect(self._saveStateChanged)
+        hb.addWidget(self._saveStateValue)
+
+        pb = QPushButton('Browse')
+        pb.clicked.connect(self._saveStateBrowse)
         hb.addWidget(pb)
+
+
+    @Slot(str)
+    def _loadConfigChanged(self,value):
+        self._loadConfigCmd.pressValue = value
 
     @Slot()
-    def _loadSettings(self):
+    def _loadConfigBrowse(self):
         dlg = QFileDialog()
 
         loadFile = dlg.getOpenFileNames(caption='Read config file', filter='Config Files(*.yml);;All Files(*.*)')
@@ -88,11 +133,14 @@ class RootControl(PyDMFrame):
             loadFile = loadFile[0]
 
         if loadFile != '':
-            self._loadSettingsCmd.setText(','.join(loadFile))
-            self._loadSettingsCmd.send_value()
+            self._loadConfigValue.setText(','.join(loadFile))
+
+    @Slot(str)
+    def _saveConfigChanged(self,value):
+        self._saveConfigCmd.pressValue = value
 
     @Slot()
-    def _saveSettings(self):
+    def _saveConfigBrowse(self):
         dlg = QFileDialog()
         sug = datetime.datetime.now().strftime("config_%Y%m%d_%H%M%S.yml") 
 
@@ -103,11 +151,14 @@ class RootControl(PyDMFrame):
             saveFile = saveFile[0]
 
         if saveFile != '':
-            self._saveSettingsCmd.setText(saveFile)
-            self._saveSettingsCmd.send_value()
+            self._saveConfigValue.setText(saveFile)
+
+    @Slot(str)
+    def _saveStateChanged(self,value):
+        self._saveStateCmd.pressValue = value
 
     @Slot()
-    def _saveState(self):
+    def _saveStateBrowse(self):
         dlg = QFileDialog()
         sug = datetime.datetime.now().strftime("state_%Y%m%d_%H%M%S.yml.gz")
 
@@ -118,6 +169,5 @@ class RootControl(PyDMFrame):
             stateFile = stateFile[0]
 
         if stateFile != '':
-            self._saveStateCmd.setText(stateFile)
-            self._saveStateCmd.send_value()
+            self._saveStateValue.setText(stateFile)
 

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -25,9 +25,10 @@ import datetime
 class RootControl(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(RootControl, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/run_control.py
+++ b/python/pyrogue/pydm/widgets/run_control.py
@@ -24,9 +24,10 @@ from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
 class RunControl(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(RunControl, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/system_log.py
+++ b/python/pyrogue/pydm/widgets/system_log.py
@@ -29,9 +29,10 @@ class SystemLog(PyDMFrame):
 
         self._systemLog = None
         self._logCount  = 0
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(SystemLog, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/system_window.py
+++ b/python/pyrogue/pydm/widgets/system_window.py
@@ -28,9 +28,10 @@ from pyrogue.pydm.widgets import SystemLog
 class SystemWindow(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
         PyDMFrame.__init__(self, parent, init_channel)
+        self._node = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(SystemWindow, self).connection_changed(connected)
 
         if not build: return

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -200,7 +200,7 @@ class VariableTree(PyDMFrame):
         self._tree      = None
 
     def connection_changed(self, connected):
-        build = self._connected != connected and connected == True
+        build = (self._node is None) and (self._connected != connected and connected == True)
         super(VariableTree, self).connection_changed(connected)
 
         if not build: return

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -269,6 +269,9 @@ class AxiVersion(pr.Device):
 
         #self.add(pr.LocalVariable(name = 'TestArray[2]',value=0))
 
+        for i in range(2):
+            self.add(pr.LocalVariable(name = f'TestArray2[{i}]',value=0)) 
+
         self.add(pr.RemoteVariable(
             name         = 'TestSpareArray[5][5]',
             description  = 'Array Test Field',


### PR DESCRIPTION
This PR changes the Time and LocalTime variables so that they are updated once a second outside of the polling loop and will update even if polling is disabled.

The VirtualClient class will use the Time variable as a heartbeat to track the link state.

When the link state goes down the GUI input fields and push buttons will be disabled.