### PR TITLE
Fix error w/ removing expired transactions.

### DIFF
--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -99,7 +99,7 @@ rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
       // Clean up if we found an expired transaction, overtime this will clean up
       // the list, even if it deletes one expired transaction per call
       if ( exp != tranMap_.end() ) {
-          printf("Removing expired transaction with id = %i\n",it->second->id());
+          printf("Removing expired transaction with id = %i\n",exp->second->id());
           tranMap_.erase(exp);
       }
 

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -99,7 +99,6 @@ rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
       // Clean up if we found an expired transaction, overtime this will clean up
       // the list, even if it deletes one expired transaction per call
       if ( exp != tranMap_.end() ) {
-          printf("Removing expired transaction with id = %i\n",exp->second->id());
           tranMap_.erase(exp);
       }
 


### PR DESCRIPTION
Got a core dump of a rogue crash and traced it to this error when removing expired transactions.
Not sure if this is the only bug in https://jira.slac.stanford.edu/projects/ESCLINK/issues/ESCLINK-37?filter=allopenissues
but it's certainly causing some of the crashes.