### PR TITLE
Improve handling of lists and numpy arrays in epics3 & epics4

### DIFF
--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -69,7 +69,7 @@ namespace rogue {
 
                std::mutex mtx_;
 
-               void initGdd(std::string typeStr, bool isEnum, uint32_t count );
+               void initGdd(std::string typeStr, bool isEnum, uint32_t count, bool forceStr );
 
                void updated();
 

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -17,7 +17,7 @@ import numpy
 class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, typeStr='UInt[]', **kwargs):
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 
@@ -45,6 +45,7 @@ class DataReceiver(pr.Device,ris.Slave):
                                   description='Data has been updated flag'))
 
         self.add(pr.LocalVariable(name='Data',
+                                  typeStr=typeStr,
                                   hidden=True,
                                   value=numpy.empty(shape=0, dtype=numpy.int8, order='C'),
                                   description='Data Frame Container'))

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -17,7 +17,7 @@ import numpy
 class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
-    def __init__(self, typeStr='UInt[]', **kwargs):
+    def __init__(self, typeStr='UInt32[]', **kwargs):
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -18,9 +18,9 @@ class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
     def __init__(self,
-                 typeStr='UInt32[]',
+                 typeStr='UInt8[np]',
                  hideData=True,
-                 value=numpy.zeros(shape=1, dtype=numpy.int8, order='C'),
+                 value=numpy.zeros(shape=1, dtype=numpy.uint8, order='C'),
                  **kwargs):
 
         pr.Device.__init__(self, **kwargs)

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -17,7 +17,12 @@ import numpy
 class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
-    def __init__(self, typeStr='UInt32[]', **kwargs):
+    def __init__(self,
+                 typeStr='UInt32[]',
+                 hideData=True,
+                 value=numpy.zeros(shape=1, dtype=numpy.int8, order='C'),
+                 **kwargs):
+
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 
@@ -46,9 +51,8 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
-                                  value=[0],
-                                  hidden=True,
-                                  #value=numpy.empty(shape=0, dtype=numpy.int8, order='C'),
+                                  value=value,
+                                  hidden=hideData,
                                   description='Data Frame Container'))
 
     def countReset(self):

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -17,7 +17,7 @@ import numpy
 class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
