### PR TITLE
Support nested yaml files

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -871,6 +871,10 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._updateQueue.task_done()
 
 def yamlToData(stream='',fName=None):
+    """
+    Load yaml to data structure.
+    A yaml string or file path may be passed.
+    """
 
     log = pr.logInit(name='yamlToData')
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -896,6 +896,7 @@ def yamlToData(stream='',fName=None):
         else:
             filename = node
 
+        # Recursive call
         return yamlToData(fName=filename)
 
     def construct_mapping(loader, node):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -716,6 +716,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 for fn in lst:
                     d = yamlToData(fName=fn)
                     self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
+
                 if not writeEach: self._write()
 
             if self.InitAfterConfig.value():

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -906,8 +906,12 @@ def yamlToData(stream='',fName=None):
     PyrogueLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,construct_mapping)
     PyrogueLoader.add_constructor('!include',include_mapping)
 
+    # Use passed string
+    if fName is None:
+        return yaml.load(stream,Loader=PyrogueLoader)
+
     # Main or sub-file is in a zip
-    if '.zip' in fName:
+    elif '.zip' in fName:
         base = fName.split('.zip')[0] + '.zip'
         sub = fName.split('.zip')[1][1:] # Strip leading '/'
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -896,8 +896,8 @@ def yamlToData(stream='',fName=None):
         else:
             filename = node
 
-        # Recursive call
-        return yamlToData(fName=filename)
+        # Recursive call, flatten relative jumps
+        return yamlToData(fName=os.path.abspath(filename))
 
     def construct_mapping(loader, node):
         loader.flatten_mapping(node)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,10 +166,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        #pyrogue.waitCntrlC()
+        pyrogue.waitCntrlC()
 
-        import pyrogue.pydm
-        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        #import pyrogue.pydm
+        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,10 +166,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
 
-        #import pyrogue.pydm
-        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)


### PR DESCRIPTION
This PR adds support for the !include tag in yaml files. The included file will be applied at the dictionary level at which it appears. The combined yaml file follows the same rules as a single yaml file when it comes to repeated tags etc.

Example: test.yml

`````
dummyTree:
  PollEn: True
  AxiVersion: !include AxiVersion.yml
  StreamWriter:
    enable: True
    DataFile: 'test2'
`````
With the included file AxiVersion.yml containing:

`````
ScratchPad: 0x000010
TestArray[6]: 8
TestBool: True
`````
The included file can be relative or absolute, and may be part of a zip file.
