### PR TITLE
Pass exceptions on to callers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,12 +112,13 @@ jobs:
       script:
         # Run tests with coverage
         - cd $TRAVIS_BUILD_DIR
-        - python3 -m pytest --cov
+        - python3 -m pytest
+        #- python3 -m pytest --cov
 
       after_success:
         # Upload coverage report
-        - codecov
-        - coverage report -m
+        #- codecov
+        #- coverage report -m
         # Publish docs.
         - if [ "$TRAVIS_BRANCH" = "documentation" ]; then
            doctr deploy . --built-docs docs/build/html --deploy-branch-name gh-pages --branch-whitelist documentation;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language:
   - python
 
 python:
-  - 3.6
+  - 3.7
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language:
   - python
 
 python:
-  - 3.7
+  - 3.6
 
 stages:
   - test

--- a/include/rogue/protocols/epicsV3/Master.h
+++ b/include/rogue/protocols/epicsV3/Master.h
@@ -8,12 +8,12 @@
  * Description:
  * Rogue stream master interface for EPICs variables
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -42,12 +42,12 @@ namespace rogue {
 
                //! Class creation
                Master ( std::string epicsName, uint32_t max, std::string type );
-               
+
                ~Master ();
 
-               void valueGet();
+               bool valueGet();
 
-               void valueSet();
+               bool valueSet();
          };
 
          // Convienence

