### PR TITLE
Update MemoryDevice to use its own transaction logic

### DIFF
--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -40,7 +40,6 @@ class MemoryDevice(pr.Device):
         )
 
         self._size    = size
-        self._lockCnt = 0
         self._txnLock = threading.RLock()
 
         if isinstance(base, pr.Model):

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -10,6 +10,8 @@
 import pyrogue as pr
 import rogue.interfaces.memory as rim
 from collections import OrderedDict as odict
+import collections
+import threading
 
 
 class MemoryDevice(pr.Device):
@@ -189,5 +191,3 @@ class MemoryDevice(pr.Device):
                 self._reqTransaction(sliceOffset, ldata, txnSize, i-offset, txnType)
 
             return ldata
-
-

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -102,14 +102,14 @@ class MemoryDevice(pr.Device):
         with self._txnLock:
             self._wrValues = self._setValues
             for offset, values in self._setValues.items():
-                self._txnChunker(offset, values, self._base, self._stride, self._wordBitSize, rim.Write)
+                self._txnChunker(offset, values, self._base, self._stride, self._wordBitSize, rim.Write, len(values))
 
             # clear out setValues when done
             self._setValues = odict()
 
 
     def verifyBlocks(self, recurse=True, variable=None, checkEach=False):
-        if not self.enable.get():
+        if (not self._verify) or (not self.enable.get()):
             return
 
         with self._txnLock:

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -150,6 +150,11 @@ class MemoryDevice(pr.Device):
     def readBlocks(self, recurse=True, variable=None, checkEach=False):
         pass
 
+    @pr.expose
+    @property
+    def size(self):
+        return self._size
+
     def _txnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):
 
         if not isinstance(base, pr.Model):


### PR DESCRIPTION
This PR installs a local txnChunker method in the MemoryDevice class in preparation for the rawWrite and rawRead methods to be deprecated from Device. MemoryDevice now has its own lock object and will store size in a local variable which will be preserved when size goes away from the Device class. 

We will keep MemoryDevice around for times when the accessed memory is too large for local shadow memory. 