### PR TITLE
Fix incorrect format string specifier

### DIFF
--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -494,7 +494,7 @@ void rim::Variable::rateTest() {
    durr = dtime.tv_sec + (float)dtime.tv_usec / 1.0e6;
    rate = count / durr;
 
-   printf("\nVariable c++ get: Read %li times in %f seconds. Rate = %f\n",count,durr,rate);
+   printf("\nVariable c++ get: Read %" PRIu64 " times in %f seconds. Rate = %f\n",count,durr,rate);
 
    gettimeofday(&stime,NULL);
    for (x=0; x < count; ++x) {
@@ -506,7 +506,7 @@ void rim::Variable::rateTest() {
    durr = dtime.tv_sec + (float)dtime.tv_usec / 1.0e6;
    rate = count / durr;
 
-   printf("\nVariable c++ set: Wrote %li times in %f seconds. Rate = %f\n",count,durr,rate);
+   printf("\nVariable c++ set: Wrote %" PRIu64 " times in %f seconds. Rate = %f\n",count,durr,rate);
 }
 
 


### PR DESCRIPTION
Fixes the following warnings when compiling on a Mac:

```
/Users/bareese/rogue/src/rogue/interfaces/memory/Variable.cpp:497:75: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
   printf("\nVariable c++ get: Read %li times in %f seconds. Rate = %f\n",count,durr,rate);
                                    ~~~                                   ^~~~~
                                    %llu
/Users/bareese/rogue/src/rogue/interfaces/memory/Variable.cpp:509:76: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
   printf("\nVariable c++ set: Wrote %li times in %f seconds. Rate = %f\n",count,durr,rate);
                                     ~~~                                   ^~~~~
                                     %llu
```