### PR TITLE
Ensure reference count to None, True and False is incremented

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -11,7 +11,7 @@ build:
 requirements:
    build:
      - python
-     - boost=1.70
+     - boost
      - {{ compiler('c') }}
      - {{ compiler('cxx') }}
      - git
@@ -24,7 +24,7 @@ requirements:
      - numpy
    host:
      - python
-     - boost=1.70
+     - boost
      - bzip2
      - zeromq
      - epics-base [linux]
@@ -33,7 +33,7 @@ requirements:
    run:
      - python
      - {{ pin_compatible('boost', min_pin='x.x', max_pin='x.x')}}
-     - boost=1.70
+     - boost
      - bzip2
      - zeromq
      - epics-base [linux]

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -617,7 +617,7 @@ bp::object rim::Block::getUIntPy (rim::Variable *var ) {
    uint64_t tmp = 0;
 
    getBytes((uint8_t *)&tmp,var);
-   
+
    PyObject *val = Py_BuildValue("K",tmp);
    bp::handle<> handle(val);
    return bp::object(handle);
@@ -732,7 +732,7 @@ bp::object rim::Block::getBoolPy ( rim::Variable *var ) {
 
    getBytes((uint8_t *)&tmp,var);
 
-   bp::handle<> handle(tmp?Py_True:Py_False);
+   bp::handle<> handle(bp::borrowed(tmp?Py_True:Py_False));
    return bp::object(handle);
 }
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -426,7 +426,7 @@ void rim::VariableWrap::set(bp::object &value) {
 //! Get value from RemoteVariable
 bp::object rim::VariableWrap::get() {
    if ( getFuncPy_ == NULL ) {
-      bp::handle<> handle(Py_None);
+      bp::handle<> handle(bp::borrowed(Py_None));
       return bp::object(handle);
    }
    return (block_->*getFuncPy_)(this);


### PR DESCRIPTION
Returning True, False and None from the Block class was wrapping the global object without properly incrementing the reference count.

This cause a free() error after running for a period of time when python tried to de-allocate a global oject.