### PR TITLE
Makefile parallelization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ stages:
 
 env:
   global:
+    - MAKEFLAGS="-j 2"
     - PY_PATH=$HOME/virtualenv/python3.6.7
     - PACKAGE_DIR=$HOME/packages
     - BOOST_DIR=$PACKAGE_DIR/boost_1_64_0


### PR DESCRIPTION
### Description
- Travis supports up to 2 cores
- adding -j 2 to make builds

### Documentation
- https://docs.travis-ci.com/user/speeding-up-the-build/#makefile-optimization
- https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
