### PR TITLE
Add memory map interface for memory transactions

### DIFF
--- a/include/rogue/hardware/MemMap.h
+++ b/include/rogue/hardware/MemMap.h
@@ -1,0 +1,79 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : Raw Memory Mapped Access
+ * ----------------------------------------------------------------------------
+ * File       : MemMap.h
+ * Created    : 2019-11-18
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#ifndef __ROGUE_HARDWARE_MEM_MAP_H__
+#define __ROGUE_HARDWARE_MEM_MAP_H__
+#include <rogue/interfaces/memory/Slave.h>
+#include <rogue/interfaces/memory/Transaction.h>
+#include <thread>
+#include <mutex>
+#include <stdint.h>
+#include <rogue/Logging.h>
+
+#define MAP_DEVICE "/dev/map"
+
+namespace rogue {
+   namespace hardware {
+
+      //! Raw Memory Map Class
+      /** This class provides a bridge between the Rogue memory interface and 
+       * a standard linux /dev/map interface. 
+       */
+      class MemMap : public rogue::interfaces::memory::Slave {
+
+            //! MemMap file descriptor
+            int32_t  fd_;
+
+            //! Size
+            uint64_t size_;
+
+            //! Memory Mapped Pointer
+            volatile uint8_t * map_;
+
+            // Logging
+            std::shared_ptr<rogue::Logging> log_;
+
+         public:
+
+            //! Class factory which returns a MemMapPtr to a newly created MemMap object
+            /** Exposed to Python as rogue.hardware.MemMap()
+             * @param base Base address to map
+             * @param size Size of address space to map
+             * @return MemMap pointer (MemMapPtr)
+             */
+            static std::shared_ptr<rogue::hardware::MemMap> create (uint64_t base, uint32_t size);
+
+            // Setup class for use in python
+            static void setup_python();
+
+            // Class Creator
+            MemMap(uint64_t base, uint32_t size);
+
+            // Destructor
+            ~MemMap();
+
+            // Accept as transaction from the memory Master as defined in the Slave class.
+            void doTransaction(std::shared_ptr<rogue::interfaces::memory::Transaction> tran);
+      };
+
+      //! Alias for using shared pointer as TcpClientPtr
+      typedef std::shared_ptr<rogue::hardware::MemMap> MemMapPtr;
+
+   }
+};
+
+#endif
+

--- a/src/rogue/hardware/CMakeLists.txt
+++ b/src/rogue/hardware/CMakeLists.txt
@@ -16,6 +16,8 @@
 add_subdirectory("pgp")
 add_subdirectory("axi")
 
