### PR TITLE
Const refs

### DIFF
--- a/include/rogue/LibraryBase.h
+++ b/include/rogue/LibraryBase.h
@@ -67,8 +67,8 @@ namespace rogue {
          //! Get variable by name
          std::shared_ptr<rogue::interfaces::memory::Variable> getVariable(const std::string & name);
 
-         //! Get a map of variables
-         const std::map< std::string, std::shared_ptr<rogue::interfaces::memory::Variable> > getVariableList();
+         //! Get a const reference to the map of variables
+         const std::map<std::string, std::shared_ptr<rogue::interfaces::memory::Variable>> & getVariableList();
 
          //! Get block by name
          std::shared_ptr<rogue::interfaces::memory::Block> getBlock(const std::string & name);

--- a/include/rogue/LibraryBase.h
+++ b/include/rogue/LibraryBase.h
@@ -65,13 +65,13 @@ namespace rogue {
          static std::shared_ptr<rogue::LibraryBase> create();
 
          //! Get variable by name
-         std::shared_ptr<rogue::interfaces::memory::Variable> getVariable(std::string name);
+         std::shared_ptr<rogue::interfaces::memory::Variable> getVariable(const std::string & name);
 
          //! Get a map of variables
          const std::map< std::string, std::shared_ptr<rogue::interfaces::memory::Variable> > getVariableList();
 
          //! Get block by name
-         std::shared_ptr<rogue::interfaces::memory::Block> getBlock(std::string name);
+         std::shared_ptr<rogue::interfaces::memory::Block> getBlock(const std::string & name);
 
          //! Get a map of blocks
          const std::map< std::string, std::shared_ptr<rogue::interfaces::memory::Block> > getBlockList();

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -47,7 +47,7 @@ void rogue::LibraryBase::addMemory (std::string name, rim::SlavePtr slave) {
 }
 
 //! Get variable by name
-rim::VariablePtr rogue::LibraryBase::getVariable(std::string name) {
+rim::VariablePtr rogue::LibraryBase::getVariable(const std::string & name) {
    return variables_[name];
 }
 
@@ -57,7 +57,7 @@ const std::map< std::string, rim::VariablePtr> rogue::LibraryBase::getVariableLi
 }
 
 //! Get block by name
-rim::BlockPtr rogue::LibraryBase::getBlock(std::string name) {
+rim::BlockPtr rogue::LibraryBase::getBlock(const std::string & name) {
    return blocks_[name];
 }
 

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -52,7 +52,7 @@ rim::VariablePtr rogue::LibraryBase::getVariable(const std::string & name) {
 }
 
 //! Get a map of variables
-const std::map< std::string, rim::VariablePtr> rogue::LibraryBase::getVariableList() {
+const std::map<std::string, rim::VariablePtr> & rogue::LibraryBase::getVariableList() {
    return variables_;
 }
 

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -769,7 +769,7 @@ void rim::Block::setStringPy ( bp::object &value, rim::Variable *var ) {
    setBytes((uint8_t *)getBuffer,var);
 }
 
-// Get data using int
+// Get data using string
 bp::object rim::Block::getStringPy ( rim::Variable *var ) {
    uint8_t * getBuffer = (uint8_t *)malloc(var->byteSize_);
 
@@ -789,7 +789,7 @@ void rim::Block::setString ( const std::string &value, rim::Variable *var ) {
    setBytes((uint8_t *)value.c_str(),var);
 }
 
-// Get data using int
+// Get data using string
 std::string rim::Block::getString ( rim::Variable *var ) {
    char getBuffer[var->byteSize_+1];
 


### PR DESCRIPTION
Using const where appropriate.   Typically we want to use const ref for args to getter functions
and to avoid unnecessary construction of temporary objects.

Moving typedef up front makes it easier for new developers to see the recommended use pattern.
i.e.
-               static std::shared_ptr<rogue::interfaces::memory::Variable> create (
+               static rogue::interfaces::memory::VariablePtr create (
We want end users to see the VariablePtr typdef when searching the docs for the create API's instead of the more dense std::shared_ptr<rogue::interfaces::memory::Variable>.