### PR TITLE
Add worker thread to sql logger

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,7 +137,7 @@ class DummyTree(pyrogue.Root):
         # Set pyroHost to the address of a network interface to specify which nework to run on
         # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
         #self.start(timeout=2.0, pollEn=True, serverPort=9099, sqlUrl='sqlite:///test.db')
-        self.start(timeout=2.0, pollEn=True, serverPort=0, sqlUrl='sqLite:///test.db')
+        self.start(timeout=2.0, pollEn=True, serverPort=0, sqlUrl='sqlite:///test.db')
 
         #self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
         #self.epics.start()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -137,7 +137,7 @@ class DummyTree(pyrogue.Root):
         # Set pyroHost to the address of a network interface to specify which nework to run on
         # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
         #self.start(timeout=2.0, pollEn=True, serverPort=9099, sqlUrl='sqlite:///test.db')
-        self.start(timeout=2.0, pollEn=True, serverPort=0)
+        self.start(timeout=2.0, pollEn=True, serverPort=0, sqlUrl='sqLite:///test.db')
 
         #self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
         #self.epics.start()


### PR DESCRIPTION
This PR adds a separate worker thread for the sql logging interface to avoid stalling update thread.