### PR TITLE
Updating to Ubuntu 20.04 LTS distro and CMAKE Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 sudo: required
 
 branches:
@@ -10,7 +10,10 @@ addons:
     packages:
       - doxygen
       - doxygen-doc
-      - python-dev
+      - python3-dev
+      - python3-pip
+      - libzmq3-dev
+      - libboost-all-dev
 
 services:
   - docker
@@ -19,7 +22,7 @@ language:
   - python
 
 python:
-  - 3.6
+  - 3.8
 
 stages:
   - test
@@ -35,11 +38,10 @@ stages:
 env:
   global:
     - MAKEFLAGS="-j 2"
-    - PY_PATH=$HOME/virtualenv/python3.6.7
     - PACKAGE_DIR=$HOME/packages
-    - BOOST_DIR=$PACKAGE_DIR/boost_1_64_0
     - EPICS_DIR=$PACKAGE_DIR/epics/base-7.0.3
     - EPICS_PCAS_DIR=$PACKAGE_DIR/pcas/pcas-4.13.2
+    - LD_LIBRARY_PATH=/usr/lib:$EPICS_DIR/lib/linux-x86_64:$EPICS_PCAS_DIR/lib/linux-x86_64
     - MINICONDA_DIR=$PACKAGE_DIR/miniconda
     - DOCKER_ORG_NAME=tidair
     - GITHUB_REPO=slaclab/rogue
@@ -50,17 +52,11 @@ jobs:
     - stage: test
       name: "Unit Tests"
       before_install:
-        # Prepare enviroment
-        - export CPLUS_INCLUDE_PATH=$PY_PATH/include/python3.6m
-        - export LD_LIBRARY_PATH=$BOOST_DIR/stage/lib:$PY_PATH/lib:$LD_LIBRARY_PATH
-        - export BOOST_ROOT=$BOOST_DIR
+        # Prepare environment
         - export EPICS_BASE=$EPICS_DIR
         - export EPICS_CA_ADDR_LIST=127.0.0.1
         - export EPICS_PCAS_ROOT=$EPICS_PCAS_DIR
-        # Install zeromq
-        - sudo apt-get install -qq libzmq3-dev
         # Prepare folders
-        - mkdir -p $BOOST_DIR
         - mkdir -p $EPICS_DIR
         - mkdir -p $EPICS_PCAS_DIR
         # Bring all the tags
@@ -69,14 +65,7 @@ jobs:
 
       install:
         # Tools
-        - pip install -r pip_requirements.txt
-
-        # Boost
-        - cd $BOOST_DIR
-        - wget -O boost_1_64_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.gz/download
-        - tar xzf boost_1_64_0.tar.gz --strip 1
-        - ./bootstrap.sh --with-libraries=system,thread,python
-        - travis_wait ./b2 link=shared threading=multi variant=release -d0
+        - pip3 install -r pip_requirements.txt
 
         # EPICS base
         - cd $EPICS_DIR
@@ -94,7 +83,7 @@ jobs:
         # Rogue
         - cd $TRAVIS_BUILD_DIR
         - mkdir build; cd build
-        - cmake .. -DROGUE_INSTALL=local -DPYTHON_LIBRARY=$PY_PATH/lib/python3.6 -DPYTHON_INCLUDE_DIR=$PY_PATH/include
+        - cmake .. -DROGUE_INSTALL=local
         - make -j4 install
 
         # Build Docs
@@ -223,4 +212,3 @@ jobs:
       #os: osx
       #language: ruby  # osx does not support language=python
       #env: CONDA_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,45 +62,27 @@ if ( NOT NO_PYTHON )
    # Boost may need help on SLAC machines
    set(BOOST_ROOT:PATHNAME $ENV{BOOST_PATH})
 
