### PR TITLE
Add support for transaction retry

### DIFF
--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -96,6 +96,9 @@ namespace rogue {
                // Verify Requred After Write, transiant
                bool verifyReq_;
 
+               // Verify transaction in progress
+               bool verifyInp_;
+
                // verifyBase byte, transiant
                uint32_t verifyBase_;
 

--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -138,6 +138,9 @@ namespace rogue {
                // Stale flag
                bool stale_;
 
+               // Retry count
+               uint32_t retryCount_;
+
 #ifndef NO_PYTHON
 
                // Call variable update for all variables

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -140,6 +140,8 @@ namespace rogue {
                // Stride per value
                uint32_t valueStride_;
 
+               // Retry count
+               uint32_t retryCount_;
 
 #ifndef NO_PYTHON
                /////////////////////////////////
@@ -255,7 +257,8 @@ namespace rogue {
                      uint32_t binPoint,
                      uint32_t numValues,
                      uint32_t valueBits,
-                     uint32_t valueStride);
+                     uint32_t valueStride,
+                     uint32_t retryCount);
 
                // Setup class for use in python
                static void setup_python();
@@ -278,7 +281,8 @@ namespace rogue {
                           uint32_t binPoint,
                           uint32_t numValues,
                           uint32_t valueBits,
-                          uint32_t valueStride);
+                          uint32_t valueStride,
+                          uint32_t retryCount);
 
                // Destroy
                virtual ~Variable();
@@ -358,6 +362,11 @@ namespace rogue {
                //! Return the stride per value
                uint32_t valueStride() {
                    return valueStride_;
+               }
+
+               //! Return the retry count
+               uint32_t retryCount() {
+                   return retryCount_;
                }
 
                //! Execute queue update, unused in C++
@@ -544,7 +553,8 @@ namespace rogue {
                               bool bulkOpEn,
                               bool updateNotify,
                               boost::python::object model,
-                              boost::python::object listData);
+                              boost::python::object listData,
+                              uint32_t retryCount);
 
                //! Update the bit offsets
                void updateOffset(boost::python::object &bitOffset);

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -585,6 +585,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         header += "NumValues\t"
         header += "ValueBits\t"
         header += "ValueStride\t"
+        header += "RetryCount\t"
         header += "Description"
 
         lines = []
@@ -614,6 +615,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 data += "{}\t".format(v._numValues())
                 data += "{}\t".format(v._valueBits())
                 data += "{}\t".format(v._valueStride())
+                data += "{}\t".format(v._retryCount())
                 # Escape " characters
                 description = v.description.replace('"',r'\"')
                 # Escape \n characters and strip each line in the description field

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -588,7 +588,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
                  updateNotify=True,
                  overlapEn=False,
                  bulkOpEn=True,
-                 verify=True, ):
+                 verify=True,
+                 retryCount=0):
 
         if disp is None:
             disp = base.defaultdisp
@@ -655,7 +656,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         # Setup C++ Base class
         rim.Variable.__init__(self,self._name,self._mode,self._minimum,self._maximum,
                               offset, bitOffset, bitSize, overlapEn, verify,
-                              self._bulkOpEn, self._updateNotify, self._base, listData)
+                              self._bulkOpEn, self._updateNotify, self._base, listData, retryCount)
 
     @pr.expose
     @property

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -127,12 +127,15 @@ def connectPgp2bSim(pgpA, pgpB):
 
 class MemEmulate(rogue.interfaces.memory.Slave):
 
-    def __init__(self, *, minWidth=4, maxSize=0xFFFFFFFF):
+    def __init__(self, *, minWidth=4, maxSize=0xFFFFFFFF, dropCount=0):
         rogue.interfaces.memory.Slave.__init__(self,4,4)
         self._minWidth = minWidth
         self._maxSize  = maxSize
         self._data = {}
         self._cb   = {}
+
+        self._count = 0
+        self._dropCount = dropCount
 
     def _checkRange(self, address, size):
         return 0
@@ -147,6 +150,12 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         address = transaction.address()
         size    = transaction.size()
         type    = transaction.type()
