### PR TITLE
Remove jsonpickle

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -11,7 +11,6 @@ dependencies:
   - ipython
   - cmake
   - pyyaml
-  - jsonpickle
   - pyzmq
   - parse
   - click

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -11,7 +11,6 @@ dependencies:
   - ipython
   - cmake
   - pyyaml
-  - jsonpickle
   - pyzmq
   - parse
   - click

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,5 +1,4 @@
 PyYAML
-jsonpickle
 parse
 click
 coverage

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -21,7 +21,7 @@ import pyrogue.interfaces
 import functools as ft
 import time
 import queue
-import jsonpickle
+import json
 import pickle
 import zipfile
 import traceback
@@ -68,7 +68,7 @@ class RootLogHandler(logging.Handler):
                     if len(msg) > 1:
                         msg += ',\n'
 
-                    msg += jsonpickle.encode(se) + ']'
+                    msg += json.dumps(se) + ']'
                     self._root.SystemLog.set(msg)
                     #print(f"Error: {msg}")
 

--- a/python/pyrogue/gui/system.py
+++ b/python/pyrogue/gui/system.py
@@ -19,7 +19,7 @@ from PyQt5.QtGui     import QPalette
 
 import pyrogue
 import datetime
-import jsonpickle
+import json
 import time
 
 
@@ -461,7 +461,7 @@ class SystemWidget(QWidget):
 
     @pyqtSlot(str)
     def updateSyslog(self,value):
-        lst = jsonpickle.decode(value)
+        lst = json.loads(value)
 
         if len(lst) == 0:
             self.systemLog.clear()

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -12,7 +12,7 @@
 
 import rogue.interfaces
 import pickle
-import jsonpickle
+import json
 
 
 class ZmqServer(rogue.interfaces.ZmqServer):
@@ -53,6 +53,6 @@ class ZmqServer(rogue.interfaces.ZmqServer):
 
     def _doString(self,data):
         try:
-            return str(self._doOperation(jsonpickle.decode(data)))
+            return str(self._doOperation(json.loads(data)))
         except Exception as msg:
             return "EXCEPTION: " + str(msg)

--- a/python/pyrogue/interfaces/__init__.py
+++ b/python/pyrogue/interfaces/__init__.py
@@ -14,7 +14,7 @@ from pyrogue.interfaces._SimpleClient import *
 from pyrogue.interfaces._SqlLogging   import *
 
 import time
-import jsonpickle
+import json
 
 # Common class for system log display
 class SystemLogMonitor(object):
@@ -24,7 +24,7 @@ class SystemLogMonitor(object):
         self._logCount = 0
 
     def processLogString(self, logstr):
-        lst = jsonpickle.decode(logstr)
+        lst = json.loads(logstr)
 
         if len(lst) > self._logCount:
             for i in range(self._logCount,len(lst)):

--- a/python/pyrogue/pydm/widgets/system_log.py
+++ b/python/pyrogue/pydm/widgets/system_log.py
@@ -15,7 +15,7 @@ from pydm.widgets import PyDMPushButton
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout, QTreeWidgetItem, QTreeWidget, QGroupBox
-import jsonpickle
+import json
 import time
 
 
@@ -59,7 +59,7 @@ class SystemLog(PyDMFrame):
         vb.addWidget(self._pb)
 
     def value_changed(self, new_val):
-        lst = jsonpickle.decode(new_val)
+        lst = json.loads(new_val)
 
         if len(lst) == 0:
             self._systemLog.clear()


### PR DESCRIPTION
jsonpickle is not available in petalinux. I have changed over to json in places where it was used. This includes the syslog interface and the c++ control interface. 