-   # First try standard suffix for boost
-   message("Looking for boost/python3")
-   find_package(Boost 1.58 QUIET COMPONENTS system thread python3)
-
-   # Next try boost/python38
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python38")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python38)
-   endif()
-
-   # Next try boost/python37
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python37")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python37)
-   endif()
-
-   # Next try boost/python-py37
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python-py37")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python-py37)
-   endif()
-
-   # Next try boost/python-py36
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python-py36")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python-py36)
-   endif()
-
-   # Next try boost/python3-py36
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python3-py36")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python3-py36)
-   endif()
-
-   # Next try boost/python36
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python36")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python36)
-   endif()
+  if (UNIX AND NOT APPLE)
+    if (PYTHON_VERSION_MAJOR EQUAL 3)
+        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_SUFFIX})
+        FIND_PACKAGE(PythonInterp 3)
+        FIND_PACKAGE(PythonLibs 3 REQUIRED)
+    else()
+        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python)
+        FIND_PACKAGE(PythonInterp)
+        FIND_PACKAGE(PythonLibs REQUIRED)
+    endif()
+  else()
+    if (PYTHON_VERSION_MAJOR EQUAL 3)
+        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+        FIND_PACKAGE(PythonInterp 3)
+        FIND_PACKAGE(PythonLibs 3 REQUIRED)
+    else()
+        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+        FIND_PACKAGE(PythonInterp)
+        FIND_PACKAGE(PythonLibs REQUIRED)
+    endif()
+  endif()
 
    # Nothing worked
    if (NOT Boost_FOUND)
@@ -485,4 +467,3 @@ endif()
 
 message("----------------------------------------------------------------------")
 message("")
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ add_definitions(-D__STDC_FORMAT_MACROS)
 # Boost + Python
 #####################################
 if ( NOT NO_PYTHON )
