### PR TITLE
epicsV3 bug fix: Allow reading arrays which contains only one element

### DIFF
--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -226,7 +226,7 @@ caStatus rpe::Value::readValue(gdd &value) {
    std::lock_guard<std::mutex> lock(mtx_);
 
    // Make sure access types match
-   if ( (array_ && value.isAtomic()) || ((!array_) && value.isScalar()) ) {
+   if ( (array_ && value.isAtomic()) || (array_ && value.isScalar()) || ((!array_) && value.isScalar()) ) {
 
       // Call value get within lock
       valueGet();


### PR DESCRIPTION
https://jira.slac.stanford.edu/browse/ESROGUE-440