+
+        self._count += 1
+
+        if self._dropCount != 0 and self._count == self._dropCount:
+            self._count = 0
+            return
 
         if (address % self._minWidth) != 0:
             transaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -145,6 +145,7 @@ void rogue::LibraryBase::createVariable(std::map<std::string, std::string> &data
    uint32_t numValues   = getFieldUInt32(data,"NumValues",true);
    uint32_t valueBits   = getFieldUInt32(data,"ValueBits",true);
    uint32_t valueStride = getFieldUInt32(data,"ValueStride",true);
+   uint32_t retryCount  = getFieldUInt32(data,"RetryCount",true);
 
    double minimum = getFieldDouble(data,"Minimum");
    double maximum = getFieldDouble(data,"Maximum");
@@ -169,7 +170,7 @@ void rogue::LibraryBase::createVariable(std::map<std::string, std::string> &data
    // Create variable
    rim::VariablePtr var = rim::Variable::create(name,mode,minimum,maximum,offset,bitOffset,bitSize,
       overlapEn,verify,bulkEn,updateNotify,modelId,byteReverse,bitReverse,binPoint,numValues,
-      valueBits,valueStride);
+      valueBits,valueStride,retryCount);
 
    // Adjust min transaction size to match blocksize field
    var->shiftOffsetDown(0, blockSize);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <memory>
 #include <cmath>
+#include <exception>
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;
@@ -257,7 +258,7 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
 
    do {
 
-      intStartTransaction(type,forceWr,check,var,index);
+      intStartTransaction(type,fWr,check,var,index);
 
       try {
          if ( check ) checkTransaction();
@@ -290,7 +291,8 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
 
    do {
 
-      intStartTransaction(type,forceWr,check,var.get(),index);
+      printf("Starting transaction, check=%i, retryCount_ = %i\n",check,retryCount_);
+      intStartTransaction(type,fWr,check,var.get(),index);
 
       try {
          if ( check ) upd = checkTransaction();
@@ -299,6 +301,7 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
          count = retryCount_;
 
       } catch ( rogue::GeneralError err ) {
+         printf("Exception caught on try %i out of %i\n",(count+1),(retryCount_+1));
          if ( (count+1) >= retryCount_ ) throw err;
          bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
          fWr = true; // Stale state is now lost

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -80,7 +80,8 @@ rim::Block::Block (uint64_t offset, uint32_t size) {
    doUpdate_   = false;
    blockPyTrans_ = false;
    enable_     = false;
-   stale_        = false;
+   stale_      = false;
+   retryCount_ = 0;
 
    verifyBase_ = 0; // Verify Range
    verifySize_ = 0; // Verify Range
@@ -248,20 +249,64 @@ void rim::Block::intStartTransaction(uint32_t type, bool forceWr, bool check, ri
 
 // Start a transaction for this block, cpp version
 void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::Variable *var, int32_t index) {
-   intStartTransaction(type,forceWr,check,var,index);
+   uint32_t count;
+   bool     fWr;
 
-   if ( check ) checkTransaction();
+   count = 0;
+   fWr = forceWr;
+
+   do {
+
+      intStartTransaction(type,forceWr,check,var,index);
+
+      try {
+         if ( check ) checkTransaction();
+
+         // Success
+         count = retryCount_;
+
+      } catch ( rogue::GeneralError err ) {
+         if ( (count+1) >= retryCount_ ) throw err;
+         bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
+         fWr = true; // State state is now lost
+      }
+   }
+   while (count++ < retryCount_);
 }
 
 #ifndef NO_PYTHON
 
 // Start a transaction for this block, python version
 void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim::VariablePtr var, int32_t index) {
+   uint32_t count;
+   bool     upd;
+   bool     fWr;
+
    if ( blockPyTrans_ ) return;
 
-   intStartTransaction(type,forceWr,check,var.get(),index);
+   count = 0;
+   upd = false;
+   fWr = forceWr;
 
-   if ( check && checkTransaction() ) varUpdate();
+   do {
+
+      intStartTransaction(type,forceWr,check,var.get(),index);
+
+      try {
+         if ( check ) upd = checkTransaction();
+
+         // Success
+         count = retryCount_;
+
+      } catch ( rogue::GeneralError err ) {
+         if ( (count+1) >= retryCount_ ) throw err;
+         bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
+         fWr = true; // State state is now lost
+      }
+   }
+   while (count++ < retryCount_);
+
+   if ( upd ) varUpdate();
 }
 
 #endif
@@ -376,6 +421,9 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
       if ( (*vit)->bulkOpEn_ ) bulkOpEn_ = true;
       if ( (*vit)->updateNotify_ ) updateEn_ = true;
 
+      // Retry count
+      if ( (*vit)->retryCount_ > retryCount_ ) retryCount_ =  (*vit)->retryCount_;
+
       // If variable modes mismatch, set block to read/write
       if ( mode_ != (*vit)->mode_ ) mode_ = "RW";
 
@@ -404,7 +452,7 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
       }
 
       bLog_->debug("Adding variable %s to block %s at offset 0x%.8x",(*vit)->name_.c_str(),path_.c_str(),offset_);
-      }
+   }
 
    // Init overlap enable before check
    overlapEn_ = true;

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -268,7 +268,7 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
          bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
-         fWr = true; // State state is now lost
+         fWr = true; // Stale state is now lost
       }
    }
    while (count++ < retryCount_);
