### PR TITLE
Support auto server port assignment

### DIFF
--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -41,10 +41,15 @@ namespace rogue {
             std::thread   * thread_;
             bool threadEn_;
 
+            std::string addr_;
+            uint16_t basePort_;
+
             //! Log 
             std::shared_ptr<rogue::Logging> log_;
 
             void runThread();
+
+            bool tryConnect();
 
          public:
 
@@ -59,6 +64,8 @@ namespace rogue {
             void publish(std::string value);
 
             virtual std::string doRequest (std::string data);
+
+            uint16_t port();
       };
       typedef std::shared_ptr<rogue::interfaces::ZmqServer> ZmqServerPtr;
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -123,8 +123,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._pollQueue = self._pollQueue = pr.PollQueue(root=self)
 
         # Zeromq server
-        self._zmqServer = None
-        self._structure = ""
+        self._zmqServer  = None
+        self._structure  = ""
+        self._serverPort = None
 
         # List of variable listeners
         self._varListeners  = []
@@ -253,7 +254,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
               initRead=False,
               initWrite=False,
               pollEn=True,
-              serverPort=None,  # 9099 is the default
+              serverPort=None,  # 9099 is the default, 0 for auto
               sqlUrl=None,
               streamIncGroups=None,
               streamExcGroups=['NoStream'],
@@ -313,8 +314,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Start server
         if serverPort is not None:
-            self._structure = jsonpickle.encode(self)
-            self._zmqServer = pr.interfaces.ZmqServer(root=self,addr="*",port=serverPort)
+            self._serverPort = serverPort
+            self._structure  = jsonpickle.encode(self)
+            self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=self._serverPort)
 
         # Start sql interface
         if sqlUrl is not None:
@@ -351,6 +353,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._zmqServer = None
 
         self._running=False
+
+    @property
+    def serverPort(self):
+        return self._serverPort
 
     def updatePickle(self):
         self._structure = jsonpickle.encode(self)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -312,11 +312,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             for key,value in self._nodes.items():
                 value._setTimeout(timeout)
 
-        # Start server
+        # Server Start
         if serverPort is not None:
-            self._serverPort = serverPort
+            self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=serverPort)
+            self._serverPort = self._zmqServer.port()
             self._structure  = jsonpickle.encode(self)
-            self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=self._serverPort)
 
         # Start sql interface
         if sqlUrl is not None:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -254,7 +254,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
               initRead=False,
               initWrite=False,
               pollEn=True,
-              serverPort=None,  # 9099 is the default, 0 for auto
+              serverPort=0,  # 9099 is the default, 0 for auto
               sqlUrl=None,
               streamIncGroups=None,
               streamExcGroups=['NoStream'],

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -18,20 +18,10 @@ import time
 
 parser = argparse.ArgumentParser('Pyrogue Client')
 
