### PR TITLE
Use native pickling instead of JSON for zmq interface

### DIFF
--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -55,7 +55,7 @@ namespace rogue {
 
          public:
 
-            static std::shared_ptr<rogue::interfaces::ZmqClient> create(std::string addr, uint16_t port, bool doString);
+            static std::shared_ptr<rogue::interfaces::ZmqClient> create(std::string addr, uint16_t port);
 
             //! Setup class in python
             static void setup_python();

--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -95,7 +95,7 @@ namespace rogue {
 
          public:
 
-            ZmqClientWrap (std::string addr, uint16_t port);
+            ZmqClientWrap (std::string addr, uint16_t port, bool doString);
 
             void doUpdate  ( boost::python::object data );
 

--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -63,22 +63,13 @@ namespace rogue {
 
             void setTimeout(uint32_t msecs, bool waitRetry);
 
-            std::string send(std::string value);
+#ifndef NO_PYTHON
+            boost::python::object send(boost::python::object data);
+
+            virtual void doUpdate (boost::python::object data);
+#endif
 
             void stop();
-
-            virtual void doUpdate (std::string data);
-
-
-            std::string sendWrapper(std::string path, std::string attr, std::string arg, bool rawStr);
-
-            std::string getDisp(std::string path);
-
-            void setDisp(std::string path, std::string value);
-
-            std::string exec(std::string path, std::string arg = "");
-
-            std::string valueDisp(std::string path);
 
       };
       typedef std::shared_ptr<rogue::interfaces::ZmqClient> ZmqClientPtr;
@@ -94,9 +85,9 @@ namespace rogue {
 
             ZmqClientWrap (std::string addr, uint16_t port);
 
-            void doUpdate  ( std::string data );
+            void doUpdate  ( boost::python::object data );
 
-            void defDoUpdate  ( std::string data );
+            void defDoUpdate  ( boost::python::object data );
       };
 
       typedef std::shared_ptr<rogue::interfaces::ZmqClientWrap> ZmqClientWrapPtr;

--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -36,7 +36,7 @@ namespace rogue {
             // Zeromq publish port
             void * zmqSub_;
 
-            // Zeromq response port
+            // Zeromq request port
             void * zmqReq_;
 
             //! Log
@@ -48,20 +48,32 @@ namespace rogue {
 
             std::thread   * thread_;
             bool threadEn_;
+            bool running_;
+            bool doString_;
 
             void runThread();
 
          public:
 
-            static std::shared_ptr<rogue::interfaces::ZmqClient> create(std::string addr, uint16_t port);
+            static std::shared_ptr<rogue::interfaces::ZmqClient> create(std::string addr, uint16_t port, bool doString);
 
             //! Setup class in python
             static void setup_python();
 
-            ZmqClient (std::string addr, uint16_t port);
+            ZmqClient (std::string addr, uint16_t port, bool doString);
             virtual ~ZmqClient();
 
             void setTimeout(uint32_t msecs, bool waitRetry);
+
+            std::string sendString(std::string path, std::string attr, std::string arg);
+
+            std::string getDisp(std::string path);
+
+            void setDisp(std::string path, std::string value);
+
+            std::string exec(std::string path, std::string arg = "");
+
+            std::string valueDisp(std::string path);
 
 #ifndef NO_PYTHON
             boost::python::object send(boost::python::object data);

--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -62,9 +62,11 @@ namespace rogue {
             ZmqServer (std::string addr, uint16_t port);
             virtual ~ZmqServer();
 
-            void publish(std::string value);
+#ifndef NO_PYTHON
+            void publish(boost::python::object data);
 
-            virtual std::string doRequest (std::string data);
+            virtual boost::python::object doRequest (boost::python::object data);
+#endif
 
             uint16_t port();
 
@@ -83,9 +85,9 @@ namespace rogue {
 
             ZmqServerWrap (std::string addr, uint16_t port);
 
-            std::string doRequest ( std::string data );
+            boost::python::object doRequest ( boost::python::object data );
 
-            std::string defDoRequest ( std::string data );
+            boost::python::object defDoRequest ( boost::python::object data );
       };
 
       typedef std::shared_ptr<rogue::interfaces::ZmqServerWrap> ZmqServerWrapPtr;

--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -39,7 +39,11 @@ namespace rogue {
             // Zeromq response port
             void * zmqRep_;
 
-            std::thread   * thread_;
+            // Zeromq string response port
+            void * zmqStr_;
+
+            std::thread   * rThread_;
+            std::thread   * sThread_;
             bool threadEn_;
 
             std::string addr_;
@@ -49,6 +53,7 @@ namespace rogue {
             std::shared_ptr<rogue::Logging> log_;
 
             void runThread();
+            void strThread();
 
             bool tryConnect();
 
@@ -67,6 +72,8 @@ namespace rogue {
 
             virtual boost::python::object doRequest (boost::python::object data);
 #endif
+
+            virtual std::string doString (std::string data);
 
             uint16_t port();
 
@@ -88,6 +95,11 @@ namespace rogue {
             boost::python::object doRequest ( boost::python::object data );
 
             boost::python::object defDoRequest ( boost::python::object data );
+
+            std::string doString ( std::string data );
+
+            std::string defDoString ( std::string data );
+
       };
 
       typedef std::shared_ptr<rogue::interfaces::ZmqServerWrap> ZmqServerWrapPtr;

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -22,6 +22,7 @@ import functools as ft
 import time
 import queue
 import jsonpickle
+import pickle
 import zipfile
 import traceback
 import datetime
@@ -996,7 +997,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                 # Send over zmq link
                 if self._zmqServer is not None:
-                    self._zmqServer._publish(jsonpickle.encode(zmq))
+                    self._zmqServer._publish(pickle.dumps(zmq))
                 zmq = {}
 
             # Set done

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -380,7 +380,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         if self._serverPort is not None:
             self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=self._serverPort)
             self._serverPort = self._zmqServer.port()
-            print("start: Started zmqServer on port %d" % self._serverPort)
+            print("start: Started zmqServer on ports {self._serverPort}-{self._serverPort+2}")
 
         # Start sql interface
         if self._sqlUrl is not None:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -380,7 +380,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         if self._serverPort is not None:
             self._zmqServer  = pr.interfaces.ZmqServer(root=self,addr="*",port=self._serverPort)
             self._serverPort = self._zmqServer.port()
-            print("start: Started zmqServer on ports {self._serverPort}-{self._serverPort+2}")
+            print(f"Start: Started zmqServer on ports {self._serverPort}-{self._serverPort+2}")
 
         # Start sql interface
         if self._sqlUrl is not None:

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue Simple ZMQ Client for Rogue
 #-----------------------------------------------------------------------------
-# To use in Matlab first you need both the zmq and jsonpickle package in your
+# To use in Matlab first you need the zmq package in your
 # python installation:
 #
 # > pip install zmq
@@ -24,7 +24,6 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import zmq
-import jsonpickle
 import threading
 
 
@@ -53,9 +52,7 @@ class SimpleClient(object):
         self._sub.setsockopt(zmq.SUBSCRIBE,"".encode('utf-8'))
 
         while self._runEn:
-            msg = self._sub.recv_string()
-
-            d = jsonpickle.decode(msg)
+            d = self._sub.recv_pyobj()
 
             for k,val in d.items():
                 self._cb(k,val)
@@ -68,8 +65,8 @@ class SimpleClient(object):
                'kwargs':kwargs}
 
         try:
-            self._req.send_string(jsonpickle.encode(msg))
-            resp = jsonpickle.decode(self._req.recv_string())
+            self._req.send_pyobj(msg)
+            resp = self._req.recv_pyobj()
         except Exception as e:
             raise Exception(f"ZMQ Interface Exception: {e}")
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -206,7 +206,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
         VirtualClient.ClientCache[hash((addr, port))] = self
 
-        rogue.interfaces.ZmqClient.__init__(self,addr,port)
+        rogue.interfaces.ZmqClient.__init__(self,addr,port,False)
         self._varListeners = []
         self._monitors = []
         self._root  = None

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -12,7 +12,7 @@
 
 import pyrogue as pr
 import rogue.interfaces
-import jsonpickle
+import pickle
 import time
 import threading
 
@@ -269,11 +269,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
-        snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
-        y = jsonpickle.encode(snd)
         try:
-            resp = self._send(y)
-            ret = jsonpickle.decode(resp)
+            ret = pickle.loads(self._send(pickle.dumps({ 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs })))
         except Exception as e:
             raise Exception(f"ZMQ Interface Exception: {e}")
 
@@ -292,7 +289,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         if self._root is None:
             return
 
-        d = jsonpickle.decode(data)
+        d = pickle.loads(data)
 
         for k,val in d.items():
             n = self._root.getNode(k,False)

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -12,6 +12,7 @@
 
 import rogue.interfaces
 import pickle
+import jsonpickle
 
 
 class ZmqServer(rogue.interfaces.ZmqServer):
@@ -51,3 +52,33 @@ class ZmqServer(rogue.interfaces.ZmqServer):
 
         except Exception as msg:
             return pickle.dumps(msg)
+
+    def _doString(self,data):
+        try:
+            d = jsonpickle.decode(data)
+
+            path    = d['path']   if 'path'   in d else None
+            attr    = d['attr']   if 'attr'   in d else None
+            args    = d['args']   if 'args'   in d else ()
+            kwargs  = d['kwargs'] if 'kwargs' in d else {}
+
+            # Special case to get root node
+            if path == "__ROOT__":
+                return "__ERROR__"
+
+            node = self._root.getNode(path)
+
+            if node is None:
+                return ""
+
+            nAttr = getattr(node, attr)
+
+            if nAttr is None:
+                return "__NONE__"
+            elif callable(nAttr):
+                return str(nAttr(*args,**kwargs))
+            else:
+                return str(nAttr)
+
+        except Exception as msg:
+            return f"__EXCEPTION__: {msg}"

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -11,7 +11,7 @@
 #-----------------------------------------------------------------------------
 
 import rogue.interfaces
-import jsonpickle
+import pickle
 
 
 class ZmqServer(rogue.interfaces.ZmqServer):
@@ -20,31 +20,23 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         rogue.interfaces.ZmqServer.__init__(self,addr,port)
         self._root = root
 
-    def encode(self,data,rawStr):
-
-        if rawStr and isinstance(data,str):
-            return data
-        else:
-            return jsonpickle.encode(data)
-
     def _doRequest(self,data):
         try:
-            d = jsonpickle.decode(data)
+            d = pickle.loads(data)
 
             path    = d['path']   if 'path'   in d else None
             attr    = d['attr']   if 'attr'   in d else None
             args    = d['args']   if 'args'   in d else ()
             kwargs  = d['kwargs'] if 'kwargs' in d else {}
-            rawStr  = d['rawStr'] if 'rawStr' in d else False
 
             # Special case to get root node
             if path == "__ROOT__":
-                return self.encode(self._root,rawStr=False)
+                return pickle.dumps(self._root)
 
             node = self._root.getNode(path)
 
             if node is None:
-                return self.encode(None,rawStr=False)
+                return pickle.dumps(None)
 
             nAttr = getattr(node, attr)
 
@@ -55,7 +47,7 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             else:
                 resp = nAttr
 
-            return self.encode(resp,rawStr=rawStr)
+            return pickle.dumps(resp)
 
         except Exception as msg:
-            return self.encode(msg,rawStr=False)
+            return pickle.dumps(msg)

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -22,35 +22,37 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         self._root = root
 
     def _doOperation(self,d):
-        try:
-            path    = d['path']   if 'path'   in d else None
-            attr    = d['attr']   if 'attr'   in d else None
-            args    = d['args']   if 'args'   in d else ()
-            kwargs  = d['kwargs'] if 'kwargs' in d else {}
+        path    = d['path']   if 'path'   in d else None
+        attr    = d['attr']   if 'attr'   in d else None
+        args    = d['args']   if 'args'   in d else ()
+        kwargs  = d['kwargs'] if 'kwargs' in d else {}
 
-            # Special case to get root node
-            if path == "__ROOT__":
-                return self._root
+        # Special case to get root node
+        if path == "__ROOT__":
+            return self._root
 
-            node = self._root.getNode(path)
+        node = self._root.getNode(path)
 
-            if node is None:
-                return None
+        if node is None:
+            return None
 
-            nAttr = getattr(node, attr)
+        nAttr = getattr(node, attr)
 
-            if nAttr is None:
-                return None
-            elif callable(nAttr):
-                return nAttr(*args,**kwargs)
-            else:
-                return nAttr
-
-        except Exception as msg:
-            return msg
+        if nAttr is None:
+            return None
+        elif callable(nAttr):
+            return nAttr(*args,**kwargs)
+        else:
+            return nAttr
 
     def _doRequest(self,data):
-        return pickle.dumps(self._doOperation(pickle.loads(data)))
+        try:
+            return pickle.dumps(self._doOperation(pickle.loads(data)))
+        except Exception as msg:
+            return pickle.dumps(msg)
 
     def _doString(self,data):
-        return str(self._doOperation(jsonpickle.decode(data)))
+        try:
+            return str(self._doOperation(jsonpickle.decode(data)))
+        except Exception as msg:
+            return "EXCEPTION: " + str(msg)

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -42,10 +42,6 @@ void rogue::interfaces::ZmqClient::setup_python() {
       .def("_doUpdate",    &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
       .def("_send",        &rogue::interfaces::ZmqClient::send)
       .def("setTimeout",   &rogue::interfaces::ZmqClient::setTimeout)
-      .def("getDisp",      &rogue::interfaces::ZmqClient::getDisp)
-      .def("setDisp",      &rogue::interfaces::ZmqClient::setDisp)
-      .def("exec",         &rogue::interfaces::ZmqClient::exec)
-      .def("valueDisp",    &rogue::interfaces::ZmqClient::valueDisp)
       .def("_stop",        &rogue::interfaces::ZmqClient::stop)
    ;
 #endif
@@ -137,65 +133,73 @@ void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs, bool waitRetry) {
          throw(rogue::GeneralError("ZmqClient::setTimeout","Failed to set socket timeout"));
 }
 
-std::string rogue::interfaces::ZmqClient::send(std::string value) {
-   zmq_msg_t msg;
-   std::string data;
+#ifndef NO_PYTHON
+
+bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
+   zmq_msg_t txMsg;
+   zmq_msg_t rxMsg;
+   Py_buffer valueBuf;
+   bp::object ret;
    double seconds = 0;
 
-   rogue::GilRelease noGil;
-   zmq_send(this->zmqReq_,value.c_str(),value.size(),0);
+   if ( PyObject_GetBuffer(value.ptr(),&(valueBuf),PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError::create("ZmqClient::send","Failed to extract object data"));
 
-   while (1) {
-   zmq_msg_init(&msg);
-      if ( zmq_recvmsg(this->zmqReq_,&msg,0) <= 0 ) {
-         seconds += (float)timeout_ / 1000.0;
-         if ( waitRetry_ ) {
-            log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...",seconds);
-            zmq_msg_close(&msg);
+   zmq_msg_init_size(&txMsg,valueBuf.len);
+   memcpy(zmq_msg_data(&txMsg),valueBuf.buf,valueBuf.len);
+   PyBuffer_Release(&valueBuf);
+
+   {
+      rogue::GilRelease noGil;
+      zmq_sendmsg(this->zmqReq_,&txMsg,0);
+
+      while (1) {
+         zmq_msg_init(&rxMsg);
+         if ( zmq_recvmsg(this->zmqReq_,&rxMsg,0) <= 0 ) {
+            seconds += (float)timeout_ / 1000.0;
+            if ( waitRetry_ ) {
+               log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...",seconds);
+               zmq_msg_close(&rxMsg);
+            }
+            else
+               throw rogue::GeneralError::create("ZmqClient::send","Timeout waiting for response after %f Seconds, server may be busy!",seconds);
          }
-         else
-            throw rogue::GeneralError::create("ZmqClient::send","Timeout waiting for response after %f Seconds, server may be busy!",seconds);
+         else break;
       }
-      else break;
    }
 
    if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!",seconds);
 
-   data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
-   zmq_msg_close(&msg);
-   return data;
+   PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+   zmq_msg_close(&rxMsg);
+
+   bp::handle<> handle(val);
+   ret = bp::object(handle);
+   return ret;
 }
 
-void rogue::interfaces::ZmqClient::doUpdate ( std::string data ) { }
-
-#ifndef NO_PYTHON
+void rogue::interfaces::ZmqClient::doUpdate ( bp::object data ) { }
 
 rogue::interfaces::ZmqClientWrap::ZmqClientWrap (std::string addr, uint16_t port) : rogue::interfaces::ZmqClient(addr,port) {}
 
-void rogue::interfaces::ZmqClientWrap::doUpdate ( std::string data ) {
-   {
-      rogue::ScopedGil gil;
-
-      if (bp::override f = this->get_override("_doUpdate")) {
-         try {
-            f(data);
-         } catch (...) {
-            PyErr_Print();
-         }
+void rogue::interfaces::ZmqClientWrap::doUpdate ( bp::object data ) {
+   if (bp::override f = this->get_override("_doUpdate")) {
+      try {
+         f(data);
+      } catch (...) {
+         PyErr_Print();
       }
    }
    rogue::interfaces::ZmqClient::doUpdate(data);
 }
 
-void rogue::interfaces::ZmqClientWrap::defDoUpdate ( std::string data ) {
+void rogue::interfaces::ZmqClientWrap::defDoUpdate ( bp::object data ) {
    rogue::interfaces::ZmqClient::doUpdate(data);
 }
 
 #endif
 
 void rogue::interfaces::ZmqClient::runThread() {
-   std::string data;
-   std::string ret;
    zmq_msg_t msg;
 
    log_->logThreadId();
@@ -205,42 +209,16 @@ void rogue::interfaces::ZmqClient::runThread() {
 
       // Get the message
       if ( zmq_recvmsg(this->zmqSub_,&msg,0) > 0 ) {
-         data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
+
+#ifndef NO_PYTHON
+         rogue::ScopedGil gil;
+         PyObject *val = Py_BuildValue("y#",zmq_msg_data(&msg),zmq_msg_size(&msg));
+         bp::handle<> handle(val);
+         bp::object dat = bp::object(handle);
+         this->doUpdate(dat);
+#endif
          zmq_msg_close(&msg);
-         this->doUpdate(data);
       }
    }
-}
-
-std::string rogue::interfaces::ZmqClient::sendWrapper(std::string path, std::string attr, std::string arg, bool rawStr) {
-   std::string snd;
-   std::string ret;
-
-   snd  = "{\"attr\": \"" + attr + "\",";
-   snd += "\"path\": \"" + path + "\",";
-
-   if (arg != "")
-      snd += "\"args\": {\"py/tuple\": [\"" + arg + "\"]},";
-
-   if ( rawStr ) snd += "\"rawStr\": true}";
-   else snd += "\"rawStr\": false}";
-
-   return(send(snd));
-}
-
-std::string rogue::interfaces::ZmqClient::getDisp(std::string path) {
-   return sendWrapper(path, "getDisp", "", true);
-}
-
-void rogue::interfaces::ZmqClient::setDisp(std::string path, std::string value) {
-   sendWrapper(path, "setDisp", value, true);
-}
-
-std::string rogue::interfaces::ZmqClient::exec(std::string path, std::string arg) {
-   return sendWrapper(path, "__call__", arg, true);
-}
-
-std::string rogue::interfaces::ZmqClient::valueDisp(std::string path) {
-   return sendWrapper(path, "valueDisp", "", true);
 }
 

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -29,7 +29,7 @@
 namespace bp = boost::python;
 #endif
 
-rogue::interfaces::ZmqClientPtr rogue::interfaces::ZmqClient::create(std::string addr, uint16_t port, bool doString) {
+rogue::interfaces::ZmqClientPtr rogue::interfaces::ZmqClient::create(std::string addr, uint16_t port) {
    rogue::interfaces::ZmqClientPtr ret = std::make_shared<rogue::interfaces::ZmqClient>(addr,port,false);
    return(ret);
 }

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -168,7 +168,7 @@ std::string rogue::interfaces::ZmqClient::sendString(std::string path, std::stri
    zmq_send(this->zmqReq_,snd.c_str(),snd.size(),0);
 
    while (1) {
-   zmq_msg_init(&msg);
+      zmq_msg_init(&msg);
       if ( zmq_recvmsg(this->zmqReq_,&msg,0) <= 0 ) {
          seconds += (float)timeout_ / 1000.0;
          if ( waitRetry_ ) {

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -172,7 +172,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    temp.append(":");
    temp.append(std::to_string(static_cast<long long>(this->basePort_+2)));
 
-   if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) {
+   if ( zmq_bind(this->zmqStr_,temp.c_str()) < 0 ) {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
       zmq_close(this->zmqStr_);

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -39,6 +39,7 @@ void rogue::interfaces::ZmqServer::setup_python() {
 
    bp::class_<rogue::interfaces::ZmqServerWrap, rogue::interfaces::ZmqServerWrapPtr, boost::noncopyable>("ZmqServer",bp::init<std::string, uint16_t>())
       .def("_doRequest", &rogue::interfaces::ZmqServer::doRequest, &rogue::interfaces::ZmqServerWrap::defDoRequest)
+      .def("_doString",  &rogue::interfaces::ZmqServer::doString, &rogue::interfaces::ZmqServerWrap::defDoString)
       .def("_publish",   &rogue::interfaces::ZmqServer::publish)
       .def("port",       &rogue::interfaces::ZmqServer::port)
       .def("_stop",      &rogue::interfaces::ZmqServer::stop)
@@ -57,7 +58,7 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
 
    // Auto port
    if ( port == 0 ) {
-      for (this->basePort_ = 9099; this->basePort_ < (9099 + 100); this->basePort_ += 2) {
+      for (this->basePort_ = 9099; this->basePort_ < (9099 + 100); this->basePort_ += 4) {
          res = this->tryConnect();
          if ( res ) break;
       }
@@ -79,7 +80,8 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
    log_->info("Started Rogue server at ports %i:%i",this->basePort_,this->basePort_+1);
 
    threadEn_ = true;
-   thread_ = new std::thread(&rogue::interfaces::ZmqServer::runThread, this);
+   rThread_ = new std::thread(&rogue::interfaces::ZmqServer::runThread, this);
+   sThread_ = new std::thread(&rogue::interfaces::ZmqServer::strThread, this);
 
    // Send empty frame
    dummy = "null\n";
@@ -95,11 +97,14 @@ void rogue::interfaces::ZmqServer::stop() {
       rogue::GilRelease noGil;
       threadEn_ = false;
       log_->info("Waiting for server thread to exit");
-      thread_->join();
+      rThread_->join();
+      sThread_->join();
       log_->info("Closing pub socket");
       zmq_close(this->zmqPub_);
       log_->info("Closing request socket");
       zmq_close(this->zmqRep_);
+      log_->info("Closing string socket");
+      zmq_close(this->zmqStr_);
       log_->info("Destroying Context");
       zmq_ctx_destroy(this->zmqCtx_);
       log_->info("Zmq server done. Exiting");
@@ -110,10 +115,11 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    std::string temp;
    uint32_t opt;
 
-   log_->debug("Trying to serve on ports %i:%i",this->basePort_,this->basePort_+1);
+   log_->debug("Trying to serve on ports %i:%i:%i",this->basePort_,this->basePort_+1,this->basePort_+2);
 
    this->zmqPub_ = zmq_socket(this->zmqCtx_,ZMQ_PUB);
    this->zmqRep_ = zmq_socket(this->zmqCtx_,ZMQ_REP);
+   this->zmqStr_ = zmq_socket(this->zmqCtx_,ZMQ_REP);
 
    opt = 0;
    if ( zmq_setsockopt (this->zmqPub_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 )
@@ -122,8 +128,14 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    if ( zmq_setsockopt (this->zmqRep_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 )
          throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket linger"));
 
+   if ( zmq_setsockopt (this->zmqStr_, ZMQ_LINGER, &opt, sizeof(int32_t)) != 0 )
+         throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket linger"));
+
    opt = 100;
    if ( zmq_setsockopt (this->zmqRep_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 )
+         throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket receive timeout"));
+
+   if ( zmq_setsockopt (this->zmqStr_, ZMQ_RCVTIMEO, &opt, sizeof(int32_t)) != 0 )
          throw(rogue::GeneralError("ZmqServer::tryConnect","Failed to set socket receive timeout"));
 
    // Setup publish port
@@ -135,6 +147,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    if ( zmq_bind(this->zmqPub_,temp.c_str()) < 0 ) {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
+      zmq_close(this->zmqStr_);
       log_->debug("Failed to bind publish to port %i",this->basePort_);
       return false;
    }
@@ -148,7 +161,22 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
+      zmq_close(this->zmqStr_);
       log_->debug("Failed to bind resp to port %i",this->basePort_+1);
+      return false;
+   }
+
+   // Setup string port
+   temp = "tcp://";
+   temp.append(this->addr_);
+   temp.append(":");
+   temp.append(std::to_string(static_cast<long long>(this->basePort_+2)));
+
+   if ( zmq_bind(this->zmqRep_,temp.c_str()) < 0 ) {
+      zmq_close(this->zmqPub_);
+      zmq_close(this->zmqRep_);
+      zmq_close(this->zmqStr_);
+      log_->debug("Failed to bind str resp to port %i",this->basePort_+2);
       return false;
    }
 
@@ -157,6 +185,10 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
 
 uint16_t rogue::interfaces::ZmqServer::port() {
    return this->basePort_;
+}
+
+std::string rogue::interfaces::ZmqServer::doString ( std::string data ) {
+   return "";
 }
 
 #ifndef NO_PYTHON
@@ -198,6 +230,24 @@ bp::object rogue::interfaces::ZmqServerWrap::defDoRequest ( bp::object data ) {
    return(rogue::interfaces::ZmqServer::doRequest(data));
 }
 
+std::string rogue::interfaces::ZmqServerWrap::doString ( std::string data ) {
+   {
+      rogue::ScopedGil gil;
+      if (bp::override f = this->get_override("_doString")) {
+         try {
+            return(f(data));
+         } catch (...) {
+            PyErr_Print();
+         }
+      }
+   }
+   return(rogue::interfaces::ZmqServer::doString(data));
+}
+
+std::string rogue::interfaces::ZmqServerWrap::defDoString ( std::string data ) {
+   return(rogue::interfaces::ZmqServer::doString(data));
+}
+
 #endif
 
 void rogue::interfaces::ZmqServer::runThread() {
@@ -235,5 +285,27 @@ void rogue::interfaces::ZmqServer::runThread() {
       }
    }
    log_->info("Stopped Rogue server thread");
+}
+
+void rogue::interfaces::ZmqServer::strThread() {
+   std::string data;
+   std::string ret;
+   zmq_msg_t msg;
+
+   log_->logThreadId();
+   log_->info("Started Rogue string server thread");
+
+   while(threadEn_) {
+      zmq_msg_init(&msg);
+
+      // Get the message
+      if ( zmq_recvmsg(this->zmqStr_,&msg,0) > 0 ) {
+         data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
+         ret = this->doString(data);
+         zmq_send(this->zmqStr_,ret.c_str(),ret.size(),0);
+         zmq_msg_close(&msg);
+      }
+   }
+   log_->info("Stopped Rogue string server thread");
 }
 

--- a/tests/epics_client_testing.py
+++ b/tests/epics_client_testing.py
@@ -1,0 +1,184 @@
+
+import epics
+import time
+import pyrogue.interfaces
+
+#class EpicsInterface(object):
+#
+#    def __init__(self):
+#        self._epicsError = None
+#        epics.ca.replace_printf_handler(self._printHandle)
+#
+#    def _printHandle(self, *argv, **kwargs):
+#        print("Callback")
+#        print(argv)
+#        print(kwargs)
+#        print("Done")
+#        #print(f"Got {argv} {kwargs}")
+#        #self._epicsError = msg
+#
+#    def caput(self, *argv, **kwargs):
+#        ret = epics.caput(*argv,**kwargs)
+#
+#        if self._epicsError is not None:
+#            raise Exception(self._epicsError)
+#            self._epicsError = None
+#
+#        return ret
+#
+#    def caget(self, *argv, **kwargs):
+#        ret = epics.caget(*argv,**kwargs)
+#
+#        if self._epicsError is not None:
+#            raise Exception(self._epicsError)
+#            self._epicsError = None
+#
+#        return ret
+#
+#
+#ep = EpicsInterface()
+
+
+
+#@withCA
+#def replace_printf_handler(fcn=None):
+#    """replace the normal printf() output handler
+#    with the supplied function (defaults to :func:`sys.stderr.write`)"""
+#    global error_message
+#    if fcn is None:
+#        fcn = sys.stderr.write
+#    error_message = ctypes.CFUNCTYPE(None, ctypes.c_char_p)(fcn)
+#    return libca.ca_replace_printf_handler(error_message)
+
+#i = 0
+
+#while True:
+#    i += 1
+
+#    caput('test:dummyTree:AxiVersion:ScratchPad',i % 1000)
+#    caput('test:dummyTree:AxiVersion:AlarmTest',i % 50 + 100)
+#    lst = [(i+j)%10 for j in range(10)]
+#    caput('test:dummyTree:AxiVersion:TestListA', lst)
+#    lst = [(i+j)%20 for j in range(10)]
+#    caput('test:dummyTree:AxiVersion:TestListB', lst)
+
+#    caget('test:dummyTree:AxiVersion:ScratchPad')
+#    caget('test:dummyTree:AxiVersion:AlarmTest')
+#    cur = caget('test:dummyTree:AxiVersion:TestListA')
+#    cur = caget('test:dummyTree:AxiVersion:TestListB')
+#    cur = caget('test:dummyTree:AxiVersion:TestString')
+
+
+pv1 = epics.PV('test:dummyTree:AxiVersion:TestListA')
+pv2 = epics.PV('test:dummyTree:AxiVersion:ScratchPad')
+
+v = pyrogue.interfaces.VirtualClient()
+test = v.dummyTree.AxiVersion.TestListA.get()
+test = v.dummyTree.AxiVersion.ScratchPad.get()
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = epics.caget('test:dummyTree:AxiVersion:TestListA')
+e = time.time()
+
+print(f"Epics list caget Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    epics.caput('test:dummyTree:AxiVersion:TestListA',cur,wait=True)
+e = time.time()
+
+print(f"Epics list caput Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = pv1.get(use_monitor=False)
+e = time.time()
+
+print(f"Epics list pv.get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    pv1.put(cur,wait=True)
+e = time.time()
+
+print(f"Epics list pv.put Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = v.dummyTree.AxiVersion.TestListA.get()
+e = time.time()
+
+print(f"zmq list get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    v.dummyTree.AxiVersion.TestListA.set(cur)
+e = time.time()
+
+print(f"zmq list set Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = epics.caget('test:dummyTree:AxiVersion:ScratchPad')
+e = time.time()
+
+print(f"Epics caget Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    epics.caput('test:dummyTree:AxiVersion:ScratchPad',cur,wait=True)
+e = time.time()
+
+print(f"Epics caput Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = pv2.get(use_monitor=False)
+e = time.time()
+
+print(f"Epics pv.get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    pv2.put(cur,wait=True)
+e = time.time()
+
+print(f"Epics pv.put Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = v.dummyTree.AxiVersion.ScratchPad.get()
+e = time.time()
+
+print(f"zmq get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    v.dummyTree.AxiVersion.ScratchPad.set(cur)
+e = time.time()
+
+print(f"zmq set Rate = {c/(e-s)}")
+
+v.stop()

--- a/tests/epics_client_testing.py
+++ b/tests/epics_client_testing.py
@@ -1,4 +1,15 @@
-
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : EPICS Testing Script
+#-----------------------------------------------------------------------------
+# This file is part of the rogue_example software. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue_example software, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
 import epics
 import time
 import pyrogue.interfaces


### PR DESCRIPTION
This change uses native python pickling instead of json encoding for sending data between the zmq client and server. 

This also uses raw bytes for data transfer between the client and server instead of passing and decoding strings.

The C++ raw client interface is still supported on a third server port.

This has resulted in a 50% speedup of zmq based transactions which should make the GUI more responsive. The Rogue zmq remains faster than the epics3 interface:

For a list transfer:
   Epics list caget Rate = 1132.6 hz
   Epics list caput Rate = 1218.6 hz
   Epics list pv.get Rate = 1145.9 hz
   Epics list pv.put Rate = 1261.5 hz
   zmq list get Rate = 3159.4 hz
   zmq list set Rate = 3048.9 hz

For a single value transfer:
   Epics caget Rate = 1668.3 hz
   Epics caput Rate = 2379.5 hz
   Epics pv.get Rate = 2105.4 hz
   Epics pv.put Rate = 2457.7 hz
   zmq get Rate = 4318.7 hz
   zmq set Rate = 4028.2 hz

