### PR TITLE
Addresses a corner case where a false timeout can occur with the TcpClient

### DIFF
--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -70,9 +70,9 @@ namespace rogue {
          static const uint32_t Info     = 20;
          static const uint32_t Debug    = 10;
 
-         static std::shared_ptr<rogue::Logging> create(std::string name);
+         static std::shared_ptr<rogue::Logging> create(std::string name, bool quiet=false);
 
-         Logging (std::string name);
+         Logging (std::string name, bool quiet=false);
          ~Logging();
 
          static void setLevel(uint32_t level);

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -54,12 +54,12 @@ std::mutex rogue::Logging::levelMtx_;
 std::vector <rogue::LogFilter *> rogue::Logging::filters_;
 
 // Crate logger
-rogue::LoggingPtr rogue::Logging::create(std::string name) {
-   rogue::LoggingPtr log = std::make_shared<rogue::Logging>(name);
+rogue::LoggingPtr rogue::Logging::create(std::string name,bool quiet) {
+   rogue::LoggingPtr log = std::make_shared<rogue::Logging>(name,quiet);
    return log;
 }
 
-rogue::Logging::Logging(std::string name) {
+rogue::Logging::Logging(std::string name, bool quiet) {
    std::vector<rogue::LogFilter *>::iterator it;
 
    name_ = "pyrogue." + name;
@@ -75,7 +75,7 @@ rogue::Logging::Logging(std::string name) {
    }
    levelMtx_.unlock();
 
-   warning("Starting logger with level = %i",level_);
+   if ( ! quiet ) warning("Starting logger with level = %i",level_);
 }
 
 rogue::Logging::~Logging() { }

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -74,6 +74,7 @@ void rim::Slave::addTransaction(rim::TransactionPtr tran) {
 rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
    rim::TransactionPtr ret;
    TransactionMap::iterator it;
+   TransactionMap::iterator exp;
 
    rogue::GilRelease noGil;
    std::lock_guard<std::mutex> lock(slaveMtx_);
@@ -84,18 +85,20 @@ rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
       // Remove from list
       tranMap_.erase(it);
 
-      // Cleanup the list, update timers
-      it = tranMap_.begin();
-      while ( it != tranMap_.end() ) {
-         if ( it->second->expired() ) {
-            tranMap_.erase(it); // Iterator no longer valid
-            it = tranMap_.begin();
-         }
-         else {
-            it->second->refreshTimer(ret);
-            ++it;
-         }
+      // Update any timers for transactions started after received transaction
+      exp = tranMap_.end();
+      for ( it = tranMap_.begin(); it != tranMap_.end(); ++it ) {
+         if ( it->second->expired() ) exp = it;
+         else it->second->refreshTimer(ret);
       }
+
+      // Clean up if we found an expired transaction, overtime this will clean up
+      // the list, even if it deletes one expired transaction per call
+      if ( exp != tranMap_.end() ) {
+          printf("Removing expired transaction with id = %i\n",it->second->id());
+          tranMap_.erase(exp);
+      }
+
    }
    return ret;
 }

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -172,16 +172,16 @@ void rim::TcpClient::doTransaction(rim::TransactionPtr tran) {
                      ", size=%" PRIu32 ", type=%" PRIu32 ", cnt=%" PRIu32
                      ", port: %s" ,id,addr,size,type,msgCnt,this->reqAddr_.c_str());
 
+   // Add transaction
+   if ( type == rim::Post ) tran->done();
+   else addTransaction(tran);
+
    // Send message
    for (x=0; x < msgCnt; x++) {
       if ( zmq_sendmsg(this->zmqReq_,&(msg[x]),((x==(msgCnt-1)?0:ZMQ_SNDMORE))|ZMQ_DONTWAIT) < 0 ) {
          bridgeLog_->warning("Failed to send transaction %" PRIu32", msg %" PRIu32, id, x);
       }
    }
-
-   // Add transaction
-   if ( type == rim::Post ) tran->done();
-   else addTransaction(tran);
 }
 
 //! Run thread

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -85,7 +85,7 @@ rim::Transaction::Transaction(struct timeval timeout) : timeout_(timeout) {
    error_   = "";
    done_    = false;
 
-   log_ = rogue::Logging::create("memory.Transaction");
+   log_ = rogue::Logging::create("memory.Transaction",true);
 
    classMtx_.lock();
    if ( classIdx_ == 0 ) classIdx_ = 1;
@@ -173,7 +173,7 @@ std::string rim::Transaction::wait() {
            timercmp(&currTime,&(endTime_),>) ) {
 
          done_  = true;
-         error_ = "Timeout waiting for register transaction message response";
+         error_ = "Timeout waiting for register transaction " + std::to_string(id_) + " message response.";
 
          log_->debug("Transaction timeout. type=%i id=%i, address=0x%.8x, size=0x%x",
                type_,id_,address_,size_);

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -168,6 +168,7 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
                tran->id(),tran->address(),tran->size(),tran->type());
    log_->debug("Send frame for id=%i, header: 0x%0.8x 0x%0.8x 0x%0.8x 0x%0.8x 0x%0.8x",
                tran->id(), header[0],header[1],header[2],header[3],header[4]);
+
    sendFrame(frame);
 }
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -17,7 +17,7 @@ import pyrogue.interfaces.simulation
 import rogue.interfaces.memory
 import time
 
-#rogue.Logging.setLevel(rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Warning)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
@@ -69,6 +69,7 @@ class DummyTree(pr.Root):
 
         # Create a memory gateway
         self.ms = rogue.interfaces.memory.TcpServer("127.0.0.1",9080);
+        time.sleep(1)
 
         # Connect the memory gateways together
         self.sim << self.ms
@@ -109,10 +110,7 @@ def test_memory():
 
         # Bulk Read Device
         root.MemDev[3].ReadDevice()
-        
-        # SW settling Time
-        time.sleep(5)
-        
+
         # Verify all the RW and RO variables
         for dev in range(4):
             for i in range(256):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -69,7 +69,6 @@ class DummyTree(pr.Root):
 
         # Create a memory gateway
         self.ms = rogue.interfaces.memory.TcpServer("127.0.0.1",9080);
-        time.sleep(1)
 
         # Connect the memory gateways together
         self.sim << self.ms
@@ -95,8 +94,6 @@ class DummyTree(pr.Root):
 def test_memory():
 
     with DummyTree() as root:
-        # SW settling Time
-        time.sleep(5)
 
         # Load the R/W variables
         for dev in range(2):


### PR DESCRIPTION
The TcpClient memory class was not adding its transaction to the tracking queue until after the transaction was sent. This resulted in a corner case where the transaction could be lost if it is received too quickly.

This also removes a possible cascading timeout error when cleaning up the transaction tracking map.

This also removes noisy creation debug messages from the transaction class.