### PR TITLE
Add warning when transaction timers are refreshed

### DIFF
--- a/include/rogue/interfaces/memory/Transaction.h
+++ b/include/rogue/interfaces/memory/Transaction.h
@@ -8,12 +8,12 @@
  * Description:
  * Memory Transaction
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -26,6 +26,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <rogue/EnableSharedFromThis.h>
+#include <rogue/Logging.h>
 
 #ifndef NO_PYTHON
 #include <boost/python.hpp>
@@ -40,19 +41,19 @@ namespace rogue {
          class Hub;
 
          //! Transaction Container
-         /** The Transaction is passed between the Master and Slave to initiate a transaction. 
-          * The Transaction class contains information about the transaction as well as the 
-          * transaction data pointer. Each created transaction object has a unique 32-bit 
+         /** The Transaction is passed between the Master and Slave to initiate a transaction.
+          * The Transaction class contains information about the transaction as well as the
+          * transaction data pointer. Each created transaction object has a unique 32-bit
           * transaction ID which is used to track the transaction. Transactions are never
           * created directly, instead they are created in the Master() class.
-          */ 
+          */
          class Transaction : public rogue::EnableSharedFromThis<rogue::interfaces::memory::Transaction> {
             friend class TransactionLock;
             friend class Master;
             friend class Hub;
 
-            public: 
-               
+            public:
+
                //! Alias for using uint8_t * as Transaction::iterator
                typedef uint8_t * iterator;
 
@@ -69,7 +70,7 @@ namespace rogue {
 
             protected:
 
-               // Transaction timeout 
+               // Transaction timeout
                struct timeval timeout_;
 
                // Transaction end time
@@ -77,6 +78,9 @@ namespace rogue {
 
                // Transaction start time
                struct timeval startTime_;
+
+               // Transaction warn time
+               struct timeval warnTime_;
 
 #ifndef NO_PYTHON
                // Transaction python buffer
@@ -109,6 +113,9 @@ namespace rogue {
 
                // Transaction lock
                std::mutex lock_;
+
+               //! Log
+               std::shared_ptr<rogue::Logging> log_;
 
                // Create a transaction container and return a TransactionPtr, called by Master
                static std::shared_ptr<rogue::interfaces::memory::Transaction> create (struct timeval timeout);
@@ -170,7 +177,7 @@ namespace rogue {
 
                //! Refresh transaction timer
                /** Called to refresh the Transaction timer. If the passed reference
-                * Transaction is NULL or the Transaction start time is later than the 
+                * Transaction is NULL or the Transaction start time is later than the
                 * reference transaction, the Transaction timer will be refreshed.
                 *
                 * Not exposed to Python

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -68,7 +68,7 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
 
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
-      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", 
+      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma",
             "Failed to open device file %s with dest 0x%x",path.c_str(),dest));
 
    }
@@ -325,10 +325,9 @@ void rha::AxiStreamDma::retBuffer(uint8_t * data, uint32_t meta, uint32_t size) 
          if ( dmaRetIndex(fd_,meta & 0x3FFFFFFF) < 0 )
             throw(rogue::GeneralError("AxiStreamDma::retBuffer","AXIS Return Buffer Call Failed!!!!"));
 
-         decCounter(size);
-
 #endif
       }
+      decCounter(size);
    }
 
    // Buffer is allocated from Pool class
@@ -394,12 +393,12 @@ void rha::AxiStreamDma::runThread() {
             rxCount = dmaReadBulkIndex(fd_, RxBufferCount, rxSize, meta, rxFlags, rxError, NULL);
 
             // Allocate a buffer, Mark zero copy meta with bit 31 set, lower bits are index
-            for (x=0; x < rxCount; x++) 
+            for (x=0; x < rxCount; x++)
                buff[x] = createBuffer(rawBuff_[meta[x]],0x80000000 | meta[x],bSize_,bSize_);
          }
 
          // Return of -1 is bad
-         if ( rxCount < 0 ) 
+         if ( rxCount < 0 )
             throw(rogue::GeneralError("AxiStreamDma::runThread","DMA Interface Failure!"));
 
          // Read was successful

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -8,12 +8,12 @@
  * Description:
  * Memory master interface.
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -74,7 +74,7 @@ rim::Master::Master() {
    rogue::defaultTimeout(sumTime_);
 
    log_ = rogue::Logging::create("memory.Master");
-} 
+}
 
 //! Destroy object
 rim::Master::~Master() { }
@@ -131,7 +131,7 @@ void rim::Master::setTimeout(uint64_t timeout) {
    if (timeout != 0 ) {
       div_t divResult = div(timeout,1000000);
       sumTime_.tv_sec  = divResult.quot;
-      sumTime_.tv_usec = divResult.rem;       
+      sumTime_.tv_usec = divResult.rem;
    }
 }
 
@@ -188,8 +188,9 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
       tranMap_[tran->id_] = tran;
    }
 
-   
    log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
+   tran->log_->debug("Created transaction type=%i id=%i, address=0x%.8x, size=0x%x",
+         tran->type_,tran->id_,tran->address_,tran->size_);
    slave->doTransaction(tran);
    tran->refreshTimer(tran);
    return(tran->id_);


### PR DESCRIPTION
This will generate a warning every timeout period when a transaction timer is refreshed. This will ensure some indication is present on the console in situations where data flow slows down enough to slow the user interface, but now slow enough to cause timeouts.

This also fixes a bug where the allocation counter was decremented in the wrong place, this is for tracking purposes only and had to real impact on system operation.