### PR TITLE
Break large array into sections on gui

### DIFF
--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -145,19 +145,14 @@ class VirtualNode(pr.Node):
     def _loadNodes(self):
         self._loaded = True
 
-        for k,v in self._nodes.items():
-            if v is None:
-
-                node = self._client._remoteAttr(self._path, 'node', k)
-
+        for k,node in self._client._remoteAttr(self._path, 'nodes').items():
+            if k in self._nodes:
                 node._parent = self
                 node._root   = self._root
                 node._client = self._client
 
                 self._nodes[k] = node
                 self._addArrayNode(node)
-
-                #print(f"Loaded node {node.path}")
 
     def _getNode(self,path,load=True):
         obj = self

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -48,11 +48,13 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             nAttr = getattr(node, attr)
 
             if nAttr is None:
-                return self.encode(None,rawStr=False)
+                resp = None
             elif callable(nAttr):
-                return self.encode(nAttr(*args,**kwargs),rawStr=rawStr)
+                resp = nAttr(*args,**kwargs)
             else:
-                return self.encode(nAttr,rawStr=rawStr)
+                resp = nAttr
+
+            return self.encode(resp,rawStr=rawStr)
 
         except Exception as msg:
             return self.encode(msg,rawStr=False)

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -1,12 +1,12 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue PyDM Package, Function to start default Rogue PyDM GUI
 #-----------------------------------------------------------------------------
-# This file is part of the rogue software platform. It is subject to 
-# the license terms in the LICENSE.txt file found in the top-level directory 
-# of this distribution and at: 
-#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
-# No part of the rogue software platform, including this file, may be 
-# copied, modified, propagated, or distributed except according to the terms 
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import os
@@ -14,9 +14,13 @@ import sys
 import pydm
 import pyrogue.pydm.data_plugins.rogue_plugin
 
-def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=800,sizeY=1000):
+def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=800,sizeY=1000,maxListExpand=5,maxListSize=100):
 
     if root is not None:
+
+        if not root.running:
+            raise Exception("Attempt to use pydm with root that has not started")
+
         os.environ['ROGUE_SERVERS'] = 'localhost:{}'.format(root.serverPort)
     else:
         os.environ['ROGUE_SERVERS'] = serverList
@@ -31,11 +35,13 @@ def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None,sizeX=80
     args.append(f"sizeX={sizeX}")
     args.append(f"sizeY={sizeY}")
     args.append(f"title='{title}'")
+    args.append(f"maxListExpand={maxListExpand}")
+    args.append(f"maxListSize={maxListSize}")
 
     app = pydm.PyDMApplication(ui_file=ui,
                                command_line_args=args,
-                               hide_nav_bar=True, 
-                               hide_menu_bar=True, 
+                               hide_nav_bar=True,
+                               hide_menu_bar=True,
                                hide_status_bar=True)
 
     print(f"Running GUI. Close window, hit cntrl-c or send SIGTERM to {os.getpid()} to exit.")

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -25,13 +25,12 @@ class DefaultTop(Display):
     def __init__(self, parent=None, args=[], macros=None):
         super(DefaultTop, self).__init__(parent=parent, args=args, macros=None)
 
-        self.setStyleSheet("*[dirty='true']\
-                           {background-color: orange;}")
-
         self.sizeX  = None
         self.sizeY  = None
         self.title  = None
-        self.maxExp = None
+
+        self.maxListExpand = None
+        self.maxListSize   = None
 
         for a in args:
             if 'sizeX=' in a:

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -11,7 +11,6 @@
 #-----------------------------------------------------------------------------
 
 import os
-from qtpy import QtCore
 from pydm import Display
 from qtpy.QtWidgets import (QVBoxLayout, QTabWidget)
 
@@ -21,24 +20,44 @@ from pyrogue.pydm.widgets import SystemWindow
 
 Channel = 'rogue://0/root'
 
+
 class DefaultTop(Display):
     def __init__(self, parent=None, args=[], macros=None):
         super(DefaultTop, self).__init__(parent=parent, args=args, macros=None)
 
-        self.sizeX = None
-        self.sizeY = None
-        self.title = None
+        self.setStyleSheet("*[dirty='true']\
+                           {background-color: orange;}")
+
+        self.sizeX  = None
+        self.sizeY  = None
+        self.title  = None
+        self.maxExp = None
 
         for a in args:
-            if 'sizeX=' in a: self.sizeX = int(a.split('=')[1])
-            if 'sizeY=' in a: self.sizeY = int(a.split('=')[1])
-            if 'title=' in a: self.title = a.split('=')[1]
+            if 'sizeX=' in a:
+                self.sizeX = int(a.split('=')[1])
+            if 'sizeY=' in a:
+                self.sizeY = int(a.split('=')[1])
+            if 'title=' in a:
+                self.title = a.split('=')[1]
+            if 'maxListExpand' in a:
+                self.maxListExpand = int(a.split('=')[1])
+            if 'maxListSize' in a:
+                self.maxListSize = int(a.split('=')[1])
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
 
