### PR TITLE
Template friendly

### DIFF
--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -458,6 +458,11 @@ namespace rogue {
                //! Get data into String, C++ Version
                void getString (rogue::interfaces::memory::Variable *var, std::string & );
 
+               //! Get data into String, C++ Version
+               void getValue (rogue::interfaces::memory::Variable *var, std::string & valueRet ) {
+                getString( var, valueRet );
+               }
+
                //////////////////////////////////////////
                // Float
                //////////////////////////////////////////

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -331,6 +331,11 @@ namespace rogue {
                //! Set unsigned int
                void setUInt(uint64_t &);
 
+               //! Set unsigned int
+               void setValue(uint64_t value) {
+                  setUInt(value);
+               }
+
                //! Get unsigned int
                uint64_t getUInt();
 
@@ -345,6 +350,11 @@ namespace rogue {
 
                //! Set signed int
                void setInt(int64_t &);
+
+               //! Set int
+               void setValue(int64_t value) {
+                  setInt(value);
+               }
 
                //! Get signed int
                int64_t getInt();
@@ -361,6 +371,11 @@ namespace rogue {
                //! Set bool
                void setBool(bool &);
 
+               //! Set bool
+               void setValue(bool value) {
+                  setBool(value);
+               }
+
                //! Get bool
                bool getBool();
 
@@ -375,6 +390,11 @@ namespace rogue {
 
                //! Set string
                void setString(const std::string &);
+
+               //! Set string
+               void setValue(const std::string & value) {
+                  setString(value);
+               }
 
                //! Get string
                std::string getString();
@@ -394,6 +414,11 @@ namespace rogue {
                //! Set Float
                void setFloat(float &);
 
+               //! Set Float
+               void setValue(float value) {
+                  setFloat(value);
+               }
+
                //! Get Float
                float getFloat();
 
@@ -408,6 +433,11 @@ namespace rogue {
 
                //! Set Double
                void setDouble(double &);
+
+               //! Set Double
+               void setValue(double value) {
+                  setDouble(value);
+               }
 
                //! Get Double
                double getDouble();

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -34,6 +34,10 @@ namespace rogue {
       namespace memory {
 
          class Block;
+         class Variable;
+
+         //! Alias for using shared pointer as VariablePtr
+         typedef std::shared_ptr<rogue::interfaces::memory::Variable> VariablePtr;
 
          //! Memory interface Variable
          class Variable {
@@ -216,7 +220,7 @@ namespace rogue {
                 * @param bitReverse Bit reverse flag
                 * @param bitPoint Bit point for fixed point values
                 */
-               static std::shared_ptr<rogue::interfaces::memory::Variable> create (
+               static rogue::interfaces::memory::VariablePtr create (
                      std::string name,
                      std::string mode,
                      double   minimum,
@@ -458,9 +462,6 @@ namespace rogue {
                double getFixed();
 
          };
-
-         //! Alias for using shared pointer as VaariablePtr
-         typedef std::shared_ptr<rogue::interfaces::memory::Variable> VariablePtr;
 
 #ifndef NO_PYTHON
 

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -334,6 +334,11 @@ namespace rogue {
                //! Get unsigned int
                uint64_t getUInt();
 
+               //! Get unsigned int
+               void getValue(uint64_t & valueRet) {
+                  valueRet = getUInt();
+               }
+
                /////////////////////////////////
                // C++ int
                /////////////////////////////////
@@ -344,6 +349,11 @@ namespace rogue {
                //! Get signed int
                int64_t getInt();
 
+               //! Get signed int
+               void getValue(int64_t & valueRet) {
+                  valueRet = getInt();
+               }
+
                /////////////////////////////////
                // C++ bool
                /////////////////////////////////
@@ -353,6 +363,11 @@ namespace rogue {
 
                //! Get bool
                bool getBool();
+
+               //! Get bool
+               void getValue(bool & valueRet) {
+                  valueRet = getBool();
+               }
 
                /////////////////////////////////
                // C++ String
@@ -365,7 +380,12 @@ namespace rogue {
                std::string getString();
 
                //! Get string
-               void getString(std::string &);
+               void getString(std::string & retString) {
+                  getValue( retString );
+               }
+
+               //! Get string
+               void getValue(std::string &);
 
                /////////////////////////////////
                // C++ Float
@@ -377,6 +397,11 @@ namespace rogue {
                //! Get Float
                float getFloat();
 
+               //! Get Float
+               void getValue(float & valueRet) {
+                  valueRet = getFloat();
+               }
+
                /////////////////////////////////
                // C++ double
                /////////////////////////////////
@@ -387,8 +412,13 @@ namespace rogue {
                //! Get Double
                double getDouble();
 
+               //! Get Double
+               void getValue(double & valueRet) {
+                  valueRet = getDouble();
+               }
+
                /////////////////////////////////
-               // C++ filed point
+               // C++ fixed point
                /////////////////////////////////
 
                //! Set fixed point

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -463,7 +463,7 @@ bp::object rim::VariableWrap::bitSize() {
    return std_vector_to_py_list<uint32_t>(bitSize_);
 }
 
-#endif	// ! NO_PYTHON
+#endif  // ! NO_PYTHON
 
 void rim::Variable::queueUpdate() { }
 
@@ -536,6 +536,7 @@ uint64_t rim::Variable::getUInt() {
    return (block_->*getUInt_)(this);
 }
 
+
 /////////////////////////////////
 // C++ int
 /////////////////////////////////
@@ -584,12 +585,12 @@ std::string rim::Variable::getString() {
    return (block_->*getString_)(this);
 }
 
-void rim::Variable::getString( std::string & retString ) {
+void rim::Variable::getValue( std::string & retString ) {
    if ( getString_ == NULL ) {
       retString = "";
    } else {
       block_->read(this);
-      retString = (block_->*getString_)(this);
+      block_->getValue(this, retString);
    }
 }
 


### PR DESCRIPTION
I'm using a C++ template based approach on the EPICS driver so need each variable type to support a getValue() and setValue() call w/ the appropriate type in the args.