### PR TITLE
Use native pickling instead of JSON for zmq interface (Rogue V4)

### DIFF
--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -5,12 +5,12 @@
  * File       : ZmqClient.h
  * Created    : 2019-05-02
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -38,7 +38,7 @@ namespace rogue {
             // Zeromq response port
             void * zmqReq_;
 
-            //! Log 
+            //! Log
             std::shared_ptr<rogue::Logging> log_;
 
             uint32_t timeout_;
@@ -62,22 +62,13 @@ namespace rogue {
 
             void setTimeout(uint32_t msecs, bool waitRetry);
 
-            std::string send(std::string value);
+#ifndef NO_PYTHON
+            boost::python::object send(boost::python::object data);
+
+            virtual void doUpdate (boost::python::object data);
+#endif
 
             void close();
-
-            virtual void doUpdate (std::string data);
-
-
-            std::string sendWrapper(std::string path, std::string attr, std::string arg, bool rawStr);
-
-            std::string getDisp(std::string path);
-
-            void setDisp(std::string path, std::string value);
-
-            std::string exec(std::string path, std::string arg = "");
-
-            std::string valueDisp(std::string path);
 
       };
       typedef std::shared_ptr<rogue::interfaces::ZmqClient> ZmqClientPtr;
@@ -85,17 +76,17 @@ namespace rogue {
 #ifndef NO_PYTHON
 
       //! Stream slave class, wrapper to enable python overload of virtual methods
-      class ZmqClientWrap : 
-         public rogue::interfaces::ZmqClient, 
+      class ZmqClientWrap :
+         public rogue::interfaces::ZmqClient,
          public boost::python::wrapper<rogue::interfaces::ZmqClient> {
 
          public:
 
             ZmqClientWrap (std::string addr, uint16_t port);
 
-            void doUpdate  ( std::string data );
+            void doUpdate  ( boost::python::object data );
 
-            void defDoUpdate  ( std::string data );
+            void defDoUpdate  ( boost::python::object data );
       };
 
       typedef std::shared_ptr<rogue::interfaces::ZmqClientWrap> ZmqClientWrapPtr;

--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -5,12 +5,12 @@
  * File       : ZmqServer.h
  * Created    : 2019-05-02
  * ----------------------------------------------------------------------------
- * This file is part of the rogue software platform. It is subject to 
- * the license terms in the LICENSE.txt file found in the top-level directory 
- * of this distribution and at: 
- *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
- * No part of the rogue software platform, including this file, may be 
- * copied, modified, propagated, or distributed except according to the terms 
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
@@ -44,7 +44,7 @@ namespace rogue {
             std::string addr_;
             uint16_t basePort_;
 
-            //! Log 
+            //! Log
             std::shared_ptr<rogue::Logging> log_;
 
             void runThread();
@@ -61,9 +61,11 @@ namespace rogue {
             ZmqServer (std::string addr, uint16_t port);
             virtual ~ZmqServer();
 
-            void publish(std::string value);
+#ifndef NO_PYTHON
+            void publish(boost::python::object data);
 
-            virtual std::string doRequest (std::string data);
+            virtual boost::python::object doRequest (boost::python::object data);
+#endif
 
             uint16_t port();
 
@@ -74,17 +76,17 @@ namespace rogue {
 #ifndef NO_PYTHON
 
       //! Stream slave class, wrapper to enable python overload of virtual methods
-      class ZmqServerWrap : 
-         public rogue::interfaces::ZmqServer, 
+      class ZmqServerWrap :
+         public rogue::interfaces::ZmqServer,
          public boost::python::wrapper<rogue::interfaces::ZmqServer> {
 
          public:
 
             ZmqServerWrap (std::string addr, uint16_t port);
 
-            std::string doRequest ( std::string data );
+            boost::python::object doRequest ( boost::python::object data );
 
-            std::string defDoRequest ( std::string data );
+            boost::python::object defDoRequest ( boost::python::object data );
       };
 
       typedef std::shared_ptr<rogue::interfaces::ZmqServerWrap> ZmqServerWrapPtr;

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -22,6 +22,7 @@ import functools as ft
 import time
 import queue
 import jsonpickle
+import pickle
 import zipfile
 import traceback
 import datetime
@@ -864,7 +865,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                 # Send over zmq link
                 if self._zmqServer is not None:
-                    self._zmqServer._publish(jsonpickle.encode(zmq))
+                    self._zmqServer._publish(pickle.dumps(zmq))
 
                 # Init var list
                 uvars = {}

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -594,7 +594,6 @@ class RemoteVariable(BaseVariable):
         self._bitSize   = bitSize
         self._bitOffset = bitOffset
         self._verify    = verify
-        self._typeStr   = self._base.name
         self._bytes     = int(math.ceil(float(self._bitOffset[-1] + self._bitSize[-1]) / 8.0))
         self._overlapEn = overlapEn
 
@@ -613,7 +612,7 @@ class RemoteVariable(BaseVariable):
                               highWarning=highWarning, highAlarm=highAlarm,
                               pollInterval=pollInterval)
 
-
+        self._typeStr   = self._base.name
 
 
     @pr.expose

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------
 # Title      : PyRogue Simple ZMQ Client for Rogue
 #-----------------------------------------------------------------------------
-# To use in Matlab first you need both the zmq and jsonpickle package in your
+# To use in Matlab first you need the zmq package in your
 # python installation:
 #
 # > pip install zmq
@@ -24,8 +24,8 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import zmq
-import jsonpickle
 import threading
+
 
 class SimpleClient(object):
 
@@ -52,9 +52,7 @@ class SimpleClient(object):
         self._sub.setsockopt(zmq.SUBSCRIBE,"".encode('utf-8'))
 
         while self._runEn:
-            msg = self._sub.recv_string()
-
-            d = jsonpickle.decode(msg)
+            d = self._sub.recv_pyobj()
 
             for k,val in d.items():
                 self._cb(k,val)
@@ -67,8 +65,8 @@ class SimpleClient(object):
                'kwargs':kwargs}
 
         try:
-            self._req.send_string(jsonpickle.encode(msg))
-            resp = jsonpickle.decode(self._req.recv_string())
+            self._req.send_pyobj(msg)
+            resp = self._req.recv_pyobj()
         except Exception as e:
             raise Exception(f"ZMQ Interface Exception: {e}")
 
@@ -97,4 +95,3 @@ class SimpleClient(object):
 
     def exec(self,path,arg):
         return self._remoteAttr(path, '__call__', arg)
-

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -16,11 +16,12 @@ import inspect
 import pyrogue as pr
 import zmq
 import rogue.interfaces
+import pickle
 import functools as ft
-import jsonpickle
 import re
 import time
 import threading
+
 
 class VirtualProperty(object):
     def __init__(self, node, attr):
@@ -269,11 +270,8 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
 
     def _remoteAttr(self, path, attr, *args, **kwargs):
-        snd = { 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs }
-        y = jsonpickle.encode(snd)
         try:
-            resp = self._send(y)
-            ret = jsonpickle.decode(resp)
+            ret = pickle.loads(self._send(pickle.dumps({ 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs })))
         except Exception as e:
             raise Exception(f"ZMQ Interface Exception: {e}")
 
@@ -292,7 +290,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         if self._root is None:
             return
 
-        d = jsonpickle.decode(data)
+        d = pickle.loads(data)
 
         for k,val in d.items():
             n = self._root.getNode(k,False)

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -158,57 +158,79 @@ uint16_t rogue::interfaces::ZmqServer::port() {
    return this->basePort_;
 }
 
-void rogue::interfaces::ZmqServer::publish(std::string value) {
-   rogue::GilRelease noGil;
-   zmq_send(this->zmqPub_,value.c_str(),value.size(),0);
-}
-
-std::string rogue::interfaces::ZmqServer::doRequest ( std::string data ) {
-   return("");
-}
-
 #ifndef NO_PYTHON
+
+void rogue::interfaces::ZmqServer::publish(bp::object value) {
+   zmq_msg_t msg;
+   Py_buffer valueBuf;
+
+   if ( PyObject_GetBuffer(value.ptr(),&(valueBuf),PyBUF_SIMPLE) < 0 )
+      throw(rogue::GeneralError::create("ZmqServer::publish","Failed to extract object data"));
+
+   zmq_msg_init_size(&msg,valueBuf.len);
+   memcpy(zmq_msg_data(&msg),valueBuf.buf,valueBuf.len);
+   PyBuffer_Release(&valueBuf);
+
+   rogue::GilRelease noGil;
+   zmq_sendmsg(this->zmqPub_,&msg,0);
+}
+
+bp::object rogue::interfaces::ZmqServer::doRequest ( bp::object data ) {
+   bp::handle<> handle(bp::borrowed(Py_None));
+   return bp::object(handle);
+}
 
 rogue::interfaces::ZmqServerWrap::ZmqServerWrap (std::string addr, uint16_t port) : rogue::interfaces::ZmqServer(addr,port) {}
 
-std::string rogue::interfaces::ZmqServerWrap::doRequest ( std::string data ) {
-   {
-      rogue::ScopedGil gil;
-
-      if (bp::override f = this->get_override("_doRequest")) {
-         try {
-            return(f(data));
-         } catch (...) {
-            PyErr_Print();
-         }
+bp::object rogue::interfaces::ZmqServerWrap::doRequest ( bp::object data ) {
+   if (bp::override f = this->get_override("_doRequest")) {
+      try {
+         return(f(data));
+      } catch (...) {
+         PyErr_Print();
       }
    }
    return(rogue::interfaces::ZmqServer::doRequest(data));
 }
 
-std::string rogue::interfaces::ZmqServerWrap::defDoRequest ( std::string data ) {
+bp::object rogue::interfaces::ZmqServerWrap::defDoRequest ( bp::object data ) {
    return(rogue::interfaces::ZmqServer::doRequest(data));
 }
 
 #endif
 
 void rogue::interfaces::ZmqServer::runThread() {
-   std::string data;
-   std::string ret;
-   zmq_msg_t msg;
+   zmq_msg_t rxMsg;
+   zmq_msg_t txMsg;
+   Py_buffer valueBuf;
 
    log_->logThreadId();
    log_->info("Started Rogue server thread");
 
    while(threadEn_) {
-      zmq_msg_init(&msg);
+      zmq_msg_init(&rxMsg);
 
       // Get the message
-      if ( zmq_recvmsg(this->zmqRep_,&msg,0) > 0 ) {
-         data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
-         ret = this->doRequest(data);
-         zmq_send(this->zmqRep_,ret.c_str(),ret.size(),0);
-         zmq_msg_close(&msg);
+      if ( zmq_recvmsg(this->zmqRep_,&rxMsg,0) > 0 ) {
+
+#ifndef NO_PYTHON
+         rogue::ScopedGil gil;
+         PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+         bp::handle<> handle(val);
+
+         bp::object ret = this->doRequest(bp::object(handle));
+
+         if ( PyObject_GetBuffer(ret.ptr(),&(valueBuf),PyBUF_SIMPLE) < 0 )
+            throw(rogue::GeneralError::create("ZmqServer::runThread","Failed to extract object data"));
+
+         zmq_msg_init_size(&txMsg,valueBuf.len);
+         memcpy(zmq_msg_data(&txMsg),valueBuf.buf,valueBuf.len);
+         PyBuffer_Release(&valueBuf);
+
+         zmq_sendmsg(this->zmqRep_,&txMsg,0);
+#endif
+
+         zmq_msg_close(&rxMsg);
       }
    }
    log_->info("Stopped Rogue server thread");

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -119,7 +119,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
 
    // Unsigned Int types, > 32-bits treated as string
    else if ( sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1 ) {
-      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8; }
+      if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8;}
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
       else { epicsType_ = aitEnumString; }
@@ -194,6 +194,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
       log_->info("Create scalar GDD for %s epicsType_=%i",epicsName_.c_str(),epicsType_);
       pValue_ = new gddScalar(gddAppType_value, epicsType_);
    }
+
 }
 
 void rpe::Value::updated() {
@@ -243,7 +244,7 @@ caStatus rpe::Value::readValue(gdd &value) {
    std::lock_guard<std::mutex> lock(mtx_);
 
    // Make sure access types match
-   if ( (array_ && value.isAtomic()) || ((!array_) && value.isScalar()) ) {
+   if ( (array_ && value.isAtomic()) || (array_ && value.isScalar()) || ((!array_) && value.isScalar()) ) {
 
       // Call value get within lock
       ret = valueGet();

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -379,7 +379,7 @@ void rpe::Variable::fromPython(bp::object value) {
          for ( i = 0; i < size_; i++ ) pF[i] = extractValue<double>(pl[i]);
          pValue_->putRef(pF, new rpe::Destructor<aitFloat64 *>);
       }
-      else throw rogue::GeneralError("Variable::fromPython","Invalid Variable Type");
+      else throw rogue::GeneralError::create("Variable::fromPython","Invalid Variable Type For %s",epicsName_.c_str());
 
    } else {
 
@@ -415,13 +415,13 @@ void rpe::Variable::fromPython(bp::object value) {
          else if ( enumBool.check() ) idx = (enumBool)?1:0;
 
          // Invalid
-         else throw rogue::GeneralError("Variable::fromPython","Invalid enum");
+         else throw rogue::GeneralError::create("Variable::fromPython","Invalid enum for %s",epicsName_.c_str());
 
          log_->info("Python set enum for %s: Enum Value=%i", epicsName_.c_str(),idx);
          pValue_->putConvert(idx);
       }
 
-      else throw rogue::GeneralError("Variable::fromPython","Invalid Variable Type");
+      else throw rogue::GeneralError::create("Variable::fromPython","Invalid Variable Type for %s",epicsName_.c_str());
 
    }
 

--- a/tests/epics_client_testing.py
+++ b/tests/epics_client_testing.py
@@ -1,0 +1,184 @@
+
+import epics
+import time
+import pyrogue.interfaces
+
+#class EpicsInterface(object):
+#
+#    def __init__(self):
+#        self._epicsError = None
+#        epics.ca.replace_printf_handler(self._printHandle)
+#
+#    def _printHandle(self, *argv, **kwargs):
+#        print("Callback")
+#        print(argv)
+#        print(kwargs)
+#        print("Done")
+#        #print(f"Got {argv} {kwargs}")
+#        #self._epicsError = msg
+#
+#    def caput(self, *argv, **kwargs):
+#        ret = epics.caput(*argv,**kwargs)
+#
+#        if self._epicsError is not None:
+#            raise Exception(self._epicsError)
+#            self._epicsError = None
+#
+#        return ret
+#
+#    def caget(self, *argv, **kwargs):
+#        ret = epics.caget(*argv,**kwargs)
+#
+#        if self._epicsError is not None:
+#            raise Exception(self._epicsError)
+#            self._epicsError = None
+#
+#        return ret
+#
+#
+#ep = EpicsInterface()
+
+
+
+#@withCA
+#def replace_printf_handler(fcn=None):
+#    """replace the normal printf() output handler
+#    with the supplied function (defaults to :func:`sys.stderr.write`)"""
+#    global error_message
+#    if fcn is None:
+#        fcn = sys.stderr.write
+#    error_message = ctypes.CFUNCTYPE(None, ctypes.c_char_p)(fcn)
+#    return libca.ca_replace_printf_handler(error_message)
+
+#i = 0
+
+#while True:
+#    i += 1
+
+#    caput('test:dummyTree:AxiVersion:ScratchPad',i % 1000)
+#    caput('test:dummyTree:AxiVersion:AlarmTest',i % 50 + 100)
+#    lst = [(i+j)%10 for j in range(10)]
+#    caput('test:dummyTree:AxiVersion:TestListA', lst)
+#    lst = [(i+j)%20 for j in range(10)]
+#    caput('test:dummyTree:AxiVersion:TestListB', lst)
+
+#    caget('test:dummyTree:AxiVersion:ScratchPad')
+#    caget('test:dummyTree:AxiVersion:AlarmTest')
+#    cur = caget('test:dummyTree:AxiVersion:TestListA')
+#    cur = caget('test:dummyTree:AxiVersion:TestListB')
+#    cur = caget('test:dummyTree:AxiVersion:TestString')
+
+
+pv1 = epics.PV('test:dummyTree:AxiVersion:TestListA')
+pv2 = epics.PV('test:dummyTree:AxiVersion:ScratchPad')
+
+v = pyrogue.interfaces.VirtualClient()
+test = v.dummyTree.AxiVersion.TestListA.get()
+test = v.dummyTree.AxiVersion.ScratchPad.get()
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = epics.caget('test:dummyTree:AxiVersion:TestListA')
+e = time.time()
+
+print(f"Epics list caget Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    epics.caput('test:dummyTree:AxiVersion:TestListA',cur,wait=True)
+e = time.time()
+
+print(f"Epics list caput Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = pv1.get(use_monitor=False)
+e = time.time()
+
+print(f"Epics list pv.get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    pv1.put(cur,wait=True)
+e = time.time()
+
+print(f"Epics list pv.put Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = v.dummyTree.AxiVersion.TestListA.get()
+e = time.time()
+
+print(f"zmq list get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur[0]  = i
+    cur[-1] = i
+    v.dummyTree.AxiVersion.TestListA.set(cur)
+e = time.time()
+
+print(f"zmq list set Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = epics.caget('test:dummyTree:AxiVersion:ScratchPad')
+e = time.time()
+
+print(f"Epics caget Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    epics.caput('test:dummyTree:AxiVersion:ScratchPad',cur,wait=True)
+e = time.time()
+
+print(f"Epics caput Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = pv2.get(use_monitor=False)
+e = time.time()
+
+print(f"Epics pv.get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    pv2.put(cur,wait=True)
+e = time.time()
+
+print(f"Epics pv.put Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = v.dummyTree.AxiVersion.ScratchPad.get()
+e = time.time()
+
+print(f"zmq get Rate = {c/(e-s)}")
+
+c = 100000
+s = time.time()
+for i in range(c):
+    cur = i
+    v.dummyTree.AxiVersion.ScratchPad.set(cur)
+e = time.time()
+
+print(f"zmq set Rate = {c/(e-s)}")
+
+v.stop()


### PR DESCRIPTION
This change uses native python pickling instead of json encoding for sending data between the zmq client and server. This is the Rogue version 4 application of this change.

This also uses raw bytes for data transfer between the client and server instead of passing and decoding strings.

The C++ raw client interface is removed for now as it is not used and will need a json specific interface which we may add later.

This has resulted in a 50% speedup of zmq based transactions which should make the GUI more responsive. The Rogue zmq remains faster than the epics3 interface:

For a list transfer:
Epics list caget Rate = 808.5 hz
Epics list caput Rate = 906.8 hz
Epics list pv.get Rate = 928.8 hz
Epics list pv.put Rate = 1014.7 hz
zmq list get Rate = 2981.1 hz
zmq list set Rate = 2651.9 hz

For a single value transfer:
Epics caput Rate = 1457.4 hz
Epics pv.get Rate = 1445.6 hz
Epics pv.put Rate = 1565.5 hz
zmq get Rate = 2318.8 hz
zmq set Rate = 1866.2 hz
