### PR TITLE
Add wheel filter for qcombobox and qspinbox

### DIFF
--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -114,12 +114,14 @@ class CommandLink(QObject):
                 for i in self._command.enum:
                     self._widget.addItem(self._command.enum[i])
                 self._widget.setCurrentIndex(self._widget.findText(self._command.valueDisp()))
+                self._widget.installEventFilter(self)
 
             elif self._command.minimum is not None and self._command.maximum is not None:
                 self._widget = QSpinBox();
                 self._widget.setMinimum(self._command.minimum)
                 self._widget.setMaximum(self._command.maximum)
                 self._widget.setValue(self._command.value())
+                self._widget.installEventFilter(self)
 
             else:
                 self._widget = QLineEdit()
@@ -141,6 +143,12 @@ class CommandLink(QObject):
                 pass
         else:
             self._command()
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
 
 class CommandWidget(QWidget):
     def __init__(self, *, parent=None):

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -128,6 +128,8 @@ class VariableLink(QObject):
             for i in self._variable.enum:
                 self._widget.addItem(self._variable.enum[i])
 
+            self._widget.installEventFilter(self)
+
         elif self._variable.minimum is not None and self._variable.maximum is not None and \
              self._variable.disp == '{}' and self._variable.mode != 'RO':
             self._widget = QSpinBox();
@@ -136,6 +138,8 @@ class VariableLink(QObject):
             self._widget.valueChanged.connect(self.sbChanged)
 
             self.updateGui.connect(self._widget.setValue)
+
+            self._widget.installEventFilter(self)
 
         else:
             self._widget = QLineEdit()
@@ -311,6 +315,12 @@ class VariableLink(QObject):
         self._inEdit = True
         self._variable.setDisp(self._widget.itemText(value))
         self._inEdit = False
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
 
 
 class VariableWidget(QWidget):

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -20,7 +20,7 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLineEdit, PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from pyrogue.interfaces import VirtualClient
-from qtpy.QtCore import Qt, Property, Slot, QPoint
+from qtpy.QtCore import Qt, Property, Slot, QPoint, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy, QMenu, QDialog, QPushButton, QComboBox
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLineEdit, QFormLayout, QGroupBox
 
@@ -130,6 +130,7 @@ class CommandHolder(QTreeWidgetItem):
                 self._widget.setToolTip(self._cmd.description)
 
                 self._widget.currentTextChanged.connect(self._argChanged)
+                self._widget.installEventFilter(self._top)
 
             else:
                 self._widget = QLineEdit()
@@ -233,4 +234,10 @@ class CommandTree(PyDMFrame):
             self._excGroups = None
         else:
             self._excGroups = value.split(',')
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
 

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -20,7 +20,7 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLineEdit, PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from pyrogue.interfaces import VirtualClient
-from qtpy.QtCore import Qt, Property, Slot
+from qtpy.QtCore import Qt, Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QMenu, QDialog, QPushButton
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLineEdit, QFormLayout, QLabel
 import re
@@ -164,6 +164,7 @@ class VariableHolder(QTreeWidgetItem):
             w = PyDMEnumComboBox(parent=None, init_channel=self._path)
             w.alarmSensitiveContent = False
             w.alarmSensitiveBorder  = True
+            w.installEventFilter(self._top)
 
         elif self._var.minimum is not None and self._var.maximum is not None and self._var.disp == '{}' and self._var.mode != 'RO':
             w = PyDMSpinbox(parent=None, init_channel=self._path)
@@ -173,6 +174,7 @@ class VariableHolder(QTreeWidgetItem):
             w.alarmSensitiveContent = False
             w.alarmSensitiveBorder  = True
             w.showStepExponent      = False
+            w.installEventFilter(self._top)
 
         else:
             w = PyDMLineEdit(parent=None, init_channel=self._path + '/disp')
@@ -275,4 +277,10 @@ class VariableTree(PyDMFrame):
             self._excGroups = None
         else:
             self._excGroups = value.split(',')
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
 


### PR DESCRIPTION
This PR adds a mouse wheel event filter for qcomboboxes and qspinboxes contained in a qtreewidget.