### PR TITLE
Pass exceptions on to callers - Pre-release Version 

### DIFF
--- a/include/rogue/protocols/epicsV3/Master.h
+++ b/include/rogue/protocols/epicsV3/Master.h
@@ -46,9 +46,9 @@ namespace rogue {
 
                ~Master ();
 
-               void valueGet();
+               bool valueGet();
 
-               void valueSet();
+               bool valueSet();
          };
 
          // Convienence

--- a/include/rogue/protocols/epicsV3/Slave.h
+++ b/include/rogue/protocols/epicsV3/Slave.h
@@ -48,10 +48,10 @@ namespace rogue {
                ~Slave ();
 
                // Lock held when called
-               void valueGet();
+               bool valueGet();
 
                // Lock held when called
-               void valueSet();
+               bool valueSet();
 
                //! Accept a frame from master
                void acceptFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -85,9 +85,9 @@ namespace rogue {
 
                std::string epicsName();
 
-               virtual void valueSet();
+               virtual bool valueSet();
 
-               virtual void valueGet();
+               virtual bool valueGet();
 
                void setPv(rogue::protocols::epicsV3::Pv * pv);
 

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -66,10 +66,10 @@ namespace rogue {
                void updateAlarm(boost::python::object status, boost::python::object severity);
 
                // Lock held when called
-               void valueGet();
+               bool valueGet();
 
                // Lock held when called
-               void valueSet();
+               bool valueSet();
 
          };
 

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -4,7 +4,8 @@ parse
 click
 coverage
 codecov
-pytest
+pytest>=3.6
+pytest-cov
 pyepics
 doctr
 sphinx

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -4,8 +4,7 @@ parse
 click
 coverage
 codecov
-pytest>=3.6
-pytest-cov
+pytest
 pyepics
 doctr
 sphinx

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -115,6 +115,7 @@ class BaseCommand(pr.BaseVariable):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
     @pr.expose
     def call(self,arg=None):
@@ -138,8 +139,6 @@ class BaseCommand(pr.BaseVariable):
         ret = cmd.get()
         if ret != arg:
             raise CommandError(
-                f'Verification failed for {cmd.path}. \nSet to {arg} but read back {ret}')
-
 
     @staticmethod
     def createToggle(sets):
@@ -263,6 +262,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
 
         except Exception as e:
             pr.logException(self._log,e)
+            raise e
 
 
     def get(self, read=True):
@@ -274,7 +274,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
 
         except Exception as e:
             pr.logException(self._log,e)
-            return None
+            raise e
 
 # Alias
 Command = BaseCommand

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -138,7 +138,7 @@ class BaseCommand(pr.BaseVariable):
         cmd.set(arg)
         ret = cmd.get()
         if ret != arg:
-            raise CommandError(
+            raise CommandError(f'Verification failed for {cmd.path}. \nSet to {arg} but read back {ret}')
 
     @staticmethod
     def createToggle(sets):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -591,53 +591,46 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 data += "{}".format(description)
                 lines.append(data)
 
-        try:
-            with open(fname,'w') as f:
+        with open(fname,'w') as f:
 
-                if headerEn:
-                    f.write('// #############################################\n')
-                    f.write('// Auto Generated Header File From Rogue\n')
-                    f.write('// #############################################\n')
-                    f.write('#ifndef __ROGUE_ADDR_MAP_H__\n')
-                    f.write('#define __ROGUE_ADDR_MAP_H__\n\n')
-                    f.write(f'#define ROGUE_ADDR_MAP "{header}|"\\\n')
+            if headerEn:
+                f.write('// #############################################\n')
+                f.write('// Auto Generated Header File From Rogue\n')
+                f.write('// #############################################\n')
+                f.write('#ifndef __ROGUE_ADDR_MAP_H__\n')
+                f.write('#define __ROGUE_ADDR_MAP_H__\n\n')
+                f.write(f'#define ROGUE_ADDR_MAP "{header}|"\\\n')
 
-                    for line in lines:
-                        f.write(f'     "{line}|"\\\n')
+                for line in lines:
+                    f.write(f'     "{line}|"\\\n')
 
-                    f.write('\n#endif\n')
-                else:
-                    f.write(header + '\n')
-                    for line in lines:
-                        f.write(line + '\n')
-
-        except Exception as e:
-            pr.logException(self._log,e)
+                f.write('\n#endif\n')
+            else:
+                f.write(header + '\n')
+                for line in lines:
+                    f.write(line + '\n')
 
     @pr.expose
     def saveVariableList(self,fname,polledOnly=False,incGroups=None):
-        try:
-            with open(fname,'w') as f:
-                f.write("Path\t")
-                f.write("TypeStr\t")
-                f.write("Mode\t")
-                f.write("Enum\t")
-                f.write("PollInterval\t")
-                f.write("Groups\t")
-                f.write("Description\n")
+        with open(fname,'w') as f:
+            f.write("Path\t")
+            f.write("TypeStr\t")
+            f.write("Mode\t")
+            f.write("Enum\t")
+            f.write("PollInterval\t")
+            f.write("Groups\t")
+            f.write("Description\n")
 
-                for v in self.variableList:
-                    if ((not polledOnly) or (v.pollInterval > 0)) and v.filterByGroup(incGroups=incGroups,excGroups=None):
-                        f.write("{}\t".format(v.path))
-                        f.write("{}\t".format(v.typeStr))
-                        f.write("{}\t".format(v.mode))
-                        f.write("{}\t".format(v.enum))
-                        f.write("{}\t".format(v.pollInterval))
-                        f.write("{}\t".format(v.groups))
-                        f.write("{}\n".format(v.description))
+            for v in self.variableList:
+                if ((not polledOnly) or (v.pollInterval > 0)) and v.filterByGroup(incGroups=incGroups,excGroups=None):
+                    f.write("{}\t".format(v.path))
+                    f.write("{}\t".format(v.typeStr))
+                    f.write("{}\t".format(v.mode))
+                    f.write("{}\t".format(v.enum))
+                    f.write("{}\t".format(v.pollInterval))
+                    f.write("{}\t".format(v.groups))
+                    f.write("{}\n".format(v.description))
 
-        except Exception as e:
-            pr.logException(self._log,e)
 
     def _heartbeat(self):
         if self._running and self._doHeartbeat:
@@ -709,15 +702,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Write all blocks"""
         self._log.info("Start root write")
         with self.pollBlock(), self.updateGroup():
-            try:
-                self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
-                self._log.info("Verify root read")
-                self.verifyBlocks(recurse=True)
-                self._log.info("Check root read")
-                self.checkBlocks(recurse=True)
-            except Exception as e:
-                pr.logException(self._log,e)
-                return False
+            self.writeBlocks(force=self.ForceWrite.value(), recurse=True)
+            self._log.info("Verify root read")
+            self.verifyBlocks(recurse=True)
+            self._log.info("Check root read")
+            self.checkBlocks(recurse=True)
 
         self._log.info("Done root write")
         return True
@@ -726,13 +715,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         """Read all blocks"""
         self._log.info("Start root read")
         with self.pollBlock(), self.updateGroup():
-            try:
-                self.readBlocks(recurse=True)
-                self._log.info("Check root read")
-                self.checkBlocks(recurse=True)
-            except Exception as e:
-                pr.logException(self._log,e)
-                return False
+            self.readBlocks(recurse=True)
+            self._log.info("Check root read")
+            self.checkBlocks(recurse=True)
 
         self._log.info("Done root read")
         return True
@@ -746,20 +731,15 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
             if autoCompress:
                 name += '.zip'
-        try:
-            yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
+        yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
-            if name.split('.')[-1] == 'zip':
-                with zipfile.ZipFile(name, 'w', compression=zipfile.ZIP_LZMA) as zf:
-                    with zf.open(os.path.basename(name[:-4]),'w') as f:
-                        f.write(yml.encode('utf-8'))
-            else:
-                with open(name,'w') as f:
-                    f.write(yml)
-
-        except Exception as e:
-            pr.logException(self._log,e)
-            return False
+        if name.split('.')[-1] == 'zip':
+            with zipfile.ZipFile(name, 'w', compression=zipfile.ZIP_LZMA) as zf:
+                with zf.open(os.path.basename(name[:-4]),'w') as f:
+                    f.write(yml.encode('utf-8'))
+        else:
+            with open(name,'w') as f:
+                f.write(yml)
 
         return True
 
@@ -799,7 +779,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                     # Check if passed name is a directory, otherwise generate an error
                     if not any(x.startswith("%s/" % sub.rstrip("/")) for x in myzip.namelist()):
-                        self._log.error("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
+                        raise Exception("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
                     else:
 
@@ -822,24 +802,18 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
             # Not a zipfile, not a directory and does not end in .yml
             else:
-                self._log.error("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
+                raise Exception("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
         # Read each file
-        try:
-            with self.pollBlock(), self.updateGroup():
-                for fn in lst:
-                    d = pr.yamlToData(fName=fn)
-                    self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
+        with self.pollBlock(), self.updateGroup():
+            for fn in lst:
+                d = pr.yamlToData(fName=fn)
+                self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
-                if not writeEach:
-                    self._write()
+            if not writeEach: self._write()
 
-            if self.InitAfterConfig.value():
-                self.initialize()
-
-        except Exception as e:
-            pr.logException(self._log,e)
-            return False
+        if self.InitAfterConfig.value():
+            self.initialize()
 
         return True
 
@@ -849,15 +823,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         modes is a list of variable modes to include.
         If readFirst=True a full read from hardware is performed.
         """
-
         if readFirst:
             self._read()
-        try:
-            return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
-        except Exception as e:
-            pr.logException(self._log,e)
-            return ""
-
+        return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
 
     def setYaml(self,yml,writeEach,modes,incGroups,excGroups):
         """

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -731,6 +731,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
             if autoCompress:
                 name += '.zip'
+
         yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
         if name.split('.')[-1] == 'zip':

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -811,7 +811,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 d = pr.yamlToData(fName=fn)
                 self._setDictRoot(d=d,writeEach=writeEach,modes=modes,incGroups=incGroups,excGroups=excGroups)
 
-            if not writeEach: self._write()
+            if not writeEach:
+                self._write()
 
         if self.InitAfterConfig.value():
             self.initialize()

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -370,7 +370,7 @@ class BaseVariable(pr.Node):
                     return self.enum[value]
                 else:
                     self._log.warning("Invalid enum value {} in variable '{}'".format(value,self.path))
-                    ret = 'INVALID: {:#x}'.format(value)
+                    return 'INVALID: {:#x}'.format(value)
             else:
                 if self.typeStr == 'ndarray':
                     return str(value)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -367,24 +367,23 @@ class BaseVariable(pr.Node):
             #print('{}.genDisp(read={}) disp={} value={}'.format(self.path, read, self.disp, value))
             if self.disp == 'enum':
                 if value in self.enum:
-                    ret = self.enum[value]
+                    return self.enum[value]
                 else:
                     self._log.warning("Invalid enum value {} in variable '{}'".format(value,self.path))
                     ret = 'INVALID: {:#x}'.format(value)
             else:
                 if self.typeStr == 'ndarray':
-                    ret = str(value)
+                    return str(value)
                 elif (value == '' or value is None):
-                    ret = value
+                    return value
                 else:
-                    ret = self.disp.format(value)
+                    return self.disp.format(value)
 
         except Exception as e:
             pr.logException(self._log,e)
             self._log.error(f"Error generating disp for value {value} in variable {self.path}")
-            ret = None
+            raise e
 
-        return ret
 
     @pr.expose
     def getDisp(self, read=True):
@@ -416,16 +415,15 @@ class BaseVariable(pr.Node):
                         return eval(sValue)
                     else:
                         return sValue
+
         except Exception:
-            raise VariableError("Invalid value {} for variable {} with type {}".format(sValue,self.name,self.nativeType()))
+            msg = "Invalid value {} for variable {} with type {}".format(sValue,self.name,self.nativeType())
+            self._log.error(msg)
+            raise VariableError(msg)
 
     @pr.expose
     def setDisp(self, sValue, write=True):
-        try:
-            self.set(self.parseDisp(sValue), write)
-        except Exception as e:
-            pr.logException(self._log,e)
-            self._log.error("Error setting value '{}' to variable '{}' with type {}".format(sValue,self.path,self.typeStr))
+        self.set(self.parseDisp(sValue), write)
 
     @pr.expose
     def nativeType(self):
@@ -534,7 +532,6 @@ class RemoteVariable(BaseVariable,rim.Variable):
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
                               pollInterval=pollInterval,updateNotify=updateNotify)
-
 
         self._block    = None
 

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -54,7 +54,7 @@ try:
     host = args.server.split(',')[0].split(':')[0]
     port = int(args.server.split(',')[0].split(':')[1])
 except Exception:
-    print("Failed to extract server host & port")
+    raise Exception("Failed to extract server host & port")
 
 print("Connecting to {}".format(args.server))
 

--- a/python/pyrogue/gui/commands.py
+++ b/python/pyrogue/gui/commands.py
@@ -127,13 +127,13 @@ class CommandLink(QObject):
         else:
             value=None
 
-        if self._command.arg:
-            try:
+        try:
+            if self._command.arg:
                 self._command(self._command.parseDisp(value))
-            except Exception:
-                pass
-        else:
-            self._command()
+            else:
+                self._command()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Wheel:

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -582,4 +582,3 @@ class SystemWidget(QWidget):
                 self.root.SaveState(stateFile)
             except Exception as msg:
                 print(f"Got Exception: {msg}")
-

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -155,11 +155,16 @@ class DataLink(QObject):
             dataFile = dataFile[0]
 
         if dataFile != '':
-            self.writer.DataFile.setDisp(dataFile)
+            try:
+                self.writer.DataFile.setDisp(dataFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 
     def genName(self):
-        self.writer.AutoName()
-        pass
+        try:
+            self.writer.AutoName()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def varListener(self,path,value):
         if self.block:
@@ -201,16 +206,26 @@ class DataLink(QObject):
         self.dataFile.setPalette(p)
 
         self.block = True
-        self.writer.DataFile.setDisp(self.dataFile.text())
+        try:
+            self.writer.DataFile.setDisp(self.dataFile.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self.block = False
 
     @pyqtSlot()
     def open(self):
-        self.writer.Open()
+        try:
+            self.writer.Open()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def close(self):
-        self.writer.Close()
+        try:
+            self.writer.Close()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def bufferSizeEdited(self):
@@ -225,7 +240,10 @@ class DataLink(QObject):
         self.bufferSize.setPalette(p)
 
         self.block = True
-        self.writer.BufferSize.setDisp(self.bufferSize.text())
+        try:
+            self.writer.BufferSize.setDisp(self.bufferSize.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
     @pyqtSlot()
@@ -241,7 +259,10 @@ class DataLink(QObject):
         self.maxSize.setPalette(p)
 
         self.block = True
-        self.writer.MaxFileSize.setDisp(self.maxSize.text())
+        try:
+            self.writer.MaxFileSize.setDisp(self.maxSize.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
 
@@ -329,13 +350,19 @@ class ControlLink(QObject):
     @pyqtSlot(int)
     def runStateChanged(self,value):
         self.block = True
-        self.control.runState.setDisp(self.runState.itemText(value))
+        try:
+            self.control.runState.setDisp(self.runState.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
     @pyqtSlot(int)
     def runRateChanged(self,value):
         self.block = True
-        self.control.runRate.setDisp(self.runRate.itemText(value))
+        try:
+            self.control.runRate.setDisp(self.runRate.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
         self.block = False
 
 
@@ -474,7 +501,10 @@ class SystemWidget(QWidget):
 
     @pyqtSlot()
     def resetLog(self):
-        self.root.ClearLog()
+        try:
+            self.root.ClearLog()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def varListener(self,path,value):
         name = path.split('.')[-1]
@@ -484,15 +514,24 @@ class SystemWidget(QWidget):
 
     @pyqtSlot()
     def hardReset(self):
-        self.root.HardReset()
+        try:
+            self.root.HardReset()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def initialize(self):
-        self.root.Initialize()
+        try:
+            self.root.Initialize()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def countReset(self):
-        self.root.CountReset()
+        try:
+            self.root.CountReset()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def loadSettings(self):
@@ -505,7 +544,10 @@ class SystemWidget(QWidget):
             loadFile = loadFile[0]
 
         if loadFile != '':
-            self.root.LoadConfig(loadFile)
+            try:
+                self.root.LoadConfig(loadFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def saveSettings(self):
@@ -519,7 +561,10 @@ class SystemWidget(QWidget):
             saveFile = saveFile[0]
 
         if saveFile != '':
-            self.root.SaveConfig(saveFile)
+            try:
+                self.root.SaveConfig(saveFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
 
     @pyqtSlot()
     def saveState(self):
@@ -533,4 +578,8 @@ class SystemWidget(QWidget):
             stateFile = stateFile[0]
 
         if stateFile != '':
-            self.root.SaveState(stateFile)
+            try:
+                self.root.SaveState(stateFile)
+            except Exception as msg:
+                print(f"Got Exception: {msg}")
+

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -381,4 +381,3 @@ class VariableWidget(QWidget):
                 root.ReadAll()
         except Exception as msg:
             print(f"Got Exception: {msg}")
-

--- a/python/pyrogue/gui/variables.py
+++ b/python/pyrogue/gui/variables.py
@@ -174,25 +174,29 @@ class VariableLink(QObject):
 
         action = menu.exec_(self._widget.mapToGlobal(event))
 
-        if action == var_info:
-            self.infoDialog()
-        elif action == read_recurse:
-            self._variable.parent.ReadDevice(True)
-        elif action == write_recurse:
-            self._variable.parent.WriteDevice(True)
-        elif action == read_device:
-            self._variable.parent.ReadDevice(False)
-        elif action == write_device:
-            self._variable.parent.WriteDevice(False)
-        elif action == read_variable:
-            self._variable.get()
-        elif action == write_variable:
-            if isinstance(self._widget, QComboBox):
-                self._variable.setDisp(self._widget.currentText())
-            elif isinstance(self._widget, QSpinBox):
-                self._variable.set(self._widget.value())
-            else:
-                self._variable.setDisp(self._widget.text())
+        try:
+            if action == var_info:
+                self.infoDialog()
+            elif action == read_recurse:
+                self._variable.parent.ReadDevice(True)
+            elif action == write_recurse:
+                self._variable.parent.WriteDevice(True)
+            elif action == read_device:
+                self._variable.parent.ReadDevice(False)
+            elif action == write_device:
+                self._variable.parent.WriteDevice(False)
+            elif action == read_variable:
+                self._variable.get()
+            elif action == write_variable:
+                if isinstance(self._widget, QComboBox):
+                    self._variable.setDisp(self._widget.currentText())
+                elif isinstance(self._widget, QSpinBox):
+                    self._variable.set(self._widget.value())
+                else:
+                    self._variable.setDisp(self._widget.text())
+
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
 
     def infoDialog(self):
 
@@ -291,7 +295,11 @@ class VariableLink(QObject):
         p = QPalette()
         self._widget.setPalette(p)
 
-        self._variable.setDisp(self._widget.text())
+        try:
+            self._variable.setDisp(self._widget.text())
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
         self.updateGui.emit(self._variable.valueDisp())
 
@@ -301,7 +309,12 @@ class VariableLink(QObject):
             return
 
         self._inEdit = True
-        self._variable.setDisp(value)
+
+        try:
+            self._variable.setDisp(value)
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
 
     @pyqtSlot(int)
@@ -310,7 +323,12 @@ class VariableLink(QObject):
             return
 
         self._inEdit = True
-        self._variable.setDisp(self._widget.itemText(value))
+
+        try:
+            self._variable.setDisp(self._widget.itemText(value))
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+
         self._inEdit = False
 
     def eventFilter(self, obj, event):
@@ -358,5 +376,9 @@ class VariableWidget(QWidget):
 
     @pyqtSlot()
     def readPressed(self):
-        for root in self.roots:
-            root.ReadAll()
+        try:
+            for root in self.roots:
+                root.ReadAll()
+        except Exception as msg:
+            print(f"Got Exception: {msg}")
+

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -66,12 +66,15 @@ class SimpleClient(object):
                'attr':attr,
                'args':args,
                'kwargs':kwargs}
+
         try:
             self._req.send_string(jsonpickle.encode(msg))
             resp = jsonpickle.decode(self._req.recv_string())
-        except Exception as msg:
-            print("got remote exception: {}".format(msg))
-            resp = None
+        except Exception as e:
+            raise Exception(f"ZMQ Interface Exception: {e}")
+
+        if isinstance(resp,Exception):
+            raise resp
 
         return resp
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -278,9 +278,11 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         try:
             resp = self._send(y)
             ret = jsonpickle.decode(resp)
-        except Exception as msg:
-            print("got remote exception: {}".format(msg))
-            ret = None
+        except Exception as e:
+            raise Exception(f"ZMQ Interface Exception: {e}")
+
+        if isinstance(ret,Exception):
+            raise(ret)
 
         return ret
 

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -56,5 +56,5 @@ class ZmqServer(rogue.interfaces.ZmqServer):
                 return self.encode(nAttr,rawStr=rawStr)
 
         except Exception as msg:
-            print("ZMQ Got Exception: {}".format(msg))
-            return 'null\n'
+            return self.encode(msg,rawStr=False)
+

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -57,4 +57,3 @@ class ZmqServer(rogue.interfaces.ZmqServer):
 
         except Exception as msg:
             return self.encode(msg,rawStr=False)
-

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -82,11 +82,12 @@ class EpicsPvHandler(p4p.server.thread.Handler):
                 else:
                     ret = self._var()
 
-            if ret is None:
-                ret = 'None'
+                if ret is None:
+                    ret = 'None'
 
                 v = p4p.Value(p4p.Type([('value',self._valType)]), {'value':ret})
                 op.done(value=(v))
+
             except Exception as msg:
                 op.done(error=msg)
 

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -55,15 +55,19 @@ class EpicsPvHandler(p4p.server.thread.Handler):
 
     def put(self, pv, op):
         if self._var.isVariable and (self._var.mode == 'RW' or self._var.mode == 'WO'):
-            if self._valType == 'enum':
-                self._var.setDisp(str(op.value()))
-            elif self._valType == 's':
-                self._var.setDisp(op.value().raw.value)
-            else:
-                self._var.set(op.value().raw.value)
+            try:
+                if self._valType == 'enum':
+                    self._var.setDisp(str(op.value()))
+                elif self._valType == 's':
+                    self._var.setDisp(op.value().raw.value)
+                else:
+                    self._var.set(op.value().raw.value)
 
-            # Need enum processing
-            op.done()
+                # Need enum processing
+                op.done()
+
+            except Exception as msg:
+                op.done(error=msg)
 
         else:
             op.done(error='Put Not Supported On This Variable')
@@ -72,16 +76,19 @@ class EpicsPvHandler(p4p.server.thread.Handler):
         if self._var.isCommand:
             val = op.value().query
 
-            if 'arg' in val:
-                ret = self._var(val.arg)
-            else:
-                ret = self._var()
+            try:
+                if 'arg' in val:
+                    ret = self._var(val.arg)
+                else:
+                    ret = self._var()
 
             if ret is None:
                 ret = 'None'
 
-            v = p4p.Value(p4p.Type([('value',self._valType)]), {'value':ret})
-            op.done(value=(v))
+                v = p4p.Value(p4p.Type([('value',self._valType)]), {'value':ret})
+                op.done(value=(v))
+            except Exception as msg:
+                op.done(error=msg)
 
         else:
             op.done(error='Rpc Not Supported On Variables')

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -129,24 +129,21 @@ class RogueConnection(PyDMConnection):
     def put_value(self, new_value):
         if self._node is None or not self._notDev:
             return
-        try:
 
-            if new_value is None:
-                val = None
-            elif self._enum is not None and not isinstance(new_value,str):
-                val = self._enum[new_value]
-            elif self._int:
-                val = int(new_value)
-            else:
-                val = new_value
+        if new_value is None:
+            val = None
+        elif self._enum is not None and not isinstance(new_value,str):
+            val = self._enum[new_value]
+        elif self._int:
+            val = int(new_value)
+        else:
+            val = new_value
 
-            # st = time.time()
-            if self._cmd:
-                self._node.__call__(val)
-            else:
-                self._node.setDisp(val)
-        except Exception as e:
-            logger.error("Unable to put %s to %s.  Exception: %s", new_value, self.address, str(e))
+        st = time.time()
+        if self._cmd:
+            self._node.__call__(val)
+        else:
+            self._node.setDisp(val)
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/utilities/fileio/_FileReader.py
+++ b/python/pyrogue/utilities/fileio/_FileReader.py
@@ -88,7 +88,7 @@ class FileReader(object):
             else:
                 try:
                     self._data = numpy.fromfile(self._currFile, dtype=numpy.int8, count=payload)
-                except:
+                except Exception:
                     raise rogue.GeneralError('fileio.FileReader',f'Failed to read data from {self._currFname}')
 
                 self._currCount += 1

--- a/python/pyrogue/utilities/fileio/_FileReader.py
+++ b/python/pyrogue/utilities/fileio/_FileReader.py
@@ -82,16 +82,13 @@ class FileReader(object):
 
             # Process meta data
             if self._configChan is not None and self._header.channel == self._configChan:
-                try:
-                    pyrogue.yamlUpdate(self._config, self._currFile.read(payload).decode('utf-8'))
-                except Exception:
-                    self._log.warning(f"Error processing meta data in {self._currFName}")
+                pyrogue.yamlUpdate(self._config, self._currFile.read(payload).decode('utf-8'))
 
             # This is a data channel
             else:
                 try:
                     self._data = numpy.fromfile(self._currFile, dtype=numpy.int8, count=payload)
-                except Exception:
+                except:
                     raise rogue.GeneralError('fileio.FileReader',f'Failed to read data from {self._currFname}')
 
                 self._currCount += 1

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -27,10 +27,7 @@ class StreamWriter(pyrogue.DataWriter):
         self._configEn = configEn
 
     def _open(self):
-        try:
-            self._writer.open(self.DataFile.value())
-        except Exception as e:
-            pyrogue.logException(self._log,e)
+        self._writer.open(self.DataFile.value())
 
         # Dump config/status to file
         if self._configEn:

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -101,9 +101,9 @@ rpe::Master::Master (std::string epicsName, uint32_t max, std::string type) : Va
 
 rpe::Master::~Master() { }
 
-void rpe::Master::valueGet() { }
+bool rpe::Master::valueGet() { return true;}
 
-void rpe::Master::valueSet() {
+bool rpe::Master::valueSet() {
    ris::FramePtr frame;
    ris::FrameIterator iter;
    uint32_t txSize;
@@ -166,5 +166,6 @@ void rpe::Master::valueSet() {
 
    // Should this be pushed to a queue for a worker thread to call slaves?
    sendFrame(frame);
+   return true;
 }
 

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -108,9 +108,9 @@ rpe::Slave::Slave (std::string epicsName, uint32_t max, std::string type) : Valu
 
 rpe::Slave::~Slave() { }
 
-void rpe::Slave::valueGet() { }
+bool rpe::Slave::valueGet() { return true; }
 
-void rpe::Slave::valueSet() { }
+bool rpe::Slave::valueSet() { return true; }
 
 void rpe::Slave::acceptFrame ( ris::FramePtr frame ) {
    ris::FrameIterator iter;

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -199,10 +199,10 @@ std::string rpe::Value::epicsName() {
 }
 
 // Value lock held when this is called
-void rpe::Value::valueSet() { }
+bool rpe::Value::valueSet() { return true; }
 
 // Value lock held when this is called
-void rpe::Value::valueGet() { }
+bool rpe::Value::valueGet() { return true; }
 
 void rpe::Value::setPv(rpe::Pv * pv) {
    pv_ = pv;
@@ -223,6 +223,7 @@ caStatus rpe::Value::read(gdd &prototype) {
 
 caStatus rpe::Value::readValue(gdd &value) {
    gddStatus gdds;
+   bool ret;
 
    std::lock_guard<std::mutex> lock(mtx_);
 
@@ -230,10 +231,10 @@ caStatus rpe::Value::readValue(gdd &value) {
    if ( (array_ && value.isAtomic()) || (array_ && value.isScalar()) || ((!array_) && value.isScalar()) ) {
 
       // Call value get within lock
-      valueGet();
+      ret = valueGet();
       gdds = gddApplicationTypeTable::app_table.smartCopy(&value, pValue_);
 
-      if (gdds) return S_cas_noConvert;
+      if (gdds || !ret) return S_cas_noConvert;
       else return S_casApp_success;
    }
    else return S_cas_noConvert;
@@ -295,8 +296,8 @@ caStatus rpe::Value::write(const gdd &value) {
    pValue_->setTimeStamp(&t);
 
    // Cal value set and update within lock
-   this->valueSet();
-   return S_casApp_success;
+   if ( this->valueSet() ) return S_casApp_success;
+   else return S_cas_noConvert;
 }
 
 aitEnum rpe::Value::bestExternalType() {

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -234,6 +234,9 @@ caStatus rpe::Value::readValue(gdd &value) {
       ret = valueGet();
       gdds = gddApplicationTypeTable::app_table.smartCopy(&value, pValue_);
 
+
+      if (!ret ) pValue_->setStatSevr(epicsAlarmRead,epicsSevMajor);
+
       if (gdds || !ret) return S_cas_noConvert;
       else return S_casApp_success;
    }
@@ -297,7 +300,10 @@ caStatus rpe::Value::write(const gdd &value) {
 
    // Cal value set and update within lock
    if ( this->valueSet() ) return S_casApp_success;
-   else return S_cas_noConvert;
+   else {
+       pValue_->setStatSevr(epicsAlarmWrite,epicsSevMajor);
+       return S_cas_noConvert;
+   }
 }
 
 aitEnum rpe::Value::bestExternalType() {

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -277,7 +277,7 @@ void rpe::Variable::updateAlarm(bp::object status, bp::object severity) {
 }
 
 // Lock held when called
-void rpe::Variable::valueGet() {
+bool rpe::Variable::valueGet() {
 
    if ( syncRead_ ) {
       { // GIL Scope
@@ -293,9 +293,11 @@ void rpe::Variable::valueGet() {
             }
          } catch (...) {
             log_->error("Error getting values from epics: %s\n",epicsName_.c_str());
+            return false;
          }
       }
    }
+   return true;
 }
 
 // Lock held when called
@@ -439,7 +441,7 @@ void rpe::Variable::fromPython(bp::object value) {
 }
 
 // Lock already held
-void rpe::Variable::valueSet() {
+bool rpe::Variable::valueSet() {
    rogue::ScopedGil gil;
    bp::list pl;
    uint32_t i;
@@ -537,7 +539,9 @@ void rpe::Variable::valueSet() {
       }
    } catch (...) {
       log_->error("Error setting value from epics: %s\n",epicsName_.c_str());
+      return false;
    }
+   return true;
 }
 
 template<typename T>


### PR DESCRIPTION
This PR changes the Rogue approach to handling errors. Previously the errors were caught and logged. In this new model the exceptions are passed on to the caller. This allows the caller to become aware of the errors and avoids some errors being masked, sometimes resulting a sequence of commands continuing event after a fatal error occurs.

With this change, exceptions are now passed across the ZMQ client/server link.

The legacy pyqt GUI will simply log an error. The PYDM interface will open an error dialog box.

I am still looking at the proper way to deal with exceptions called from the epics3 and epics4 interfaces.