### PR TITLE
Remove dynamic resize to avoid qtimer message

### DIFF
--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -423,6 +423,7 @@ class SystemWidget(QWidget):
 
         self.systemLog.setColumnCount(2)
         self.systemLog.setHeaderLabels(['Field','Value'])
+        self.systemLog.setColumnWidth(0,200)
 
         self.logCount = 0
 
@@ -472,7 +473,6 @@ class SystemWidget(QWidget):
                         temp.setText(0,'')
                         temp.setText(1,v)
 
-        self.systemLog.resizeColumnToContents(0)
         self.logCount = len(lst)
 
     @pyqtSlot()

--- a/python/pyrogue/pydm/widgets/system_log.py
+++ b/python/pyrogue/pydm/widgets/system_log.py
@@ -98,6 +98,5 @@ class SystemLog(PyDMFrame):
                         temp.setText(0,'')
                         temp.setText(1,v)
 
-        self._systemLog.resizeColumnToContents(0)
         self._logCount = len(lst)
 

--- a/python/pyrogue/pydm/widgets/system_log.py
+++ b/python/pyrogue/pydm/widgets/system_log.py
@@ -54,6 +54,7 @@ class SystemLog(PyDMFrame):
 
         self._systemLog.setColumnCount(2)
         self._systemLog.setHeaderLabels(['Field','Value'])
+        self._systemLog.setColumnWidth(0,200)
 
         self._logCount = 0
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,7 +27,7 @@ import math
 import numpy as np
 
 #import pyrogue.pydm
-import pyrogue.gui
+#import pyrogue.gui
 
 #rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
 #rogue.Logging.setLevel(rogue.Logging.Debug)
@@ -161,7 +161,7 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        #pyrogue.waitCntrlC()
+        pyrogue.waitCntrlC()
         #pyrogue.pydm.runPyDM(root=dummyTree)
-        pyrogue.gui.runGui(root=dummyTree)
+        #pyrogue.gui.runGui(root=dummyTree)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -27,6 +27,7 @@ import math
 import numpy as np
 
 #import pyrogue.pydm
+import pyrogue.gui
 
 #rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
 #rogue.Logging.setLevel(rogue.Logging.Debug)
@@ -160,6 +161,7 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
         #pyrogue.pydm.runPyDM(root=dummyTree)
+        pyrogue.gui.runGui(root=dummyTree)
 


### PR DESCRIPTION
The QBasicTimer::start was being generated by the syslog column dynamic resize. This has been removed and the column size is now fixed. The same potential issue in the pydm gui was fixed as well.