### PR TITLE
Add RSSI value check, and proper python init values

### DIFF
--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -137,7 +137,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locTryPeriod',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocTryPeriod(),
             typeStr     = 'UInt32',
             localGet    = lambda: self._rssi.getLocTryPeriod(),
             localSet    = lambda value: self._rssi.setLocTryPeriod(value)
@@ -146,7 +146,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxBuffers',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocMaxBuffers(),
             typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxBuffers(),
             localSet    = lambda value: self._rssi.setLocMaxBuffers(value)
@@ -155,7 +155,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxSegment',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocMaxSegment(),
             typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocMaxSegment(),
             localSet    = lambda value: self._rssi.setLocMaxSegment(value)
@@ -164,7 +164,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locCumAckTout',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocCumAckTout(),
             typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocCumAckTout(),
             localSet    = lambda value: self._rssi.setLocCumAckTout(value)
@@ -173,7 +173,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locRetranTout',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocRetranTout(),
             typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocRetranTout(),
             localSet    = lambda value: self._rssi.setLocRetranTout(value)
@@ -182,7 +182,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locNullTout',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocNullTout(),
             typeStr     = 'UInt16',
             localGet    = lambda: self._rssi.getLocNullTout(),
             localSet    = lambda value: self._rssi.setLocNullTout(value)
@@ -191,7 +191,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxRetran',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocMaxRetran(),
             typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxRetran(),
             localSet    = lambda value: self._rssi.setLocMaxRetran(value)
@@ -200,7 +200,7 @@ class UdpRssiPack(pr.Device):
         self.add(pr.LocalVariable(
             name        = 'locMaxCumAck',
             mode        = 'RW', 
-            value       = 0,
+            value       = self._rssi.getLocMaxCumAck(),
             typeStr     = 'UInt8',
             localGet    = lambda: self._rssi.getLocMaxCumAck(),
             localSet    = lambda value: self._rssi.setLocMaxCumAck(value)

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -98,7 +98,7 @@ class PrbsTx(pyrogue.Device):
         self._prbs.sendCount(sendCount)
 
         self.add(pyrogue.LocalVariable(name='txSize', description='PRBS Frame Size', units='Bytes',
-                                       localSet=self._txSize, mode='RW', value=0, typeStr='UInt32'))
+                                       localSet=self._txSize, mode='RW', value=1024, typeStr='UInt32'))
 
         self.add(pyrogue.LocalVariable(name='txEnable', description='PRBS Run Enable', mode='RW',
                                        value=False, localSet=self._txEnable))

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -425,6 +425,9 @@ uint32_t rpr::Controller::getRemBusyCnt() {
 }
 
 void rpr::Controller::setLocTryPeriod(uint32_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocTryPeriod",
+                                            "Invalid LocTryPeriod Value = %i",val);
    locTryPeriod_ = val;
    convTime(tryPeriodD1_,  locTryPeriod_);
    convTime(tryPeriodD4_,  locTryPeriod_ / 4);
@@ -435,6 +438,10 @@ uint32_t rpr::Controller::getLocTryPeriod() {
 }
 
 void rpr::Controller::setLocMaxBuffers(uint8_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocMaxBuffers",
+                                            "Invalid LocMaxBuffers Value = %i",val);
+
    locMaxBuffers_ = val;
 }
 
@@ -443,6 +450,9 @@ uint8_t rpr::Controller::getLocMaxBuffers() {
 }
 
 void rpr::Controller::setLocMaxSegment(uint16_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocMaxSegment",
+                                            "Invalid LocMaxSegment Value = %i",val);
    locMaxSegment_ = val;
 }
 
@@ -451,6 +461,9 @@ uint16_t rpr::Controller::getLocMaxSegment() {
 }
 
 void rpr::Controller::setLocCumAckTout(uint16_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocCumAckTout",
+                                            "Invalid LocCumAckTout Value = %i",val);
    locCumAckTout_ = val;
 }
 
@@ -459,6 +472,9 @@ uint16_t rpr::Controller::getLocCumAckTout() {
 }
 
 void rpr::Controller::setLocRetranTout(uint16_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocRetranTout",
+                                            "Invalid LocRetranTout Value = %i",val);
    locRetranTout_ = val;
 }
 
@@ -467,6 +483,9 @@ uint16_t rpr::Controller::getLocRetranTout() {
 }
 
 void rpr::Controller::setLocNullTout(uint16_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocNullTout",
+                                            "Invalid LocNullTout Value = %i",val);
    locNullTout_ = val;
 }
 
@@ -475,6 +494,9 @@ uint16_t rpr::Controller::getLocNullTout() {
 }
 
 void rpr::Controller::setLocMaxRetran(uint8_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocMaxRetran",
+                                            "Invalid LocMaxRetran Value = %i",val);
    locMaxRetran_ = val;
 }
 
@@ -483,6 +505,9 @@ uint8_t rpr::Controller::getLocMaxRetran() {
 }
 
 void rpr::Controller::setLocMaxCumAck(uint8_t val) {
+   if ( val == 0 ) 
+      throw rogue::GeneralError::create("Rssi::Controller::setLocMaxAck",
+                                            "Invalid LocMaxAck Value = %i",val);
    locMaxCumAck_ = val;
 }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@
 import pyrogue
 import pyrogue.interfaces.simulation
 import pyrogue.utilities.fileio
+import pyrogue.utilities.prbs
 import rogue.interfaces.stream
 import test_device
 import time
@@ -112,6 +113,7 @@ class DummyTree(pyrogue.Root):
         self.rudpServer = pyrogue.protocols.UdpRssiPack(
             name    = 'UdpServer',
             port    = 8192,
+            pollInterval=0,
             jumbo   = True,
             server  = True,
             expand  = False,
@@ -123,11 +125,17 @@ class DummyTree(pyrogue.Root):
             name    = 'UdpClient',
             host    = "127.0.0.1",
             port    = 8192,
+            pollInterval=0,
             jumbo   = True,
             expand  = False,
             )
 
         self.add(self.rudpClient)
+
+        self.prbsTx = pyrogue.utilities.prbs.PrbsTx()
+        self.add(self.prbsTx)
+
+        pyrogue.streamConnect(self.prbsTx,self.rudpClient.application(0))
 
         # Start the tree with pyrogue server, internal nameserver, default interface
         # Set pyroHost to the address of a network interface to specify which nework to run on

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,7 +113,6 @@ class DummyTree(pyrogue.Root):
         self.rudpServer = pyrogue.protocols.UdpRssiPack(
             name    = 'UdpServer',
             port    = 8192,
-            pollInterval=0,
             jumbo   = True,
             server  = True,
             expand  = False,
@@ -125,7 +124,6 @@ class DummyTree(pyrogue.Root):
             name    = 'UdpClient',
             host    = "127.0.0.1",
             port    = 8192,
-            pollInterval=0,
             jumbo   = True,
             expand  = False,
             )


### PR DESCRIPTION
This PR generates an error when 0 values are set to certain RSSI parameters. It also pulls the C++ defaults into the python variables.