### PR TITLE
Set line edit background to orange when an edit is in progress

### DIFF
--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -139,7 +139,6 @@ class RogueConnection(PyDMConnection):
         else:
             val = new_value
 
-        st = time.time()
         if self._cmd:
             self._node.__call__(val)
         else:
@@ -191,7 +190,6 @@ class RogueConnection(PyDMConnection):
                 self.new_value_signal[str].emit(self._node.path)
             else:
                 self.write_access_signal.emit(self._cmd or self._node.mode=='RW')
-                # st = time.time()
                 self._updateVariable(self._node.path,self._node.getVariableValue(read=False))
 
         else:

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -25,6 +25,9 @@ class DefaultTop(Display):
     def __init__(self, parent=None, args=[], macros=None):
         super(DefaultTop, self).__init__(parent=parent, args=args, macros=None)
 
+        self.setStyleSheet("*[dirty='true']\
+                           {background-color: orange;}")
+
         self.sizeX = None
         self.sizeY = None
         self.title = None

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -20,3 +20,4 @@ from pyrogue.pydm.widgets.system_window import SystemWindow
 from pyrogue.pydm.widgets.variable_tree import VariableTree
 from pyrogue.pydm.widgets.process       import Process
 from pyrogue.pydm.widgets.command       import Command
+from pyrogue.pydm.widgets.line_edit     import PyRogueLineEdit

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -11,6 +11,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+from pyrogue.pydm.widgets.line_edit     import PyRogueLineEdit
 from pyrogue.pydm.widgets.command_tree  import CommandTree
 from pyrogue.pydm.widgets.data_writer   import DataWriter
 from pyrogue.pydm.widgets.root_control  import RootControl
@@ -20,4 +21,3 @@ from pyrogue.pydm.widgets.system_window import SystemWindow
 from pyrogue.pydm.widgets.variable_tree import VariableTree
 from pyrogue.pydm.widgets.process       import Process
 from pyrogue.pydm.widgets.command       import Command
-from pyrogue.pydm.widgets.line_edit     import PyRogueLineEdit

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -11,7 +11,8 @@
 #-----------------------------------------------------------------------------
 
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLineEdit, PyDMPushButton
+from pydm.widgets import PyDMPushButton
+from pyrogue.pydm.widgets import PyRogueLineEdit
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton
@@ -49,7 +50,7 @@ class DataWriter(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         vb.addLayout(fl)
 
-        self._dataFile = PyDMLineEdit(parent=None, init_channel=self._path + '.DataFile')
+        self._dataFile = PyRogueLineEdit(parent=None, init_channel=self._path + '.DataFile')
         self._dataFile.alarmSensitiveContent = False
         self._dataFile.alarmSensitiveBorder  = True
         fl.addRow('Data File:',self._dataFile)
@@ -82,17 +83,17 @@ class DataWriter(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         vbl.addLayout(fl)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.BufferSize')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.BufferSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Buffer Size:',w)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.IsOpen/disp')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.IsOpen/disp')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('File Open:',w)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.CurrentSize')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.CurrentSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Current File Size:',w)
@@ -106,17 +107,17 @@ class DataWriter(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         vbr.addLayout(fl)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.MaxFileSize')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.MaxFileSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Max Size:',w)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.FrameCount')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.FrameCount')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Frame Count:',w)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.TotalSize')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.TotalSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Total File Size:',w)

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -1,0 +1,24 @@
+
+from pydm.widgets import PyDMLineEdit
+from qtpy.QtCore import Property
+from pydm.widgets.base import refresh_style
+
+class PyRogueLineEdit(PyDMLineEdit):
+    def __init__(self, parent=None, init_channel=None):
+        PyDMLineEdit.__init__(self,parent=parent,init_channel=init_channel)
+
+        self.textEdited.connect(self.text_edited)
+        self._dirty = False
+
+    def text_edited(self):
+        self._dirty = True
+        refresh_style(self)
+
+    def focusOutEvent(self, event):
+        self._dirty = False
+        super(PyRogueLineEdit, self).focusOutEvent(event)
+        refresh_style(self)
+
+    @Property(bool)
+    def dirty(self):
+        return self._dirty

--- a/python/pyrogue/pydm/widgets/process.py
+++ b/python/pyrogue/pydm/widgets/process.py
@@ -11,8 +11,9 @@
 #-----------------------------------------------------------------------------
 
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLineEdit, PyDMPushButton, PyDMScaleIndicator
+from pydm.widgets import PyDMPushButton, PyDMScaleIndicator
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
+from pyrogue.pydm.widgets import PyRogueLineEdit
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
 
@@ -56,7 +57,7 @@ class Process(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.Running/disp')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.Running/disp')
         w.showUnits             = False
         w.precisionFromPV       = False
         w.alarmSensitiveContent = False
@@ -82,7 +83,7 @@ class Process(PyDMFrame):
 
         fl.addRow('Progress:',w)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.Message/disp')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.Message/disp')
         w.showUnits             = False
         w.precisionFromPV       = False
         w.alarmSensitiveContent = False
@@ -97,7 +98,7 @@ class Process(PyDMFrame):
 
         for k,v in prc.nodes.items():
             if v.name not in noAdd and not v.hidden:
-                w = PyDMLineEdit(parent=None, init_channel=self._path + '.{}/disp'.format(v.name))
+                w = PyRogueLineEdit(parent=None, init_channel=self._path + '.{}/disp'.format(v.name))
                 w.showUnits             = False
                 w.precisionFromPV       = True
                 w.alarmSensitiveContent = False

--- a/python/pyrogue/pydm/widgets/run_control.py
+++ b/python/pyrogue/pydm/widgets/run_control.py
@@ -11,8 +11,9 @@
 #-----------------------------------------------------------------------------
 
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox
+from pydm.widgets import PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
+from pyrogue.pydm.widgets import PyRogueLineEdit
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
 
@@ -72,7 +73,7 @@ class RunControl(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         hb.addLayout(fl)
 
-        w = PyDMLineEdit(parent=None, init_channel=self._path + '.runCount')
+        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.runCount')
         w.showUnits             = False
         w.precisionFromPV       = True
         w.alarmSensitiveContent = False

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -13,7 +13,7 @@
 import pyrogue
 import pyrogue.pydm.widgets
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLineEdit, PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
+from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
@@ -189,7 +189,7 @@ class VariableHolder(QTreeWidgetItem):
             w.installEventFilter(self._top)
 
         else:
-            w = PyDMLineEdit(parent=None, init_channel=self._path + '/disp')
+            w = PyRogueLineEdit(parent=None, init_channel=self._path + '/disp')
             w.showUnits             = False
             w.precisionFromPV       = True
             w.alarmSensitiveContent = False

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -15,6 +15,7 @@ import pyrogue.pydm.widgets
 from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
+from pyrogue.pydm.widgets import PyRogueLineEdit
 from qtpy.QtCore import Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel


### PR DESCRIPTION
This replicates the behavior of the original rogue gui where fields being edited showed up orange until return is pressed or focus is lost and the value reverts back.