### PR TITLE
Make base path determination more robust in _HelperFunctions.py

### DIFF
--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -26,7 +26,7 @@ def addLibraryPath(path):
     Passed strings can either be relative: ../path/to/library
     or absolute: /path/to/library
     """
-    base = os.path.dirname(sys.argv[0])
+    base = os.path.dirname(os.path.realpath(__file__))
 
     # If script was not started with ./
     if base == '': base = '.'


### PR DESCRIPTION
When embedding pyrogue, sys.argv is empty.
Traceback (most recent call last):
  File "/reg/g/pcds/epics-dev/bhill/modules/ADPgpCamlink-git/pgpCamlinkApp/pythonSrc/pgpCamLink.py", line 11, in <module>
    import setupLibPaths
  File "/reg/neh/home/bhill/git-wa-neh/slaclab/cameralink-gateway-git/software/scripts/setupLibPaths.py", line 16, in <module>
    pr.addLibraryPath(top_level+'firmware/submodules/axi-pcie-core/python')
  File "/reg/neh/home/bhill/git-wa-neh/slaclab/rogue-git/python/pyrogue/_HelperFunctions.py", line 29, in addLibraryPath
    base = os.path.dirname(sys.argv[0])
IndexError: list index out of range