### PR TITLE
Move Root start params to init method

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -294,17 +294,17 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             print("    Example: pyrogue.Root(timeout=1.0, pollEn=True")
             print("==========================================================")
 
-        # Override startup parameters if passed in start()
-        if 'streamIncGroups' in kwargs: self._streamIncGroups = kwargs['streamIncGroups']
-        if 'streamExcGroups' in kwargs: self._streamExcGroups = kwargs['streamExcGroups']
-        if 'sqlIncGroups'    in kwargs: self._sqlIncGroups    = kwargs['sqlIncGroups']
-        if 'sqlExcGroups'    in kwargs: self._sqlExcGroups    = kwargs['sqlExcGroups']
-        if 'timeout'         in kwargs: self._timeout         = kwargs['timeout']
-        if 'initRead'        in kwargs: self._initRead        = kwargs['initRead']
-        if 'initWrite'       in kwargs: self._initWrite       = kwargs['initWrite']
-        if 'pollEn'          in kwargs: self._pollEn          = kwargs['pollEn']
-        if 'serverPort'      in kwargs: self._serverPort      = kwargs['serverPort']
-        if 'sqlUrl'          in kwargs: self._sqlUrl          = kwargs['sqlUrl']
+            # Override startup parameters if passed in start()
+            if 'streamIncGroups' in kwargs: self._streamIncGroups = kwargs['streamIncGroups']
+            if 'streamExcGroups' in kwargs: self._streamExcGroups = kwargs['streamExcGroups']
+            if 'sqlIncGroups'    in kwargs: self._sqlIncGroups    = kwargs['sqlIncGroups']
+            if 'sqlExcGroups'    in kwargs: self._sqlExcGroups    = kwargs['sqlExcGroups']
+            if 'timeout'         in kwargs: self._timeout         = kwargs['timeout']
+            if 'initRead'        in kwargs: self._initRead        = kwargs['initRead']
+            if 'initWrite'       in kwargs: self._initWrite       = kwargs['initWrite']
+            if 'pollEn'          in kwargs: self._pollEn          = kwargs['pollEn']
+            if 'serverPort'      in kwargs: self._serverPort      = kwargs['serverPort']
+            if 'sqlUrl'          in kwargs: self._sqlUrl          = kwargs['sqlUrl']
 
         # Call special root level rootAttached
         self._rootAttached()

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -41,6 +41,7 @@ def runGui(root,incGroups=None,excGroups=None):
     guiTop = pyrogue.gui.GuiTop(incGroups=incGroups,excGroups=excGroups)
     guiTop.setWindowTitle("Rogue Server: {}".format(socket.gethostname()))
     guiTop.addTree(root)
+    guiTop.resize(800,1000)
     appTop.exec_()
 
 def application(argv):

--- a/python/pyrogue/protocols/epics.py
+++ b/python/pyrogue/protocols/epics.py
@@ -32,20 +32,9 @@ class EpicsCaServer(object):
         self._log       = pyrogue.logInit(cls=self)
         self._syncRead  = syncRead
         self._srv       = rogue.protocols.epicsV3.Server(threadCount)
-
-        if not root.running:
-            raise Exception("Epics can not be setup on a tree which is not started")
-
-        if pvMap is None:
-            doAll = True
-            self._pvMap = {}
-        else:
-            doAll = False
-            self._pvMap = pvMap
-
-        # Create PVs
-        for v in self._root.variableList:
-            self._addPv(v,doAll,incGroups,excGroups)
+        self._pvMap     = pvMap
+        self._incGroups = incGroups
+        self._excGroups = excGroups
 
     def createSlave(self, name, maxSize, type):
         slave = rogue.protocols.epicsV3.Slave(self._base + ':' + name,maxSize,type)
@@ -61,6 +50,20 @@ class EpicsCaServer(object):
         self._srv.stop()
 
     def start(self):
+
+        if not self._root.running:
+            raise Exception("Epics can not be setup on a tree which is not started")
+
+        if self._pvMap is None:
+            doAll = True
+            self._pvMap = {}
+        else:
+            doAll = False
+
+        # Create PVs
+        for v in self._root.variableList:
+            self._addPv(v,doAll,self._incGroups,self._excGroups)
+
         self._srv.start()
 
     def list(self):

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -33,8 +33,8 @@ class LocalRootWithEpics(LocalRoot):
 
         if use_map:
             # PV map
