### PR TITLE
Allow clean termination on signal reception

### DIFF
--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -9,6 +9,7 @@
 #-----------------------------------------------------------------------------
 import sys
 import os
+import signal
 
 MIN_PYTHON = (3,6)
 if sys.version_info < MIN_PYTHON:
@@ -66,11 +67,23 @@ def addLibraryPath(path):
 def waitCntrlC():
     """Helper Function To Wait For Cntrl-c"""
 
-    print("Running. Hit cntrl-c to exit.")
+    class monitorSignal(object):
+        def __init__(self):
+            self.runEnable = True
+
+        def receiveSignal(self,*args):
+            print("Got SIGTERM, exiting")
+            self.runEnable = False
+
+    mon = monitorSignal()
+    signal.signal(signal.SIGTERM, mon.receiveSignal)
+
+    print(f"Running. Hit cntrl-c or send SIGTERM to {os.getpid()} to exit.")
     try:
-        while True:
-            time.sleep(1)
+        while mon.runEnable:
+            time.sleep(0.5)
     except KeyboardInterrupt:
+        print("Got cntrl-c, exiting")
         return
 
 def streamConnect(source, dest):

--- a/python/pyrogue/gui/_gui.py
+++ b/python/pyrogue/gui/_gui.py
@@ -22,9 +22,11 @@ try:
     from PyQt5.QtWidgets import *
     from PyQt5.QtCore    import *
     from PyQt5.QtGui     import *
+    from PyQt5.QtNetwork import *
 except ImportError:
     from PyQt4.QtCore    import *
     from PyQt4.QtGui     import *
+    from PyQt4.QtNetwork import *
 
 import pyrogue
 import pyrogue.interfaces
@@ -35,16 +37,31 @@ import pyrogue.gui.system
 import threading
 import socket
 import sys
+import os
+import signal
 
 def runGui(root,incGroups=None,excGroups=None,title=None,sizeX=800,sizeY=1000):
+
     appTop = QApplication(sys.argv)
+    RogueSignalWakeupHandler(appTop)
+
+    def signalRx(self,*args):
+        print("Got signal, exiting")
+        appTop.quit()
+
+    signal.signal(signal.SIGTERM, signalRx)
+    signal.signal(signal.SIGINT,  signalRx)
+
     guiTop = pyrogue.gui.GuiTop(incGroups=incGroups,excGroups=excGroups)
     if title is None:
         title = "Rogue Server: {}".format(socket.gethostname())
     guiTop.setWindowTitle(title)
     guiTop.addTree(root)
     guiTop.resize(sizeX,sizeY)
+
+    print(f"Running GUI. Close window, hit cntrl-c or send SIGTERM to {os.getpid()} to exit.")
     appTop.exec_()
+
 
 def application(argv):
     return QApplication(argv)
@@ -131,4 +148,38 @@ class GuiTop(QWidget):
         self.sys = pyrogue.gui.system.SystemWidget(root=root,parent=self.tab)
         self.tab.addTab(self.sys,root.name)
         self.adjustSize()
+
+
+class RogueSignalWakeupHandler(QAbstractSocket):
+
+    def __init__(self, parent=None):
+        super().__init__(QAbstractSocket.UdpSocket, parent)
+        self.old_fd = None
+        # Create a socket pair
+        self.wsock, self.rsock = socket.socketpair(type=socket.SOCK_DGRAM)
+        # Let Qt listen on the one end
+        self.setSocketDescriptor(self.rsock.fileno())
+        # And let Python write on the other end
+        self.wsock.setblocking(False)
+        self.old_fd = signal.set_wakeup_fd(self.wsock.fileno())
+        # First Python code executed gets any exception from
+        # the signal handler, so add a dummy handler first
+        self.readyRead.connect(lambda : None)
+        # Second handler does the real handling
+        self.readyRead.connect(self._readSignal)
+
+    def __del__(self):
+        # Restore any old handler on deletion
+        if self.old_fd is not None and signal and signal.set_wakeup_fd:
+            signal.set_wakeup_fd(self.old_fd)
+
+    def _readSignal(self):
+        # Read the written byte.
+        # Note: readyRead is blocked from occuring again until readData()
+        # was called, so call it, even if you don't need the value.
+        data = self.readData(1)
+        # Emit a Qt signal for convenience
+        self.signalReceived.emit(data[0])
+
+    signalReceived = pyqtSignal(int)
 

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -41,5 +41,8 @@ def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=80
                                hide_nav_bar=True, 
                                hide_menu_bar=True, 
                                hide_status_bar=True)
+
+    print(f"Running GUI. Close window, hit cntrl-c or send SIGTERM to {os.getpid()} to exit.")
+
     app.exec()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,10 +166,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        #pyrogue.waitCntrlC()
+        pyrogue.waitCntrlC()
 
-        import pyrogue.pydm
-        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        #import pyrogue.pydm
+        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,10 +166,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
 
-        #import pyrogue.pydm
-        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)


### PR DESCRIPTION
This adds signal handlers to the runGui (legacy) and waitCntrl-c helper functions to allow Rogue to terminate gracefully when receiving a SIGTERM signal (kill without the -9).

This will also allow cntrl-c to close the gui properly.

The pydm version (runPyDM) already supports this natively.