+target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/MemMap.cpp")
+
 if (NOT NO_PYTHON)
    target_sources(rogue-core PRIVATE "${CMAKE_CURRENT_LIST_DIR}/module.cpp")
 endif()

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -1,9 +1,9 @@
 /**
  *-----------------------------------------------------------------------------
- * Title      : AXI Memory Mapped Access
+ * Title      : Raw Memory Mapped Access
  * ----------------------------------------------------------------------------
  * File       : MemMap.cpp
- * Created    : 2017-03-21
+ * Created    : 2019-11-18
  * ----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to 
  * the license terms in the LICENSE.txt file found in the top-level directory 

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -1,0 +1,117 @@
+/**
+ *-----------------------------------------------------------------------------
+ * Title      : AXI Memory Mapped Access
+ * ----------------------------------------------------------------------------
+ * File       : MemMap.cpp
+ * Created    : 2017-03-21
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to 
+ * the license terms in the LICENSE.txt file found in the top-level directory 
+ * of this distribution and at: 
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+ * No part of the rogue software platform, including this file, may be 
+ * copied, modified, propagated, or distributed except according to the terms 
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+**/
+#include <rogue/hardware/MemMap.h>
+#include <rogue/interfaces/memory/Constants.h>
+#include <rogue/interfaces/memory/Transaction.h>
+#include <rogue/interfaces/memory/TransactionLock.h>
+#include <rogue/GeneralError.h>
+#include <rogue/GilRelease.h>
+#include <memory>
+#include <cstring>
+#include <thread>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+
+namespace rh  = rogue::hardware;
+namespace rim = rogue::interfaces::memory;
+
+#ifndef NO_PYTHON
+#include <boost/python.hpp>
+namespace bp  = boost::python;
+#endif
+
+//! Class creation
+rh::MemMapPtr rh::MemMap::create (uint64_t base, uint32_t size) {
+   rh::MemMapPtr r = std::make_shared<rh::MemMap>(base,size);
+   return(r);
+}
+
+//! Creator
+rh::MemMap::MemMap(uint64_t base, uint32_t size) : rim::Slave(4,0xFFFFFFFF) {
+   log_ = rogue::Logging::create("MemMap");
+
+   size_ = size;
+
+   fd_ = ::open(MAP_DEVICE, O_RDWR);
+
+   if ( fd_ < 0 ) 
+      throw(rogue::GeneralError::create("MemMap::MemMap", "Failed to open device file: %s",MAP_DEVICE));
+
+   if ( (map_ = (uint8_t *)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, base)) == (void *) -1)
+      throw(rogue::GeneralError::create("MemMap::MemMap", "Failed to map memory to user space."));
+
+   log_->debug("Created map to 0x%x with size 0x%x", base, size);
+}
+
+//! Destructor
+rh::MemMap::~MemMap() {
+   ::close(fd_);
+}
+
+//! Post a transaction
+void rh::MemMap::doTransaction(rim::TransactionPtr tran) {
+   uint32_t * tPtr;
+   uint32_t * mPtr;
+   uint32_t   count;
+
+   rogue::GilRelease noGil;
+   rim::TransactionLockPtr lock = tran->lock();
+
+   if ( (tran->size() % 4) != 0 ) {
+      tran->error("Invalid transaction size %i, must be an integer number of 4 bytes",tran->size());
+      return;
+   }
+
+   // Check that the address is legal
+   if ( (tran->address() + tran->size()) > size_ ) {
+      tran->error("Request transaction to address 0x%x with size %i is out of bounds",tran->address(),tran->size());
+      return;
+   }
+
+   tPtr = (uint32_t *)tran->begin();
+   mPtr = (uint32_t *)(map_ + tran->address());
+
+   while ( count != tran->size() ) {
+
+      // Write or post
+      if (tran->type() == rim::Write || tran->type() == rim::Post) *mPtr = *tPtr;
+
+      // Read or verify
+      else *tPtr = *mPtr;
+
+      ++mPtr;
+      ++tPtr;
+      count += 4;
+   }
+
+   log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i",tran->id(),tran->address(),tran->size(),tran->type());
+   tran->done();
+}
+
+void rh::MemMap::setup_python () {
+#ifndef NO_PYTHON
+
+   bp::class_<rh::MemMap, rh::MemMapPtr, bp::bases<rim::Slave>, boost::noncopyable >("MemMap",bp::init<uint64_t, uint32_t>());
+
+   bp::implicitly_convertible<rh::MemMapPtr, rim::SlavePtr>();
+#endif
+}
+

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -71,9 +71,11 @@ void rha::AxiMemMap::doTransaction(rim::TransactionPtr tran) {
    dataSize = sizeof(uint32_t);
    ptr = (uint8_t *)(&data);
 
-   if ( (tran->size() % dataSize) != 0 ) 
+   if ( (tran->size() % dataSize) != 0 ) {
       tran->error("Invalid transaction size %i, must be an integer number of %i bytes",tran->size(),dataSize);
 
+      return;
+   }
    count = 0;
    ret = 0;
 

--- a/src/rogue/hardware/module.cpp
+++ b/src/rogue/hardware/module.cpp
@@ -24,6 +24,7 @@
 #include <rogue/hardware/module.h>
 #include <rogue/hardware/pgp/module.h>
 #include <rogue/hardware/axi/module.h>
+#include <rogue/hardware/MemMap.h>
 
 namespace bp  = boost::python;
 
@@ -40,6 +41,7 @@ void rogue::hardware::setup_module() {
 
    rogue::hardware::pgp::setup_module();
    rogue::hardware::axi::setup_module();
+   rogue::hardware::MemMap::setup_python();
 
 }
 


### PR DESCRIPTION
This adds a memory transaction interface to mapped memory using /dev/map.

map = rogue.hardware.MemMap(baseAddr, size)

The base address is the memory address to map the interface at, the size is the amount of memory space to map. The transaction address is relative to the base address mapped. 