### PR TITLE
Add node name schema check warning

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -270,6 +270,10 @@ class Node(object):
             raise NodeError('Error adding node with name %s to %s. Name collision.' % 
                              (node.name,self.name))
 
+        # Add some checking for charaters which will make lookups problematic
+        if re.match('^[\w_\[\]]+$',node.name) is None:
+            self._log.warning('Node {} with one or more special characters will cause lookup errors.'.format(node.name))
+
         # Detect and add array nodes
         self._addArrayNode(node)
 
@@ -288,7 +292,7 @@ class Node(object):
         keys  = fields[1:-1]
 
         if not all([key.isdigit() for key in keys]):
-            self._log.warning('Array node with non numeric key: {} may cause lookup errors.'.format(node.name))
+            self._log.warning('Array node {} with non numeric key will cause lookup errors.'.format(node.name))
             return
 
         # Detect collisions

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -24,14 +24,17 @@ import time
 
 class UdpRssiPack(pr.Device):
 
-    def __init__(self,*,host,port, jumbo=False, wait=True, packVer=1, pollInterval=1, enSsi=True, **kwargs):
+    def __init__(self,*, port, host='127.0.0.1', jumbo=False, wait=True, packVer=1, pollInterval=1, enSsi=True, server=False, **kwargs):
         super(self.__class__, self).__init__(**kwargs)
         self._host = host
         self._port = port
 
-        self._udp  = rogue.protocols.udp.Client(host,port,jumbo)
-
-        self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
+        if server:
+            self._udp  = rogue.protocols.udp.Server(port,jumbo)
+            self._rssi = rogue.protocols.rssi.Server(self._udp.maxPayload())
+        else:
+            self._udp  = rogue.protocols.udp.Client(host,port,jumbo)
+            self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
 
         if packVer == 2:
             self._pack = rogue.protocols.packetizer.CoreV2(False,True,enSsi) # ibCRC = False, obCRC = True
@@ -46,7 +49,7 @@ class UdpRssiPack(pr.Device):
 
         self._rssi.start()
 
-        if wait:
+        if wait and not server:
             curr = int(time.time())
             last = curr
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,6 +88,26 @@ class DummyTree(pyrogue.Root):
             disp='{:1.2f}',
             value = np.array(0)))
 
+        self.add(pyrogue.LocalVariable(
+            name = 'Test/Slash',
+            mode = 'RW',
+            value = ''))
+
+        self.add(pyrogue.LocalVariable(
+            name = 'Test.Dot',
+            mode = 'RW',
+            value = ''))
+
+        self.add(pyrogue.LocalVariable(
+            name = 'Test\BackSlash',
+            mode = 'RW',
+            value = ''))
+
+        self.add(pyrogue.LocalVariable(
+            name = 'Test&And',
+            mode = 'RW',
+            value = ''))
+
         # Start the tree with pyrogue server, internal nameserver, default interface
         # Set pyroHost to the address of a network interface to specify which nework to run on
         # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,6 +23,7 @@ import rogue
 #import pyrogue.protocols.epics
 #import pyrogue.gui
 #import pyrogue.protocols.epicsV4
+import pyrogue.protocols
 import logging
 import math
 import numpy as np
@@ -88,25 +89,45 @@ class DummyTree(pyrogue.Root):
             disp='{:1.2f}',
             value = np.array(0)))
 
-        self.add(pyrogue.LocalVariable(
-            name = 'Test/Slash',
-            mode = 'RW',
-            value = ''))
+        #self.add(pyrogue.LocalVariable(
+        #    name = 'Test/Slash',
+        #    mode = 'RW',
+        #    value = ''))
 
-        self.add(pyrogue.LocalVariable(
-            name = 'Test.Dot',
-            mode = 'RW',
-            value = ''))
+        #self.add(pyrogue.LocalVariable(
+        #    name = 'Test.Dot',
+        #    mode = 'RW',
+        #    value = ''))
 
-        self.add(pyrogue.LocalVariable(
-            name = 'Test\BackSlash',
-            mode = 'RW',
-            value = ''))
+        #self.add(pyrogue.LocalVariable(
+        #    name = 'Test\BackSlash',
+        #    mode = 'RW',
+        #    value = ''))
 
-        self.add(pyrogue.LocalVariable(
-            name = 'Test&And',
-            mode = 'RW',
-            value = ''))
+        #self.add(pyrogue.LocalVariable(
+        #    name = 'Test&And',
+        #    mode = 'RW',
+        #    value = ''))
+
+        self.rudpServer = pyrogue.protocols.UdpRssiPack(
+            name    = 'UdpServer',
+            port    = 8192,
+            jumbo   = True,
+            server  = True,
+            expand  = False,
+            )
+        self.add(self.rudpServer)
+
+        # Create the ETH interface @ IP Address = args.dev
+        self.rudpClient = pyrogue.protocols.UdpRssiPack(
+            name    = 'UdpClient',
+            host    = "127.0.0.1",
+            port    = 8192,
+            jumbo   = True,
+            expand  = False,
+            )
+
+        self.add(self.rudpClient)
 
         # Start the tree with pyrogue server, internal nameserver, default interface
         # Set pyroHost to the address of a network interface to specify which nework to run on


### PR DESCRIPTION
This will generate a warning if the node name contains any non alphanumeric characters other than _, [, ].