### PR TITLE
Escape \n and " characters when generating dump header.

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -583,7 +583,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 data += "{}\t".format(v._block._reqSlaveName())
                 data += "{}\t".format(v._block.path)
                 data += "{:#x}\t".format(v._block.size)
-                data += "{}".format(v.description)
+                # Escape " characters
+                description = v.description.split('"')
+                description = '\\"'.join(description)
+                # Escape \n characters and strip each line in the description field
+                description = description.split('\n')
+                description = '\\\n'.join([x.strip() for x in description])
+                data += "{}".format(description)
                 lines.append(data)
 
         try:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -584,8 +584,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 data += "{}\t".format(v._block.path)
                 data += "{:#x}\t".format(v._block.size)
                 # Escape " characters
-                description = v.description.split('"')
-                description = '\\"'.join(description)
+                description = v.description.replace('"',r'\"')
                 # Escape \n characters and strip each line in the description field
                 description = description.split('\n')
                 description = '\\\n'.join([x.strip() for x in description])


### PR DESCRIPTION
Was able to compile and parse cameralink-gateway header file w/ this fix.