### PR TITLE
Allow config files to load from zip files

### DIFF
--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -52,7 +52,7 @@ def addLibraryPath(path):
         # Relative path
         else:
             np = base + '/' + p
-        
+
         # Verify directory or archive exists and is readable
         if '.zip/' in np:
             tst = np[:np.find['.zip/']+4]


### PR DESCRIPTION
This PR allows zip based files and directories to be passed as entries in the LoadConfig filename or filename list. The access occurs just as if the zip file based directory was file system based.

Because of zip file filtering, only files ending in .yml or .yaml will be supported for config loads.

All three of the below commands will load the config.yml file


````
root.LoadConfig('/path/to/zipfile.zip/directory1/')
root.LoadConfig('/path/to/zipfile.zip/directory1')
root.LoadConfig('/path/to/zipfile.zip/directory1/config.yml')
````
