### PR TITLE
Add guiGroup attribute to Node, allowing GUI tree organization

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -33,7 +33,8 @@ class BaseCommand(pr.BaseVariable):
                  minimum=None,
                  maximum=None,
                  function=None,
-                 background=False):
+                 background=False,
+                 guiGroup=None):
 
         pr.BaseVariable.__init__(
             self,
@@ -46,7 +47,8 @@ class BaseCommand(pr.BaseVariable):
             groups=groups,
             minimum=minimum,
             maximum=maximum,
-            bulkOpEn=False)
+            bulkOpEn=False,
+            guiGroup=guiGroup)
 
         self._function = function if function is not None else BaseCommand.nothing
         self._thread = None
@@ -224,14 +226,16 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
                  offset=None,
                  bitSize=32,
                  bitOffset=0,
-                 overlapEn=False):
+                 overlapEn=False,
+                 guiGroup=None):
 
         # RemoteVariable constructor will handle assignment of most params
         BaseCommand.__init__(
             self,
             name=name,
             retValue=retValue,
-            function=function)
+            function=function,
+            guiGroup=guiGroup)
 
         pr.RemoteVariable.__init__(
             self,
@@ -250,7 +254,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             bitOffset=bitOffset,
             overlapEn=overlapEn,
             bulkOpEn=False,
-            verify=False)
+            verify=False,
+            guiGroup=guiGroup)
 
     def set(self, value, write=True, index=-1):
         self._log.debug("{}.set({})".format(self, value))

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -129,7 +129,8 @@ class Device(pr.Node,rim.Hub):
                  defaults=None,
                  enableDeps=None,
                  hubMin=0,
-                 hubMax=0):
+                 hubMax=0,
+                 guiGroup=None):
 
 
         """Initialize device class"""
@@ -156,7 +157,7 @@ class Device(pr.Node,rim.Hub):
             self._setSlave(memBase)
 
         # Node.__init__ can't be called until after self._memBase is created
