### PR TITLE
Avoid string copies

### DIFF
--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -455,6 +455,9 @@ namespace rogue {
                //! Get data using String, C++ Version
                std::string getString (rogue::interfaces::memory::Variable *var );
 
+               //! Get data into String, C++ Version
+               void getString (rogue::interfaces::memory::Variable *var, std::string & );
+
                //////////////////////////////////////////
                // Float
                //////////////////////////////////////////

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -364,6 +364,9 @@ namespace rogue {
                //! Get string
                std::string getString();
 
+               //! Get string
+               void getString(std::string &);
+
                /////////////////////////////////
                // C++ Float
                /////////////////////////////////

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -801,6 +801,16 @@ std::string rim::Block::getString ( rim::Variable *var ) {
    return ret;
 }
 
+// Get data into string
+void rim::Block::getString ( rim::Variable *var, std::string & retString ) {
+   char getBuffer[var->byteSize_+1];
+
+   getBytes((uint8_t *)getBuffer, var);
+   getBuffer[var->byteSize_] = 0;
+
+   retString = getBuffer;
+}
+
 
 //////////////////////////////////////////
 // Float

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -584,6 +584,15 @@ std::string rim::Variable::getString() {
    return (block_->*getString_)(this);
 }
 
+void rim::Variable::getString( std::string & retString ) {
+   if ( getString_ == NULL ) {
+      retString = "";
+   } else {
+      block_->read(this);
+      retString = (block_->*getString_)(this);
+   }
+}
+
 /////////////////////////////////
 // C++ Float
 /////////////////////////////////


### PR DESCRIPTION
Using reference args for std::string avoids unnecessary string class constructor and destructor calls for temporary string objects.