### PR TITLE
Add guiGroup attribute to Node, allowing GUI tree organization (V4)

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -34,7 +34,8 @@ class BaseCommand(pr.BaseVariable):
                  minimum=None,
                  maximum=None,
                  function=None,
-                 background=False):
+                 background=False,
+                 guiGroup=None):
 
         pr.BaseVariable.__init__(
             self,
@@ -46,7 +47,8 @@ class BaseCommand(pr.BaseVariable):
             hidden=hidden,
             groups=groups,
             minimum=minimum,
-            maximum=maximum)
+            maximum=maximum,
+            guiGroup=guiGroup)
 
         self._function = function if function is not None else BaseCommand.nothing
         self._thread = None
@@ -227,14 +229,16 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
                  offset=None,
                  bitSize=32,
                  bitOffset=0,
-                 overlapEn=False):
+                 overlapEn=False,
+                 guiGroup=None):
 
         # RemoteVariable constructor will handle assignment of most params
         BaseCommand.__init__(
             self,
             name=name,
             retValue=retValue,
-            function=function)
+            function=function,
+            guiGroup=guiGroup)
 
         pr.RemoteVariable.__init__(
             self,
@@ -252,7 +256,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             bitSize=bitSize,
             bitOffset=bitOffset,
             overlapEn=overlapEn,
-            verify=False)
+            verify=False,
+            guiGroup=guiGroup)
 
 
     def set(self, value, write=True):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -94,7 +94,7 @@ class Node(object):
     attribute. This allows tree browsing using: node1.node2.node3
     """
 
-    def __init__(self, *, name, description="", expand=True, hidden=False, groups=None):
+    def __init__(self, *, name, description="", expand=True, hidden=False, groups=None, guiGroup=None):
         """Init the node with passed attributes"""
 
         # Public attributes
@@ -102,6 +102,7 @@ class Node(object):
         self._description = description
         self._path        = name
         self._expand      = expand
+        self._guiGroup    = guiGroup
 
         # Tracking
         self._parent  = None
@@ -183,6 +184,10 @@ class Node(object):
     def expand(self):
         return self._expand
 
+    @property
+    def guiGroup(self):
+        return self._guiGroup
+
     def __repr__(self):
         return self.path
 
@@ -217,6 +222,7 @@ class Node(object):
         attr['groups']      = self._groups
         attr['path']        = self._path
         attr['expand']      = self._expand
+        attr['guiGroup']    = self._guiGroup
         attr['nodes']       = odict({k:None for k,v in self._nodes.items() if not v.inGroup('NoServe')})
         attr['props']       = []
         attr['funcs']       = {}

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -115,8 +115,8 @@ class BaseVariable(pr.Node):
                  highAlarm=None,
                  pollInterval=0,
                  typeStr='Unknown',
-                 offset=0
-                ):
+                 offset=0,
+                 guiGroup=None):
 
         # Public Attributes
         self._mode          = mode
@@ -171,7 +171,7 @@ class BaseVariable(pr.Node):
             raise VariableError(f'Invalid variable mode {self._mode}. Supported: RW, RO, WO')
 
         # Call super constructor
-        pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups)
+        pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups, guiGroup=guiGroup)
 
     @pr.expose
     @property
@@ -558,7 +558,8 @@ class RemoteVariable(BaseVariable):
                  bitOffset=0,
                  pollInterval=0,
                  overlapEn=False,
-                 verify=True, ):
+                 verify=True,
+                 guiGroup=None):
 
         if disp is None:
             disp = base.defaultdisp
@@ -611,7 +612,8 @@ class RemoteVariable(BaseVariable):
                               minimum=minimum, maximum=maximum,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval)
+                              pollInterval=pollInterval,
+                              guiGroup=guiGroup)
 
 
 
@@ -706,7 +708,8 @@ class LocalVariable(BaseVariable):
                  localSet=None,
                  localGet=None,
                  typeStr='Unknown',
-                 pollInterval=0):
+                 pollInterval=0,
+                 guiGroup=None):
 
         if value is None and localGet is None:
             raise VariableError(f'LocalVariable {self.path} without localGet() must specify value= argument in constructor')
@@ -717,7 +720,8 @@ class LocalVariable(BaseVariable):
                               minimum=minimum, maximum=maximum, typeStr=typeStr,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval)
+                              pollInterval=pollInterval,
+                              guiGroup=guiGroup)
 
         self._block = pr.LocalBlock(variable=self,localSet=localSet,localGet=localGet,value=self._default)
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -82,7 +82,8 @@ class VirtualNode(pr.Node):
         super().__init__(name=attrs['name'],
                          description=attrs['description'],
                          expand=attrs['expand'],
-                         groups=attrs['groups'])
+                         groups=attrs['groups'],
+                         guiGroup=attrs['guiGroup'])
 
         self._path  = attrs['path']
         self._class = attrs['class']

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -29,9 +29,6 @@ class DefaultTop(Display):
         self.sizeY  = None
         self.title  = None
 
-        self.maxListExpand = None
-        self.maxListSize   = None
-
         for a in args:
             if 'sizeX=' in a:
                 self.sizeX = int(a.split('=')[1])
@@ -39,10 +36,6 @@ class DefaultTop(Display):
                 self.sizeY = int(a.split('=')[1])
             if 'title=' in a:
                 self.title = a.split('=')[1]
-            if 'maxListExpand' in a:
-                self.maxListExpand = int(a.split('=')[1])
-            if 'maxListSize' in a:
-                self.maxListSize = int(a.split('=')[1])
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
@@ -52,12 +45,6 @@ class DefaultTop(Display):
         if self.sizeY is None:
             self.sizeY = 1000
 
-        if self.maxListExpand is None:
-            self.maxListExpand = 5
-
-        if self.maxListSize is None:
-            self.maxListSize = 100
-
         self.setWindowTitle(self.title)
 
         vb = QVBoxLayout()
@@ -66,7 +53,7 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
-        var = VariableTree(parent=None, init_channel=Channel, maxListExpand=self.maxListExpand, maxListSize=self.maxListSize)
+        var = VariableTree(parent=None, init_channel=Channel)
         self.tab.addTab(var,'Variables')
 
         cmd = CommandTree(parent=None, init_channel=Channel)

--- a/python/pyrogue/pydm/widgets/variable_tree.py
+++ b/python/pyrogue/pydm/widgets/variable_tree.py
@@ -31,7 +31,7 @@ class VariableDev(QTreeWidgetItem):
         self._dev      = dev
         self._dummy    = None
         self._path     = path
-        self._avars    = {}
+        self._groups   = {}
 
         if isinstance(parent,VariableDev):
             self._depth = parent._depth+1
@@ -63,37 +63,42 @@ class VariableDev(QTreeWidgetItem):
     def _setup(self,noExpand):
 
         # First create variables
-        for key,val in self._dev.variablesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups).items():
+        for key,val in self._dev.variablesByGroup(incGroups=self._top._incGroups,
+                                                  excGroups=self._top._excGroups).items():
 
-            # Test for array
-            fields = re.split('\\]\\[|\\[|\\]',val.name)
-            if len(fields) < 3:
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = VariableGroup(path=self._path,
+                                                               top=self._top,
+                                                               parent=self,
+                                                               name=val.guiGroup)
+
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
                 VariableHolder(path=self._path + '.' + val.name,
                                top=self._top,
                                parent=self,
                                variable=val)
-            else:
-                if not fields[0] in self._avars or self._avars[fields[0]].length() >= self._top._maxListSize:
-                    self._avars[fields[0]] = VariableArray(path=self._path,
-                                                           top=self._top,
-                                                           parent=self,
-                                                           name=fields[0])
-
-
-                self._avars[fields[0]].addNode(val,fields[1])
 
         # Then create devices
         for key,val in self._dev.devicesByGroup(incGroups=self._top._incGroups,
                                                 excGroups=self._top._excGroups).items():
 
-            VariableDev(path=self._path + '.' + val.name,
-                        top=self._top, parent=self,
-                        dev=val,
-                        noExpand=noExpand)
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = VariableGroup(path=self._path,
+                                                               top=self._top,
+                                                               parent=self,
+                                                               name=val.guiGroup)
 
-        # Auto expand list variables
-        for k,v in self._avars.items():
-            v._autoExpand()
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
+                VariableDev(path=self._path + '.' + val.name,
+                            top=self._top, parent=self,
+                            dev=val,
+                            noExpand=noExpand)
 
     def _expand(self):
         if self._dummy is None:
@@ -104,7 +109,7 @@ class VariableDev(QTreeWidgetItem):
         self._setup(True)
 
 
-class VariableArray(QTreeWidgetItem):
+class VariableGroup(QTreeWidgetItem):
 
     def __init__(self,*, path, top, parent, name):
         QTreeWidgetItem.__init__(self,parent)
@@ -115,10 +120,8 @@ class VariableArray(QTreeWidgetItem):
         self._path     = path
         self._list     = []
         self._depth    = parent._depth+1
-        self._first    = None
-        self._last     = None
 
-        self._lab = QLabel(parent=None, text=self._name + ' (0)')
+        self._lab = QLabel(parent=None, text=self._name)
 
         self._top._tree.setItemWidget(self,0,self._lab)
         self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
@@ -127,11 +130,20 @@ class VariableArray(QTreeWidgetItem):
     def _setup(self):
 
         # Create variables
-        for val in self._list:
-            VariableHolder(path=self._path + '.' + val.name,
-                           top=self._top,
-                           parent=self,
-                           variable=val)
+        for n in self._list:
+
+            if n.isDevice:
+                VariableDev(path=self._path + '.' + n.name,
+                            top=self._top,
+                            parent=self,
+                            dev=n,
+                            noExpand=True)
+
+            elif n.isVariable:
+                VariableHolder(path=self._path + '.' + n.name,
+                               top=self._top,
+                               parent=self,
+                               variable=n)
 
     def _expand(self):
         if self._dummy is None:
@@ -141,23 +153,9 @@ class VariableArray(QTreeWidgetItem):
         self._dummy = None
         self._setup()
 
-    def _autoExpand(self):
-        if len(self._list) <= self._top._maxListExpand:
-            self.setExpanded(True)
-
-    def addNode(self,node,idx):
+    def addNode(self,node):
         self._list.append(node)
 
-        if self._first is None or idx < self._first:
-            self._first = idx
-
-        if self._last is None or idx > self._last:
-            self._last = idx
-
-        self._lab.setText(self._name + f' ({self._first} - {self._last})')
-
-    def length(self):
-        return len(self._list)
 
 class VariableHolder(QTreeWidgetItem):
 
@@ -233,7 +231,7 @@ class VariableHolder(QTreeWidgetItem):
 
 
 class VariableTree(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden'], maxListExpand=5, maxListSize=100):
+    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._node = None
@@ -242,9 +240,6 @@ class VariableTree(PyDMFrame):
         self._incGroups = incGroups
         self._excGroups = excGroups
         self._tree      = None
-
-        self._maxListExpand = maxListExpand
-        self._maxListSize   = maxListSize
 
         self._colWidths = [250,50,75,200,50]
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -258,15 +258,23 @@ class AxiVersion(pr.Device):
         for i in range(4):
             for j in range(4):
                 for k in range(4):
-                    self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]',value=0))
+                    self.add(pr.LocalVariable(name = f'TestArray[{i}][{j}][{k}]',
+                                              value=0,
+                                              guiGroup='TestArray'))
 
-        self.add(pr.LocalVariable(name = 'TestArray[4][5]',value=0))
-        self.add(pr.LocalVariable(name = 'TestArray[6]',value=0))
+        self.add(pr.LocalVariable(name = 'TestArray[4][5]',
+                                  value=0,
+                                  guiGroup='TestArray'))
+        self.add(pr.LocalVariable(name = 'TestArray[6]',
+                                  value=0,
+                                  guiGroup='TestArray'))
 
         #self.add(pr.LocalVariable(name = 'TestArray[2]',value=0))
 
         for i in range(2):
-            self.add(pr.LocalVariable(name = f'TestArray2[{i}]',value=0))
+            self.add(pr.LocalVariable(name = f'TestArray2[{i}]',
+                                      value=0,
+                                      guiGroup='TestArray'))
 
         self.add(pr.RemoteVariable(
             name         = 'TestSpareArray[5][5]',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,7 +53,7 @@ class DummyTree(pyrogue.Root):
         sim = pyrogue.interfaces.simulation.MemEmulate()
 
         # Add Device
-        self.add(test_device.AxiVersion(memBase=sim,offset=0x0))
+        self.add(test_device.AxiVersion(memBase=sim,offset=0x0,guiGroup='TestGroup'))
 
         # Add Data Writer
         self._prbsTx = pyrogue.utilities.prbs.PrbsTx()
@@ -97,7 +97,8 @@ class DummyTree(pyrogue.Root):
             pollInterval=1.0,
             localGet = self._myArray,
             disp='{:1.2f}',
-            value = np.array(0)))
+            value = np.array(0),
+            guiGroup='TestGroup'))
 
         #self.add(test_large.TestLarge())
 


### PR DESCRIPTION
This PR changes the behavior of the pydm GUI tree in how it handles large arrays of Variables, Command and Devices. 

The previous version would auto-detect variable arrays and group them in a sub-tree item which sped up the GUI load as it avoided creating large arrays of tree elements. 

This PR removes the auto organization and adds a Node attribute 'guiGroup' which defines how Variables, Command and Devices are group in the pydm tree. By default the created group is not auto expanded and the group's members are not populated in the GUI until they are needed. 

The developer is encouraged to use this feature to minimize the number of elements that need to be populated in the GUI at any given time.