-            pv_map = { self.myDevice.var.path       : epics_prefix+':LocalRoot:myDevice:var', \
-                       self.myDevice.var_float.path : epics_prefix+':LocalRoot:myDevice:var_float', \
+            pv_map = { 'LocalRoot.myDevice.var'       : epics_prefix+':LocalRoot:myDevice:var', \
+                       'LocalRoot.myDevice.var_float' : epics_prefix+':LocalRoot:myDevice:var_float', \
                     }
         else:
             pv_map=None
@@ -60,6 +60,7 @@ def test_local_root():
 
     for s in pv_map_states:
         with LocalRootWithEpics(use_map=s) as root:
+            time.sleep(1)
 
             # Device EPICS PV name prefix
             device_epics_prefix=epics_prefix+':LocalRoot:myDevice'
@@ -97,6 +98,7 @@ def test_local_root():
     try:
         root=pyrogue.Root(name='LocalRoot', description='Local root')
         root.epics=pyrogue.protocols.epics.EpicsCaServer(base=epics_prefix, root=root)
+        root.epics.start()
         raise AssertionError('Attaching a pyrogue.epics to a non-started tree did not throw exception')
     except Exception as e:
         pass
@@ -110,3 +112,4 @@ def test_local_root():
 
 if __name__ == "__main__":
     test_local_root()
+

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -23,10 +23,9 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root', serverPort=None)
         my_device=myDevice()
         self.add(my_device)
-        self.start(serverPort=None)
 
 class LocalRootWithEpics(LocalRoot):
     def __init__(self, use_map=False):
@@ -41,6 +40,9 @@ class LocalRootWithEpics(LocalRoot):
             pv_map=None
 
         self.epics=pyrogue.protocols.epics.EpicsCaServer(base=epics_prefix, root=self, pvMap=pv_map)
+
+    def start(self):
+        pyrogue.Root.start(self)
         self.epics.start()
 
     def stop(self):

--- a/tests/test_localcommand.py
+++ b/tests/test_localcommand.py
@@ -31,10 +31,9 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root',serverPort=None)
         my_device=myDevice()
         self.add(my_device)
-        self.start(serverPort=None)
 
 def test_local_cmd():
     """

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -81,10 +81,9 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root',serverPort=None)
         my_device=myDevice()
         self.add(my_device)
-        self.start(serverPort=None)
 
 def test_local_root():
     """

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -60,7 +60,12 @@ class AxiVersion(pr.Device):
 class DummyTree(pr.Root):
 
     def __init__(self):
-        pr.Root.__init__(self,name='dummyTree',description="Dummy tree for example")
+        pr.Root.__init__(self,
+                         name='dummyTree',
+                         description="Dummy tree for example",
+                         timeout=2.0,
+                         pollEn=False,
+                         serverPort=None)
 
         # Use a memory space emulator
         self.sim = pr.interfaces.simulation.MemEmulate()
@@ -74,11 +79,6 @@ class DummyTree(pr.Root):
 
         # Add Device
         self.add(AxiVersion(memBase=self.mc,offset=0x0))
-
-        # Start the tree with pyrogue server, internal nameserver, default interface
-        # Set pyroHost to the address of a network interface to specify which nework to run on
-        # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
-        self.start(timeout=2.0, pollEn=False, serverPort=None)
 
     def stop(self):
         self.ms.close()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -5,12 +5,12 @@ import pyrogue
 def test_root():
 
     # Test __enter__ and __exit_ methods
-    with pyrogue.Root(name='root') as root:
+    with pyrogue.Root(name='root',timeout=2.0, initRead=True, initWrite=True, serverPort=None) as root:
         # Test:
         # - a non-default poll value
         # - set the initRead to true
         # - set the initWrite to true
-        root.start(timeout=2.0, initRead=True, initWrite=True, serverPort=None)
+        pass
 
 if __name__ == "__main__":
     test_root()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,7 +41,13 @@ class DummyTree(pyrogue.Root):
         self._scnt = 0
         self._sdata = np.array(0)
 
-        pyrogue.Root.__init__(self,name='dummyTree',description="Dummy tree for example")
+        pyrogue.Root.__init__(self,
+                              name='dummyTree',
+                              description="Dummy tree for example",
+                              timeout=2.0,
+                              pollEn=True,
+                              serverPort=0,
+                              sqlUrl='sqlite:///test.db')
 
         # Use a memory space emulator
         sim = pyrogue.interfaces.simulation.MemEmulate()
@@ -133,17 +139,18 @@ class DummyTree(pyrogue.Root):
 
         #pyrogue.streamConnect(self.prbsTx,self.rudpClient.application(0))
 
-        # Start the tree with pyrogue server, internal nameserver, default interface
-        # Set pyroHost to the address of a network interface to specify which nework to run on
-        # set pyroNs to the address of a standalone nameserver (startPyrorNs.py)
-        #self.start(timeout=2.0, pollEn=True, serverPort=9099, sqlUrl='sqlite:///test.db')
-        self.start(timeout=2.0, pollEn=True, serverPort=0, sqlUrl='sqlite:///test.db')
-
         #self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
-        #self.epics.start()
-
         #self.epics4=pyrogue.protocols.epicsV4.EpicsPvServer(base="test", root=self)
+
+    def start(self):
+        #self.epics.start()
         #self.epics4.start()
+        pass
+
+    def stop(self):
+        #self.epics.stop()
+        #self.epics4.stop()
+        pass
 
     def _mySin(self):
         val = math.sin(2*math.pi*self._scnt / 100)


### PR DESCRIPTION
This addresses a nagging problem with how we have been using start() combined with the root context managers. It also addresses the problem where duplicate parameters are passed through the root's init() method to be passed to start.

The parameters passed to the start() method are now passed to Root at creation. Legacy code using start() parameters will still be supported, but with a deprecation warning. 

Also we should no longer call start() in a Root's init method as it is inconsistent with the context manager. Instead the method should be defined in the sub-class to call whatever startup calls need to be made. The context manager __enter__ method will start() the root if not already started and will generate a warning if it detect's the root has been started in init.

Previous root classes:

`````python
class DummyTree(pyrogue.Root):
    def __init__(self):
        pyrogue.Root.__init__(self,name='dummyTree',description="Dummy example")
        self.start(timeout=2.0, pollEn=True, serverPort=0)

        self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
        self.epics.start()

    def stop(self):
        self.epics.stop()
        pyrogue.Root.stop()
`````
Proper method:
`````python
class DummyTree(pyrogue.Root):
    def __init__(self):
        pyrogue.Root.__init__(self,
                                  name='dummyTree',
                                  description="Dummy example",
                                  timeout=2.0,
                                  pollEn=True,
                                  serverPort=0)

        self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)

    def start(self):
        pyrogue.Root.start()
        self.epics.start()

    def stop(self):
        self.epics.stop()
        pyrogue.Root.stop()
`````

