### PR TITLE
Deprecate python streamTap and Master::setSlave

### DIFF
--- a/docs/src/custom_module/wrapper.rst
+++ b/docs/src/custom_module/wrapper.rst
@@ -37,7 +37,7 @@ the output of the :ref:`custom_makefile` step.
                                          mode='RO', pollInterval=1, value=0,
                                          localGet=self._mySlave.getTotalBytes))
 
-      # Method called by streamConnect, streamTap and streamConnectBiDir to access slave
+      # Method called by streamConnect and streamConnectBiDir to access slave
       def _getStreamSlave(self):
           return self._mySlave
 
@@ -70,7 +70,7 @@ the output of the :ref:`custom_makefile` step.
           self.add(pyrogue.LocalCommand(name='MyFrameGen',description='Generate a single frame',
                                         function=self._myMast.myFrameGen))
 
-      # Method called by streamConnect, streamTap and streamConnectBiDir to access master
+      # Method called by streamConnect and streamConnectBiDir to access master
       def _getStreamMaster(self):
           return self._myMast
 

--- a/docs/src/interfaces/stream/connecting.rst
+++ b/docs/src/interfaces/stream/connecting.rst
@@ -6,7 +6,7 @@ Connecting Streams
 
 The stream interface is made up of a master which is the source of frame data
 and a slave which is a receiver of frame data. Each master can be connected to 
-one or more slaves, with one slave connected as the primary slave.  The concept of a
+one or more slaves, with the first slave connected being the primary slave.  The concept of a
 primary slave is important because in most cases it is the slave from which the master
 will request new frames. The primary slave is also the last slave to receive data
 from the master. This is an important distinction when interfacing to a slave which will
@@ -30,15 +30,15 @@ A similiar line of code is used to connect a master and slave in c++:
 
 The above command examples attaches the primary slave to the master.
 
-Additional receivers can be added to a master using a streamTap function. This allows more than
-one Slave to receive data from a Master. Each tapped slave will be passed the frame in turn before
+Additional receivers can be added to a master. This allows more than
+one Slave to receive data from a Master. Each additional slave will be passed the frame in turn before
 it is passed to the primary slave:
 
 .. code-block:: python
 
    import pyrogue
 
-   pyrogue.streamTap(myMaster, mySlave)
+   pyrogue.streamConnect(myMaster, mySlave)
 
 And in C++:
 
@@ -46,7 +46,7 @@ And in C++:
 
    #include <rogue/Helpers.h>
 
-   rogueStreamTap(myMaster, mySlave)
+   rogueStreamConnect(myMaster, mySlave)
 
 In some cases rogue entties can serve as both a stream Master and Slave. This is often the case when
 using a network protocol such as UDP or TCP. Two dual purpose enpoints can be connected together
@@ -58,8 +58,8 @@ to create a bi-directional data stream using the following command in python:
 
    pyrogue.streamConnectBiDir(enPointA, endPointB)
 
-This command sets endPointB as the primary Slave for endPointA at the same time setting endPointA as the
-primary slave for endPointB. A similiar command is available in C++:
+This command adds endPointB as a Slave for endPointA at the same time adding endPointA as a
+slave for endPointB. A similiar command is available in C++:
 
 .. code-block:: c
 

--- a/docs/src/interfaces/stream/debugStreams.rst
+++ b/docs/src/interfaces/stream/debugStreams.rst
@@ -32,8 +32,8 @@ between an existing Master and Slave instance.
    # Connect the src and dst
    pyrogue.streamConnect(src, dst)
 
-   # Add the debug slave as a stream tap
-   pyrogue.streamTap(src, dbg)
+   # Add the debug slave as a second slave
+   pyrogue.streamConnect(src, dbg)
 
 Below is the equivalent code in C++
 

--- a/docs/src/interfaces/stream/usingFifo.rst
+++ b/docs/src/interfaces/stream/usingFifo.rst
@@ -95,8 +95,8 @@ and a slave. This Fifo is configured to only copy the first 20 bytes of the Fram
    # Connect the src and dst
    pyrogue.streamConnect(src, dst)
 
-   # Add the FIFO as a stream tap
-   pyrogue.streamTap(src, fifo)
+   # Add the FIFO as a second slave
+   pyrogue.streamConnect(src, fifo)
 
    # Connect the monitor to the FIfo output
    pyrogue.streamConnect(fifo, mon)

--- a/include/rogue/Helpers.h
+++ b/include/rogue/Helpers.h
@@ -21,15 +21,15 @@
 #define __ROGUE_HELPERS_H__
 
 // Connect stream 
-#define rogueStreamConnect(src,dst) src->setSlave(dst);
+#define rogueStreamConnect(src,dst) src->addSlave(dst);
 
-// Add stream tap
+// Add stream tap, DEPRECATED
 #define rogueStreamTap(src,dst) src->addSlave(dst);
 
 // Connect stream bi-directionally
 #define rogueStreamConnectBiDir(devA,devB) \
