### PR TITLE
Deprecate beginWrite and beginRead FrameIterator creators

### DIFF
--- a/docs/src/custom_module/sourcefile.rst
+++ b/docs/src/custom_module/sourcefile.rst
@@ -140,12 +140,12 @@ This module is compiled with the :ref:`custom_makefile` described in this sectio
             // Here we request a frame capable of holding 100 bytes
             frame = reqFrame(frameSize_,true);
 
+            // Unlike the python API we must now specify the new payload size
+            frame->setPayload(frameSize_);
+
             // Set an incrementing value to the first 10 locations
             x = 0;
-            for ( it=frame->beginWrite(); it < frame->endWrite(); ++it ) *it = x++;
-
-            // Unlink the python API we must now specify the new payload size
-            frame->setPayload(frameSize_);
+            for ( it=frame->begin(); it < frame->end(); ++it ) *it = x++;
 
             //Send frame
             sendFrame(frame);

--- a/docs/src/interfaces/stream/receiving.rst
+++ b/docs/src/interfaces/stream/receiving.rst
@@ -89,8 +89,8 @@ and we use std::copy to move data from the Frame to a data buffer.
             // Acquire lock on frame. Will be release when lock class goes out of scope
             rogue::interfaces::stream::FrameLock lock = frame->lock();
 
-            // Here we get an iterator to the frame data in read mode
-            it = frame->beginRead();
+            // Here we get an iterator to the frame data
+            it = frame->begin();
 
             // Print the values in the first 10 locations
             for (x=0; x < 10; x++) {
@@ -100,7 +100,7 @@ and we use std::copy to move data from the Frame to a data buffer.
 
             // Use std::copy to copy data to a data buffer
             // Here we copy the entire frame payload to the data buffer
-            std::copy(frame->beginRead(), frame->endRead, data);
+            std::copy(frame->begin(), frame->end(), data);
          }
    };
 
@@ -121,10 +121,10 @@ the received Frame to a memory array.
 .. code-block:: c
 
    // Get an iterator to the start of the Frame
-   it = frame->beginRead();
+   it = frame->begin();
 
    // Keep going until we get to the end of the Frame
