### PR TITLE
Add variable dump for python and CPP APIs

### DIFF
--- a/include/rogue/LibraryBase.h
+++ b/include/rogue/LibraryBase.h
@@ -100,6 +100,9 @@ namespace rogue {
          //! Helper function to get uint32_t vector from fields
          std::vector<uint32_t> getFieldVectorUInt32(std::map<std::string, std::string> fields, std::string name);
 
+         //! Dump the current state of the registers in the system
+         void dumpRegisterStatus(std::string filename, bool read);
+
    };
 
    typedef std::shared_ptr<rogue::LibraryBase> LibraryBasePtr;

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -331,6 +331,9 @@ namespace rogue {
                //! Set logging level for Variable's block
                void setLogLevel(uint32_t level);
 
+               //! Return string representation of value using default converters
+               std::string getDumpValue(bool read);
+
                /////////////////////////////////
                // C++ Byte Array
                /////////////////////////////////

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -243,7 +243,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         self.add(pr.LocalCommand(name='RemoteVariableDump', value='',
                                  function=lambda arg: self.remoteVariableDump(name=arg, readFirst=True),
-                                 hidden=False,
+                                 hidden=True,
                                  description='Save a dump of the remote variable state'))
 
         self.add(pr.LocalCommand(name='Initialize', function=self.initialize, hidden=True,

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -241,6 +241,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  hidden=True,
                                  description='Read configuration from passed filename in YAML format'))
 
+        self.add(pr.LocalCommand(name='RemoteVariableDump', value='',
+                                 function=lambda arg: self.remoteVariableDump(name=arg, readFirst=True),
+                                 hidden=True,
+                                 description='Save a dump of the remote variable state'))
+
         self.add(pr.LocalCommand(name='Initialize', function=self.initialize, hidden=True,
                                  description='Generate a soft reset to each device in the tree'))
 
@@ -283,6 +288,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         self.add(pr.LocalCommand(name='Exit', function=self._exit,
                                  description='Exit the server application'))
+
 
     def start(self, **kwargs):
         """Setup the tree. Start the polling thread."""
@@ -856,6 +862,24 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         if self.InitAfterConfig.value():
             self.initialize()
+
+
+    def remoteVariableDump(self,name,readFirst):
+        """Dump remote variable values to a file."""
+
+        # Auto generate name if no arg
+        if name is None or name == '':
+            name = datetime.datetime.now().strftime(autoPrefix + "_%Y%m%d_%H%M%S.txt")
+
+        if readFirst:
+            self._read()
+
+        with open(name,'w') as f:
+            for v in self.variableList:
+                if hasattr(v,'_getDumpValue'):
+                    f.write(v._getDumpValue(False))
+
+        return True
 
 
     def _setDictRoot(self,d,writeEach,modes,incGroups,excGroups):

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -243,7 +243,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         self.add(pr.LocalCommand(name='RemoteVariableDump', value='',
                                  function=lambda arg: self.remoteVariableDump(name=arg, readFirst=True),
-                                 hidden=True,
+                                 hidden=False,
                                  description='Save a dump of the remote variable state'))
 
         self.add(pr.LocalCommand(name='Initialize', function=self.initialize, hidden=True,
@@ -869,7 +869,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         # Auto generate name if no arg
         if name is None or name == '':
-            name = datetime.datetime.now().strftime(autoPrefix + "_%Y%m%d_%H%M%S.txt")
+            name = datetime.datetime.now().strftime("regdump_%Y%m%d_%H%M%S.txt")
 
         if readFirst:
             self._read()

--- a/python/pyrogue/pydm/widgets/command.py
+++ b/python/pyrogue/pydm/widgets/command.py
@@ -73,7 +73,7 @@ class Command(PyDMFrame):
 
         hb.addWidget(self._btn)
 
-    @Slot(str)
+    #@Slot(str)
     def _argChanged(self,value):
         self._btn.pressValue = value
 

--- a/python/pyrogue/pydm/widgets/command.py
+++ b/python/pyrogue/pydm/widgets/command.py
@@ -13,7 +13,8 @@
 from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMPushButton
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from qtpy.QtCore import Slot, Signal
+from qtpy.QtCore import Signal
+#from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QComboBox
 
 
@@ -73,7 +74,6 @@ class Command(PyDMFrame):
 
         hb.addWidget(self._btn)
 
-    #@Slot(str)
     def _argChanged(self,value):
         self._btn.pressValue = value
 

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -159,7 +159,7 @@ class CommandHolder(QTreeWidgetItem):
                 self._top._colWidths[3] = width
 
 
-    @Slot(str)
+    #@Slot(str)
     def _argChanged(self,value):
         self._btn.pressValue = value
 

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -159,7 +159,6 @@ class CommandHolder(QTreeWidgetItem):
                 self._top._colWidths[3] = width
 
 
-    #@Slot(str)
     def _argChanged(self,value):
         self._btn.pressValue = value
 

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -26,6 +26,8 @@
 #include <map>
 #include <string>
 #include <sstream>
+#include <iostream>
+#include <fstream>
 
 namespace ris  = rogue::interfaces::stream;
 namespace rim  = rogue::interfaces::memory;
@@ -267,5 +269,20 @@ std::vector<uint32_t> rogue::LibraryBase::getFieldVectorUInt32(std::map<std::str
       ret.push_back(val);
    }
    return ret;
+}
+
+
+//! Dump the current state of the registers in the system
+void rogue::LibraryBase::dumpRegisterStatus(std::string filename, bool read) {
+   std::map< std::string, rim::VariablePtr>::iterator it;
+
+   std::ofstream myfile;
+
+   myfile.open(filename);
+
+   for (it=variables_.begin(); it != variables_.end(); ++it) myfile << it->second->getDumpValue(read);
+
+   myfile.close();
+
 }
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -25,6 +25,8 @@
 #include <memory>
 #include <cmath>
 #include <sys/time.h>
+#include <iostream>
+#include <iomanip>
 
 namespace rim = rogue::interfaces::memory;
 
@@ -73,7 +75,8 @@ void rim::Variable::setup_python() {
       .def("_set",             &rim::VariableWrap::set)
       .def("_rateTest",        &rim::VariableWrap::rateTest)
       .def("_queueUpdate",     &rim::Variable::queueUpdate, &rim::VariableWrap::defQueueUpdate)
-	  .def("_setLogLevel",     &rim::Variable::setLogLevel)
+	   .def("_setLogLevel",     &rim::Variable::setLogLevel)
+	   .def("_getDumpValue",    &rim::Variable::getDumpValue)
    ;
 #endif
 }
@@ -503,6 +506,72 @@ void rim::Variable::rateTest() {
    rate = count / durr;
 
    printf("\nVariable c++ set: Wrote %li times in %f seconds. Rate = %f\n",count,durr,rate);
+}
+
+
+//! Return string representation of value using default converters
+std::string rim::Variable::getDumpValue(bool read) {
+   std::stringstream ret;
+   uint32_t x;
+   uint8_t byteData[byteSize_];
+
+   if (read) block_->read(this);
+
+   ret << path_ << " = ";
+
+   switch (modelId_) {
+
+      case rim::Bytes :
+         (block_->*getByteArray_)(byteData,this);
+         ret << "0x";
+         for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+         break;
+
+      case rim::UInt :
+         if (bitTotal_ > 64) {
+            (block_->*getByteArray_)(byteData,this);
+            ret << "0x";
+            for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+         }
+         else ret << (block_->*getUInt_)(this);
+         break;
+
+      case rim::Int :
+         if (bitTotal_ > 64) {
+            (block_->*getByteArray_)(byteData,this);
+            ret << "0x";
+            for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+         }
+         else ret << (block_->*getInt_)(this);
+         break;
+
+      case rim::Bool :
+         ret << (block_->*getBool_)(this);
+         break;
+
+      case rim::String :
+         ret << (block_->*getString_)(this);
+         break;
+
+      case rim::Float :
+         ret << (block_->*getFloat_)(this);
+         break;
+
+      case rim::Double :
+         ret << (block_->*getDouble_)(this);
+         break;
+
+      case rim::Fixed :
+         ret << (block_->*getFixed_)(this);
+         break;
+
+      default :
+         ret << "UNDEFINED";
+         break;
+   }
+
+   ret << "\n";
+   return ret.str();
 }
 
 /////////////////////////////////

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -524,14 +524,14 @@ std::string rim::Variable::getDumpValue(bool read) {
       case rim::Bytes :
          (block_->*getByteArray_)(byteData,this);
          ret << "0x";
-         for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+         for (x=0; x < byteSize_; x++) ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
          break;
 
       case rim::UInt :
          if (bitTotal_ > 64) {
             (block_->*getByteArray_)(byteData,this);
             ret << "0x";
-            for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+            for (x=0; x < byteSize_; x++) ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
          }
          else ret << (block_->*getUInt_)(this);
          break;
@@ -540,7 +540,7 @@ std::string rim::Variable::getDumpValue(bool read) {
          if (bitTotal_ > 64) {
             (block_->*getByteArray_)(byteData,this);
             ret << "0x";
-            for (x=0; x < byteSize_; x++) ret << std::setw(2) << std::setfill('0') << std::hex << byteData[x];
+            for (x=0; x < byteSize_; x++) ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
          }
          else ret << (block_->*getInt_)(this);
          break;


### PR DESCRIPTION
This creates a register state dump which uses the same format for both the CPP and python versions. This will allows comparisons between a working python version of the software and a CPP API. Its possible that the exported lists may need to be sorted externally before a compare. 

To generate the python dump run the root command:

root.RemoteVariableDump(path)

To generate the cpp dump run the command:

LibraryBase::dumpRegisterStatus(std::string filename, bool read)

The format of the file is:

MultiRenaRoot.Node[0].RceVersion.FpgaVersion = 1
MultiRenaRoot.Node[0].RceVersion.ScratchPad = 0
MultiRenaRoot.Node[0].RceVersion.RceVersion = 20
MultiRenaRoot.Node[0].RceVersion.DeviceDna = 14826940677015636
MultiRenaRoot.Node[0].RceVersion.EFuseValue = 0
MultiRenaRoot.Node[0].RceVersion.EthMode = 2
MultiRenaRoot.Node[0].RceVersion.HeartBeat = 3634079405
MultiRenaRoot.Node[0].RceVersion.GitHash = 0x001556139c88569803617c0bfc303f20fc7a60fc
MultiRenaRoot.Node[0].RceVersion.BuildStamp = MultiRena: Vivado v2019.2, rdsrv302 (x86_64), Built Tue 12 May 2020 12:18:24 PM PDT by ruckman
MultiRenaRoot.Node[0].RceVersion.SerialNumber = 0
MultiRenaRoot.Node[0].RceVersion.AtcaSlot = 0
MultiRenaRoot.Node[0].RceVersion.CobBay = 0
MultiRenaRoot.Node[0].RceVersion.CobElement = 0