-    def __init__(self, typeStr='UInt[]', **kwargs):
+    def __init__(self, **kwargs):
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 
@@ -45,7 +45,7 @@ class DataReceiver(pr.Device,ris.Slave):
                                   description='Data has been updated flag'))
 
         self.add(pr.LocalVariable(name='Data',
-                                  typeStr=typeStr,
+                                  value=[0],
                                   hidden=True,
                                   value=numpy.empty(shape=0, dtype=numpy.int8, order='C'),
                                   description='Data Frame Container'))

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -17,7 +17,7 @@ import numpy
 class DataReceiver(pr.Device,ris.Slave):
     """Data Receiver Devicer."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, typeStr='UInt[]', **kwargs):
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 
@@ -45,9 +45,10 @@ class DataReceiver(pr.Device,ris.Slave):
                                   description='Data has been updated flag'))
 
         self.add(pr.LocalVariable(name='Data',
+                                  typeStr=typeStr,
                                   value=[0],
                                   hidden=True,
-                                  value=numpy.empty(shape=0, dtype=numpy.int8, order='C'),
+                                  #value=numpy.empty(shape=0, dtype=numpy.int8, order='C'),
                                   description='Data Frame Container'))
 
     def countReset(self):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -16,6 +16,7 @@ import threading
 import re
 import time
 import shlex
+import numpy as np
 from collections import OrderedDict as odict
 from collections.abc import Iterable
 
@@ -161,13 +162,15 @@ class BaseVariable(pr.Node):
         if enum is not None:
             self._disp = 'enum'
 
-        if value is not None and isinstance(value, list):
+        if value is not None and (isinstance(value, list) or isinstance(value, np.ndarray)):
             self._isList = True
 
         # Determine typeStr from value type
         if typeStr == 'Unknown' and value is not None:
             if isinstance(value, list):
                 self._typeStr = f'{value[0].__class__.__name__}[]'
+            elif isinstance(value, np.ndarray):
+                self._typeStr = str(value.dtype).capitalize() + '[np]'
             else:
                 self._typeStr = value.__class__.__name__
         else:

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -19,7 +19,6 @@ import pyrogue
 import time
 import warnings
 import re
-import numpy as np
 
 try:
     import p4p.server.thread
@@ -126,7 +125,7 @@ class EpicsPvHolder(object):
 
             # Unsigned
             if 'UInt' in typeStr:
-                m = re.search('^UInt(\d+)\.*',typeStr)
+                m = re.search('^UInt(\\d+)\\.*',typeStr)
 
                 if m is not None and m.lastindex == 1:
                     bits = int(m[1])
@@ -146,7 +145,7 @@ class EpicsPvHolder(object):
 
             # Signed
             elif 'int' in typeStr or 'Int' in typeStr:
-                m = re.search('^Int(\d+)\.*',typeStr)
+                m = re.search('^Int(\\d+)\\.*',typeStr)
 
                 if m is not None and m.lastindex == 1:
                     bits = int(m[1])

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -18,6 +18,8 @@
 import pyrogue
 import time
 import warnings
+import re
+import numpy as np
 
 try:
     import p4p.server.thread
@@ -118,18 +120,24 @@ class EpicsPvHolder(object):
         # Convert valType
         if self._var.disp == 'enum':
             self._valType = 'enum'
+        elif typeStr is None:
+            self._valType = 's'
         else:
 
             # Unsigned
-            if typeStr is not None and 'UInt' in typeStr:
-                if isinstance(self._var,pyrogue.RemoteVariable):
-                    if sum(self._var.bitSize) <= 8:
+            if 'UInt' in typeStr:
+                m = re.search('^UInt(\d+)\.*',typeStr)
+
+                if m is not None and m.lastindex == 1:
+                    bits = int(m[1])
+
+                    if bits <= 8:
                         self._valType = 'B'
-                    elif sum(self._var.bitSize) <= 16:
+                    elif bits <= 16:
                         self._valType = 'H'
-                    elif sum(self._var.bitSize) <= 32:
+                    elif bits <= 32:
                         self._valType = 'I'
-                    elif sum(self._var.bitSize) <= 64:
+                    elif bits <= 64:
                         self._valType = 'L'
                     else:
                         self._valType = 's'
@@ -137,50 +145,59 @@ class EpicsPvHolder(object):
                     self._valType = 'L'
 
             # Signed
-            elif typeStr is not None and ('int' in typeStr or 'Int' in typeStr):
-                if isinstance(self._var,pyrogue.RemoteVariable):
-                    if sum(self._var.bitSize) <= 8:
+            elif 'int' in typeStr or 'Int' in typeStr:
+                m = re.search('^Int(\d+)\.*',typeStr)
+
+                if m is not None and m.lastindex == 1:
+                    bits = int(m[1])
+
+                    if bits <= 8:
                         self._valType = 'b'
-                    elif sum(self._var.bitSize) <= 16:
+                    elif bits <= 16:
                         self._valType = 'h'
-                    elif sum(self._var.bitSize) <= 32:
+                    elif bits <= 32:
                         self._valType = 'i'
-                    else:
+                    elif bits <= 64:
                         self._valType = 'l'
+                    else:
+                        self._valType = 's'
                 else:
                     self._valType = 'l'
 
             # Float
-            elif typeStr is not None and ('float' in typeStr or 'Float' in typeStr):
-                if isinstance(self._var,pyrogue.RemoteVariable):
-                    if sum(self._var.bitSize)   <= 32:
-                        self._valType = 'f'
-                    else:
-                        self._valType = 'd'
-                else:
-                    self._valType = 'd'
+            elif 'float' in typeStr or 'Float32' in typeStr:
+                self._valType = 'f'
 
+            # Double
+            elif 'Double64' in typeStr or 'Float64' in typeStr:
+                self._valType = 'd'
+
+            # Default to string
             else:
                 self._valType = 's'
+
+        # Get initial value
+        varVal = var.getVariableValue(read=False)
 
         # Detect array
         if self._var.isList:
             self._valType = 'a' + self._valType
 
-        # Get initial value
-        varVal = var.getVariableValue(read=False)
         self._log.info("Adding {} with type {} init={}".format(self._name,self._valType,varVal.valueDisp))
-
-        if self._valType == 'enum':
-            nt = p4p.nt.NTEnum(display=False, control=False, valueAlarm=False)
-            enum = list(self._var.enum.values())
-            iv = {'choices':enum, 'index':enum.index(varVal.valueDisp)}
-        elif self._valType == 's':
-            nt = p4p.nt.NTScalar(self._valType, display=False, control=False, valueAlarm=False)
-            iv = nt.wrap(varVal.valueDisp)
-        else:
-            nt = p4p.nt.NTScalar(self._valType, display=True, control=True,  valueAlarm=True)
-            iv = nt.wrap(varVal.value)
+        try:
+            if self._valType == 'enum':
+                nt = p4p.nt.NTEnum(display=False, control=False, valueAlarm=False)
+                enum = list(self._var.enum.values())
+                iv = {'choices':enum, 'index':enum.index(varVal.valueDisp)}
+            elif self._valType == 's':
+                nt = p4p.nt.NTScalar(self._valType, display=False, control=False, valueAlarm=False)
+                iv = nt.wrap(varVal.valueDisp)
+            else:
+                nt = p4p.nt.NTScalar(self._valType, display=True, control=True,  valueAlarm=True)
+                #print(f"Setting value {varVal.value} to {self._name}")
+                iv = nt.wrap(varVal.value)
+        except Exception as e:
+            raise Exception("Failed to add {} with type {} init={}. Error={}".format(self._name,self._valType,varVal.valueDisp,e))
 
         # Setup variable
         self._pv = p4p.server.thread.SharedPV(queue=None,

--- a/src/rogue/protocols/epicsV3/Master.cpp
+++ b/src/rogue/protocols/epicsV3/Master.cpp
@@ -45,7 +45,7 @@ void rpe::Master::setup_python() {
 rpe::Master::Master (std::string epicsName, uint32_t max, std::string type) : Value(epicsName) {
 
    // Init gdd record
-   this->initGdd(type, false, 1);
+   this->initGdd(type, false, 1, false);
    max_ = max;
 
    // Determine size in bytes & init data

--- a/src/rogue/protocols/epicsV3/Slave.cpp
+++ b/src/rogue/protocols/epicsV3/Slave.cpp
@@ -52,7 +52,7 @@ void rpe::Slave::setup_python() {
 rpe::Slave::Slave (std::string epicsName, uint32_t max, std::string type) : Value(epicsName) {
 
    // Init gdd record
-   this->initGdd(type, false, 1);
+   this->initGdd(type, false, 1, false);
    max_ = max;
 
    // Determine size in bytes & init data

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -103,7 +103,7 @@ rpe::Value::~Value () {
 }
 
 
-void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
+void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool forceStr) {
    uint32_t bitSize;
 
    log_->info("Init GDD for %s typeStr=%s, isEnum=%i, count=%i",
@@ -117,6 +117,9 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
       epicsType_ = aitEnumEnum16;
       log_->info("Detected enum for %s typeStr=%s", epicsName_.c_str(),typeStr.c_str());
    }
+
+   // Force to string
+   else if ( forceStr ) epicsType_ = aitEnumString;
 
    // Unsigned Int types, > 32-bits treated as string
    else if ( sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1 ) {
@@ -141,7 +144,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    }
 
    // Python int
-   else if ( typeStr == "int" ) {
+   else if ( typeStr.find("int") == 0 ) {
       fSize_ = 4;
       epicsType_ = aitEnumInt32;
       log_->info("Detected python int with size %i for %s typeStr=%s",
@@ -149,14 +152,14 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count) {
    }
 
    // 32-bit Float
-   else if ( typeStr == "float" or typeStr == "Float32" ) {
+   else if ( typeStr.find("float") == 0 or typeStr.find("Float32") == 0 ) {
       log_->info("Detected 32-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumFloat32;
       fSize_ = 4;
    }
 
    // 64-bit float
-   else if ( typeStr == "Float64" ) {
+   else if (( typeStr.find("Double64") == 0 ) || ( typeStr.find("Float64") == 0 )) {
       log_->info("Detected 64-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
       epicsType_ = aitEnumFloat64;
       fSize_ = 8;

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -36,7 +36,9 @@ namespace rpe = rogue::protocols::epicsV3;
 
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
+#include <boost/python/numpy.hpp>
 namespace bp  = boost::python;
+namespace np  = boost::python::numpy;
 
 //! Setup class in python
 void rpe::Variable::setup_python() {
@@ -58,10 +60,12 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
    bp::list    el;
    std::string val;
    uint32_t    count;
+   bool        forceStr;
 
    var_      = bp::object(p);
    syncRead_ = syncRead;
    setAttr_  = "setDisp";
+   forceStr  = false;
 
    // Get type and determine if this is an enum
    type = std::string(bp::extract<char *>(var_.attr("typeStr")));
@@ -73,13 +77,25 @@ rpe::Variable::Variable (std::string epicsName, bp::object p, bool syncRead) : V
    if ( isList ) {
       type = type.substr(0,type.find("["));
 
-      // Get initial element count
-      count = len(bp::extract<bp::list>(var_.attr("value")()));
-      log_->info("Detected list for %s with type = %s and count = %i", epicsName.c_str(),type.c_str(),count);
+      // First try native list
+      bp::extract<bp::list> ldata(var_.attr("value")());
+
+      if ( ldata.check() ) {
+         count = len(ldata);
+
+         // Get initial element count
+         log_->info("Detected list for %s with type = %s and count = %i", epicsName.c_str(),type.c_str(),count);
+      }
+
+      else {
+         forceStr = true;
+         count = 0;
+         log_->info("Unsupported list for %s with type = %s. Forcing to string\n", epicsName.c_str(),type.c_str());
+      }
    }
 
    // Init gdd record
-   this->initGdd(type, isEnum, count);
+   this->initGdd(type, isEnum, count, forceStr);
 
    // Extract units
    bp::extract<char *> ret(var_.attr("units"));

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -36,9 +36,7 @@ namespace rpe = rogue::protocols::epicsV3;
 
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
-#include <boost/python/numpy.hpp>
 namespace bp  = boost::python;
-namespace np  = boost::python::numpy;
 
 //! Setup class in python
 void rpe::Variable::setup_python() {

--- a/tests/run_server.py
+++ b/tests/run_server.py
@@ -106,7 +106,7 @@ class DummyTree(pyrogue.Root):
         self._prbsTx >> self._fw.getChannel(0)
 
         # Add Data Receiver
-        drx = pyrogue.DataReceiver()
+        drx = pyrogue.DataReceiver(typeStr='Int8[]') #,value=[0]*100)
         self._prbsTx >> drx
         self.add(drx)
 
@@ -145,7 +145,7 @@ class DummyTree(pyrogue.Root):
             pollInterval=1.0,
             localGet = self._myArray,
             disp='{:1.2f}',
-            value = np.array(0)))
+            value = np.zeros(100,dtype=np.float64)))
 
         #self.add(pyrogue.LocalVariable(
         #    name = 'Test/Slash',

--- a/tests/run_server.py
+++ b/tests/run_server.py
@@ -106,7 +106,7 @@ class DummyTree(pyrogue.Root):
         self._prbsTx >> self._fw.getChannel(0)
 
         # Add Data Receiver
-        drx = pyrogue.DataReceiver(typeStr='Int8[]') #,value=[0]*100)
+        drx = pyrogue.DataReceiver()
         self._prbsTx >> drx
         self.add(drx)
 


### PR DESCRIPTION
This PR improves the general handling of lists and numpy arrays, particularly when using the epics3 & epics4 protocols. This PR also extracts the numpy type and displays the typeStr properly to indicate the value is a numpy array and the underlying value type, for example:

Int32[np] 

where [np] indicates a numpy array type vs [] or a standard list. In epics3 numpy arrays are converted to strings.