-   while ( it != frame->endRead() ) {
+   while ( it != frame->end() ) {
 
       // Copy the buffer data
       data = std::copy(it, it->endBuffer(), data);
@@ -140,7 +140,7 @@ they can make use of the fromFrame helper function defined in :ref:`interfaces_s
    uint32_t data32;
    uint8_t  data8;
   
-   it = frame->beginRead(); 
+   it = frame->begin(); 
 
    // Read 64-bits and advance iterator 8 bytes 
    fromFrame(it, 8, &data64); 

--- a/docs/src/interfaces/stream/sending.rst
+++ b/docs/src/interfaces/stream/sending.rst
@@ -118,8 +118,11 @@ and we use std::copy to move data from data buffer into the Frame.
             // Here we request a frame capable of holding 100 bytes
             frame = reqFrame(100,true);
 
-            // Here we get an iterator to the frame data in write mode
-            it = frame->beginWrite();
+            // Unlike the python API we must now specify the new payload size
+            frame->setPayload(20);
+
+            // Here we get an iterator to the frame data
+            it = frame->begin();
 
             // Set an incrementing value to the first 10 locations
             for (x=0; x < 10; x++) {
@@ -131,9 +134,6 @@ and we use std::copy to move data from data buffer into the Frame.
             // Here we copy 10 bytes starting a the current position of 10
             // Update the iterator
             it = std::copy(data, data+10, it);
-
-            // Unlink the python API we must now specify the new payload size
-            frame->setPayload(20);
 
             //Send frame
             sendFrame(frame);
@@ -162,11 +162,14 @@ a passed data buffer into the Rogue frame, ensuring that the most effeciant copy
    // Request a new buffer with 100 bytes
    frame = reqFrame(100,true);
 
+   // Update the new payload size 
+   frame->setPayload(100);
+
    // Get an iterator to the start of the Frame
-   it = frame->beginWrite();
+   it = frame->begin();
 
    // Keep going until we get to the end of the Frame, assume the passed data pointer has 100 bytes
-   while ( it != frame->endWrite() ) {
+   while ( it != frame->end() ) {
 
       // The rem buffer method returns the number of bytes left in the current contigous buffer
       size = it->remBuffer();
@@ -176,8 +179,6 @@ a passed data buffer into the Rogue frame, ensuring that the most effeciant copy
       data += size;
    }
 
-   // Remember to update the new payload size 
-   frame->setPayload(100);
 
 Alternatively if the user wishes to access individual values in the data frame at various offsets, 
 they can make use of the toFrame helper function defined in :ref:`interfaces_stream_helpers`. 
@@ -187,8 +188,11 @@ they can make use of the toFrame helper function defined in :ref:`interfaces_str
    uint64_t data64;
    uint32_t data32;
    uint8_t  data8;
-  
-   it = frame->beginWrite(); 
+
+   // Update frame payload size
+   frame->setPayload(13);
+
+   it = frame->begin(); 
 
    // Write 64-bits and advance iterator 8 bytes 
    toFrame(it, 8, &data64); 
@@ -198,9 +202,6 @@ they can make use of the toFrame helper function defined in :ref:`interfaces_str
 
    // Write 8-bits and advance iterator 1 byte
    toFrame(it, 1, &data8);
-
-   // Update frame payload size
-   frame->setPayload(13);
 
 Further study of the :ref:`interfaces_stream_frame` and :ref:`interfaces_stream_buffer` APIs will reveal more 
 advanced methods of access frame and buffer data. 

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -91,9 +91,6 @@ namespace rogue {
                //! Alias for using std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator as Buffer::iterator
                typedef std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator BufferIterator;
 
-               //! Alias for using FrameIterator as Frame::iterator
-               typedef rogue::interfaces::stream::FrameIterator iterator;
-
                // Setup class for use in python
                static void setup_python();
 
@@ -114,14 +111,6 @@ namespace rogue {
                 */
                std::shared_ptr<rogue::interfaces::stream::FrameLock> lock();
 
-               //! Add a buffer to end of frame,
-               /** Not exposed to Python
-                * @param buff The buffer pointer (BufferPtr) to append to the end of the frame
-                * @return Buffer list iterator (Frame::BufferIterator) pointing to the added buffer
-                */
-               std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator
-                  appendBuffer(std::shared_ptr<rogue::interfaces::stream::Buffer> buff);
-
                //! Append passed frame to the end of this frame.
                /** Buffers from the passed frame are appened to the end of this frame and
                 * will be removed from the source frame.
@@ -133,20 +122,32 @@ namespace rogue {
                std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator
                   appendFrame(std::shared_ptr<rogue::interfaces::stream::Frame> frame);
 
+               //! Add a buffer to end of frame,
+               /** Not exposed to Python
+                * This is for advanced manipulation of the underlying buffers.
+                * @param buff The buffer pointer (BufferPtr) to append to the end of the frame
+                * @return Buffer list iterator (Frame::BufferIterator) pointing to the added buffer
+                */
+               std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator
+                  appendBuffer(std::shared_ptr<rogue::interfaces::stream::Buffer> buff);
+
                //! Get Buffer list begin iterator
                /** Not exposed to Python
+                * This is for advanced manipulation of the underlying buffers.
                 * @return Buffer list iterator (Frame::BufferIterator) pointing to the start of the Buffer list
                 */
                std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator beginBuffer();
 
                //! Get Buffer list end iterator
                /** Not exposed to Python
+                * This is for advanced manipulation of the underlying buffers.
                 * @return Buffer list iterator (Frame::BufferIterator) pointing to the end of the Buffer list
                 */
                std::vector<std::shared_ptr<rogue::interfaces::stream::Buffer> >::iterator endBuffer();
 
                //! Get Buffer list count
                /** Not exposed to Python
+                * This is for advanced manipulation of the underlying buffers.
                 * @return Number of buffers in the Buffer list
                 */
                uint32_t bufferCount();
@@ -293,45 +294,37 @@ namespace rogue {
                 */
                void setError(uint8_t error);
 
-               //! Get read start FrameIterator
-               /** The read start iterator points to the start of the Frame
-                * and operates in read mode. This iterator should not be used 
-                * for updating the frame.
+               //! Get begin FrameIterator
+               /** Return an iterator for accessing data within the Frame.
+                * This iterator assumes the payload size of the frame has
+                * already been set. This means the frame has either been 
+                * received already containing data, or the setPayload() method 
+                * has been called.
                 * 
                 * Not exposed to Python
                 * @return FrameIterator pointing to beginning of payload
                 */
-               rogue::interfaces::stream::FrameIterator beginRead();
+               rogue::interfaces::stream::FrameIterator begin();
 
-               //! Get read end FrameIterator
+               //! Get end FrameIterator
                 /** This iterator is used to detect when the end of the 
-                * Frame payload is reached when iterating through the Frame 
-                * during a read operation.
+                * Frame payload is reached when iterating through the Frame. 
                 * 
                 * Not exposed to Python
                 * @return FrameIterator read end position
                 */
+               rogue::interfaces::stream::FrameIterator end();
+
+               // Get read start FrameIterator, LEGACY TO BE DEPRECATED
+               rogue::interfaces::stream::FrameIterator beginRead();
+
+               // Get read end FrameIterator, LEGACY TO BE DEPRECATED
                rogue::interfaces::stream::FrameIterator endRead();
 
-               //! Get write start FrameIterator
-               /** The write start iterator points to the start of the Frame
-                * and operates in write mode. This iterator should not be used 
-                * for reading from the frame. Using this iterator to update
-                * the frame does not adjust the Frame payload size.
-                * 
-                * Not exposed to Python
-                * @return FrameIterator pointing to beginning of payload
-                */
+               // Get write start FrameIterator, LEGACY TO BE DEPRECATED
                rogue::interfaces::stream::FrameIterator beginWrite();
 
-               //! Get write end FrameIterator
-                /** This iterator is used to detect when the end of the 
-                * available frame space is reached when iterator through
-                * the frame during a write operation.
-                * 
-                * Not exposed to Python
-                * @return FrameIterator write end position
-                */
+               // Get write end FrameIterator, LEGACY TO BE DEPRECATED
                rogue::interfaces::stream::FrameIterator endWrite();
 
 #ifndef NO_PYTHON
@@ -378,7 +371,7 @@ namespace rogue {
                                uint32_t          offset);
 #endif
 
-               //! Debug Buffer
+               //! Debug Frame
                void debug();
 
          };

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -83,8 +83,8 @@ ris::Fifo::~Fifo() {
 void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
    uint32_t       size;
    ris::FramePtr  nFrame;
-   ris::Frame::iterator src;
-   ris::Frame::iterator dst;
+   ris::FrameIterator src;
+   ris::FrameIterator dst;
 
    // FIFO is full, drop frame
    if ( queue_.busy() ) return;
@@ -102,14 +102,14 @@ void ris::Fifo::acceptFrame ( ris::FramePtr frame ) {
 
       // Request a new frame to hold the data
       nFrame = reqFrame(size,true);
+      nFrame->setPayload(size);
 
       // Get destination pointer
-      src = frame->beginRead();
-      dst = nFrame->beginWrite();
+      src = frame->begin();
+      dst = nFrame->begin();
 
       // Copy the frame
       ris::copyFrame(src, size, dst);
-      nFrame->setPayload(size);
       nFrame->setError(frame->getError());
       nFrame->setChannel(frame->getChannel());
       nFrame->setFlags(frame->getFlags());

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -103,11 +103,12 @@ bool ris::Master::ensureSingleBuffer ( ris::FramePtr &frame, bool reqEn ) {
       if  ( nFrame->bufferCount() != 1 ) return false;
 
       else {
-         ris::FrameIterator srcIter = frame->beginRead();
-         ris::FrameIterator dstIter = nFrame->beginWrite();
+         nFrame->setPayload(size);
+
+         ris::FrameIterator srcIter = frame->begin();
+         ris::FrameIterator dstIter = nFrame->begin();
          
          ris::copyFrame(srcIter, size, dstIter);
-         nFrame->setPayload(size);
          frame = nFrame;
          return true;
       }

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -65,7 +65,7 @@ void ris::Slave::setDebug(uint32_t debug, std::string name) {
 
 //! Accept a frame from master
 void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
-   ris::Frame::iterator it;
+   ris::FrameIterator it;
 
    uint32_t count;
    uint8_t  val;
@@ -83,7 +83,7 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
       sprintf(buffer,"     ");
 
       count = 0;
-      for (it = frame->beginRead(); (count < debug_) && (it != frame->endRead()); ++it) {
+      for (it = frame->begin(); (count < debug_) && (it != frame->end()); ++it) {
          count++;
          val = *it;
 

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -175,7 +175,7 @@ void ris::TcpCore::acceptFrame ( ris::FramePtr frame ) {
    std::memcpy(zmq_msg_data(&(msg[2])), &err,   1);
 
    // Copy data
-   ris::FrameIterator iter = frame->beginRead();
+   ris::FrameIterator iter = frame->begin();
    data = (uint8_t *)zmq_msg_data(&(msg[3]));
    ris::fromFrame(iter, frame->getPayload(), data);
 
@@ -245,13 +245,13 @@ void ris::TcpCore::runThread() {
 
          // Generate frame
          frame = ris::Pool::acceptReq(size,false);
+         frame->setPayload(size);
 
          // Copy data
-         ris::FrameIterator iter = frame->beginWrite();
+         ris::FrameIterator iter = frame->begin();
          ris::toFrame(iter, size, data);
 
-         // Set frame size and send
-         frame->setPayload(size);
+         // Set frame meta data and send
          frame->setFlags(flags);
          frame->setChannel(chan);
          frame->setError(err);

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -94,12 +94,12 @@ uint32_t rpb::CoreV1::headerSize() {
 
 //! Get beginning of header iterator
 ris::FrameIterator rpb::CoreV1::beginHeader() {
-   return frame_->beginRead();
+   return frame_->begin();
 }
 
 //! Get end of header iterator
 ris::FrameIterator rpb::CoreV1::endHeader() {
-   return frame_->beginRead() + headerSize_;
+   return frame_->begin() + headerSize_;
 }
 
 //! Get tail size
@@ -172,7 +172,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
    }
 
    // Get version & size
-   beg = frame->beginRead();
+   beg = frame->begin();
    ris::fromFrame(beg, 1, &temp);
    
    /////////////////////////////////////////////////////////////////////////
@@ -224,7 +224,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
    rem -= headerSize_;
 
    // Set marker to end of frame
-   mark = frame->endRead();
+   mark = frame->end();
 
    // Process each frame, stop when we have reached just after the header
    while (mark != beg) {

--- a/src/rogue/protocols/batcher/SplitterV1.cpp
+++ b/src/rogue/protocols/batcher/SplitterV1.cpp
@@ -75,10 +75,11 @@ void rpb::SplitterV1::acceptFrame ( ris::FramePtr frame ) {
 
       // Create a new frame
       nFrame = reqFrame(data->size(),true);
-      ris::FrameIterator fIter = nFrame->beginWrite();
+      nFrame->setPayload(data->size());
+
+      ris::FrameIterator fIter = nFrame->begin();
       ris::FrameIterator dIter = data->begin();
       ris::copyFrame(dIter, data->size(), fIter);
-      nFrame->setPayload(data->size());
 
       // Set flags
       nFrame->setFirstUser(data->fUser());

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -104,13 +104,15 @@ void rpe::Master::valueGet() { }
 
 void rpe::Master::valueSet() {
    ris::FramePtr frame;
-   ris::Frame::iterator iter;
+   ris::FrameIterator iter;
    uint32_t txSize;
    uint32_t i;
 
    txSize = size_ * fSize_;
    frame = reqFrame(txSize, true);
-   iter = frame->beginWrite();
+   frame->setPayload(txSize);
+
+   iter = frame->begin();
 
    // Create vector of appropriate type
    if ( epicsType_ == aitEnumUint8 ) {
@@ -162,7 +164,6 @@ void rpe::Master::valueSet() {
    }
 
    // Should this be pushed to a queue for a worker thread to call slaves?
-   frame->setPayload(txSize);
    sendFrame(frame);
 }
 

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -112,7 +112,7 @@ void rpe::Slave::valueGet() { }
 void rpe::Slave::valueSet() { }
 
 void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
-   ris::Frame::iterator iter;
+   ris::FrameIterator iter;
    struct timespec t;
    uint32_t fSize;
    uint32_t size_;
@@ -127,7 +127,7 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    }
 
    fSize = frame->getPayload();
-   iter = frame->beginRead();
+   iter = frame->begin();
 
    // First check to see if frame is valid
    if ( (fSize % fSize_) != 0 ) {

--- a/src/rogue/protocols/srp/Cmd.cpp
+++ b/src/rogue/protocols/srp/Cmd.cpp
@@ -59,7 +59,7 @@ rps::Cmd::~Cmd() {}
 
 //! Post a transaction
 void rps::Cmd::sendCmd(uint8_t opCode, uint32_t context) {
-   ris::Frame::iterator it;
+   ris::FrameIterator it;
    ris::FramePtr frame;
    uint32_t txData[4];
 
@@ -71,11 +71,11 @@ void rps::Cmd::sendCmd(uint8_t opCode, uint32_t context) {
 
    // Request frame
    frame = reqFrame(sizeof(txData), true);
-   it = frame->beginWrite();
+   frame->setPayload(sizeof(txData));
+   it = frame->begin();
 
    // Copy frame
    ris::toFrame(it,sizeof(txData),txData);
-   frame->setPayload(sizeof(txData));
    sendFrame(frame);
 }
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -96,7 +96,7 @@ bool rps::SrpV0::setupHeader(rim::TransactionPtr tran, uint32_t *header, uint32_
 
 //! Post a transaction
 void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
-   ris::Frame::iterator fIter;
+   ris::FrameIterator fIter;
    rim::Transaction::iterator tIter;
    ris::FramePtr  frame;
    uint32_t frameSize;
@@ -132,7 +132,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    // Setup iterators
    rogue::GilRelease noGil;
    rim::TransactionLockPtr lock = tran->lock();
-   fIter = frame->beginWrite();
+   fIter = frame->begin();
    tIter = tran->begin();
 
    // Write header
@@ -158,7 +158,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
 
 //! Accept a frame from master
 void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
-   ris::Frame::iterator fIter;
+   ris::FrameIterator fIter;
    rim::Transaction::iterator tIter;
    rim::TransactionPtr tran;
    uint32_t header[MaxHeadLen/4];
@@ -186,7 +186,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Setup frame iterator
-   fIter = frame->beginRead();
+   fIter = frame->begin();
 
    // Get the header
    ris::fromFrame(fIter,RxHeadLen,header);
@@ -228,7 +228,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Read tail error value, complete if error is set
-   fIter = frame->endRead()-TailLen;
+   fIter = frame->end()-TailLen;
    ris::fromFrame(fIter,TailLen,tail);
    if ( tail[0] != 0 ) {
       if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
@@ -240,7 +240,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Copy data if read
    if ( ! doWrite ) {
-      fIter = frame->beginRead() + RxHeadLen;
+      fIter = frame->begin() + RxHeadLen;
       ris::fromFrame(fIter, tran->size(), tIter);
    }
 

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -117,7 +117,7 @@ bool rps::SrpV3::setupHeader(rim::TransactionPtr tran, uint32_t *header, uint32_
 
 //! Post a transaction
 void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
-   ris::Frame::iterator fIter;
+   ris::FrameIterator fIter;
    rim::Transaction::iterator tIter;
    ris::FramePtr  frame;
    uint32_t frameSize;
@@ -151,7 +151,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    // Setup iterators
    rogue::GilRelease noGil;
    rim::TransactionLockPtr lock = tran->lock();
-   fIter = frame->beginWrite();
+   fIter = frame->begin();
    tIter = tran->begin();
 
    // Write header
@@ -172,7 +172,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
 
 //! Accept a frame from master
 void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
-   ris::Frame::iterator fIter;
+   ris::FrameIterator fIter;
    rim::Transaction::iterator tIter;
    rim::TransactionPtr tran;
    uint32_t header[HeadLen/4];
@@ -198,11 +198,11 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    }
 
    // Get the tail
-   fIter = frame->endRead()-TailLen;
+   fIter = frame->end()-TailLen;
    ris::fromFrame(fIter,TailLen,tail);
 
    // Get the header
-   fIter = frame->beginRead();
+   fIter = frame->begin();
    ris::fromFrame(fIter,HeadLen,header);
 
    // Extract the id

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -307,8 +307,8 @@ void ru::Prbs::resetCount() {
 
 //! Generate a data frame
 void ru::Prbs::genFrame (uint32_t size) {
-   ris::Frame::iterator frIter;
-   ris::Frame::iterator frEnd;
+   ris::FrameIterator frIter;
+   ris::FrameIterator frEnd;
    uint32_t      frSeq[MaxBytes/4];
    uint32_t      frSize[MaxBytes/4];
    uint32_t      wCount[MaxBytes/4];
@@ -336,8 +336,9 @@ void ru::Prbs::genFrame (uint32_t size) {
 
    // Get frame
    fr = reqFrame(size,true);
+   fr->setPayload(size);
 
-   frIter = fr->beginWrite();
+   frIter = fr->begin();
    frEnd  = frIter + size;
 
    // First word is sequence
@@ -365,7 +366,6 @@ void ru::Prbs::genFrame (uint32_t size) {
       }
    }
 
-   fr->setPayload(size);
    sendFrame(fr);
 
    // Update counters
@@ -383,8 +383,8 @@ void ru::Prbs::genFrame (uint32_t size) {
 
 //! Accept a frame from master
 void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
-   ris::Frame::iterator frIter;
-   ris::Frame::iterator frEnd;
+   ris::FrameIterator frIter;
+   ris::FrameIterator frEnd;
    uint32_t      frSeq[MaxBytes/4];
    uint32_t      frSize[MaxBytes/4];
    uint32_t      expSeq;
@@ -402,8 +402,8 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    std::lock_guard<std::mutex> lock(pMtx_);
 
    size = frame->getPayload();
-   frIter = frame->beginRead();
-   frEnd  = frame->endRead();
+   frIter = frame->begin();
+   frEnd  = frame->end();
 
    // Check for frame errors
    if ( frame->getError() ) {


### PR DESCRIPTION
This PR simplifies the FrameIterator use modes by adding Frame::begin() and Frame::end() iterator access methods, deprecating Frame::beginRead() and Frame::beginWrite. In the new use model the user will first specify the payload size of a frame using Frame::setPayload() and then create a single type of iterator, instead of read and write iterators as previously described. 