### PR TITLE
Addresses concerns in ESCRYODET-638 and handles errors properly

### DIFF
--- a/python/pyrogue/protocols/_uart.py
+++ b/python/pyrogue/protocols/_uart.py
@@ -53,6 +53,83 @@ class UartMemory(rogue.interfaces.memory.Slave):
     def _doTransaction(self, transaction):
         self._workerQueue.put(transaction)
 
+
+    def _doWrite(self,transaction):
+
+        address = transaction.address()
+        dataBa = bytearray(transaction.size())
+        transaction.getData(dataBa, 0)
+        dataWords = [int.from_bytes(dataBa[i:i+4], 'little', signed=False) for i in range(0, len(dataBa), 4)]
+
+        # Need to issue a UART command for each 32 bit word
+        for i, (addr, data) in enumerate(zip(range(address, address+len(dataBa), 4), dataWords)):
+            sendString = f'w {addr:08x} {data:08x} \n'.encode('ASCII')
+            # self._log.debug(f'Sending write transaction part {i}: {repr(sendString)}')
+            self.serialPort.write(sendString)
+            response = self.readline() #self.serialPort.readline().decode('ASCII')
+
+            # If response is empty, a timeout occurred
+            if len(response) == 0:
+                transaction.error(f'Empty transaction response (likely timeout) for transaction part {i}: {repr(sendString)}')
+                return
+
+            # parse the response string
+            parts = response.split()
+
+            # Check for correct response
+            if (len(parts) != 4 or parts[0].lower() != 'w' or int(parts[1], 16) != addr or int(parts[2],16) != data):
+                transaction.error(f'Malformed response for part {i}: {repr(response)} to transaction: {repr(sendString)}')
+                return
+            # else:
+                # self._log.debug(f'Transaction part {i}: {repr(sendString)} completed successfully')
+
+            # Check response code
+            resp = int(parts[3],16)
+
+            if resp != 0:
+                transaction.error(f"Non zero status message returned on axi bus in hardware: {resp:#x}")
+                return
+
+        transaction.done()
+
+
+    def _doRead(self,transaction):
+
+        address = transaction.address()
+        size = transaction.size()
+
+        for i, addr in enumerate(range(address, address+size, 4)):
+            sendString = f'r {addr:08x} \n'.encode('ASCII')
+            # self._log.debug(f'Sending read transaction part {i}: {repr(sendString)}')
+            self.serialPort.write(sendString)
+            response = self.readline() #self.serialPort.readline().decode('ASCII')
+
+            # If response is empty, a timeout occurred
+            if len(response) == 0:
+                transaction.error(f'Empty transaction response (likely timeout) for transaction part {i}: {repr(sendString)}')
+                return
+
+            # parse the response string
+            parts = response.split()
+
+            if (len(parts) != 4 or parts[0].lower() != 'r' or int(parts[1], 16) != addr):
+                transaction.error(f'Malformed response part {i}: {repr(response)} to transaction: {repr(sendString)}')
+            else:
+                dataInt = int(parts[2], 16)
+                rdData = bytearray(dataInt.to_bytes(4, 'little', signed=False))
+                transaction.setData(rdData, i*4)
+                # self._log.debug(f'Transaction part {i}: {repr(sendString)} with response data: {dataInt:#08x} completed successfully')
+
+            # Check response code
+            resp = int(parts[3],16)
+
+            if resp != 0:
+                transaction.error(f"Non zero status message returned on axi bus in hardware: {resp:#x}")
+                return
+
+        transaction.done()
+
+
     def _worker(self):
         while True:
             transaction = self._workerQueue.get()
@@ -61,67 +138,13 @@ class UartMemory(rogue.interfaces.memory.Slave):
                 break
 
             with transaction.lock():
-                address = transaction.address()
 
                 # Write path
                 if transaction.type() == rogue.interfaces.memory.Write:
