### PR TITLE
Set default log level to warning

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -146,7 +146,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         # Create log listener to add to SystemLog variable
         formatter = logging.Formatter("%(msg)s")
         handler = RootLogHandler(root=self)
-        handler.setLevel(logging.ERROR)
         handler.setFormatter(formatter)
         self._logger = logging.getLogger('pyrogue')
         self._logger.addHandler(handler)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -364,7 +364,7 @@ class BaseVariable(pr.Node):
                 if value in self.enum:
                     ret = self.enum[value]
                 else:
-                    self._log.error("Invalid enum value {} in variable '{}'".format(value,self.path))
+                    self._log.warning("Invalid enum value {} in variable '{}'".format(value,self.path))
                     ret = 'INVALID: {:#x}'.format(value)
             else:
                 if self.typeStr == 'ndarray':


### PR DESCRIPTION
It appears our previous attempt to set the log level to error was not working and we ended up with warning as our level. Making this official and changing the enum error to a warning.