### PR TITLE
Fix bulk enable flag 

### DIFF
--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -7,12 +7,12 @@
  * Description:
  * Interface between RemoteVariables and lower level memory transactions.
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -84,7 +84,7 @@ namespace rogue {
                std::string mode_;
 
                // Bulk Enable
-               bool bulkEn_;
+               bool bulkOpEn_;
 
                // Block level update enable
                bool updateEn_;
@@ -203,10 +203,10 @@ namespace rogue {
                /** Return the bulk enable flag, indicating if this block should be included
                 * in bulk read and write operations.
                 *
-                * Exposed as bulkEn property to Python
+                * Exposed as bulkOpEn property to Python
                 * @return bulk enable flag
                 */
-               bool bulkEn();
+               bool bulkOpEn();
 
                //! Return overlap enable flag
                /** Return the overlap enable flag

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -7,12 +7,12 @@
  * Description:
  * Base class for RemoteVariable as well as direct C++ access
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -54,7 +54,7 @@ namespace rogue {
 
                // Byte reverse flag
                bool byteReverse_;
-   
+
                // Total number of bits for this value
                uint32_t bitTotal_;
 
@@ -83,7 +83,7 @@ namespace rogue {
                double maxValue_;
 
                // Bulk Enable Flag
-               bool bulkEn_;
+               bool bulkOpEn_;
 
                // Enable update calls
                bool updateEn_;
@@ -199,7 +199,7 @@ namespace rogue {
                 * @param bitSize Bit size vector
                 * @param overlapEn Overlap enable flag
                 * @param verify Verify enable flag
-                * @param bulkEn Bulk read/write flag
+                * @param bulkOpEn Bulk read/write flag
                 * @param updateEn Enable variable tree updates
                 * @param modelId Variable model ID
                 * @param byteReverse Byte reverse flag
@@ -215,12 +215,12 @@ namespace rogue {
                      std::vector<uint32_t> bitSize,
                      bool overlapEn,
                      bool verify,
-                     bool bulkEn,
+                     bool bulkOpEn,
                      bool noUpdate,
                      uint32_t modelId,
                      bool byteReverse,
                      uint32_t binPoint);
-                     
+
                // Setup class for use in python
                static void setup_python();
 
@@ -234,7 +234,7 @@ namespace rogue {
                           std::vector<uint32_t> bitSize,
                           bool overlapEn,
                           bool verify,
-                          bool bulkEn,
+                          bool bulkOpEn,
                           bool noUpdate,
                           uint32_t modelId,
                           bool byteReverse,
@@ -272,7 +272,7 @@ namespace rogue {
 
                //! Execute queue update, unused in C++
                virtual void queueUpdate();
-   
+
                //! Rate test for debugging
                void rateTest();
 
@@ -280,10 +280,10 @@ namespace rogue {
                // C++ Byte Array
                /////////////////////////////////
 
-               //! Set byte array 
+               //! Set byte array
                void setBytArray(uint8_t *);
 
-               //! Get byte array 
+               //! Get byte array
                void getByteArray(uint8_t *);
 
                /////////////////////////////////
@@ -364,7 +364,7 @@ namespace rogue {
 #ifndef NO_PYTHON
 
          // Stream slave class, wrapper to enable python overload of virtual methods
-         class VariableWrap : 
+         class VariableWrap :
             public rogue::interfaces::memory::Variable,
             public boost::python::wrapper<rogue::interfaces::memory::Variable> {
 
@@ -382,7 +382,7 @@ namespace rogue {
                               boost::python::object bitSize,
                               bool overlapEn,
                               bool verify,
-                              bool bulkEn,
+                              bool bulkOpEn,
                               bool noUpdate,
                               boost::python::object model);
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -58,7 +58,7 @@ class LocalBlock(object):
         return self._mode
 
     @property
-    def bulkEn(self):
+    def bulkOpEn(self):
         return True
 
     def forceStale(self):

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -45,15 +45,13 @@ class BaseCommand(pr.BaseVariable):
             hidden=hidden,
             groups=groups,
             minimum=minimum,
-            maximum=maximum)
+            maximum=maximum,
+            bulkOpEn=False)
 
         self._function = function if function is not None else BaseCommand.nothing
         self._thread = None
         self._lock = threading.Lock()
         self._background = background
-
-        # Disable bulk operations for commands
-        self._bulkEn = False
 
         if self._background:
             self._log.error('Background commands are deprecated. Please use a Process device instead.')
@@ -252,10 +250,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             bitSize=bitSize,
             bitOffset=bitOffset,
             overlapEn=overlapEn,
+            bulkOpEn=False,
             verify=False)
-
-        # Disable bulk operations for commands
-        self._bulkEn = False
 
     def set(self, value, write=True):
         self._log.debug("{}.set({})".format(self, value))

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -283,7 +283,7 @@ class Device(pr.Node,rim.Hub):
 
         else:
             for block in self._blocks:
-                if block.bulkEn:
+                if block.bulkOpEn:
                     block.startTransaction(rim.Write, force, checkEach, None)
 
             if recurse:
@@ -303,7 +303,7 @@ class Device(pr.Node,rim.Hub):
 
         else:
             for block in self._blocks:
-                if block.bulkEn:
+                if block.bulkOpEn:
 
                     # Force=False
                     block.startTransaction(rim.Verify, False, checkEach, None)
@@ -325,7 +325,7 @@ class Device(pr.Node,rim.Hub):
 
         else:
             for block in self._blocks:
-                if block.bulkEn:
+                if block.bulkOpEn:
 
                     # Force=False
                     block.startTransaction(rim.Read, False, checkEach, None)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -114,10 +114,11 @@ class BaseVariable(pr.Node):
                  pollInterval=0,
                  updateNotify=True,
                  typeStr='Unknown',
+                 bulkOpEn=True,
                  offset=0):
 
         # Public Attributes
-        self._bulkEn        = True
+        self._bulkOpEn      = bulkOpEn
         self._updateNotify  = updateNotify
         self._mode          = mode
         self._units         = units
@@ -515,6 +516,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
                  pollInterval=0,
                  updateNotify=True,
                  overlapEn=False,
+                 bulkOpEn=True,
                  verify=True, ):
 
         if disp is None:
@@ -523,7 +525,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         BaseVariable.__init__(self, name=name, description=description,
                               mode=mode, value=value, disp=disp,
                               enum=enum, units=units, hidden=hidden, groups=groups,
-                              minimum=minimum, maximum=maximum,
+                              minimum=minimum, maximum=maximum, bulkOpEn=bulkOpEn,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
                               pollInterval=pollInterval,updateNotify=updateNotify)
@@ -561,7 +563,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         # Setup C++ Base class
         rim.Variable.__init__(self,self._name,self._mode,self._minimum,self._maximum,
                               offset, bitOffset, bitSize, overlapEn, verify,
-                              self._bulkEn, self._updateNotify, self._base)
+                              self._bulkOpEn, self._updateNotify, self._base)
 
     @pr.expose
     @property
@@ -703,7 +705,8 @@ class LocalVariable(BaseVariable):
                  localGet=None,
                  typeStr='Unknown',
                  pollInterval=0,
-                 updateNotify=True):
+                 updateNotify=True,
+                 bulkOpEn=True):
 
         if value is None and localGet is None:
             raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
@@ -714,7 +717,7 @@ class LocalVariable(BaseVariable):
                               minimum=minimum, maximum=maximum, typeStr=typeStr,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval,updateNotify=updateNotify)
+                              pollInterval=pollInterval,updateNotify=updateNotify, bulkOpEn=bulkOpEn)
 
         self._block = pr.LocalBlock(variable=self,localSet=localSet,localGet=localGet,value=self._default)
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -7,12 +7,12 @@
  * Description:
  * Interface between RemoteVariables and lower level memory transactions.
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -40,14 +40,14 @@ rim::VariablePtr create ( std::string name,
                           std::vector<uint32_t> bitSize,
                           bool overlapEn,
                           bool verify,
-                          bool bulkEn,
+                          bool bulkOpEn,
                           bool updateEn,
                           uint32_t modelId,
                           bool byteReverse,
                           uint32_t binPoint ) {
 
    rim::VariablePtr v = std::make_shared<rim::Variable>( name, mode, minimum, maximum,
-         offset, bitOffset, bitSize, overlapEn, verify, bulkEn, updateEn, modelId, byteReverse, binPoint);
+         offset, bitOffset, bitSize, overlapEn, verify, bulkOpEn, updateEn, modelId, byteReverse, binPoint);
    return(v);
 }
 
@@ -80,7 +80,7 @@ rim::Variable::Variable ( std::string name,
                           std::vector<uint32_t> bitSize,
                           bool overlapEn,
                           bool verifyEn,
-                          bool bulkEn,
+                          bool bulkOpEn,
                           bool updateEn,
                           uint32_t modelId,
                           bool byteReverse,
@@ -98,7 +98,7 @@ rim::Variable::Variable ( std::string name,
    overlapEn_   = overlapEn;
    verifyEn_    = verifyEn;
    byteReverse_ = byteReverse;
-   bulkEn_      = bulkEn;
+   bulkOpEn_    = bulkOpEn;
    updateEn_    = updateEn;
    minValue_    = minimum;
    maxValue_    = maximum;
@@ -148,14 +148,14 @@ rim::Variable::Variable ( std::string name,
 
    // Define set function
    switch (modelId_) {
-      case rim::PyFunc : 
+      case rim::PyFunc :
          setFuncPy_    = &rim::Block::setPyFunc;
          break;
-      case rim::Bytes : 
-         setFuncPy_    = &rim::Block::setByteArrayPy; 
+      case rim::Bytes :
+         setFuncPy_    = &rim::Block::setByteArrayPy;
          setByteArray_ = &rim::Block::setByteArray;
          break;
-      case rim::UInt : 
+      case rim::UInt :
          if (bitTotal_ > 64) {
             setFuncPy_    = &rim::Block::setPyFunc;
             setByteArray_ = &rim::Block::setByteArray;
@@ -175,41 +175,41 @@ rim::Variable::Variable ( std::string name,
             setInt_    = &rim::Block::setInt;
          }
          break;
-      case rim::Bool : 
-         setFuncPy_ = &rim::Block::setBoolPy;   
+      case rim::Bool :
+         setFuncPy_ = &rim::Block::setBoolPy;
          setBool_   = &rim::Block::setBool;
          break;
-      case rim::String : 
-         setFuncPy_ = &rim::Block::setStringPy; 
+      case rim::String :
+         setFuncPy_ = &rim::Block::setStringPy;
          setString_ = &rim::Block::setString;
          break;
-      case rim::Float : 
-         setFuncPy_ = &rim::Block::setFloatPy;  
+      case rim::Float :
+         setFuncPy_ = &rim::Block::setFloatPy;
          setFloat_  = &rim::Block::setFloat;
          break;
       case rim::Double :
-         setFuncPy_ = &rim::Block::setDoublePy; 
+         setFuncPy_ = &rim::Block::setDoublePy;
          setDouble_ = &rim::Block::setDouble;
          break;
-      case rim::Fixed : 
-         setFuncPy_ = &rim::Block::setFixedPy;  
+      case rim::Fixed :
+         setFuncPy_ = &rim::Block::setFixedPy;
          setFixed_  = &rim::Block::setFixed;
          break;
-      default : 
-         getFuncPy_ = NULL; 
+      default :
+         getFuncPy_ = NULL;
          break;
    }
 
    // Define get function
    switch (modelId_) {
-      case rim::PyFunc : 
-         getFuncPy_ = &rim::Block::getPyFunc;      
+      case rim::PyFunc :
+         getFuncPy_ = &rim::Block::getPyFunc;
          break;
-      case rim::Bytes : 
-         getFuncPy_    = &rim::Block::getByteArrayPy; 
+      case rim::Bytes :
+         getFuncPy_    = &rim::Block::getByteArrayPy;
          getByteArray_ = &rim::Block::getByteArray;
          break;
-      case rim::UInt : 
+      case rim::UInt :
          if (bitTotal_ > 64) {
             getFuncPy_    = &rim::Block::getPyFunc;
             getByteArray_ = &rim::Block::getByteArray;
@@ -229,28 +229,28 @@ rim::Variable::Variable ( std::string name,
             getInt_    = &rim::Block::getInt;
          }
          break;
-      case rim::Bool : 
-         getFuncPy_ = &rim::Block::getBoolPy; 
+      case rim::Bool :
+         getFuncPy_ = &rim::Block::getBoolPy;
          getBool_   = &rim::Block::getBool;
          break;
-      case rim::String : 
-         getFuncPy_ = &rim::Block::getStringPy; 
+      case rim::String :
+         getFuncPy_ = &rim::Block::getStringPy;
          getString_ = &rim::Block::getString;
          break;
-      case rim::Float : 
-         getFuncPy_ = &rim::Block::getFloatPy; 
+      case rim::Float :
+         getFuncPy_ = &rim::Block::getFloatPy;
          getFloat_  = &rim::Block::getFloat;
          break;
-      case rim::Double : 
-         getFuncPy_ = &rim::Block::getFloatPy; 
+      case rim::Double :
+         getFuncPy_ = &rim::Block::getFloatPy;
          getDouble_ = &rim::Block::getDouble;
          break;
-      case rim::Fixed : 
-         getFuncPy_ = &rim::Block::getFixedPy; 
+      case rim::Fixed :
+         getFuncPy_ = &rim::Block::getFixedPy;
          getFixed_  = &rim::Block::getFixed;
          break;
-      default : 
-         getFuncPy_ = NULL; 
+      default :
+         getFuncPy_ = NULL;
          break;
    }
 }
@@ -306,7 +306,7 @@ uint32_t rim::Variable::varBytes() {
    return varBytes_;
 }
 
-//! Get offset 
+//! Get offset
 uint64_t rim::Variable::offset() {
    return offset_;
 }
@@ -317,34 +317,34 @@ bool rim::Variable::verifyEn() {
 }
 
 // Create a Variable
-rim::VariableWrap::VariableWrap ( std::string name, 
-                                  std::string mode, 
+rim::VariableWrap::VariableWrap ( std::string name,
+                                  std::string mode,
                                   bp::object minimum,
-                                  bp::object maximum, 
+                                  bp::object maximum,
                                   uint64_t offset,
                                   bp::object bitOffset,
-                                  bp::object bitSize, 
-                                  bool overlapEn, 
+                                  bp::object bitSize,
+                                  bool overlapEn,
                                   bool verify,
-                                  bool bulkEn,
+                                  bool bulkOpEn,
                                   bool updateEn,
                                   bp::object model)
-                     : rim::Variable ( name, 
-                                       mode, 
+                     : rim::Variable ( name,
+                                       mode,
                                        py_object_convert<double>(minimum),
                                        py_object_convert<double>(maximum),
                                        offset,
                                        py_list_to_std_vector<uint32_t>(bitOffset),
                                        py_list_to_std_vector<uint32_t>(bitSize),
-                                       overlapEn, 
+                                       overlapEn,
                                        verify,
-                                       bulkEn,
+                                       bulkOpEn,
                                        updateEn,
                                        bp::extract<uint32_t>(model.attr("modelId")),
                                        bp::extract<bool>(model.attr("isBigEndian")),
                                        bp::extract<uint32_t>(model.attr("binPoint")) ) {
 
-   model_ = model;                     
+   model_ = model;
 }
 
 //! Set value from RemoteVariable


### PR DESCRIPTION
The bulk enable flag is used to block bulk transactions for some variables and blocks such as remote commands.  This could also be used for variables that eventually replace rawWrite and rawRead.