-   devA->setSlave(devB); \
-   devB->setSlave(devA);
+   devA->addSlave(devB); \
+   devB->addSlave(devA);
 
 // Connect memory bus
 #define rogueBusConnect(src,dst) src->setSlave(dst);

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -65,6 +65,13 @@ namespace rogue {
                // Destroy the object
                virtual ~Master();
 
+               //! Get Slave Count
+               /** Return the number of slaves.
+                *
+                * Exposed as _slaveCount() to Python. 
+                */
+               uint32_t slaveCount ();
+
                //! Add a slave object
                /** Multiple slaves are allowed.
                 * The first added slave is the Slave object from which the Master will request

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -36,14 +36,10 @@ namespace rogue {
 
          //! Stream master class
          /** This class serves as the source for sending Frame data to a Slave. Each master
-          * interfaces to a primary stream Slave and multiple secondar stream Slave ojects.
-          * The primary stream Slave is used to allocated new Frame objects and it the
-          * last Slave to receive frame data.
+          * interfaces to one or more stream slave objects. The frst stream Slave is used 
+          * to allocated new Frame objects and it the last Slave to receive frame data.
           */
          class Master {
-
-               // Primary slave. Used for request forwards.
-               std::shared_ptr<rogue::interfaces::stream::Slave> primary_;
 
                // Vector of slaves
                std::vector<std::shared_ptr<rogue::interfaces::stream::Slave> > slaves_;
@@ -69,19 +65,11 @@ namespace rogue {
                // Destroy the object
                virtual ~Master();
 
-               //! Set primary slave
-               /** The primary slave is the Slave object from which the Master will request
-                * new Frame allocations. The primary Slave is also the last Slave object
-                * which will receive the Frame. Only one Slave can be set as Primary.
-                *
-                * Exposed as _setSlave() to Python. Called in Python by the
-                * pyrogue.streamConnect() and pyrogue.streamConnectBiDir() methods.
-                * @param slave Stream Slave pointer (SlavePtr)
-                */
-               void setSlave ( std::shared_ptr<rogue::interfaces::stream::Slave> slave );
-
-               //! Add secondary slave
-               /** Multiple secondary slaves are allowed.
+               //! Add a slave object
+               /** Multiple slaves are allowed.
+                * The first added slave is the Slave object from which the Master will request
+                * new Frame allocations. The first Slave is also the last Slave object
+                * which will receive the Frame.
                 *
                 * Exposed as _addSlave() to Python. Called in Python by the
                 * pyrogue.streamTop() method.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -584,6 +584,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         stream. If this list is not NULL only these variables will be included.
         """
 
+        # Don't send if there are not any Slaves connected
+        if self._slaveCount == 0: return
+
         # Inherit include and exclude groups from global if not passed
         if incGroups is None: incGroups = self._streamIncGroups
         if excGroups is None: excGroups = self._streamExcGroups
@@ -838,7 +841,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                         val = v._doUpdate()
 
                         # Add to stream
-                        if v.filterByGroup(self._streamIncGroups, self._streamExcGroups):
+                        if self._slaveCount() != 0 and v.filterByGroup(self._streamIncGroups, self._streamExcGroups):
                             strm[p] = val
 
                         # Add to zmq publish

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -108,33 +108,15 @@ def streamConnect(source, dest):
     else:
         slave = dest._getStreamSlave()
 
-    master._setSlave(slave)
+    master._addSlave(slave)
 
 
 def streamTap(source, tap):
     """
-    Attach the passed dest object to the source for a streams
-    as a secondary destination.
-    Connect source and destination stream devices.
-    source is either a stream master sub class or implements
-    the _getStreamMaster call to return a contained master.
-    Similiarly dest is either a stream slave sub class or implements
-    the _getStreamSlave call to return a contained slave.
+    DEPRECATED!
     """
-
-    # Is object a native master or wrapped?
-    if isinstance(source,rogue.interfaces.stream.Master):
-        master = source
-    else:
-        master = source._getStreamMaster()
-
-    # Is object a native slave or wrapped?
-    if isinstance(tap,rogue.interfaces.stream.Slave):
-        slave = tap
-    else:
-        slave = tap._getStreamSlave()
-
-    master._addSlave(slave)
+    #print("******** Stream TAP is deprecated. Use streamConnect instead. ********")
+    streamConnect(source,tap)
 
 
 def streamConnectBiDir(deviceA, deviceB):

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -45,6 +45,11 @@ ris::Master::Master() { }
 //! Destructor
 ris::Master::~Master() { }
 
+// Get Slave Count
+uint32_t ris::Master::slaveCount () {
+   return slaves_.size();
+}
+
 //! Add slave
 void ris::Master::addSlave ( ris::SlavePtr slave ) {
    rogue::GilRelease noGil;
@@ -109,6 +114,7 @@ void ris::Master::setup_python() {
 
    bp::class_<ris::Master, ris::MasterPtr, boost::noncopyable>("Master",bp::init<>())
       .def("_addSlave",      &ris::Master::addSlave)
+      .def("_slaveCount",    &ris::Master::slaveCount)
       .def("_reqFrame",      &ris::Master::reqFrame)
       .def("_sendFrame",     &ris::Master::sendFrame)
    ;

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -46,7 +46,7 @@ def write_files():
     comp = rogue.utilities.StreamZip()
 
     pyrogue.streamConnect(prbs,fwrU.getChannel(0))
-    pyrogue.streamTap(prbs,comp)
+    pyrogue.streamConnect(prbs,comp)
     pyrogue.streamConnect(comp,fwrC.getChannel(0))
 
     fwrC.open("compressed.dat")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -103,3 +103,4 @@ if __name__ == "__main__":
     write_files()
     read_files()
 
+


### PR DESCRIPTION
This PR eliminates the Master::setSlave command, using only addSlave to connect Slaves to a master. The first slave added is considered the "primary" slave and is used for reqFrame calls. Frames are sent to the Slaves in the reverse order of how they were connected.

pyrogue.streamTap will be deprecated and users should just use pyrogue.streamConnect to add additional slaves. 

