### PR TITLE
Fix zmq exit by using receive timeout

### DIFF
--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -115,10 +115,10 @@ void rogue::interfaces::ZmqClient::close() {
    if ( threadEn_ ) {
       rogue::GilRelease noGil;
       threadEn_ = false;
+      thread_->join();
       zmq_close(this->zmqSub_);
       zmq_close(this->zmqReq_);
       zmq_ctx_destroy(this->zmqCtx_);
-      thread_->join();
    }
 }
 

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -90,10 +90,10 @@ void rogue::interfaces::ZmqServer::close() {
    if ( threadEn_ ) {
       rogue::GilRelease noGil;
       threadEn_ = false;
+      thread_->join();
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
-      //zmq_ctx_destroy(this->zmqCtx_);
-      //thread_->join();
+      zmq_ctx_destroy(this->zmqCtx_);
    }
 }
 
@@ -137,6 +137,10 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
 
    if ( zmq_setsockopt (this->zmqRep_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket linger"));
+
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqRep_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket receive timeout"));
 
    return true;
 }

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -83,6 +83,10 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
    if ( zmq_setsockopt (this->zmqReq_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("memory::TcpClient::TcpClient","Failed to set socket linger"));
 
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqResp_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("memory::TcpClient::TcpClient","Failed to set socket receive timeout"));
+
    if ( zmq_connect(this->zmqResp_,this->respAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpClient::TcpClient",
                "Failed to connect to remote port %i at address %s",port+1,addr.c_str()));
@@ -112,10 +116,10 @@ void rim::TcpClient::close() {
    if ( threadEn_ ) {
       rogue::GilRelease noGil;
       threadEn_ = false;
+      thread_->join();
       zmq_close(this->zmqResp_);
       zmq_close(this->zmqReq_);
       zmq_ctx_destroy(this->zmqCtx_);
-      thread_->join();
    }
 }  
 

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -76,6 +76,10 @@ rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
    if ( zmq_setsockopt (this->zmqReq_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("memory::TcpServer::TcpServer","Failed to set socket linger"));
 
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqReq_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("memory::TcpServer::TcpServer","Failed to set socket receive timeout"));
+
    if ( zmq_bind(this->zmqResp_,this->respAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpServer::TcpServer",
                "Failed to bind server to port %i at address %s, another process may be using this port",port+1,addr.c_str()));
@@ -105,10 +109,10 @@ void rim::TcpServer::close() {
    if ( threadEn_ ) {
       rogue::GilRelease noGil;
       threadEn_ = false;
+      thread_->join();
       zmq_close(this->zmqResp_);
       zmq_close(this->zmqReq_);
       zmq_ctx_destroy(this->zmqCtx_);
-      thread_->join();
    }
 }
 

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -78,6 +78,10 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
    if ( zmq_setsockopt (this->zmqPull_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 ) 
          throw(rogue::GeneralError("stream::TcpCore::TcpCore","Failed to set socket linger"));
 
+   opt = 100;
+   if ( zmq_setsockopt (this->zmqPull_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 ) 
+         throw(rogue::GeneralError("stream::TcpCore::TcpCore","Failed to set socket receive timeout"));
+
    // Server mode
    if (server) {
       this->pullAddr_.append(std::to_string(static_cast<long long>(port)));
@@ -133,10 +137,10 @@ void ris::TcpCore::close() {
    if ( threadEn_ ) {
       rogue::GilRelease noGil;
       threadEn_ = false;
+      thread_->join();
       zmq_close(this->zmqPull_);
       zmq_close(this->zmqPush_);
       zmq_ctx_destroy(this->zmqCtx_);
-      thread_->join();
    }
 }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,7 +46,8 @@ class DummyTree(pyrogue.Root):
                               timeout=2.0,
                               pollEn=True,
                               serverPort=0,
-                              sqlUrl='sqlite:///test.db')
+                              #sqlUrl='sqlite:///test.db')
+                            )
 
         # Use a memory space emulator
         sim = pyrogue.interfaces.simulation.MemEmulate()
@@ -166,10 +167,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
 
-        #import pyrogue.pydm
-        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,10 +167,10 @@ class DummyTree(pyrogue.Root):
 if __name__ == "__main__":
 
     with DummyTree() as dummyTree:
-        #pyrogue.waitCntrlC()
+        pyrogue.waitCntrlC()
 
-        import pyrogue.pydm
-        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
+        #import pyrogue.pydm
+        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeY=2000)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)


### PR DESCRIPTION
It appears the zmq exist problems where multi-tread related. This change includes a receive timeout for the socket used in the receive thread. This allows the thread to exit cleanly before closing the socket and context.