### PR TITLE
Auto expand small lists

### DIFF
--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -14,7 +14,7 @@ import sys
 import pydm
 import pyrogue.pydm.data_plugins.rogue_plugin
 
-def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=800,sizeY=1000):
+def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=800,sizeY=1000,maxListExpand=5):
 
     if root is not None:
 
@@ -35,6 +35,7 @@ def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=80
     args.append(f"sizeX={sizeX}")
     args.append(f"sizeY={sizeY}")
     args.append(f"title='{title}'")
+    args.append(f"maxListExpand={maxListExpand}")
 
     app = pydm.PyDMApplication(ui_file=ui,
                                command_line_args=args,

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -31,7 +31,7 @@ class DefaultTop(Display):
         self.sizeX  = None
         self.sizeY  = None
         self.title  = None
-        self.maxExp = 5
+        self.maxExp = None
 
         for a in args:
             if 'sizeX=' in a:

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -28,9 +28,10 @@ class DefaultTop(Display):
         self.setStyleSheet("*[dirty='true']\
                            {background-color: orange;}")
 
-        self.sizeX = None
-        self.sizeY = None
-        self.title = None
+        self.sizeX  = None
+        self.sizeY  = None
+        self.title  = None
+        self.maxExp = 5
 
         for a in args:
             if 'sizeX=' in a:
@@ -39,6 +40,8 @@ class DefaultTop(Display):
                 self.sizeY = int(a.split('=')[1])
             if 'title=' in a:
                 self.title = a.split('=')[1]
+            if 'maxListExpand' in a:
+                self.maxExp = int(a.split('=')[1])
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
@@ -48,6 +51,9 @@ class DefaultTop(Display):
         if self.sizeY is None:
             self.sizeY = 1000
 
+        if self.maxExp is None:
+            self.maxExp = 5
+
         self.setWindowTitle(self.title)
 
         vb = QVBoxLayout()
@@ -56,7 +62,7 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        var = VariableTree(parent=None, init_channel=Channel)
+        var = VariableTree(parent=None, init_channel=Channel, maxListExpand=self.maxExp)
         self.tab.addTab(var,'Variables')
 
         cmd = CommandTree(parent=None, init_channel=Channel)

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -92,6 +92,10 @@ class VariableDev(QTreeWidgetItem):
                         dev=val,
                         noExpand=noExpand)
 
+        # Auto expand list variables
+        for k,v in self._avars.items():
+            v._autoExpand()
+
     def _expand(self):
         if self._dummy is None:
             return
@@ -111,7 +115,7 @@ class VariableArray(QTreeWidgetItem):
         self._dummy    = None
         self._path     = path
         self._list     = []
-        self._depth     = parent._depth+1
+        self._depth    = parent._depth+1
 
         self._lab = QLabel(parent=None, text=self._name + ' (0)')
 
@@ -135,6 +139,10 @@ class VariableArray(QTreeWidgetItem):
         self.removeChild(self._dummy)
         self._dummy = None
         self._setup()
+
+    def _autoExpand(self):
+        if len(self._list) <= self._top._maxListExpand:
+            self.setExpanded(True)
 
     def addNode(self,node):
         self._list.append(node)
@@ -215,7 +223,7 @@ class VariableHolder(QTreeWidgetItem):
 
 
 class VariableTree(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden'], maxListExpand=5):
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._node = None
@@ -224,6 +232,8 @@ class VariableTree(PyDMFrame):
         self._incGroups = incGroups
         self._excGroups = excGroups
         self._tree      = None
+
+        self._maxListExpand = maxListExpand
 
         self._colWidths = [250,50,75,200,50]
 


### PR DESCRIPTION
This adds are arg to the VariableList widget 'maxListExpand' which defines the max number of entries a list can have and be auto expanded. This arg is  also available at the runPyDM() method.