-        pr.Node.__init__(self, name=name, hidden=hidden, groups=groups, description=description, expand=expand)
+        pr.Node.__init__(self, name=name, hidden=hidden, groups=groups, description=description, expand=expand, guiGroup=guiGroup)
 
         self._log.info("Making device {:s}".format(name))
 

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -94,7 +94,7 @@ class Node(object):
     attribute. This allows tree browsing using: node1.node2.node3
     """
 
-    def __init__(self, *, name, description="", expand=True, hidden=False, groups=None):
+    def __init__(self, *, name, description="", expand=True, hidden=False, groups=None, guiGroup=None):
         """Init the node with passed attributes"""
 
         # Public attributes
@@ -102,6 +102,7 @@ class Node(object):
         self._description = description
         self._path        = name
         self._expand      = expand
+        self._guiGroup    = guiGroup
 
         # Tracking
         self._parent  = None
@@ -183,6 +184,10 @@ class Node(object):
     def expand(self):
         return self._expand
 
+    @property
+    def guiGroup(self):
+        return self._guiGroup
+
     def __repr__(self):
         return self.path
 
@@ -217,6 +222,7 @@ class Node(object):
         attr['groups']      = self._groups
         attr['path']        = self._path
         attr['expand']      = self._expand
+        attr['guiGroup']    = self._guiGroup
         attr['nodes']       = odict({k:None for k,v in self._nodes.items() if not v.inGroup('NoServe')})
         attr['props']       = []
         attr['funcs']       = {}

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -123,7 +123,8 @@ class BaseVariable(pr.Node):
                  updateNotify=True,
                  typeStr='Unknown',
                  bulkOpEn=True,
-                 offset=0):
+                 offset=0,
+                 guiGroup=None):
 
         # Public Attributes
         self._bulkOpEn      = bulkOpEn
@@ -184,7 +185,7 @@ class BaseVariable(pr.Node):
             raise VariableError(f'Invalid variable mode {self._mode}. Supported: RW, RO, WO')
 
         # Call super constructor
-        pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups)
+        pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups, guiGroup=guiGroup)
 
     @pr.expose
     @property
@@ -589,7 +590,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
                  overlapEn=False,
                  bulkOpEn=True,
                  verify=True,
-                 retryCount=0):
+                 retryCount=0,
+                 guiGroup=None):
 
         if disp is None:
             disp = base.defaultdisp
@@ -636,7 +638,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
                               minimum=minimum, maximum=maximum, bulkOpEn=bulkOpEn,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval,updateNotify=updateNotify)
+                              pollInterval=pollInterval,updateNotify=updateNotify,
+                              guiGroup=guiGroup)
 
         self._typeStr = self._base.name
 
@@ -812,7 +815,8 @@ class LocalVariable(BaseVariable):
                  typeStr='Unknown',
                  pollInterval=0,
                  updateNotify=True,
-                 bulkOpEn=True):
+                 bulkOpEn=True,
+                 guiGroup=None):
 
         if value is None and localGet is None:
             raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
@@ -823,7 +827,8 @@ class LocalVariable(BaseVariable):
                               minimum=minimum, maximum=maximum, typeStr=typeStr,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval,updateNotify=updateNotify, bulkOpEn=bulkOpEn)
+                              pollInterval=pollInterval,updateNotify=updateNotify, bulkOpEn=bulkOpEn,
+                              guiGroup=guiGroup)
 
         self._block = pr.LocalBlock(variable=self,localSet=localSet,localGet=localGet,value=self._default)
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -77,7 +77,8 @@ class VirtualNode(pr.Node):
         super().__init__(name=attrs['name'],
                          description=attrs['description'],
                          expand=attrs['expand'],
-                         groups=attrs['groups'])
+                         groups=attrs['groups'],
+                         guiGroup=attrs['guiGroup'])
 
         self._path  = attrs['path']
         self._class = attrs['class']

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -32,9 +32,6 @@ class DefaultTop(Display):
         self.sizeY  = None
         self.title  = None
 
-        self.maxListExpand = None
-        self.maxListSize   = None
-
         for a in args:
             if 'sizeX=' in a:
                 self.sizeX = int(a.split('=')[1])
@@ -42,10 +39,6 @@ class DefaultTop(Display):
                 self.sizeY = int(a.split('=')[1])
             if 'title=' in a:
                 self.title = a.split('=')[1]
-            if 'maxListExpand' in a:
-                self.maxListExpand = int(a.split('=')[1])
-            if 'maxListSize' in a:
-                self.maxListSize = int(a.split('=')[1])
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
@@ -55,12 +48,6 @@ class DefaultTop(Display):
         if self.sizeY is None:
             self.sizeY = 1000
 
-        if self.maxListExpand is None:
-            self.maxListExpand = 5
-
-        if self.maxListSize is None:
-            self.maxListSize = 100
-
         self.setWindowTitle(self.title)
 
         vb = QVBoxLayout()
@@ -69,7 +56,7 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        var = VariableTree(parent=None, init_channel=Channel, maxListExpand=self.maxListExpand, maxListSize=self.maxListSize)
+        var = VariableTree(parent=None, init_channel=Channel)
         self.tab.addTab(var,'Variables')
 
         cmd = CommandTree(parent=None, init_channel=Channel)

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -14,7 +14,7 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLabel, PyDMPushButton
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt, Property, Slot, QEvent
-from qtpy.QtWidgets import QVBoxLayout, QComboBox
+from qtpy.QtWidgets import QVBoxLayout, QComboBox, QLabel
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLineEdit
 from qtpy.QtGui import QFontMetrics
 

--- a/python/pyrogue/pydm/widgets/command_tree.py
+++ b/python/pyrogue/pydm/widgets/command_tree.py
@@ -27,6 +27,7 @@ class CommandDev(QTreeWidgetItem):
         self._dev      = dev
         self._dummy    = None
         self._path     = path
+        self._groups   = {}
 
         if isinstance(parent,CommandDev):
             self._depth = parent._depth+1
@@ -60,20 +61,40 @@ class CommandDev(QTreeWidgetItem):
         for key,val in self._dev.commandsByGroup(incGroups=self._top._incGroups,
                                                  excGroups=self._top._excGroups).items():
 
-            CommandHolder(path=self._path + '.' + val.name,
-                          top=self._top,
-                          parent=self,
-                          command=val)
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = CommandGroup(path=self._path,
+                                                              top=self._top,
+                                                              parent=self,
+                                                              name=val.guiGroup)
+
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
+                CommandHolder(path=self._path + '.' + val.name,
+                              top=self._top,
+                              parent=self,
+                              command=val)
 
         # Then create devices
         for key,val in self._dev.devicesByGroup(incGroups=self._top._incGroups,
                                                 excGroups=self._top._excGroups).items():
 
-            CommandDev(path=self._path + '.' + val.name,
-                       top=self._top,
-                       parent=self,
-                       dev=val,
-                       noExpand=noExpand)
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = CommandGroup(path=self._path,
+                                                              top=self._top,
+                                                              parent=self,
+                                                              name=val.guiGroup)
+
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
+                CommandDev(path=self._path + '.' + val.name,
+                           top=self._top,
+                           parent=self,
+                           dev=val,
+                           noExpand=noExpand)
 
     def _expand(self):
         if self._dummy is None:
@@ -82,6 +103,54 @@ class CommandDev(QTreeWidgetItem):
         self.removeChild(self._dummy)
         self._dummy = None
         self._setup(True)
+
+
+class CommandGroup(QTreeWidgetItem):
+
+    def __init__(self,*, path, top, parent, name):
+        QTreeWidgetItem.__init__(self,parent)
+        self._top      = top
+        self._parent   = parent
+        self._name     = name
+        self._dummy    = None
+        self._path     = path
+        self._list     = []
+        self._depth    = parent._depth+1
+
+        self._lab = QLabel(parent=None, text=self._name)
+
+        self._top._tree.setItemWidget(self,0,self._lab)
+        self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
+        self.setExpanded(False)
+
+    def _setup(self):
+
+        # Create variables
+        for n in self._list:
+
+            if n.isDevice:
+                CommandDev(path=self._path + '.' + n.name,
+                           top=self._top,
+                           parent=self,
+                           dev=n,
+                           noExpand=True)
+
+            elif n.isVariable:
+                CommandHolder(path=self._path + '.' + n.name,
+                              top=self._top,
+                              parent=self,
+                              command=n)
+
+    def _expand(self):
+        if self._dummy is None:
+            return
+
+        self.removeChild(self._dummy)
+        self._dummy = None
+        self._setup()
+
+    def addNode(self,node):
+        self._list.append(node)
 
 
 class CommandHolder(QTreeWidgetItem):

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -20,7 +20,6 @@ from qtpy.QtCore import Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel
 from qtpy.QtGui import QFontMetrics
-import re
 
 
 class VariableDev(QTreeWidgetItem):

--- a/tests/run_server.py
+++ b/tests/run_server.py
@@ -95,8 +95,10 @@ class DummyTree(pyrogue.Root):
         sim.setName("SimSlave")
 
         # Add Device
-        self.add(test_device.AxiVersion(memBase=sim,offset=0x0))
-        self.add(test_large.TestLarge())
+        self.add(test_device.AxiVersion(memBase=sim,
+                                        guiGroup='TestGroup',
+                                        offset=0x0))
+        self.add(test_large.TestLarge(guiGroup='TestGroup'))
 
         # Add Data Writer
         self._prbsTx = pyrogue.utilities.prbs.PrbsTx()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -258,15 +258,23 @@ class AxiVersion(pr.Device):
         for i in range(4):
             for j in range(4):
                 for k in range(4):
-                    self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]',value=0))
+                    self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]',
+                                              guiGroup='TestArray',
+                                              value=0))
 
-        self.add(pr.LocalVariable(name = 'TestArray[4][5]',value=0))
-        self.add(pr.LocalVariable(name = 'TestArray[6]',value=0))
+        self.add(pr.LocalVariable(name = 'TestArray[4][5]',
+                                  guiGroup='TestArray',
+                                  value=0))
+        self.add(pr.LocalVariable(name = 'TestArray[6]',
+                                  guiGroup='TestArray',
+                                  value=0))
 
         #self.add(pr.LocalVariable(name = 'TestArray[2]',value=0))
 
         for i in range(2):
-            self.add(pr.LocalVariable(name = f'TestArray2[{i}]',value=0))
+            self.add(pr.LocalVariable(name = f'TestArray2[{i}]',
+                                      guiGroup='TestArray',
+                                      value=0))
 
         self.add(pr.RemoteVariable(
             name         = 'TestSpareArray[5][5]',

--- a/tests/test_large.py
+++ b/tests/test_large.py
@@ -19,7 +19,10 @@ class TestLarge(pyrogue.Device):
 
 
         for i in range(4096):
+            b = (i // 100) * 100
+            t = (i // 100) * 100 + 99
             self.add(pyrogue.LocalVariable(
                 name = f'TestValue[{i}]',
                 mode = 'RW',
+                guiGroup=f'TestLargeGroup[{b}-{t}]',
                 value = 0))


### PR DESCRIPTION
This PR changes the behavior of the pydm GUI tree in how it handles large arrays of Variables, Command and Devices. 

The previous version would auto-detect variable arrays and group them in a sub-tree item which sped up the GUI load as it avoided creating large arrays of tree elements. 

This PR removes the auto organization and adds a Node attribute 'guiGroup' which defines how Variables, Command and Devices are group in the pydm tree. By default the created group is not auto expanded and the group's members are not populated in the GUI until they are needed. 

The developer is encouraged to use this feature to minimize the number of elements that need to be populated in the GUI at any given time.