-   find_package(PythonInterp 3.6 QUIET REQUIRED)
-   find_package(PythonLibs 3.6 QUIET REQUIRED)
+   find_package(PythonInterp 3 QUIET REQUIRED)
+   find_package(PythonLibs 3 QUIET REQUIRED)
 
    # Find Numpy
    execute_process(
@@ -59,30 +59,42 @@ if ( NOT NO_PYTHON )
 
    set(Boost_USE_MULTITHREADED ON)
 
-   # Boost may need help on SLAC machines
-   set(BOOST_ROOT:PATHNAME $ENV{BOOST_PATH})
+   # Hint for boost on anaconda
+   if (DEFINED ENV{CONDA_PREFIX})
+      set(BOOST_ROOT $ENV{CONDA_PREFIX})
 
-  if (UNIX AND NOT APPLE)
-    if (PYTHON_VERSION_MAJOR EQUAL 3)
-        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_SUFFIX})
-        FIND_PACKAGE(PythonInterp 3)
-        FIND_PACKAGE(PythonLibs 3 REQUIRED)
-    else()
-        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python)
-        FIND_PACKAGE(PythonInterp)
-        FIND_PACKAGE(PythonLibs REQUIRED)
-    endif()
-  else()
-    if (PYTHON_VERSION_MAJOR EQUAL 3)
-        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-        FIND_PACKAGE(PythonInterp 3)
-        FIND_PACKAGE(PythonLibs 3 REQUIRED)
-    else()
-        FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-        FIND_PACKAGE(PythonInterp)
-        FIND_PACKAGE(PythonLibs REQUIRED)
-    endif()
-  endif()
+   # SLAC AFS custom path
+   elseif (DEFINED ENV{BOOST_PATH})
+      set(BOOST_ROOT $ENV{BOOST_PATH})
+   endif()
+
+   # libboost_python3.7 style libraries
+   message("Looking for libboost_python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+   FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+
+   # libboost_python3 style libraries
+   if (NOT Boost_FOUND)
+      message("Looking for libboost_python${PYTHON_VERSION_MAJOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR})
+   endif()
+
+   # libboost_python style libraries
+   if (NOT Boost_FOUND)
+      message("Looking for libboost_python")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python)
+   endif()
+
+   # libboost_python-py37 style libraries
+   if (NOT Boost_FOUND)
+      message("Looking for libboost_python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+   endif()
+
+   # libboost_python3-py37 style libraries
+   if (NOT Boost_FOUND)
+      message("Looking for libboost_python3-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python3-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+   endif()
 
    # Nothing worked
    if (NOT Boost_FOUND)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ requirements:
    build:
      - python
      - boost
+     - boost-cpp
      - gcc_linux-64   [linux]
      - gxx_linux-64   [linux]
      - clang_osx-64   [osx]
@@ -28,6 +29,7 @@ requirements:
    run:
      - python
      - boost
+     - boost-cpp
      - gcc_linux-64   [linux]
      - gxx_linux-64   [linux]
      - clang_osx-64   [osx]

--- a/templates/RogueConfig.cmake.in
+++ b/templates/RogueConfig.cmake.in
@@ -6,12 +6,12 @@
 # Description:
 # Rogue export file to be overridden by Cmake.
 # ----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software package. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software package, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
@@ -26,9 +26,9 @@ set(NO_EPICS    @NO_EPICS@)
 #####################################
 # Boost + Python
 #####################################
-if ( NOT NO_PYTHON ) 
-   find_package(PythonInterp 3.6 QUIET REQUIRED)
-   find_package(PythonLibs 3.6 QUIET REQUIRED)
+if ( NOT NO_PYTHON )
+   find_package(PythonInterp 3 QUIET REQUIRED)
+   find_package(PythonLibs 3 QUIET REQUIRED)
 
    # Find Numpy
    execute_process(
@@ -45,35 +45,41 @@ if ( NOT NO_PYTHON )
 
    set(Boost_USE_MULTITHREADED ON)
 
-   # Boost may need help on SLAC machines
-   set(BOOST_ROOT:PATHNAME $ENV{BOOST_PATH})
+   # Hint for boost on anaconda
+   if (DEFINED ENV{CONDA_PREFIX})
+      set(BOOST_ROOT $ENV{CONDA_PREFIX})
 
-   # First try standard suffix for boost
-   message("Looking for boost/python3")
-   find_package(Boost 1.58 QUIET COMPONENTS system thread python3)
-
-   # Next try boost/python38
-   if (NOT Boost_FOUND)
-      message("Looking for boost/python38")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python38)
+   # SLAC AFS custom path
+   elseif (DEFINED ENV{BOOST_PATH})
+      set(BOOST_ROOT $ENV{BOOST_PATH})
    endif()
 
-   # Next try boost/python37
+   # libboost_python3.7 style libraries
+   message("Looking for libboost_python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+   FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+
+   # libboost_python3 style libraries
    if (NOT Boost_FOUND)
-      message("Looking for boost/python37")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python37)
+      message("Looking for libboost_python${PYTHON_VERSION_MAJOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python${PYTHON_VERSION_MAJOR})
    endif()
 
-   # Next try boost/python-py36
+   # libboost_python style libraries
    if (NOT Boost_FOUND)
-      message("Looking for boost/python-py36")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python-py36)
+      message("Looking for libboost_python")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python)
    endif()
 
-   # Next try boost/python36
+   # libboost_python-py37 style libraries
    if (NOT Boost_FOUND)
-      message("Looking for boost/python36")
-      find_package(Boost 1.58 QUIET COMPONENTS system thread python36)
+      message("Looking for libboost_python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+   endif()
+
+   # libboost_python3-py37 style libraries
+   if (NOT Boost_FOUND)
+      message("Looking for libboost_python3-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+      FIND_PACKAGE(Boost 1.58 QUIET COMPONENTS python3-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
    endif()
 
    # Nothing worked
@@ -93,12 +99,12 @@ find_package(BZip2 QUIET REQUIRED)
 #####################################
 # ZeroMQ
 #####################################
-# First try with Cmake packages
+# First try with cmake packages
 find_package(ZeroMQ QUIET)
 
 # ZeroMQ does not always support cmake, use brute force
 if (NOT ZeroMQ_FOUND)
-   
+
    # Convert LD_LIBRARY PATH for search
    if(DEFINED ENV{LD_LIBRARY_PATH})
       string(REPLACE ":" ";" HINT_PATHS $ENV{LD_LIBRARY_PATH})
@@ -107,12 +113,12 @@ if (NOT ZeroMQ_FOUND)
    endif()
 
    # See if zmq library is in LD_LIBRARY_PATH
-   find_library(ZeroMQ_LIBRARY 
-                NAMES zmq 
+   find_library(ZeroMQ_LIBRARY
+                NAMES zmq
                 PATHS ${HINT_PATHS})
 
    # Found it
-   if (ZeroMQ_LIBRARY) 
+   if (ZeroMQ_LIBRARY)
 
       # Get the base directory
       get_filename_component(ZMQ_LIBDIR ${ZeroMQ_LIBRARY} DIRECTORY)
@@ -142,7 +148,7 @@ if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
    if(DEFINED ENV{EPICS_HOST_ARCH})
        set(EPICS_ARCH $ENV{EPICS_HOST_ARCH})
    else()
-       execute_process(COMMAND ${EPICS_BASE_DIR}/startup/EpicsHostArch 
+       execute_process(COMMAND ${EPICS_BASE_DIR}/startup/EpicsHostArch
                        OUTPUT_VARIABLE EPICS_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
        string(REGEX REPLACE "\n$" "" EPICS_ARCH "${EPICS_ARCH}")
    endif()
@@ -164,23 +170,23 @@ if((NOT NO_PYTHON) AND (NOT NO_EPICS) AND DEFINED ENV{EPICS_BASE})
 
       set(EPICS_INCLUDES    ${EPICS_PCAS_DIR}/include
                             ${EPICS_BASE_DIR}/include
-                            ${EPICS_BASE_DIR}/include/compiler/gcc 
+                            ${EPICS_BASE_DIR}/include/compiler/gcc
                             ${EPICS_BASE_DIR}/include/os/Darwin)
 
-      set(EPICS_LIBRARIES   ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libcas.dylib 
+      set(EPICS_LIBRARIES   ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libcas.dylib
                             ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libgdd.dylib
-                            ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libca.dylib 
+                            ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libca.dylib
                             ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libCom.dylib )
    else()
 
       set(EPICS_INCLUDES    ${EPICS_PCAS_DIR}/include
                             ${EPICS_BASE_DIR}/include
-                            ${EPICS_BASE_DIR}/include/compiler/gcc 
+                            ${EPICS_BASE_DIR}/include/compiler/gcc
                             ${EPICS_BASE_DIR}/include/os/Linux)
 
-      set(EPICS_LIBRARIES   ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libcas.so 
+      set(EPICS_LIBRARIES   ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libcas.so
                             ${EPICS_PCAS_DIR}/lib/${EPICS_ARCH}/libgdd.so
-                            ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libca.so 
+                            ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libca.so
                             ${EPICS_BASE_DIR}/lib/${EPICS_ARCH}/libCom.so )
    endif()
 else()
@@ -246,6 +252,7 @@ if (NO_PYTHON)
    message("-- Compiling without boost & python!")
 else()
    message("-- Found boost: ${Boost_INCLUDE_DIRS}")
+   message("-- Found boost: ${Boost_LIBRARIES}")
    message("")
    message("-- Found python: ${PYTHON_LIBRARIES}")
    message("")
@@ -256,6 +263,7 @@ message("")
 
 if (DO_EPICS_V3)
    message("-- Found EPICS: ${EPICS_BASE_DIR}")
+   message("")
    message("-- Found PCAS:  ${EPICS_PCAS_DIR}")
 else()
    message("-- EPICS V3 not included!")


### PR DESCRIPTION
### Description
- Ubuntu 20.04 LTS distro
- Use 'apt install libboost-all-dev` instead of building for source
- Updated CMakeLists for using apt install of boost in travis CI
  - Based on this [CMakeLists.txt](https://github.com/TNG/boost-python-examples/blob/master/CMakeLists.txt)