-parser.add_argument('--host', 
+parser.add_argument('--server',
                     type=str, 
-                    help='Server host name or address for gui or client',
-                    default='localhost')
-
-parser.add_argument('--port', 
-                    type=int, 
-                    help='Server port number for gui or client',
-                    default=9099)
-
-parser.add_argument('--servers',
-                    type=str, 
-                    help='Server & port list for gui (cmd=gui): host1:port1,host2:port2',
-                    default=None)
+                    help="Server address: 'host:port' or list of addresses: 'host1:port1,host2:port2'",
+                    default='localhost:9099')
 
 parser.add_argument('--ui',
                     type=str, 
@@ -59,20 +49,24 @@ parser.add_argument('value',
 
 args = parser.parse_args()
 
-print("Connecting to host {} port {}".format(args.host,args.port))
+
+# Common extraction for single server address
+try:
+    host = args.server.split(',')[0].split(':')[0]
+    port = args.server.split(',')[0].split(':')[1]
+except:
+    print("Failed to extract server host & port")
+
+print("Connecting to {}".format(args.server))
 
 # GUI Client
 if args.cmd == 'gui':
-    if args.servers is not None:
-        addrList = args.servers
-    else:
-        addrList = '{}:{}'.format(args.host,args.port)
-    pyrogue.pydm.runPyDM(addrList,args.ui)
+    pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui)
 
 # System log
 elif args.cmd == 'syslog':
     sl = pyrogue.interfaces.SystemLogMonitor(args.details)
-    client = pyrogue.interfaces.SimpleClient(args.host,args.port,cb=sl.varUpdated)
+    client = pyrogue.interfaces.SimpleClient(host,port,cb=sl.varUpdated)
 
     print("Listening for system log message:")
     print("")
@@ -93,7 +87,7 @@ elif args.cmd == 'monitor':
         exit()
 
     vm = pyrogue.interfaces.VariableMonitor(args.path)
-    client = pyrogue.interfaces.SimpleClient(args.host,args.port,cb=vm.varUpdated)
+    client = pyrogue.interfaces.SimpleClient(host,port,cb=vm.varUpdated)
 
     ret = client.valueDisp(args.path)
     print("")
@@ -109,7 +103,7 @@ elif args.cmd == 'monitor':
 # All Other Commands
 else:
 
-    client = pyrogue.interfaces.SimpleClient(args.host,args.port)
+    client = pyrogue.interfaces.SimpleClient(host,port)
 
     if args.path is None:
         print("Error: A path must be provided")

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -53,7 +53,7 @@ args = parser.parse_args()
 # Common extraction for single server address
 try:
     host = args.server.split(',')[0].split(':')[0]
-    port = args.server.split(',')[0].split(':')[1]
+    port = int(args.server.split(',')[0].split(':')[1])
 except:
     print("Failed to extract server host & port")
 

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -54,12 +54,27 @@ class GuiTop(QWidget):
     def __init__(self,*, parent=None, incGroups=None, excGroups=None, group=None):
         super(GuiTop,self).__init__(parent)
 
-        print("---------------------------------------------------------------")
+        print("-------------------------------------------------------------------------")
         print("The legacy GUI is now deprecated. Please use pyDM.")
-        print("   To start in python script see: pyrogue.pydm.runPyDM().")
-        print("   To start from command line: python -m pyrogue --help")
-        print("   serverPort must be set in root.start() to use pydm")
-        print("---------------------------------------------------------------")
+        print("")
+        print("   To use pydm serverPort must be set in root.start():")
+        print("")
+        print("      root.start(serverPort=9099)")
+        print("")
+        print("    when using a fixed port or for auto port assignment you can use:")
+        print("")
+        print("      root.start(serverPort=0)")
+        print("")
+        print("   To start pydm client from command line:")
+        print("")
+        print("      python -m pyrogue gui --server=localhost:9099")
+        print("")
+        print("   To start in top level python script:")
+        print("")
+        print("      pyrogue.pydm.runPyDM(root=root)")
+        print("")
+        print("   the server port will be extracted from the root object.")
+        print("-------------------------------------------------------------------------")
 
         if incGroups is None:
             self._incGroups=[]

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -18,9 +18,12 @@ import sys
 import pydm
 import pyrogue.pydm.data_plugins.rogue_plugin
 
-def runPyDM(addrList='localhost:9090', ui=None):
+def runPyDM(serverList='localhost:9090', root=None, ui=None):
 
-    os.environ['ROGUE_SERVERS'] = addrList
+    if root is not None:
+        os.environ['ROGUE_SERVERS'] = 'localhost:{}'.format(root.serverPort)
+    else:
+        os.environ['ROGUE_SERVERS'] = serverList
 
     if ui is None or ui == '':
         ui = os.path.dirname(os.path.abspath(__file__)) + '/pydmTop.py'

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -39,40 +39,37 @@ void rogue::interfaces::ZmqServer::setup_python() {
    bp::class_<rogue::interfaces::ZmqServerWrap, rogue::interfaces::ZmqServerWrapPtr, boost::noncopyable>("ZmqServer",bp::init<std::string, uint16_t>())
       .def("_doRequest", &rogue::interfaces::ZmqServer::doRequest, &rogue::interfaces::ZmqServerWrap::defDoRequest)
       .def("_publish",   &rogue::interfaces::ZmqServer::publish)
+      .def("port",       &rogue::interfaces::ZmqServer::port)
    ;
 #endif
 }
 
 rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
-   std::string temp;
+   bool res = false;
 
    log_ = rogue::Logging::create("ZmqServer");
 
+   this->addr_    = addr;
    this->zmqCtx_  = zmq_ctx_new();
-   this->zmqPub_  = zmq_socket(this->zmqCtx_,ZMQ_PUB);
-   this->zmqRep_  = zmq_socket(this->zmqCtx_,ZMQ_REP);
 
-   // Setup publish port
-   temp = "tcp://";
-   temp.append(addr);
-   temp.append(":");
-   temp.append(std::to_string(static_cast<long long>(port)));
+   // Auto port
+   if ( port == 0 ) {
+      for (this->basePort_ = 9099; this->basePort_ < (9099 + 100); this->basePort_ += 2) {
+         res = this->tryConnect();
+         if ( res ) break;
+      }
+   }
+   else res = this->tryConnect();
 
-   if ( zmq_bind(this->zmqPub_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
-               "Failed to bind server to port %i on interface %i. Another process may be using this port.",port,addr.c_str()));
+   if ( ! res ) 
+      if (port == 0) 
+         throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
+            "Failed to auto bind server on interface %s.",addr.c_str()));
+      else
+         throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
+            "Failed to bind server to port %i on interface %s. Another process may be using this port.",port+1,addr.c_str()));
 
-   // Setup response port
-   temp = "tcp://";
-   temp.append(addr);
-   temp.append(":");
-   temp.append(std::to_string(static_cast<long long>(port+1)));
-
-   if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) 
-      throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
-               "Failed to bind server to port %i on interface %i. Another process may be using this port.",port+1,addr.c_str()));
-
-   log_->info("Started to Rogue server at ports %i:%i:",port,port+1);
+   log_->info("Started Rogue server at ports %i:%i",this->basePort_,this->basePort_+1);
 
    threadEn_ = true;
    thread_ = new std::thread(&rogue::interfaces::ZmqServer::runThread, this);
