### PR TITLE
Library base updates

### DIFF
--- a/include/rogue/LibraryBase.h
+++ b/include/rogue/LibraryBase.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <vector>
 #include <map>
+#include <set>
 #include <string>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
@@ -46,6 +47,9 @@ namespace rogue {
 
          //! Map of memory interfaces
          std::map< std::string, std::shared_ptr<rogue::interfaces::memory::Slave> > memSlaves_;
+
+         //! Map of missing memory interfaces
+         std::set< std::string  > memSlavesMissing_;
 
       public:
 

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -156,6 +156,7 @@ void rogue::LibraryBase::createVariable(std::map<std::string, std::string> &data
 
    // Add to block list
    blockVars[blkName].push_back(var);
+   variables_[name]=var;
 }
 
 //! Helper function to get string from fields

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -117,6 +117,17 @@ void rogue::LibraryBase::createVariable(std::map<std::string, std::string> &data
    std::string mbName  = getFieldString(data,"MemBaseName");
    std::string blkName = getFieldString(data,"BlockName");
 
+   // Verify memory slave exists
+   if ( memSlaves_.find(mbName) == memSlaves_.end() ) {
+      if ( memSlavesMissing_.find(mbName) != memSlavesMissing_.end() ) {
+         // Just return as we've already reported this.
+         return;
+      }
+      memSlavesMissing_.insert(mbName);
+      log_->info("LibraryBase::createVariable: '%s' memory interface '%s' not found!",name.c_str(),mbName.c_str());
+      return;
+   }
+
    bool overlapEn    = getFieldBool(data,"OverlapEn");
    bool verify       = getFieldBool(data,"Verify");
    bool bulkEn       = getFieldBool(data,"BulkEn");
@@ -141,10 +152,6 @@ void rogue::LibraryBase::createVariable(std::map<std::string, std::string> &data
       blocks_.insert(std::pair<std::string,rim::BlockPtr>(blkName,block));
       std::vector<rim::VariablePtr> vp;
       blockVars.insert(std::pair<std::string,std::vector<rim::VariablePtr>>(blkName,vp));
-
-      // Verify memory slave exists
-      if ( memSlaves_.find(mbName) == memSlaves_.end() )
-         throw(rogue::GeneralError::create("LibraryBase::createVariable","Memory slave '%s' does not exist!",mbName.c_str()));
 
       // Connect to memory slave
       *block >> memSlaves_[mbName];


### PR DESCRIPTION
These fixes populate the variables_ list w/ one log info msg per missing interface.

All calls to Variable::get*() routines returning 0, so other problems remain.