### PR TITLE
Fix Cmake template for external builds

### DIFF
--- a/templates/RogueConfig.cmake.in
+++ b/templates/RogueConfig.cmake.in
@@ -90,7 +90,7 @@ find_package(ZeroMQ QUIET)
 if (NOT ZeroMQ_FOUND)
    
    # Convert LD_LIBRARY PATH for search
-   if(ENV{LD_LIBRARY_PATH})
+   if(DEFINED ENV{LD_LIBRARY_PATH})
       string(REPLACE ":" ";" HINT_PATHS $ENV{LD_LIBRARY_PATH})
    else()
       set(HINT_PATHS, "")
@@ -112,10 +112,12 @@ if (NOT ZeroMQ_FOUND)
               NAMES zmq.h
               PATHS ${ZMQ_LIBDIR}/../include
               )
-   endif()
-
-   # Failed to find it
-   if (NOT ZeroMQ_INCLUDE_DIR)
+      if (NOT ZeroMQ_INCLUDE_DIR)
+         message("")
+         message(FATAL_ERROR "Failed to find ZeroMQ_INCLUDE_DIR!")
+      endif()
+   else()
+      # Failed to find it
       message("")
       message(FATAL_ERROR "Failed to find zeroMQ!")
    endif()
@@ -126,36 +128,48 @@ endif()
 #####################################
 if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
    set(DO_EPICS_V3 1)
-   set(EPICSV3_BASE_DIR  $ENV{EPICS_BASE})
+   set(EPICSV3_BASE_DIR $ENV{EPICS_BASE})
    if(DEFINED ENV{EPICS_HOST_ARCH})
-       set(EPICSV3_ARCH      $ENV{EPICS_HOST_ARCH})
+       set(EPICSV3_ARCH $ENV{EPICS_HOST_ARCH})
    else()
        execute_process(COMMAND ${EPICSV3_BASE_DIR}/startup/EpicsHostArch 
                        OUTPUT_VARIABLE EPICSV3_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
        string(REGEX REPLACE "\n$" "" EPICSV3_ARCH "${EPICSV3_ARCH}")
    endif()
-   set(EPICSV3_LIB_DIR   ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH} )
 
-   if(APPLE)
+   # PCAS is part of epics before version 4
+   if(DEFINED ENV{EPICS_PCAS_ROOT})
+      set(EPICSV3_PCAS_DIR $ENV{EPICS_PCAS_ROOT})
+   else()
+      set(EPICSV3_PCAS_DIR $ENV{EPICS_BASE})
+   endif()
 
-      set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
+   # See if we can find the pcas header, may not exist if epics 7 without pcas is installed
+   find_path(E3_TEST_INCLUDE_DIR NAMES casdef.h PATHS ${EPICSV3_PCAS_DIR}/include)
+   if (NOT E3_TEST_INCLUDE_DIR)
+      set(DO_EPICS_V3 0)
+   elseif(APPLE)
+
+      set(EPICSV3_INCLUDES  ${EPICSV3_PCAS_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include
                             ${EPICSV3_BASE_DIR}/include/compiler/gcc 
                             ${EPICSV3_BASE_DIR}/include/os/Darwin)
 
-      set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.dylib 
-                            ${EPICSV3_LIB_DIR}/libca.dylib 
-                            ${EPICSV3_LIB_DIR}/libCom.dylib 
-                            ${EPICSV3_LIB_DIR}/libgdd.dylib)
+      set(EPICSV3_LIBRARIES ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libcas.dylib 
+                            ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libgdd.dylib
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libca.dylib 
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libCom.dylib )
    else()
 
-      set(EPICSV3_INCLUDES  ${EPICSV3_BASE_DIR}/include
+      set(EPICSV3_INCLUDES  ${EPICSV3_PCAS_DIR}/include
+                            ${EPICSV3_BASE_DIR}/include
                             ${EPICSV3_BASE_DIR}/include/compiler/gcc 
                             ${EPICSV3_BASE_DIR}/include/os/Linux)
 
-      set(EPICSV3_LIBRARIES ${EPICSV3_LIB_DIR}/libcas.so 
-                            ${EPICSV3_LIB_DIR}/libca.so 
-                            ${EPICSV3_LIB_DIR}/libCom.so 
-                            ${EPICSV3_LIB_DIR}/libgdd.so )
+      set(EPICSV3_LIBRARIES ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libcas.so 
+                            ${EPICSV3_PCAS_DIR}/lib/${EPICSV3_ARCH}/libgdd.so
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libca.so 
+                            ${EPICSV3_BASE_DIR}/lib/${EPICSV3_ARCH}/libCom.so )
    endif()
 else()
    set(DO_EPICS_V3 0)
@@ -229,7 +243,7 @@ endif()
 message("")
 
 if (DO_EPICS_V3)
-   message("-- Found EPICS V3: ${EPICSV3_BASE_DIR}")
+   message("-- Found EPICS: ${EPICSV3_PCAS_DIR}")
 else()
    message("-- EPICS V3 not included!")
 endif()


### PR DESCRIPTION
The external cmake file for linking to the Rogue libraries was not supporting EPICS7 with an external pcas package.