-        if self.sizeX is None: self.sizeX = 800
-        if self.sizeY is None: self.sizeY = 1000
+        if self.sizeX is None:
+            self.sizeX = 800
+        if self.sizeY is None:
+            self.sizeY = 1000
+
+        if self.maxListExpand is None:
+            self.maxListExpand = 5
+
+        if self.maxListSize is None:
+            self.maxListSize = 100
 
         self.setWindowTitle(self.title)
 
@@ -48,7 +67,7 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        var = VariableTree(parent=None, init_channel=Channel)
+        var = VariableTree(parent=None, init_channel=Channel, maxListExpand=self.maxListExpand, maxListSize=self.maxListSize)
         self.tab.addTab(var,'Variables')
 
         cmd = CommandTree(parent=None, init_channel=Channel)
@@ -62,4 +81,3 @@ class DefaultTop(Display):
     def ui_filepath(self):
         # No UI file is being used
         return None
-

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -13,14 +13,15 @@
 import pyrogue
 import pyrogue.pydm.widgets
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLineEdit, PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
+from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from pyrogue.interfaces import VirtualClient
+from pyrogue.pydm.widgets import PyRogueLineEdit
+from qtpy.QtCore import Property, Slot, QEvent
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
+from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel
 from qtpy.QtGui import QFontMetrics
-from qtpy.QtCore import Qt, Property, Slot, QEvent
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QMenu, QDialog, QPushButton
-from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLineEdit, QFormLayout, QLabel
 import re
+
 
 class VariableDev(QTreeWidgetItem):
 
@@ -63,24 +64,26 @@ class VariableDev(QTreeWidgetItem):
     def _setup(self,noExpand):
 
         # First create variables
-        for key,val in self._dev.variablesByGroup(incGroups=self._top._incGroups,
-                                                  excGroups=self._top._excGroups).items():
+        lst = self._dev.variablesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups)
+
+        for key,val in lst.items():
 
             # Test for array
-            fields = re.split('\]\[|\[|\]',val.name)
+            fields = re.split('\\]\\[|\\[|\\]',val.name)
             if len(fields) < 3:
                 VariableHolder(path=self._path + '.' + val.name,
                                top=self._top,
                                parent=self,
                                variable=val)
             else:
-                if not fields[0] in self._avars:
+                if not fields[0] in self._avars or self._avars[fields[0]].length() >= self._top._maxListSize:
                     self._avars[fields[0]] = VariableArray(path=self._path,
                                                            top=self._top,
                                                            parent=self,
                                                            name=fields[0])
-                self._avars[fields[0]].addNode(val)
 
+
+                self._avars[fields[0]].addNode(val,fields[1])
 
         # Then create devices
         for key,val in self._dev.devicesByGroup(incGroups=self._top._incGroups,
@@ -90,6 +93,10 @@ class VariableDev(QTreeWidgetItem):
                         top=self._top, parent=self,
                         dev=val,
                         noExpand=noExpand)
+
+        # Auto expand list variables
+        for k,v in self._avars.items():
+            v._autoExpand()
 
     def _expand(self):
         if self._dummy is None:
@@ -110,7 +117,9 @@ class VariableArray(QTreeWidgetItem):
         self._dummy    = None
         self._path     = path
         self._list     = []
-        self._depth     = parent._depth+1
+        self._depth    = parent._depth+1
+        self._first    = None
+        self._last     = None
 
         self._lab = QLabel(parent=None, text=self._name + ' (0)')
 
@@ -135,10 +144,23 @@ class VariableArray(QTreeWidgetItem):
         self._dummy = None
         self._setup()
 
-    def addNode(self,node):
-        self._list.append(node)
-        self._lab.setText(self._name + ' ({})'.format(len(self._list)))
+    def _autoExpand(self):
+        if len(self._list) <= self._top._maxListExpand:
+            self.setExpanded(True)
 
+    def addNode(self,node,idx):
+        self._list.append(node)
+
+        if self._first is None or idx < self._first:
+            self._first = idx
+
+        if self._last is None or idx > self._last:
+            self._last = idx
+
+        self._lab.setText(self._name + f' ({self._first} - {self._last})')
+
+    def length(self):
+        return len(self._list)
 
 class VariableHolder(QTreeWidgetItem):
 
@@ -188,8 +210,14 @@ class VariableHolder(QTreeWidgetItem):
             w.showStepExponent      = False
             w.installEventFilter(self._top)
 
+        elif self._var.mode == 'RO':
+            w = PyDMLabel(parent=None, init_channel=self._path + '/disp')
+            w.showUnits             = False
+            w.precisionFromPV       = True
+            w.alarmSensitiveContent = False
+            w.alarmSensitiveBorder  = True
         else:
-            w = PyDMLineEdit(parent=None, init_channel=self._path + '/disp')
+            w = PyRogueLineEdit(parent=None, init_channel=self._path + '/disp')
             w.showUnits             = False
             w.precisionFromPV       = True
             w.alarmSensitiveContent = False
@@ -208,7 +236,7 @@ class VariableHolder(QTreeWidgetItem):
 
 
 class VariableTree(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden'], maxListExpand=5, maxListSize=100):
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._node = None
@@ -218,13 +246,17 @@ class VariableTree(PyDMFrame):
         self._excGroups = excGroups
         self._tree      = None
 
+        self._maxListExpand = maxListExpand
+        self._maxListSize   = maxListSize
+
         self._colWidths = [250,50,75,200,50]
 
     def connection_changed(self, connected):
-        build = (self._node is None) and (self._connected != connected and connected == True)
+        build = (self._node is None) and (self._connected != connected and connected is True)
         super(VariableTree, self).connection_changed(connected)
 
-        if not build: return
+        if not build:
+            return
 
         self._node = nodeFromAddress(self.channel)
         self._path = self.channel
@@ -303,4 +335,3 @@ class VariableTree(PyDMFrame):
             return True
         else:
             return False
-

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -13,9 +13,8 @@
 import pyrogue
 import pyrogue.pydm.widgets
 from pydm.widgets.frame import PyDMFrame
-from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
+from pydm.widgets import PyDMLineEdit, PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from pyrogue.pydm.widgets import PyRogueLineEdit
 from qtpy.QtCore import Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -63,9 +63,7 @@ class VariableDev(QTreeWidgetItem):
     def _setup(self,noExpand):
 
         # First create variables
-        lst = self._dev.variablesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups)
-
-        for key,val in lst.items():
+        for key,val in self._dev.variablesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups).items():
 
             # Test for array
             fields = re.split('\\]\\[|\\[|\\]',val.name)
@@ -216,7 +214,7 @@ class VariableHolder(QTreeWidgetItem):
             w.alarmSensitiveContent = False
             w.alarmSensitiveBorder  = True
         else:
-            w = PyRogueLineEdit(parent=None, init_channel=self._path + '/disp')
+            w = PyDMLineEdit(parent=None, init_channel=self._path + '/disp')
             w.showUnits             = False
             w.precisionFromPV       = True
             w.alarmSensitiveContent = False

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -86,7 +86,7 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
    }
    else units_->putConvert("");
 
-   if ( epicsType_ == aitEnumUint8 || epicsType_ == aitEnumUint16 || epicsType_ == aitEnumUint32 ) {
+   if ( (! isString_) && (epicsType_ == aitEnumUint8 || epicsType_ == aitEnumUint16 || epicsType_ == aitEnumUint32 )) {
       bp::extract<uint32_t> hopr(var_.attr("maximum"));
       bp::extract<uint32_t> lopr(var_.attr("minimum"));
       bp::extract<uint32_t> ha(var_.attr("highAlarm"));

--- a/tests/test_large.py
+++ b/tests/test_large.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Server only test script
+#-----------------------------------------------------------------------------
+# This file is part of the rogue_example software. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue_example software, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import pyrogue
+
+class TestLarge(pyrogue.Device):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+        for i in range(4096):
+            self.add(pyrogue.LocalVariable(
+                name = f'TestValue[{i}]',
+                mode = 'RW',
+                value = 0))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -98,6 +98,8 @@ class DummyTree(pyrogue.Root):
             disp='{:1.2f}',
             value = np.array(0)))
 
+        self.add(test_large.TestLarge())
+
         #self.add(pyrogue.LocalVariable(
         #    name = 'Test/Slash',
         #    mode = 'RW',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@ import pyrogue.protocols
 import logging
 import math
 import numpy as np
+import test_large
 
 
 #rogue.Logging.setFilter('pyrogue.epicsV3.Value',rogue.Logging.Debug)
@@ -98,7 +99,7 @@ class DummyTree(pyrogue.Root):
             disp='{:1.2f}',
             value = np.array(0)))
 
-        self.add(test_large.TestLarge())
+        #self.add(test_large.TestLarge())
 
         #self.add(pyrogue.LocalVariable(
         #    name = 'Test/Slash',
@@ -174,10 +175,10 @@ if __name__ == "__main__":
     with DummyTree() as dummyTree:
         dummyTree.saveAddressMap('test.csv')
 
-        pyrogue.waitCntrlC()
+        #pyrogue.waitCntrlC()
 
-        #import pyrogue.pydm
-        #pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
+        import pyrogue.pydm
+        pyrogue.pydm.runPyDM(root=dummyTree,title='test123',sizeX=1000,sizeY=500)
 
         #import pyrogue.gui
         #pyrogue.gui.runGui(root=dummyTree)


### PR DESCRIPTION
Avoid building arrays larger than 100 entries on expansion. This also groups node fetches into bursts which reduces the time to interact with the server. 

This also fixes an epics bug already fixed in Rogue 5.