@@ -85,6 +82,45 @@ rogue::interfaces::ZmqServer::~ZmqServer() {
    zmq_close(this->zmqRep_);
    zmq_term(this->zmqCtx_);
    thread_->join();
+}
+
+bool rogue::interfaces::ZmqServer::tryConnect() {
+   std::string temp;
+
+   log_->debug("Trying to serve on ports %i:%i",this->basePort_,this->basePort_+1);
+
+   this->zmqPub_ = zmq_socket(this->zmqCtx_,ZMQ_PUB);
+   this->zmqRep_ = zmq_socket(this->zmqCtx_,ZMQ_REP);
+
+   // Setup publish port
+   temp = "tcp://";
+   temp.append(this->addr_);
+   temp.append(":");
+   temp.append(std::to_string(static_cast<long long>(this->basePort_)));
+
+   if ( zmq_bind(this->zmqPub_,temp.c_str()) < 0 ) {
+      zmq_close(this->zmqPub_);
+      log_->debug("Failed to bind publish to port %i",this->basePort_);
+      return false;
+   }
+
+   // Setup response port
+   temp = "tcp://";
+   temp.append(this->addr_);
+   temp.append(":");
+   temp.append(std::to_string(static_cast<long long>(this->basePort_+1)));
+
+   if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) {
+      zmq_close(this->zmqPub_);
+      zmq_close(this->zmqRep_);
+      log_->debug("Failed to bind resp to port %i",this->basePort_+1);
+      return false;
+   }
+   return true;
+}
+
+uint16_t rogue::interfaces::ZmqServer::port() {
+   return this->basePort_;
 }
 
 void rogue::interfaces::ZmqServer::publish(std::string value) {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,10 +21,8 @@ import rogue.interfaces.stream
 import test_device
 import time
 import rogue
-#import pyrogue.protocols.epics
-#import pyrogue.gui
-#import pyrogue.protocols.epicsV4
 import pyrogue.protocols
+import pyrogue.pydm
 import logging
 import math
 import numpy as np
@@ -110,36 +108,35 @@ class DummyTree(pyrogue.Root):
         #    mode = 'RW',
         #    value = ''))
 
-        self.rudpServer = pyrogue.protocols.UdpRssiPack(
-            name    = 'UdpServer',
-            port    = 8192,
-            jumbo   = True,
-            server  = True,
-            expand  = False,
-            )
-        self.add(self.rudpServer)
+        #self.rudpServer = pyrogue.protocols.UdpRssiPack(
+        #    name    = 'UdpServer',
+        #    port    = 8192,
+        #    jumbo   = True,
+        #    server  = True,
+        #    expand  = False,
+        #    )
+        #self.add(self.rudpServer)
 
         # Create the ETH interface @ IP Address = args.dev
-        self.rudpClient = pyrogue.protocols.UdpRssiPack(
-            name    = 'UdpClient',
-            host    = "127.0.0.1",
-            port    = 8192,
-            jumbo   = True,
-            expand  = False,
-            )
+        #self.rudpClient = pyrogue.protocols.UdpRssiPack(
+        #    name    = 'UdpClient',
+        #    host    = "127.0.0.1",
+        #    port    = 8192,
+        #    jumbo   = True,
+        #    expand  = False,
+        #    )
+        #self.add(self.rudpClient)
 
-        self.add(self.rudpClient)
+        #self.prbsTx = pyrogue.utilities.prbs.PrbsTx()
+        #self.add(self.prbsTx)
 
-        self.prbsTx = pyrogue.utilities.prbs.PrbsTx()
-        self.add(self.prbsTx)
-
-        pyrogue.streamConnect(self.prbsTx,self.rudpClient.application(0))
+        #pyrogue.streamConnect(self.prbsTx,self.rudpClient.application(0))
 
         # Start the tree with pyrogue server, internal nameserver, default interface
         # Set pyroHost to the address of a network interface to specify which nework to run on
         # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
         #self.start(timeout=2.0, pollEn=True, serverPort=9099, sqlUrl='sqlite:///test.db')
-        self.start(timeout=2.0, pollEn=True, serverPort=9099)
+        self.start(timeout=2.0, pollEn=True, serverPort=0)
 
         #self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
         #self.epics.start()
@@ -162,6 +159,6 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
-        #pyrogue.gui.runGui(dummyTree)
+        #pyrogue.waitCntrlC()
+        pyrogue.pydm.runPyDM(root=dummyTree)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,7 +22,7 @@ import test_device
 import time
 import rogue
 import pyrogue.protocols
-import pyrogue.pydm
+#import pyrogue.pydm
 import logging
 import math
 import numpy as np
@@ -159,6 +159,6 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        #pyrogue.waitCntrlC()
-        pyrogue.pydm.runPyDM(root=dummyTree)
+        pyrogue.waitCntrlC()
+        #pyrogue.pydm.runPyDM(root=dummyTree)
 


### PR DESCRIPTION
This PR makes it easier to use the pyrogue server on a shared machine. Passing serverPort=0 will auto assign a free port.

I have also clarified the instructions for switching to pyDM and provided a function to start the GUI from the main thread, extracting the auto assigned server port.

The server in auto assign mode is now enabled by default.