### PR TITLE
Update anaconda.rst

### DIFF
--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -55,7 +55,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_3.0.2 -c tidair-packages -c pydm-tag -c conda-forge -c tidair-tag rogue=v3.0.2
+   $ conda create -n rogue_4.2.1 -c tidair-packages -c pydm-tag -c conda-forge -c tidair-tag rogue=v4.2.1
 
 Using Rogue In Anaconda
 =======================
@@ -68,7 +68,7 @@ To activate:
 
    $ conda activate rogue_tag
 
-Replace rogue_tag with the name you used when creating your environment (rogue_dev or rogue_3.0.2).
+Replace rogue_tag with the name you used when creating your environment (rogue_dev or rogue_4.2.1).
 
 
 To deactivate:


### PR DESCRIPTION
### Description
The old instructions are the following ...
```
$ conda create -n rogue_3.0.2 -c defaults -c conda-forge -c paulscherrerinstitute -c tidair-tag rogue=v3.0.
```
But because rogue versions before v4.0.0 didn't have pydm support, we can't use `-c pydm-tag`.
Moving forward I am assuming that all tagged installs will be v4.0.0 (else we should consider adding a note in the anaconda.rst about how to install v3 versus v4 tags).