@@ -301,7 +301,7 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
          bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
-         fWr = true; // State state is now lost
+         fWr = true; // Stale state is now lost
       }
    }
    while (count++ < retryCount_);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -261,7 +261,7 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
       intStartTransaction(type,fWr,check,var,index);
 
       try {
-         if ( check ) checkTransaction();
+         if ( check || retryCount_ > 0 ) checkTransaction();
 
          // Success
          count = retryCount_;
@@ -295,7 +295,7 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
       intStartTransaction(type,fWr,check,var.get(),index);
 
       try {
-         if ( check ) upd = checkTransaction();
+         if ( check || retryCount_ > 0 ) upd = checkTransaction();
 
          // Success
          count = retryCount_;

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -59,7 +59,7 @@ rim::VariablePtr rim::Variable::create ( std::string name,
                           uint32_t retryCount) {
 
    rim::VariablePtr v = std::make_shared<rim::Variable>( name, mode, minimum, maximum,
-         offset, bitOffset, bitSize, overlapEn, verify, bulkOpEn, updateNotify, modelId, byteReverse, bitReverse, binPoint,numValues,valueBits,valueStride);
+         offset, bitOffset, bitSize, overlapEn, verify, bulkOpEn, updateNotify, modelId, byteReverse, bitReverse, binPoint,numValues,valueBits,valueStride,retryCount);
    return(v);
 }
 
@@ -67,7 +67,7 @@ rim::VariablePtr rim::Variable::create ( std::string name,
 void rim::Variable::setup_python() {
 
 #ifndef NO_PYTHON
-   bp::class_<rim::VariableWrap, rim::VariableWrapPtr, boost::noncopyable>("Variable",bp::init<std::string, std::string, bp::object, bp::object, uint64_t, bp::object, bp::object, bool,bool,bool,bool,bp::object,bp::object>(),uint32_t)
+   bp::class_<rim::VariableWrap, rim::VariableWrapPtr, boost::noncopyable>("Variable",bp::init<std::string, std::string, bp::object, bp::object, uint64_t, bp::object, bp::object, bool,bool,bool,bool,bp::object,bp::object,uint32_t>())
       .def("_varBytes",        &rim::Variable::varBytes)
       .def("_offset",          &rim::Variable::offset)
       .def("_shiftOffsetDown", &rim::Variable::shiftOffsetDown)

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -55,7 +55,8 @@ rim::VariablePtr rim::Variable::create ( std::string name,
                           uint32_t binPoint,
                           uint32_t numValues,
                           uint32_t valueBits,
-                          uint32_t valueStride) {
+                          uint32_t valueStride,
+                          uint32_t retryCount) {
 
    rim::VariablePtr v = std::make_shared<rim::Variable>( name, mode, minimum, maximum,
          offset, bitOffset, bitSize, overlapEn, verify, bulkOpEn, updateNotify, modelId, byteReverse, bitReverse, binPoint,numValues,valueBits,valueStride);
@@ -66,7 +67,7 @@ rim::VariablePtr rim::Variable::create ( std::string name,
 void rim::Variable::setup_python() {
 
 #ifndef NO_PYTHON
-   bp::class_<rim::VariableWrap, rim::VariableWrapPtr, boost::noncopyable>("Variable",bp::init<std::string, std::string, bp::object, bp::object, uint64_t, bp::object, bp::object, bool,bool,bool,bool,bp::object,bp::object>())
+   bp::class_<rim::VariableWrap, rim::VariableWrapPtr, boost::noncopyable>("Variable",bp::init<std::string, std::string, bp::object, bp::object, uint64_t, bp::object, bp::object, bool,bool,bool,bool,bp::object,bp::object>(),uint32_t)
       .def("_varBytes",        &rim::Variable::varBytes)
       .def("_offset",          &rim::Variable::offset)
       .def("_shiftOffsetDown", &rim::Variable::shiftOffsetDown)
@@ -84,6 +85,7 @@ void rim::Variable::setup_python() {
       .def("_numValues",       &rim::Variable::numValues)
       .def("_valueBits",       &rim::Variable::valueBits)
       .def("_valueStride",     &rim::Variable::valueStride)
+      .def("_retryCount",      &rim::Variable::retryCount)
    ;
 #endif
 }
@@ -106,7 +108,8 @@ rim::Variable::Variable ( std::string name,
                           uint32_t binPoint,
                           uint32_t numValues,
                           uint32_t valueBits,
-                          uint32_t valueStride) {
+                          uint32_t valueStride,
+                          uint32_t retryCount) {
 
    uint32_t x;
    uint32_t bl;
@@ -131,6 +134,7 @@ rim::Variable::Variable ( std::string name,
    valueBits_    = valueBits;
    valueStride_  = valueStride;
    stale_        = false;
+   retryCount_   = retryCount;
 
    // Compute bit total
    bitTotal_ = bitSize_[0];
@@ -483,7 +487,8 @@ rim::VariableWrap::VariableWrap ( std::string name,
                                   bool bulkOpEn,
                                   bool updateNotify,
                                   bp::object model,
-                                  bp::object listData)
+                                  bp::object listData,
+                                  uint32_t retryCount)
 
                      : rim::Variable ( name,
                                        mode,
@@ -502,7 +507,8 @@ rim::VariableWrap::VariableWrap ( std::string name,
                                        bp::extract<uint32_t>(model.attr("binPoint")),
                                        bp::extract<uint32_t>(listData.attr("numValues")),
                                        bp::extract<uint32_t>(listData.attr("valueBits")),
-                                       bp::extract<uint32_t>(listData.attr("valueStride"))) {
+                                       bp::extract<uint32_t>(listData.attr("valueStride")),
+                                       retryCount) {
 
    model_ = model;
 }

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import datetime
+import parse
+import pyrogue as pr
+import pyrogue.interfaces.simulation
+import rogue.interfaces.memory
+import time
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+#import logging
+#logger = logging.getLogger('pyrogue')
+#logger.setLevel(logging.DEBUG)
+
+class SimpleDev(pr.Device):
+
+    def __init__(self,**kwargs):
+
+        super().__init__(**kwargs)
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestAA",
+            offset       =  0x1c,
+            bitSize      =  16,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestAB",
+            offset       =  0x1e,
+            bitSize      =  16,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestBA",
+            offset       =  0x20,
+            bitSize      =  8,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestBB",
+            offset       =  0x21,
+            bitSize      =  8,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestBC",
+            offset       =  0x22,
+            bitSize      =  8,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "SimpleTestBD",
+            offset       =  0x23,
+            bitSize      =  8,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+            retryCount   = 2
+        ))
+
+
+class DummyTree(pr.Root):
+
+    def __init__(self):
+        pr.Root.__init__(self,
+                         name='dummyTree',
+                         description="Dummy tree for example",
+                         timeout=2.0,
+                         pollEn=False,
+                         serverPort=None)
+
+        # Use a memory space emulator
+        sim = pr.interfaces.simulation.MemEmulate(dropCount=2)
+        self.addInterface(sim)
+
+        self.add(SimpleDev(
+                name       = 'SimpleDev',
+                offset     = 0x80000,
+                memBase    = sim
+            ))
+
+def test_memory():
+
+    with DummyTree() as root:
+
+        for i in range(10):
+
+            root.SimpleDev.SimpleTestAA.set(0x40 + i)
+            root.SimpleDev.SimpleTestAB.set(0x80 + i)
+            root.SimpleDev.SimpleTestBA.set(0x41 + i)
+            root.SimpleDev.SimpleTestBB.set(0x42 + i)
+            root.SimpleDev.SimpleTestBC.set(0x43 + i)
+            root.SimpleDev.SimpleTestBD.set(0x44 + i)
+
+            retAA = root.SimpleDev.SimpleTestAA.get()
+            retAB = root.SimpleDev.SimpleTestAB.get()
+            retBA = root.SimpleDev.SimpleTestBA.get()
+            retBB = root.SimpleDev.SimpleTestBB.get()
+            retBC = root.SimpleDev.SimpleTestBC.get()
+            retBD = root.SimpleDev.SimpleTestBD.get()
+
+            if (retAA != 0x40 + i) or (retAB != 0x80 + i) or (retBA != 0x41 + i) or (retBB != 0x42 + i) or (retBC != 0x43 + i) or (retBD != 0x44 + i):
+                raise AssertionError(f'Verification Failure: retAA={retAA}, retAB={retAB}, retBA={retBA}, retBB={retBB}, retBC={retBC}, retBD={retBD}')
+
+
+if __name__ == "__main__":
+    test_memory()


### PR DESCRIPTION
This PR adds support for transaction retry in remote variables/blocks. Retry is enabled for a block when retryCount is set to a non zero value when creating one of its variables. The variable with the largest retryCount will set the block level retryCount. When setting retryCount to a non zero value, any transactions initiated for the block will be checked immediately, waiting for the transaction to complete, as if checkEach where set for the Device. If an error occurs in the transaction it will be immediately retried up to retryCount times. If the error is a verify error the transaction will not be retried. 

Retries will occur both in variable level transactions (set/get) or in bulk transactions initiated by the poll queue or Root level configuration writes and reads. 