### PR TITLE
Force poll loop to start over on wakeup

### DIFF
--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -120,7 +120,11 @@ class PollQueue(object):
                 with self._condLock:
                     self._condLock.wait()
 
-                continue
+                if self._run is False:
+                    self._log.info("PollQueue thread exiting")
+                    return
+                else:
+                    continue
             else:
                 # Sleep until the top entry is ready to be polled
                 # Or a new entry is added by updatePollInterval

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -120,6 +120,8 @@ class PollQueue(object):
                 # Sleep until woken
                 with self._condLock:
                     self._condLock.wait()
+
+                continue
             else:
                 # Sleep until the top entry is ready to be polled
                 # Or a new entry is added by updatePollInterval

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -114,7 +114,6 @@ class PollQueue(object):
     def _poll(self):
         """Run by the poll thread"""
         while True:
-            now = datetime.datetime.now()
 
             if self.empty() or self.paused():
                 # Sleep until woken
@@ -125,6 +124,7 @@ class PollQueue(object):
             else:
                 # Sleep until the top entry is ready to be polled
                 # Or a new entry is added by updatePollInterval
+                now = datetime.datetime.now()
                 readTime = self.peek().readTime
                 waitTime = (readTime - now).total_seconds()
                 with self._condLock:


### PR DESCRIPTION
This ensures that the poll enable and empty states are re-checked over the conditional fires. Otherwise any readAll call causes a single poll cycle to execute even if the poller is disabled. 