### PR TITLE
Check for invalid bool bitsize

### DIFF
--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -180,8 +180,7 @@ class Bool(Model):
     modelId     = rim.Bool
 
     def __init__(self, bitSize):
-        if bitSize != 1:
-            assert bitSize == 1, f"The bitSize param of Model {self.__class__.__name__} must be 1"
+        assert bitSize == 1, f"The bitSize param of Model {self.__class__.__name__} must be 1"
         super().__init__(bitSize)
 
     def fromString(self, string):

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -180,6 +180,8 @@ class Bool(Model):
     modelId     = rim.Bool
 
     def __init__(self, bitSize):
+        if bitSize != 1:
+            assert bitSize == 1, f"The bitSize param of Model {self.__class__.__name__} must be 1"
         super().__init__(bitSize)
 
     def fromString(self, string):


### PR DESCRIPTION
Creating a remote variable of type bool with a bit size greater than 1 can create a seg fault. This check will raise an error when this condition is found.