### PR TITLE
Generate clear error for unconnected memory devices

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -257,7 +257,7 @@ class RemoteBlock(BaseBlock, rim.Master):
         self._variables   = variables
 
         if self._minSize == 0 or self._maxSize == 0:
-            raise MemoryError(name=self.path, address=self.address, msg="Invalid min/max size")
+            raise MemoryError(name=self.path, address=self.address, msg="Invalid min/max memory interface size. Device or Variable may be unconnected!")
 
         # Range check
         if self._size > self._maxSize:

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -68,7 +68,7 @@ void rim::Master::setup_python() {
 //! Create object
 rim::Master::Master() {
    error_   = "";
-   slave_   = rim::Slave::create(4,4); // Empty placeholder
+   slave_   = rim::Slave::create(4,0); // Empty placeholder
 
    rogue::defaultTimeout(sumTime_);
 


### PR DESCRIPTION
This PR will ensure an error like below is generated if the user fails to properly connect the memory bus:

pyrogue._Block.MemoryError: 'Memory Error for dummyTree.AxiVersion.FpgaVersion at address 0x000000 Invalid min/max memory interface size. Device or Variable may be unconnected!'
