### PR TITLE
Add default min/max values based upon register parameters

### DIFF
--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -19,8 +19,10 @@ def wordCount(bits, wordSize):
         ret += 1
     return ret
 
+
 def byteCount(bits):
     return wordCount(bits, 8)
+
 
 def reverseBits(value, bitSize):
     result = 0
@@ -30,17 +32,18 @@ def reverseBits(value, bitSize):
         value >>= 1
     return result
 
+
 def twosComplement(value, bitSize):
     """compute the 2's complement of int value"""
     if (value & (1 << (bitSize - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
         value = value - (1 << bitSize)      # compute negative value
     return value                            # return positive value as is
 
+
 class ModelMeta(type):
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
         cls.subclasses = {}
-
 
     def __call__(cls, *args, **kwargs):
         key = cls.__name__ + str(args) + str(kwargs)
@@ -63,6 +66,12 @@ class Model(object, metaclass=ModelMeta):
 
     def check(self, value):
         return type(value) == self.pytype
+
+    def minValue(self):
+        return None
+
+    def maxValue(self):
+        return None
 
 
 class UInt(Model):
@@ -88,6 +97,11 @@ class UInt(Model):
     def fromString(self, string):
         return int(string, 0)
 
+    def minValue(self):
+        return 0
+
+    def maxValue(self):
+        return (2**self.bitSize)-1
 
 class UIntReversed(UInt):
     """Converts Unsigned Integer to and from bytearray with reserved bit ordering"""
@@ -134,11 +148,20 @@ class Int(UInt):
             i = i - (1 << self.bitSize)
         return i
 
+    def minValue(self):
+        return -1 * ((2**(self.bitSize-1))-1)
+
+    def maxValue(self):
+        return (2**(self.bitSize-1))-1
+
+
 class UIntBE(UInt):
     endianness = 'big'
 
+
 class IntBE(Int):
     endianness = 'big'
+
 
 class Bool(Model):
 
@@ -156,6 +179,12 @@ class Bool(Model):
 
     def fromString(self, string):
         return str.lower(string) == "true"
+
+    def minValue(self):
+        return 0
+
+    def maxValue(self):
+        return 1
 
 
 class String(Model):
@@ -205,11 +234,23 @@ class Float(Model):
     def fromString(self, string):
         return float(string)
 
+    def minValue(self):
+        return -3.4e38
+
+    def maxValue(self):
+        return 3.4e38
 
 
 class Double(Float):
     fstring = 'd'
     bitSize = 64
+
+    def minValue(self):
+        return -1.80e308
+
+    def maxValue(self):
+        return 1.80e308
+
 
 class FloatBE(Float):
     fstring = '!f'

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -563,16 +563,7 @@ class RemoteVariable(BaseVariable):
         if disp is None:
             disp = base.defaultdisp
 
-        BaseVariable.__init__(self, name=name, description=description,
-                              mode=mode, value=value, disp=disp,
-                              enum=enum, units=units, hidden=hidden, groups=groups,
-                              minimum=minimum, maximum=maximum,
-                              lowWarning=lowWarning, lowAlarm=lowAlarm,
-                              highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval)
-
-
-        self._block    = None
+        self._block = None
 
         # Convert the address parameters into lists
         addrParams = [offset, bitOffset, bitSize] # Make a copy
@@ -606,6 +597,23 @@ class RemoteVariable(BaseVariable):
         self._typeStr   = self._base.name
         self._bytes     = int(math.ceil(float(self._bitOffset[-1] + self._bitSize[-1]) / 8.0))
         self._overlapEn = overlapEn
+
+        # Apply default min and max
+        if minimum is None or (self._base.minValue() is not None and minimum < self._base.minValue()):
+            minimum = self._base.minValue()
+
+        if maximum is None or (self._base.maxValue() is not None and maximum > self._base.maxValue()):
+            maximum = self._base.maxValue()
+
+        BaseVariable.__init__(self, name=name, description=description,
+                              mode=mode, value=value, disp=disp,
+                              enum=enum, units=units, hidden=hidden, groups=groups,
+                              minimum=minimum, maximum=maximum,
+                              lowWarning=lowWarning, lowAlarm=lowAlarm,
+                              highWarning=highWarning, highAlarm=highAlarm,
+                              pollInterval=pollInterval)
+
+
 
 
     @pr.expose


### PR DESCRIPTION
This PR adds a default min/max value for Remote variables. The min and max values are computed based upon the register bit size parameters. The user can still provide min and max values that are more constrained.

This feature already exists in Rogue Version 5. This PR adds this to a incremental release in Rogue version 4.