-                    dataBa = bytearray(transaction.size())
-                    transaction.getData(dataBa, 0)
-                    dataWords = [int.from_bytes(dataBa[i:i+4], 'little', signed=False) for i in range(0, len(dataBa), 4)]
-
-                    # Need to issue a UART command for each 32 bit word
-                    for i, (addr, data) in enumerate(zip(range(address, address+len(dataBa), 4), dataWords)):
-                        sendString = f'w {addr:08x} {data:08x} \n'.encode('ASCII')
-                        # self._log.debug(f'Sending write transaction part {i}: {repr(sendString)}')
-                        self.serialPort.write(sendString)
-                        response = self.readline() #self.serialPort.readline().decode('ASCII')
-
-                        # If response is empty, a timeout occurred
-                        if len(response) == 0:
-                            transaction.error(f'Empty transaction response (likely timeout) for transaction part {i}: {repr(sendString)}')
-                            return
-
-                        # parse the response string
-                        parts = response.split()
-                        # Check for correct response
-
-#_uart.py (line#89 and line#115) should include int(parts[2], 16) != data) (same data echo'd back on a write) and int(parts[3], 16) != 0) (non-zero reponse) checking
-                        if (len(parts) != 4 or parts[0].lower() != 'w' or int(parts[1], 16) != addr):
-                            transaction.error(f'Malformed response for part {i}: {repr(response)} to transaction: {repr(sendString)}')
-                            return
-                        # else:
-                            # self._log.debug(f'Transaction part {i}: {repr(sendString)} completed successfully')
-
-                    transaction.done()
+                    self._doWrite(transaction)
 
                 elif (transaction.type() == rogue.interfaces.memory.Read or transaction.type() == rogue.interfaces.memory.Verify):
-                    size = transaction.size()
-
-                    for i, addr in enumerate(range(address, address+size, 4)):
-                        sendString = f'r {addr:08x} \n'.encode('ASCII')
-                        # self._log.debug(f'Sending read transaction part {i}: {repr(sendString)}')
-                        self.serialPort.write(sendString)
-                        response = self.readline() #self.serialPort.readline().decode('ASCII')
-
-                        # If response is empty, a timeout occurred
-                        if len(response) == 0:
-                            transaction.error(f'Empty transaction response (likely timeout) for transaction part {i}: {repr(sendString)}')
-                            return
-
-                        # parse the response string
-                        parts = response.split()
-
-#_uart.py (line#89 and line#115) should include int(parts[2], 16) != data) (same data echo'd back on a write) and int(parts[3], 16) != 0) (non-zero reponse) checking
-
-                        if (len(parts) != 4 or parts[0].lower() != 'r' or int(parts[1], 16) != addr):
-                            transaction.error(f'Malformed response part {i}: {repr(response)} to transaction: {repr(sendString)}')
-                        else:
-                            dataInt = int(parts[2], 16)
-                            rdData = bytearray(dataInt.to_bytes(4, 'little', signed=False))
-                            transaction.setData(rdData, i*4)
-                            # self._log.debug(f'Transaction part {i}: {repr(sendString)} with response data: {dataInt:#08x} completed successfully')
-
-                    transaction.done()
+                    self._doRead(transaction)
                 else:
                     # Posted writes not supported (for now)
                     transaction.error(f'Unsupported transaction type: {transaction.type()}')

--- a/python/pyrogue/protocols/_uart.py
+++ b/python/pyrogue/protocols/_uart.py
@@ -84,6 +84,8 @@ class UartMemory(rogue.interfaces.memory.Slave):
                         # parse the response string
                         parts = response.split()
                         # Check for correct response
+
+#_uart.py (line#89 and line#115) should include int(parts[2], 16) != data) (same data echo'd back on a write) and int(parts[3], 16) != 0) (non-zero reponse) checking
                         if (len(parts) != 4 or parts[0].lower() != 'w' or int(parts[1], 16) != addr):
                             transaction.error(f'Malformed response for part {i}: {repr(response)} to transaction: {repr(sendString)}')
                             return
@@ -108,6 +110,8 @@ class UartMemory(rogue.interfaces.memory.Slave):
 
                         # parse the response string
                         parts = response.split()
+
+#_uart.py (line#89 and line#115) should include int(parts[2], 16) != data) (same data echo'd back on a write) and int(parts[3], 16) != 0) (non-zero reponse) checking
 
                         if (len(parts) != 4 or parts[0].lower() != 'r' or int(parts[1], 16) != addr):
                             transaction.error(f'Malformed response part {i}: {repr(response)} to transaction: {repr(sendString)}')


### PR DESCRIPTION
Adds the following check:

1. Verifies response message contains proper data echo for writes.
2. Checks for a response code of zero for read and write

The previous code had a number of return statements in the thread loop which would kill the thread if an error would to occur. This updated code moves and read and write processor into separate methods, allow return statements to be used to return to the main loop. 