### PR TITLE
Add helper function for ensuring single buffer frames

### DIFF
--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -114,6 +114,21 @@ namespace rogue {
                 * @param frame Frame pointer (FramePtr) to send
                 */
                void sendFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );
+
+               //! Ensure frame is a single buffer
+               /** This method makes sure the passed frame is composed of a single buffer.
+                *  If the reqNew flag is true and the passed frame is not a single buffer, a
+                *  new frame will be requested and the frame data will be copied, with the passed
+                *  frame pointer being updated. The return value will indicate if the frame is a 
+                *  single buffer at the end of the process. A frame lock must be held when this 
+                *  method is called.
+                *
+                * Not exposed to Python 
+                * @param frame Reference to frame pointer (FramePtr)
+                * @param rewEn Flag to determine if a new frame should be requested
+                */
+               bool ensureSingleBuffer ( std::shared_ptr<rogue::interfaces::stream::Frame> &frame, bool reqEn );
+
          };
 
          //! Alias for using shared pointer as MasterPtr


### PR DESCRIPTION
This adds a ensureSingleBuffer() call to the stream master which allows the user to safely manipulate frame data as a single buffer. 

Example usage for moving data between two frames:

`````
   size = frame->getPayload();

   dstFrame = mast->reqFrame(size,true);

   // Sanity check
   if ( ! (this->ensureSingleBuffer(frame,true) && this->ensureSingleBuffer(dstFrame,false)) ) {
      printf("Source or dest frame is not a single buffer!");
      return NULL;
   }

   // Init pointers
   srcIter = frame->beginRead();   
   dstIter = dstFrame->beginWrite();

   // Copy header data
   ris::copyFrame(srcIter, 128, dstIter);

   copyCount = (size - 128) / 2;

   rawSrc = (uint16_t *)srcIter.ptr();
   rawDst = (uint16_t *)dstIter.ptr();

   for (x=0; x < copyCount; x++) rawDst[x] = rawSrc[x];

   dstFrame->setPayload(size);

`````