### PR TITLE
Modify VirtualClient to load nodes on demand

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -160,7 +160,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Zeromq server
         self._zmqServer  = None
-        self._structure  = ""
 
         # List of variable listeners
         self._varListeners  = []
@@ -356,7 +355,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         if self._serverPort is not None:
             self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=self._serverPort)
             self._serverPort = self._zmqServer.port()
-            self._structure  = jsonpickle.encode(self)
 
         # Start sql interface
         if self._sqlUrl is not None:
@@ -400,9 +398,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     @property
     def serverPort(self):
         return self._serverPort
-
-    def updatePickle(self):
-        self._structure = jsonpickle.encode(self)
 
     @pr.expose
     @property

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -26,8 +26,6 @@ import re
 import time
 import threading
 
-import cProfile
-
 class VirtualProperty(object):
     def __init__(self, node, attr):
         self._attr = attr
@@ -149,6 +147,8 @@ class VirtualNode(pr.Node):
         self._client._addVarListener(func)
 
     def _loadNodes(self):
+        self._loaded = True
+
         for k,v in self._nodes.items():
             if v is None:
 

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -40,13 +40,9 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             kwargs  = d['kwargs'] if 'kwargs' in d else {}
             rawStr  = d['rawStr'] if 'rawStr' in d else False
 
-            # Special case to get name
-            if path == "__rootname__":
-                return self.encode(self._root.name,rawStr=rawStr)
-
-            # Special case to get structure
-            if path == "__structure__":
-                return self._root._structure
+            # Special case to get root node
+            if path == "__ROOT__":
+                return self.encode(self._root,rawStr=False)
 
             node = self._root.getNode(path)
 


### PR DESCRIPTION
Instead of re-creating the entire tree when first connecting, the VirtualClient will now only load nodes as they are accessed. 

This dynamic loading of Nodes reduces the initial startup delay when connecting to large trees. This improves the startup time of the PyDM GUI.