--- a/include/rogue/protocols/epicsV3/Slave.h
+++ b/include/rogue/protocols/epicsV3/Slave.h
@@ -8,12 +8,12 @@
  * Description:
  * Stream slave to epics variables
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -43,14 +43,14 @@ namespace rogue {
 
                //! Class creation
                Slave ( std::string epicsName, uint32_t max, std::string type );
-               
+
                ~Slave ();
 
                // Lock held when called
-               void valueGet();
+               bool valueGet();
 
                // Lock held when called
-               void valueSet();
+               bool valueSet();
 
                //! Accept a frame from master
                void acceptFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -8,12 +8,12 @@
  * Description:
  * Class to store an EPICs PV attributes along with its current value
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -84,9 +84,9 @@ namespace rogue {
 
                std::string epicsName();
 
-               virtual void valueSet();
+               virtual bool valueSet();
 
-               virtual void valueGet();
+               virtual bool valueGet();
 
                void setPv(rogue::protocols::epicsV3::Pv * pv);
 
@@ -139,7 +139,7 @@ namespace rogue {
          typedef std::shared_ptr<rogue::protocols::epicsV3::Value> ValuePtr;
 
          // Destructor
-         template<typename T> 
+         template<typename T>
          class Destructor : public gddDestructor {
             virtual void run (void * pUntyped) {
                T ps = reinterpret_cast <T>(pUntyped);

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -65,10 +65,10 @@ namespace rogue {
                void updateAlarm(boost::python::object status, boost::python::object severity);
 
                // Lock held when called
-               void valueGet();
+               bool valueGet();
 
                // Lock held when called
-               void valueSet();
+               bool valueSet();
 
          };
 

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -4,8 +4,7 @@ parse
 click
 coverage
 codecov
-pytest>=3.6
-pytest-cov
+pytest
 pyepics
 doctr
 sphinx

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue base module - Command Class
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import rogue.interfaces.memory
@@ -29,7 +29,7 @@ class BaseCommand(pr.BaseVariable):
                  value=0,
                  retValue=None,
                  enum=None,
-                 hidden=False,                 
+                 hidden=False,
                  groups=None,
                  minimum=None,
                  maximum=None,
@@ -47,7 +47,7 @@ class BaseCommand(pr.BaseVariable):
             groups=groups,
             minimum=minimum,
             maximum=maximum)
-        
+
         self._function = function if function is not None else BaseCommand.nothing
         self._thread = None
         self._lock = threading.Lock()
@@ -115,6 +115,7 @@ class BaseCommand(pr.BaseVariable):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
     @pr.expose
     def call(self,arg=None):
@@ -140,7 +141,7 @@ class BaseCommand(pr.BaseVariable):
             raise CommandError(
                 f'Verification failed for {cmd.path}. \n'+
                 f'Set to {arg} but read back {ret}')
-        
+
 
     @staticmethod
     def createToggle(sets):
@@ -195,7 +196,7 @@ class BaseCommand(pr.BaseVariable):
 
     def replaceFunction(self, function):
         self._function = function
-        
+
     def _setDict(self,d,writeEach,modes,incGroups,excGroups):
         pass
 
@@ -264,20 +265,20 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
- 
+
     def get(self, read=True):
         try:
             if read:
                 self._block.startTransaction(rogue.interfaces.memory.Read, check=True)
-                
-            ret = self._block.get(self)
+
+            return self._block.get(self)
 
         except Exception as e:
             pr.logException(self._log,e)
-            return None
+            raise e
 
-        return ret
 
 # Alias
 Command = BaseCommand

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue base module - Node Classes
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import sys
@@ -80,11 +80,11 @@ class NodeError(Exception):
 
 class Node(object):
     """
-    Class which serves as a managed object within the pyrogue package. 
+    Class which serves as a managed object within the pyrogue package.
     Each node has the following public fields:
         name: Global name of object
         description: Description of the object.
-        groups: Group or groups this node belongs to. 
+        groups: Group or groups this node belongs to.
            Examples: 'Hidden', 'NoState', 'NoConfig', 'NoStream', 'NoSql', 'NoServe'
         classtype: text string matching name of node sub-class
         path: Full path to the node (ie. node1.node2.node3)
@@ -136,7 +136,7 @@ class Node(object):
         return self._groups
 
     def inGroup(self, group):
-        """ 
+        """
         Return true if this node is part of the passed group or one of the groups in a list
         """
         if isinstance(group,list):
@@ -187,7 +187,7 @@ class Node(object):
         return self.path
 
     def __getattr__(self, name):
-        """Allow child Nodes with the 'name[key]' naming convention to be accessed as if they belong to a 
+        """Allow child Nodes with the 'name[key]' naming convention to be accessed as if they belong to a
         dictionary of Nodes with that 'name'.
         This override builds an OrderedDict of all child nodes named as 'name[key]' and returns it.
         Raises AttributeError if no such named Nodes are found. """
@@ -248,22 +248,22 @@ class Node(object):
 
         # Fail if added to a non device node (may change in future)
         if not isinstance(self,pr.Device):
-            raise NodeError('Attempting to add node with name %s to non device node %s.' % 
+            raise NodeError('Attempting to add node with name %s to non device node %s.' %
                              (node.name,self.name))
 
         # Fail if root already exists
         if self._root is not None:
-            raise NodeError('Error adding node with name %s to %s. Tree is already started.' % 
+            raise NodeError('Error adding node with name %s to %s. Tree is already started.' %
                              (node.name,self.name))
 
         # Error if added node already has a parent
         if node._parent is not None:
-            raise NodeError('Error adding node with name %s to %s. Node is already attached.' % 
+            raise NodeError('Error adding node with name %s to %s. Node is already attached.' %
                              (node.name,self.name))
 
         # Names of all sub-nodes must be unique
         if node.name in self.__dir__() or node.name in self._anodes:
-            raise NodeError('Error adding node with name %s to %s. Name collision.' % 
+            raise NodeError('Error adding node with name %s to %s. Name collision.' %
                              (node.name,self.name))
 
         # Add some checking for characters which will make lookups problematic
@@ -274,7 +274,7 @@ class Node(object):
         self._addArrayNode(node)
 
         # Add to primary list
-        self._nodes[node.name] = node 
+        self._nodes[node.name] = node
 
     def _addArrayNode(self, node):
 
@@ -306,7 +306,7 @@ class Node(object):
             k = int(keys[i])
 
             # Last key, set node, check for overlaps
-            if i == (len(keys)-1): 
+            if i == (len(keys)-1):
                 if k in sub:
                     raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
 
@@ -320,7 +320,7 @@ class Node(object):
             # check for overlaps
             elif isinstance(sub[k],Node):
                 raise NodeError('Error adding node with name %s to %s. Name collision.' % (node.name,self.name))
-            
+
             sub = sub[k]
 
 
@@ -332,7 +332,7 @@ class Node(object):
         offset = kwargs.pop('offset')
         for i in range(number):
             self.add(nodeClass(name='{:s}[{:d}]'.format(name, i), offset=offset+(i*stride), **kwargs))
-    
+
     @property
     def nodeList(self):
         """
@@ -345,7 +345,7 @@ class Node(object):
         Get a filtered ordered dictionary of nodes.
         pass a class type to receive a certain type of node
         class type may be a string when called over Pyro4
-        exc is a class type to exclude, 
+        exc is a class type to exclude,
         incGroups is an optional group or list of groups that this node must be part of
         excGroups is an optional group or list of groups that this node must not be part of
         """
@@ -460,12 +460,12 @@ class Node(object):
         return self.isinstance(pr.BaseCommand)
 
     def find(self, *, recurse=True, typ=None, **kwargs):
-        """ 
+        """
         Find all child nodes that are a base class of 'typ'
         and whose properties match all of the kwargs.
         For string properties, accepts regexes.
         """
-    
+
         if typ is None:
             typ = pr.Node
 

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue base module - PollQueue Class
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import sys
@@ -54,7 +54,7 @@ class PollQueue(object):
     def _addEntry(self, block, interval):
         with self._condLock:
             timedelta = datetime.timedelta(seconds=interval)
-            # new entries are always polled first immediately 
+            # new entries are always polled first immediately
             # (rounded up to the next second)
             readTime = datetime.datetime.now()
             readTime = readTime.replace(microsecond=0)
@@ -171,8 +171,8 @@ class PollQueue(object):
 
 
     def _expiredEntries(self, time=None):
-        """An iterator of all entries that expire by a given time. 
-        Use datetime.now() if no time provided. Each entry is popped from the queue before being 
+        """An iterator of all entries that expire by a given time.
+        Use datetime.now() if no time provided. Each entry is popped from the queue before being
         yielded by the iterator
         """
         with self._condLock:
@@ -201,7 +201,7 @@ class PollQueue(object):
             self._condLock.notify()
 
     def pause(self, value):
-        if value is True:        
+        if value is True:
             with self._condLock:
                 self._pause = True
         else:
@@ -213,4 +213,4 @@ class PollQueue(object):
     def paused(self):
         with self._condLock:
             return self._pause
-            
+

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -718,7 +718,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
             # Not a zipfile, not a directory and does not end in .yml
             else:
-                self._log.error("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
+                raise Exception("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
         # Read each file
         with self.pollBlock(), self.updateGroup():

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue base module - Root Class
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import sys
@@ -108,9 +108,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Root exit."""
         self.stop()
 
-    def __init__(self, *, 
-                 name=None, 
-                 description='', 
+    def __init__(self, *,
+                 name=None,
+                 description='',
                  expand=True,
                  timeout=1.0,
                  initRead=False,
@@ -166,7 +166,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         # SQL URL
         self._sqlLog = None
 
-        # Init 
+        # Init
         pr.Device.__init__(self, name=name, description=description, expand=expand)
 
         # Variables
@@ -203,7 +203,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name="ReadAll", function=self._read, hidden=True,
                                  description='Read all values from the hardware'))
 
-        self.add(pr.LocalCommand(name='SaveState', value='', 
+        self.add(pr.LocalCommand(name='SaveState', value='',
                                  function=lambda arg: self.saveYaml(name=arg,
                                                                     readFirst=True,
                                                                     modes=['RW','RO','WO'],
@@ -214,7 +214,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  hidden=True,
                                  description='Save state to passed filename in YAML format'))
 
-        self.add(pr.LocalCommand(name='SaveConfig', value='', 
+        self.add(pr.LocalCommand(name='SaveConfig', value='',
                                  function=lambda arg: self.saveYaml(name=arg,
                                                                     readFirst=True,
                                                                     modes=['RW','WO'],
@@ -225,7 +225,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  hidden=True,
                                  description='Save configuration to passed filename in YAML format'))
 
-        self.add(pr.LocalCommand(name='LoadConfig', value='', 
+        self.add(pr.LocalCommand(name='LoadConfig', value='',
                                  function=lambda arg: self.loadYaml(name=arg,
                                                                     writeEach=False,
                                                                     modes=['RW','WO'],
@@ -246,12 +246,12 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.add(pr.LocalCommand(name='ClearLog', function=self._clearLog, hidden=True,
                                  description='Clear the message log contained in the SystemLog variable'))
 
-        self.add(pr.LocalCommand(name='SetYamlConfig', value='', 
+        self.add(pr.LocalCommand(name='SetYamlConfig', value='',
                                  function=lambda arg: self.setYaml(yml=arg,
                                                                    writeEach=False,
                                                                    modes=['RW','WO'],
                                                                    incGroups=None,
-                                                                   excGroups='NoConfig'), 
+                                                                   excGroups='NoConfig'),
                                  hidden=True,
                                  description='Set configuration from passed YAML string'))
 
@@ -259,7 +259,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  function=lambda arg: self.getYaml(readFirst=arg,
                                                                    modes=['RW','WO'],
                                                                    incGroups=None,
-                                                                   excGroups='NoConfig'), 
+                                                                   excGroups='NoConfig'),
                                  hidden=True,
                                  description='Get current configuration as YAML string. Pass read first arg.'))
 
@@ -267,7 +267,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  function=lambda arg: self.getYaml(readFirst=arg,
                                                                    modes=['RW','RO','WO'],
                                                                    incGroups=None,
-                                                                   excGroups='NoState'), 
+                                                                   excGroups='NoState'),
                                  hidden=True,
                                  description='Get current state as YAML string. Pass read first arg.'))
 
@@ -330,7 +330,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                (tmpList[i].address < (tmpList[i-1].address + tmpList[i-1].size)):
 
                 # Allow overlaps between Devices and Blocks if the Device is an ancestor of the Block and the block allows overlap.
-                # Check for instances when device comes before block and when block comes before device 
+                # Check for instances when device comes before block and when block comes before device
                 if (not (isinstance(tmpList[i-1],pr.Device) and isinstance(tmpList[i],pr.BaseBlock) and \
                          (tmpList[i].path.find(tmpList[i-1].path) == 0 and tmpList[i]._overlapEn))) and \
                    (not (isinstance(tmpList[i],pr.Device) and isinstance(tmpList[i-1],pr.BaseBlock) and \
@@ -535,6 +535,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
     @pr.expose
     def saveVariableList(self,fname,polledOnly=False,incGroups=None):
@@ -560,6 +561,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
     def _heartbeat(self):
         if self._running and self._doHeartbeat:
@@ -602,11 +604,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """
         Generate a frame containing all variables values in yaml format.
         A hardware read is not generated before the frame is generated.
-        incGroups is a list of groups that the variable must be a member 
-        of in order to be included in the stream. excGroups is a list of 
-        groups that the variable must not be a member of to include. 
-        excGroups takes precedence over incGroups. If excGroups or 
-        incGroups are None, the default set of stream include and 
+        incGroups is a list of groups that the variable must be a member
+        of in order to be included in the stream. excGroups is a list of
+        groups that the variable must not be a member of to include.
+        excGroups takes precedence over incGroups. If excGroups or
+        incGroups are None, the default set of stream include and
         exclude groups will be used as specified when the Root class was created.
         By default all variables are included, except for members of the NoStream group.
         """
@@ -627,15 +629,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Write all blocks"""
         self._log.info("Start root write")
         with self.pollBlock(), self.updateGroup():
-            try:
-                self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
-                self._log.info("Verify root read")
-                self.verifyBlocks(recurse=True)
-                self._log.info("Check root read")
-                self.checkBlocks(recurse=True)
-            except Exception as e:
-                pr.logException(self._log,e)
-                return False
+            self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
+            self._log.info("Verify root read")
+            self.verifyBlocks(recurse=True)
+            self._log.info("Check root read")
+            self.checkBlocks(recurse=True)
 
         self._log.info("Done root write")
         return True
@@ -644,13 +642,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Read all blocks"""
         self._log.info("Start root read")
         with self.pollBlock(), self.updateGroup():
-            try:
-                self.readBlocks(recurse=True)
-                self._log.info("Check root read")
-                self.checkBlocks(recurse=True)
-            except Exception as e:
-                pr.logException(self._log,e)
-                return False
+            self.readBlocks(recurse=True)
+            self._log.info("Check root read")
+            self.checkBlocks(recurse=True)
 
         self._log.info("Done root read")
         return True
@@ -664,18 +658,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
             if autoCompress:
                 name += '.zip'
-        try:
-            yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
+        yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
-            if name.split('.')[-1] == 'zip':
-                with zipfile.ZipFile(name, 'w', compression=zipfile.ZIP_LZMA) as zf: 
-                    with zf.open(os.path.basename(name[:-4]),'w') as f: f.write(yml.encode('utf-8'))
-            else:
-                with open(name,'w') as f: f.write(yml)
-
-        except Exception as e:
-            pr.logException(self._log,e)
-            return False
+        if name.split('.')[-1] == 'zip':
+            with zipfile.ZipFile(name, 'w', compression=zipfile.ZIP_LZMA) as zf:
+                with zf.open(os.path.basename(name[:-4]),'w') as f: f.write(yml.encode('utf-8'))
+        else:
+            with open(name,'w') as f: f.write(yml)
 
         return True
 
@@ -702,7 +691,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         for rl in rawlst:
 
             # Name ends with .yml or .yaml
-            if rl[-4:] == '.yml' or rl[-5:] == '.yaml': 
+            if rl[-4:] == '.yml' or rl[-5:] == '.yaml':
                 lst.append(rl)
 
             # Entry is a zip file directory
@@ -726,8 +715,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             if zfn.find(sub) == 0:
                                 spt = zfn.split('%s/' % sub.rstrip('/'))[1]
 
-                                # Entry ends in .yml or *.yml and is in current directory 
-                                if not '/' in spt and (spt[-4:] == '.yml' or spt[-5:] == '.yaml'): 
+                                # Entry ends in .yml or *.yml and is in current directory
+                                if not '/' in spt and (spt[-4:] == '.yml' or spt[-5:] == '.yaml'):
                                     lst.append(base + '/' + zfn)
 
             # Entry is a directory
@@ -737,24 +726,19 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 lst.extend(sorted(dlst))
 
             # Not a zipfile, not a directory and does not end in .yml
-            else: 
+            else:
                 self._log.error("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
         # Read each file
-        try:
-            with self.pollBlock(), self.updateGroup():
-                for fn in lst:
-                    d = pr.yamlToData(fName=fn)
-                    self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
+        with self.pollBlock(), self.updateGroup():
+            for fn in lst:
+                d = pr.yamlToData(fName=fn)
+                self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
-                if not writeEach: self._write()
+            if not writeEach: self._write()
 
-            if self.InitAfterConfig.value():
-                self.initialize()
-
-        except Exception as e:
-            pr.logException(self._log,e)
-            return False
+        if self.InitAfterConfig.value():
+            self.initialize()
 
         return True
 
@@ -766,11 +750,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """
 
         if readFirst: self._read()
-        try:
-            return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
-        except Exception as e:
-            pr.logException(self._log,e)
-            return ""
+        return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
 
 
     def setYaml(self,yml,writeEach,modes,incGroups,excGroups):
@@ -778,7 +758,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         Set variable values from a yaml file
         modes is a list of variable modes to act on.
         writeEach is set to true if accessing a single variable at a time.
-        Writes will be performed as each variable is updated. If set to 
+        Writes will be performed as each variable is updated. If set to
         false a bulk write will be performed after all of the variable updates
         are completed. Bulk writes provide better performance when updating a large
         quantity of variables.
@@ -879,7 +859,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                             print("------------------------------------------------")
                         else:
                             pr.logException(self._log,e)
-                        
+
                 self._log.debug(F"Done update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}")
 
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -507,61 +507,52 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @pr.expose
     def saveAddressMap(self,fname):
-        try:
-            with open(fname,'w') as f:
-                f.write("Path\t")
-                f.write("TypeStr\t")
-                f.write("MemBaseId\t")
-                f.write("Full Address\t")
-                f.write("Device Offset\t")
-                f.write("Mode\t")
-                f.write("Bit Offset\t")
-                f.write("Bit Size\t")
-                f.write("Enum\t")
-                f.write("Description\n")
+        with open(fname,'w') as f:
+            f.write("Path\t")
+            f.write("TypeStr\t")
+            f.write("MemBaseId\t")
+            f.write("Full Address\t")
+            f.write("Device Offset\t")
+            f.write("Mode\t")
+            f.write("Bit Offset\t")
+            f.write("Bit Size\t")
+            f.write("Enum\t")
+            f.write("Description\n")
 
-                for v in self.variableList:
-                    if v.isinstance(pr.RemoteVariable):
-                        f.write("{}\t".format(v.path))
-                        f.write("{}\t".format(v.typeStr))
-                        f.write("{}\t".format(v._block.memBaseId))
-                        f.write("{:#x}\t".format(v.address))
-                        f.write("{:#x}\t".format(v.offset))
-                        f.write("{}\t".format(v.mode))
-                        f.write("{}\t".format(v.bitOffset))
-                        f.write("{}\t".format(v.bitSize))
-                        f.write("{}\t".format(v.enum))
-                        f.write("{}\n".format(v.description))
-
-        except Exception as e:
-            pr.logException(self._log,e)
-            raise e
+            for v in self.variableList:
+                if v.isinstance(pr.RemoteVariable):
+                    f.write("{}\t".format(v.path))
+                    f.write("{}\t".format(v.typeStr))
+                    f.write("{}\t".format(v._block.memBaseId))
+                    f.write("{:#x}\t".format(v.address))
+                    f.write("{:#x}\t".format(v.offset))
+                    f.write("{}\t".format(v.mode))
+                    f.write("{}\t".format(v.bitOffset))
+                    f.write("{}\t".format(v.bitSize))
+                    f.write("{}\t".format(v.enum))
+                    f.write("{}\n".format(v.description))
 
     @pr.expose
     def saveVariableList(self,fname,polledOnly=False,incGroups=None):
-        try:
-            with open(fname,'w') as f:
-                f.write("Path\t")
-                f.write("TypeStr\t")
-                f.write("Mode\t")
-                f.write("Enum\t")
-                f.write("PollInterval\t")
-                f.write("Groups\t")
-                f.write("Description\n")
+        with open(fname,'w') as f:
+            f.write("Path\t")
+            f.write("TypeStr\t")
+            f.write("Mode\t")
+            f.write("Enum\t")
+            f.write("PollInterval\t")
+            f.write("Groups\t")
+            f.write("Description\n")
 
-                for v in self.variableList:
-                    if ((not polledOnly) or (v.pollInterval > 0)) and v.filterByGroup(incGroups=incGroups,excGroups=None):
-                        f.write("{}\t".format(v.path))
-                        f.write("{}\t".format(v.typeStr))
-                        f.write("{}\t".format(v.mode))
-                        f.write("{}\t".format(v.enum))
-                        f.write("{}\t".format(v.pollInterval))
-                        f.write("{}\t".format(v.groups))
-                        f.write("{}\n".format(v.description))
+            for v in self.variableList:
+                if ((not polledOnly) or (v.pollInterval > 0)) and v.filterByGroup(incGroups=incGroups,excGroups=None):
+                    f.write("{}\t".format(v.path))
+                    f.write("{}\t".format(v.typeStr))
+                    f.write("{}\t".format(v.mode))
+                    f.write("{}\t".format(v.enum))
+                    f.write("{}\t".format(v.pollInterval))
+                    f.write("{}\t".format(v.groups))
+                    f.write("{}\n".format(v.description))
 
-        except Exception as e:
-            pr.logException(self._log,e)
-            raise e
 
     def _heartbeat(self):
         if self._running and self._doHeartbeat:
@@ -704,7 +695,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                     # Check if passed name is a directory, otherwise generate an error
                     if not any(x.startswith("%s/" % sub.rstrip("/")) for x in myzip.namelist()):
-                        self._log.error("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
+                        raise Exception("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
                     else:
 

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -1,10 +1,10 @@
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
@@ -19,12 +19,12 @@ import time
 parser = argparse.ArgumentParser('Pyrogue Client')
 
 parser.add_argument('--server',
-                    type=str, 
+                    type=str,
                     help="Server address: 'host:port' or list of addresses: 'host1:port1,host2:port2'",
                     default='localhost:9099')
 
 parser.add_argument('--ui',
-                    type=str, 
+                    type=str,
                     help='UI File for gui (cmd=gui)',
                     default=None)
 
@@ -32,9 +32,9 @@ parser.add_argument('--details',
                     help='Show log details with stacktrace (cmd=syslog)',
                     action='store_true')
 
-parser.add_argument('cmd',    
-                    type=str, 
-                    choices=['gui','syslog','monitor','get','value','set','exec'], 
+parser.add_argument('cmd',
+                    type=str,
+                    choices=['gui','syslog','monitor','get','value','set','exec'],
                     help='Client command to issue')
 
 parser.add_argument('path',
@@ -43,7 +43,7 @@ parser.add_argument('path',
                     help='Path to access')
 
 parser.add_argument('value',
-                    type=str, 
+                    type=str,
                     nargs='?',
                     help='Value to set')
 
@@ -55,7 +55,7 @@ try:
     host = args.server.split(',')[0].split(':')[0]
     port = int(args.server.split(',')[0].split(':')[1])
 except:
-    print("Failed to extract server host & port")
+    raise Exception("Failed to extract server host & port")
 
 print("Connecting to {}".format(args.server))
 

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -4,12 +4,12 @@
 # Description:
 # Module for functions and classes related to command display in the rogue GUI
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 try:
@@ -130,13 +130,13 @@ class CommandLink(QObject):
         else:
             value=None
 
-        if self._command.arg:
-            try:
+        try:
+            if self._command.arg:
                 self._command(self._command.parseDisp(value))
-            except Exception:
-                pass
-        else:
-            self._command()
+            else:
+                self._command()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Wheel:

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -4,12 +4,12 @@
 # Description:
 # Module for functions and classes related to variable display in the rogue GUI
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 try:
@@ -148,7 +148,7 @@ class DataLink(QObject):
     @pyqtSlot()
     def browse(self):
         dlg = QFileDialog()
-        sug = datetime.datetime.now().strftime("data_%Y%m%d_%H%M%S.dat") 
+        sug = datetime.datetime.now().strftime("data_%Y%m%d_%H%M%S.dat")
 
         dataFile = dlg.getSaveFileName(options=QFileDialog.DontConfirmOverwrite, directory=sug, caption='Select data file', filter='Data Files(*.dat);;All Files(*.*)')
 
@@ -157,11 +157,16 @@ class DataLink(QObject):
             dataFile = dataFile[0]
 
         if dataFile != '':
-            self.writer.DataFile.setDisp(dataFile)
-    
+            try:
+                self.writer.DataFile.setDisp(dataFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
+
     def genName(self):
-        self.writer.AutoName()
-        pass
+        try:
+            self.writer.AutoName()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def varListener(self,path,value):
         if self.block: return
@@ -202,16 +207,26 @@ class DataLink(QObject):
         self.dataFile.setPalette(p)
 
         self.block = True
-        self.writer.DataFile.setDisp(self.dataFile.text())
+        try:
+            self.writer.DataFile.setDisp(self.dataFile.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self.block = False
 
     @pyqtSlot()
     def open(self):
-        self.writer.Open()
+        try:
+            self.writer.Open()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def close(self):
-        self.writer.Close()
+        try:
+            self.writer.Close()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def bufferSizeEdited(self):
@@ -226,7 +241,10 @@ class DataLink(QObject):
         self.bufferSize.setPalette(p)
 
         self.block = True
-        self.writer.BufferSize.setDisp(self.bufferSize.text())
+        try:
+            self.writer.BufferSize.setDisp(self.bufferSize.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
     @pyqtSlot()
@@ -242,7 +260,10 @@ class DataLink(QObject):
         self.maxSize.setPalette(p)
 
         self.block = True
-        self.writer.MaxFileSize.setDisp(self.maxSize.text())
+        try:
+            self.writer.MaxFileSize.setDisp(self.maxSize.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
 
@@ -329,13 +350,19 @@ class ControlLink(QObject):
     @pyqtSlot(int)
     def runStateChanged(self,value):
         self.block = True
-        self.control.runState.setDisp(self.runState.itemText(value))
+        try:
+            self.control.runState.setDisp(self.runState.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
     @pyqtSlot(int)
     def runRateChanged(self,value):
         self.block = True
-        self.control.runRate.setDisp(self.runRate.itemText(value))
+        try:
+            self.control.runRate.setDisp(self.runRate.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
 
@@ -474,7 +501,10 @@ class SystemWidget(QWidget):
 
     @pyqtSlot()
     def resetLog(self):
-        self.root.ClearLog()
+        try:
+            self.root.ClearLog()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def varListener(self,path,value):
         name = path.split('.')[-1]
@@ -484,15 +514,24 @@ class SystemWidget(QWidget):
 
     @pyqtSlot()
     def hardReset(self):
-        self.root.HardReset()
+        try:
+            self.root.HardReset()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def initialize(self):
-        self.root.Initialize()
+        try:
+            self.root.Initialize()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def countReset(self):
-        self.root.CountReset()
+        try:
+            self.root.CountReset()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def loadSettings(self):
@@ -505,12 +544,15 @@ class SystemWidget(QWidget):
             loadFile = loadFile[0]
 
         if loadFile != '':
-            self.root.LoadConfig(loadFile)
+            try:
+                self.root.LoadConfig(loadFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def saveSettings(self):
         dlg = QFileDialog()
-        sug = datetime.datetime.now().strftime("config_%Y%m%d_%H%M%S.yml") 
+        sug = datetime.datetime.now().strftime("config_%Y%m%d_%H%M%S.yml")
 
         saveFile = dlg.getSaveFileName(caption='Save config file', directory=sug, filter='Config Files(*.yml);;All Files(*.*)')
 
@@ -519,7 +561,10 @@ class SystemWidget(QWidget):
             saveFile = saveFile[0]
 
         if saveFile != '':
-            self.root.SaveConfig(saveFile)
+            try:
+                self.root.SaveConfig(saveFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def saveState(self):
@@ -533,5 +578,8 @@ class SystemWidget(QWidget):
             stateFile = stateFile[0]
 
         if stateFile != '':
-            self.root.SaveState(stateFile)
+            try:
+                self.root.SaveState(stateFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -4,12 +4,12 @@
 # Description:
 # Module for functions and classes related to variable display in the rogue GUI
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 try:
@@ -103,7 +103,7 @@ class VariableLink(QObject):
         self._item.setText(1,variable.mode)
         self._item.setText(2,variable.typeStr)
 
-        
+
         self._alarm = QLineEdit()
         self._alarm.setReadOnly(True)
         #self._alarm.setText('None')
@@ -172,31 +172,35 @@ class VariableLink(QObject):
 
         action = menu.exec_(self._widget.mapToGlobal(event))
 
-        if action == var_info:
-            self.infoDialog()
-        elif action == read_recurse:
-            self._variable.parent.ReadDevice(True)
-        elif action == write_recurse:
-            self._variable.parent.WriteDevice(True)
-        elif action == read_device:
-            self._variable.parent.ReadDevice(False)
-        elif action == write_device:
-            self._variable.parent.WriteDevice(False)
-        elif action == read_variable:
-            self._variable.get()
-        elif action == write_variable:
-            if isinstance(self._widget, QComboBox):
-                self._variable.setDisp(self._widget.currentText())
-            elif isinstance(self._widget, QSpinBox):
-                self._variable.set(self._widget.value())
-            else:
-                self._variable.setDisp(self._widget.text())
+        try:
+            if action == var_info:
+                self.infoDialog()
+            elif action == read_recurse:
+                self._variable.parent.ReadDevice(True)
+            elif action == write_recurse:
+                self._variable.parent.WriteDevice(True)
+            elif action == read_device:
+                self._variable.parent.ReadDevice(False)
+            elif action == write_device:
+                self._variable.parent.WriteDevice(False)
+            elif action == read_variable:
+                self._variable.get()
+            elif action == write_variable:
+                if isinstance(self._widget, QComboBox):
+                    self._variable.setDisp(self._widget.currentText())
+                elif isinstance(self._widget, QSpinBox):
+                    self._variable.set(self._widget.value())
+                else:
+                    self._variable.setDisp(self._widget.text())
+
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def infoDialog(self):
 
-        attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum', 
-                 'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum', 
-                 'maximum', 'lowWarning', 'lowAlarm', 'highWarning', 
+        attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum',
+                 'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum',
+                 'maximum', 'lowWarning', 'lowAlarm', 'highWarning',
                  'highAlarm', 'alarmStatus', 'alarmSeverity', 'pollInterval']
 
         if self._variable.isinstance(pyrogue.RemoteVariable):
@@ -288,7 +292,11 @@ class VariableLink(QObject):
         p = QPalette()
         self._widget.setPalette(p)
 
-        self._variable.setDisp(self._widget.text())
+        try:
+            self._variable.setDisp(self._widget.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
         self.updateGui.emit(self._variable.valueDisp())
 
@@ -296,9 +304,14 @@ class VariableLink(QObject):
     def sbChanged(self, value):
         if self._swSet:
             return
-        
+
         self._inEdit = True
-        self._variable.setDisp(value)
+
+        try:
+            self._variable.setDisp(value)
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
 
     @pyqtSlot(int)
@@ -307,7 +320,12 @@ class VariableLink(QObject):
             return
 
         self._inEdit = True
-        self._variable.setDisp(self._widget.itemText(value))
+
+        try:
+            self._variable.setDisp(self._widget.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
 
     def eventFilter(self, obj, event):
@@ -355,6 +373,9 @@ class VariableWidget(QWidget):
 
     @pyqtSlot()
     def readPressed(self):
-        for root in self.roots:
-            root.ReadAll()
+        try:
+            for root in self.roots:
+                root.ReadAll()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -15,12 +15,12 @@
 # c.get("dummyTree.Time")
 #
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import zmq
@@ -61,16 +61,19 @@ class SimpleClient(object):
 
 
     def _remoteAttr(self,path,attr,*args,**kwargs):
-        msg = {'path':path, 
+        msg = {'path':path,
                'attr':attr,
                'args':args,
                'kwargs':kwargs}
+
         try:
             self._req.send_string(jsonpickle.encode(msg))
             resp = jsonpickle.decode(self._req.recv_string())
-        except Exception as msg:
-            print("got remote exception: {}".format(msg))
-            resp = None
+        except Exception as e:
+            raise Exception(f"ZMQ Interface Exception: {e}")
+
+        if isinstance(resp,Exception):
+            raise resp
 
         return resp
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -283,7 +283,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             raise Exception(f"ZMQ Interface Exception: {e}")
 
         if isinstance(ret,Exception):
-            raise ret
+            raise(ret)
 
         return ret
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -279,9 +279,11 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         try:
             resp = self._send(y)
             ret = jsonpickle.decode(resp)
-        except Exception as msg:
-            print("got remote exception: {}".format(msg))
-            ret = None
+        except Exception as e:
+            raise Exception(f"ZMQ Interface Exception: {e}")
+
+        if isinstance(ret,Exception):
+            raise ret
 
         return ret
 

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -55,5 +55,5 @@ class ZmqServer(rogue.interfaces.ZmqServer):
                 return self.encode(nAttr,rawStr=rawStr)
 
         except Exception as msg:
-            return self.encode(msg)
+            return self.encode(msg,rawStr=False)
 

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue ZMQ Server
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import rogue.interfaces
@@ -55,6 +55,5 @@ class ZmqServer(rogue.interfaces.ZmqServer):
                 return self.encode(nAttr,rawStr=rawStr)
 
         except Exception as msg:
-            print("ZMQ Got Exception: {}".format(msg))
-            return 'null\n'
+            return self.encode(msg)
 

--- a/python/pyrogue/interfaces/__init__.py
+++ b/python/pyrogue/interfaces/__init__.py
@@ -1,10 +1,10 @@
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -45,15 +45,19 @@ class EpicsPvHandler(p4p.server.thread.Handler):
 
     def put(self, pv, op):
         if self._var.isVariable and (self._var.mode == 'RW' or self._var.mode == 'WO'):
-            if self._valType == 'enum':
-                self._var.setDisp(str(op.value()))
-            elif self._valType == 's':
-                self._var.setDisp(op.value().raw.value)
-            else:
-                self._var.set(op.value().raw.value)
+            try:
+                if self._valType == 'enum':
+                    self._var.setDisp(str(op.value()))
+                elif self._valType == 's':
+                    self._var.setDisp(op.value().raw.value)
+                else:
+                    self._var.set(op.value().raw.value)
 
-            # Need enum processing
-            op.done()
+                # Need enum processing
+                op.done()
+
+            except Exception as msg:
+                op.done(error=msg)
 
         else: op.done(error='Put Not Supported On This Variable')
 
@@ -61,15 +65,18 @@ class EpicsPvHandler(p4p.server.thread.Handler):
         if self._var.isCommand:
             val = op.value().query
 
-            if 'arg' in val:
-                ret = self._var(val.arg)
-            else:
-                ret = self._var()
+            try:
+                if 'arg' in val:
+                    ret = self._var(val.arg)
+                else:
+                    ret = self._var()
 
-            if ret is None: ret = 'None'
+                if ret is None: ret = 'None'
 
-            v = p4p.Value(p4p.Type([('value',self._valType)]), {'value':ret})
-            op.done(value=(v))
+                v = p4p.Value(p4p.Type([('value',self._valType)]), {'value':ret})
+                op.done(value=(v))
+            except Exception as msg:
+                op.done(error=msg)
 
         else: op.done(error='Rpc Not Supported On Variables')
 

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -128,26 +128,25 @@ class RogueConnection(PyDMConnection):
     def put_value(self, new_value):
         if self._node is None or not self._notDev:
             return
-        #try:
+        try:
 
-        if new_value is None:
-            val = None
-        elif self._enum is not None and not isinstance(new_value,str):
-            val = self._enum[new_value]
-        elif self._int:
-            val = int(new_value)
-        else:
-            val = new_value
+            if new_value is None:
+                val = None
+            elif self._enum is not None and not isinstance(new_value,str):
+                val = self._enum[new_value]
+            elif self._int:
+                val = int(new_value)
+            else:
+                val = new_value
 
-        st = time.time()
-        if self._cmd:
-            self._node.__call__(val)
-        else:
-            self._node.setDisp(val)
-        #except Exception as e:
-        #    logger.error("Remote Exception: %s", str(e))
-            # Waiting for information from Hugo on the standard way
-            # of creating error dialogs in pydm
+            st = time.time()
+            if self._cmd:
+                self._node.__call__(val)
+            else:
+                self._node.setDisp(val)
+        except Exception as e:
+            logger.error("Remote Exception: %s", str(e))
+            raise(e)
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -145,7 +145,7 @@ class RogueConnection(PyDMConnection):
             else:
                 self._node.setDisp(val)
         except Exception as e:
-            logger.error("Unable to put %s to %s.  Exception: %s", new_value, self.address, str(e))
+            logger.error("Remote Exception: %s", str(e))
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -146,6 +146,8 @@ class RogueConnection(PyDMConnection):
                 self._node.setDisp(val)
         except Exception as e:
             logger.error("Remote Exception: %s", str(e))
+            # Waiting for information from Hugo on the standard way
+            # of creating error dialogs in pydm
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -128,25 +128,21 @@ class RogueConnection(PyDMConnection):
     def put_value(self, new_value):
         if self._node is None or not self._notDev:
             return
-        try:
 
-            if new_value is None:
-                val = None
-            elif self._enum is not None and not isinstance(new_value,str):
-                val = self._enum[new_value]
-            elif self._int:
-                val = int(new_value)
-            else:
-                val = new_value
+        if new_value is None:
+            val = None
+        elif self._enum is not None and not isinstance(new_value,str):
+            val = self._enum[new_value]
+        elif self._int:
+            val = int(new_value)
+        else:
+            val = new_value
 
-            st = time.time()
-            if self._cmd:
-                self._node.__call__(val)
-            else:
-                self._node.setDisp(val)
-        except Exception as e:
-            logger.error("Remote Exception: %s", str(e))
-            raise(e)
+        st = time.time()
+        if self._cmd:
+            self._node.__call__(val)
+        else:
+            self._node.setDisp(val)
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -128,24 +128,24 @@ class RogueConnection(PyDMConnection):
     def put_value(self, new_value):
         if self._node is None or not self._notDev:
             return
-        try:
+        #try:
 
-            if new_value is None:
-                val = None
-            elif self._enum is not None and not isinstance(new_value,str):
-                val = self._enum[new_value]
-            elif self._int:
-                val = int(new_value)
-            else:
-                val = new_value
+        if new_value is None:
+            val = None
+        elif self._enum is not None and not isinstance(new_value,str):
+            val = self._enum[new_value]
+        elif self._int:
+            val = int(new_value)
+        else:
+            val = new_value
 
-            st = time.time()
-            if self._cmd:
-                self._node.__call__(val)
-            else:
-                self._node.setDisp(val)
-        except Exception as e:
-            logger.error("Remote Exception: %s", str(e))
+        st = time.time()
+        if self._cmd:
+            self._node.__call__(val)
+        else:
+            self._node.setDisp(val)
+        #except Exception as e:
+        #    logger.error("Remote Exception: %s", str(e))
             # Waiting for information from Hugo on the standard way
             # of creating error dialogs in pydm
 

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue PyDM Top Level GUI
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 

--- a/python/pyrogue/utilities/fileio/_FileReader.py
+++ b/python/pyrogue/utilities/fileio/_FileReader.py
@@ -4,12 +4,12 @@
 # Description:
 # Module for reading file data.
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import pyrogue
@@ -82,13 +82,10 @@ class FileReader(object):
 
             # Process meta data
             if self._configChan is not None and self._header.channel == self._configChan:
-                try:
-                    pyrogue.yamlUpdate(self._config, self._currFile.read(payload).decode('utf-8'))
-                except:
-                    self._log.warning(f"Error processing meta data in {self._currFName}")
+                pyrogue.yamlUpdate(self._config, self._currFile.read(payload).decode('utf-8'))
 
             # This is a data channel
-            else: 
+            else:
                 try:
                     self._data = numpy.fromfile(self._currFile, dtype=numpy.int8, count=payload)
                 except:

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -26,11 +26,7 @@ class StreamWriter(pyrogue.DataWriter):
         self._configEn = configEn
 
     def _open(self):
-        try:
-            self._writer.open(self.DataFile.value())
-        except Exception as e:
-            pyrogue.logException(self._log,e)
-            raise e
+        self._writer.open(self.DataFile.value())
 
         # Dump config/status to file
         if self._configEn: self.root.streamYaml()

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -4,12 +4,12 @@
 # Description:
 # Module for writing stream data.
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import rogue.utilities
@@ -30,6 +30,7 @@ class StreamWriter(pyrogue.DataWriter):
             self._writer.open(self.DataFile.value())
         except Exception as e:
             pyrogue.logException(self._log,e)
+            raise e
 
         # Dump config/status to file
         if self._configEn: self.root.streamYaml()

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -8,12 +8,12 @@
  * Description:
  * Rogue stream master interface for EPICs variables
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -100,9 +100,9 @@ rpe::Master::Master (std::string epicsName, uint32_t max, std::string type) : Va
 
 rpe::Master::~Master() { }
 
-void rpe::Master::valueGet() { }
+bool rpe::Master::valueGet() { return true;}
 
-void rpe::Master::valueSet() {
+bool rpe::Master::valueSet() {
    ris::FramePtr frame;
    ris::FrameIterator iter;
    uint32_t txSize;
@@ -165,5 +165,6 @@ void rpe::Master::valueSet() {
 
    // Should this be pushed to a queue for a worker thread to call slaves?
    sendFrame(frame);
+   return true;
 }
 

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -8,12 +8,12 @@
  * Description:
  * Stream slave to epics variables
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -107,9 +107,9 @@ rpe::Slave::Slave (std::string epicsName, uint32_t max, std::string type) : Valu
 
 rpe::Slave::~Slave() { }
 
-void rpe::Slave::valueGet() { }
+bool rpe::Slave::valueGet() { return true; }
 
-void rpe::Slave::valueSet() { }
+bool rpe::Slave::valueSet() { return true; }
 
 void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    ris::FrameIterator iter;
@@ -157,7 +157,7 @@ void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
       mach_port_deallocate(mach_task_self(), cclock);
       t.tv_sec = mts.tv_sec;
       t.tv_nsec = mts.tv_nsec;
-#else      
+#else
       clock_gettime(CLOCK_REALTIME,&t);
 #endif
       pValue_->setTimeStamp(&t);

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -233,6 +233,9 @@ caStatus rpe::Value::readValue(gdd &value) {
       ret = valueGet();
       gdds = gddApplicationTypeTable::app_table.smartCopy(&value, pValue_);
 
+
+      if (!ret ) pValue_->setStatSevr(epicsAlarmRead,epicsSevMajor);
+
       if (gdds || !ret) return S_cas_noConvert;
       else return S_casApp_success;
    }
@@ -296,7 +299,10 @@ caStatus rpe::Value::write(const gdd &value) {
 
    // Cal value set and update within lock
    if ( this->valueSet() ) return S_casApp_success;
-   else return S_cas_noConvert;
+   else {
+       pValue_->setStatSevr(epicsAlarmWrite,epicsSevMajor);
+       return S_cas_noConvert;
+   }
 }
 
 aitEnum rpe::Value::bestExternalType() {

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -8,12 +8,12 @@
  * Description:
  * Class to store an EPICs PV attributes along with its current value
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -103,10 +103,10 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
 
    // Unsigned Int types, > 32-bits treated as string
    else if ( sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1 ) {
-      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8; } 
-      else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; } 
-      else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; } 
-      else { epicsType_ = aitEnumString; } 
+      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8; }
+      else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
+      else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
+      else { epicsType_ = aitEnumString; }
 
       log_->info("Detected Rogue Uint with size %i for %s typeStr=%s",
             bitSize, epicsName_.c_str(),typeStr.c_str());
@@ -114,9 +114,9 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
 
    // Signed Int types, > 32-bits treated as string
    else if ( sscanf(typeStr.c_str(),"Int%i",&bitSize) == 1 ) {
-      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; } 
-      else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; } 
-      else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; } 
+      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; }
+      else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; }
+      else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
       else { epicsType_ = aitEnumString; }
 
       log_->info("Detected Rogue Int with size %i for %s typeStr=%s",
@@ -125,12 +125,12 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
 
    // Python int
    else if ( typeStr == "int" ) {
-      fSize_ = 4; 
+      fSize_ = 4;
       epicsType_ = aitEnumInt32;
       log_->info("Detected python int with size %i for %s typeStr=%s",
             bitSize, epicsName_.c_str(),typeStr.c_str());
    }
- 
+
    // 32-bit Float
    else if ( typeStr == "float" or typeStr == "Float32" ) {
       log_->info("Detected 32-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
@@ -198,10 +198,10 @@ std::string rpe::Value::epicsName() {
 }
 
 // Value lock held when this is called
-void rpe::Value::valueSet() { }
+bool rpe::Value::valueSet() { return true; }
 
 // Value lock held when this is called
-void rpe::Value::valueGet() { }
+bool rpe::Value::valueGet() { return true; }
 
 void rpe::Value::setPv(rpe::Pv * pv) {
    pv_ = pv;
@@ -222,6 +222,7 @@ caStatus rpe::Value::read(gdd &prototype) {
 
 caStatus rpe::Value::readValue(gdd &value) {
    gddStatus gdds;
+   bool ret;
 
    std::lock_guard<std::mutex> lock(mtx_);
 
@@ -229,13 +230,13 @@ caStatus rpe::Value::readValue(gdd &value) {
    if ( (array_ && value.isAtomic()) || ((!array_) && value.isScalar()) ) {
 
       // Call value get within lock
-      valueGet();
+      ret = valueGet();
       gdds = gddApplicationTypeTable::app_table.smartCopy(&value, pValue_);
 
-      if (gdds) return S_cas_noConvert;   
+      if (gdds || !ret) return S_cas_noConvert;
       else return S_casApp_success;
    }
-   else return S_cas_noConvert;   
+   else return S_cas_noConvert;
 }
 
 caStatus rpe::Value::write(const gdd &value) {
@@ -251,8 +252,8 @@ caStatus rpe::Value::write(const gdd &value) {
       if ( value.dimension() != 1 ) return S_casApp_badDimension;
       const gddBounds* pb = value.getBounds ();
       if ( pb[0].first() != 0 ) return S_casApp_outOfBounds;
-                      
-      // Get size      
+
+      // Get size
       newSize = pb[0].size();
       if ( newSize > max_ ) return S_casApp_outOfBounds;
 
@@ -277,7 +278,7 @@ caStatus rpe::Value::write(const gdd &value) {
    }
 
    // Unsupported type
-   else return S_cas_noConvert;   
+   else return S_cas_noConvert;
 
    // Set the timespec structure to the current time stamp the gdd.
 #ifdef __MACH__ // OSX does not have clock_gettime
@@ -288,14 +289,14 @@ caStatus rpe::Value::write(const gdd &value) {
    mach_port_deallocate(mach_task_self(), cclock);
    t.tv_sec = mts.tv_sec;
    t.tv_nsec = mts.tv_nsec;
-#else      
+#else
    clock_gettime(CLOCK_REALTIME,&t);
 #endif
    pValue_->setTimeStamp(&t);
 
-   // Cal value set and update within lock 
-   this->valueSet();
-   return S_casApp_success;
+   // Cal value set and update within lock
+   if ( this->valueSet() ) return S_casApp_success;
+   else return S_cas_noConvert;
 }
 
 aitEnum rpe::Value::bestExternalType() {
@@ -384,13 +385,13 @@ gddAppFuncTableStatus rpe::Value::readEnums(gdd &value) {
 
       str = new aitFixedString[nstr];
 
-      for (i=0; i < nstr; i++) 
+      for (i=0; i < nstr; i++)
          strncpy(str[i].fixed_string, enums_[i].c_str(), sizeof(str[i].fixed_string));
 
       value.setDimension(1);
       value.setBound (0,0,nstr);
       value.putRef (str, new rpe::Destructor<aitFixedString *>);
- 
+
       return S_cas_success;
    }
 

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -271,12 +271,12 @@ void rpe::Variable::updateAlarm(bp::object status, bp::object severity) {
       else if ( sevrStr == "AlarmMajor" ) sevrVal = epicsSevMajor;
       else sevrVal = 0;
    }
-   
+
    pValue_->setStatSevr(statVal,sevrVal);
 }
 
 // Lock held when called
-void rpe::Variable::valueGet() {
+bool rpe::Variable::valueGet() {
 
    if ( syncRead_ ) {
       { // GIL Scope
@@ -292,9 +292,11 @@ void rpe::Variable::valueGet() {
             }
          } catch (...) {
             log_->error("Error getting values from epics: %s\n",epicsName_.c_str());
+            return false;
          }
       }
    }
+   return true;
 }
 
 // Lock held when called
@@ -438,7 +440,7 @@ void rpe::Variable::fromPython(bp::object value) {
 }
 
 // Lock already held
-void rpe::Variable::valueSet() {
+bool rpe::Variable::valueSet() {
    rogue::ScopedGil gil;
    bp::list pl;
    uint32_t i;
@@ -536,7 +538,9 @@ void rpe::Variable::valueSet() {
       }
    } catch (...) {
       log_->error("Error setting value from epics: %s\n",epicsName_.c_str());
+      return false;
    }
+   return true;
 }
 
 template<typename T>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,12 +2,12 @@
 #-----------------------------------------------------------------------------
 # Title      : Server only test script
 #-----------------------------------------------------------------------------
-# This file is part of the rogue_example software. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue_example software, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue_example software. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue_example software, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import pyrogue
@@ -30,6 +30,8 @@ import numpy as np
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
 
+import pyrogue.protocols.epics
+
 
 class DummyTree(pyrogue.Root):
 
@@ -48,7 +50,7 @@ class DummyTree(pyrogue.Root):
 
         # Use a memory space emulator
         sim = pyrogue.interfaces.simulation.MemEmulate()
-        
+
         # Add Device
         self.add(test_device.AxiVersion(memBase=sim,offset=0x0))
 
@@ -140,16 +142,16 @@ class DummyTree(pyrogue.Root):
 
         #pyrogue.streamConnect(self.prbsTx,self.rudpClient.application(0))
 
-        #self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
+        self.epics=pyrogue.protocols.epics.EpicsCaServer(base="test", root=self)
         #self.epics4=pyrogue.protocols.epicsV4.EpicsPvServer(base="test", root=self)
 
     def start(self):
         pyrogue.Root.start(self)
-        #self.epics.start()
+        self.epics.start()
         #self.epics4.start()
 
     def stop(self):
-        #self.epics.stop()
+        self.epics.stop()
         #self.epics4.stop()
         pyrogue.Root.stop(self)
 
@@ -170,10 +172,10 @@ if __name__ == "__main__":
     with DummyTree() as dummyTree:
         dummyTree.saveAddressMap('test.csv')
 
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
 
-        #import pyrogue.pydm
-        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -172,10 +172,10 @@ if __name__ == "__main__":
     with DummyTree() as dummyTree:
         dummyTree.saveAddressMap('test.csv')
 
-        #pyrogue.waitCntrlC()
+        pyrogue.waitCntrlC()
 
-        import pyrogue.pydm
-        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
+        #import pyrogue.pydm
+        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)


### PR DESCRIPTION
This PR changes the Rogue approach to handling errors. Previously the errors were caught and logged. In this new model the exceptions are passed on to the caller. This allows the caller to become aware of the errors and avoids some errors being masked, sometimes resulting a sequence of commands continuing event after a fatal error occurs.

With this change, exceptions are now passed across the ZMQ client/server link.

The legacy pyqt GUI will simply log an error. The PYDM interface will open an error dialog box. 

I am still looking at the proper way to deal with exceptions called from the epics3 and epics4 interfaces.