### PR TITLE
Catch out of range config fields

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -603,7 +603,10 @@ def _iterateDict(d, keys):
 
     # Single item
     elif keys[0].isdigit():
-        subList = [d[int(keys[0])]]
+        try:
+            subList = [d[int(keys[0])]]
+        except:
+            subList = []
 
     # Slice
     else:


### PR DESCRIPTION
This will avoid an exception of the config file contains an out of range index key.