### PR TITLE
Add generic file browser

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -444,7 +444,7 @@ class BaseVariable(pr.Node):
                 return self.enum[value]
             else:
                 self._log.warning("Invalid enum value {} in variable '{}'".format(value,self.path))
-                return 'INVALID: {:#x}'.format(value)
+                return f'INVALID: {value}'
 
         elif (value == '' or value is None):
             return value

--- a/python/pyrogue/pydm/tools/generic_file_browser.py
+++ b/python/pyrogue/pydm/tools/generic_file_browser.py
@@ -13,8 +13,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
-from qtpy.QtWidgets import QVBoxLayout, QFileDialog, QDialog, QPushButton, QFormLayout, QLineEdit
-from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QFileDialog
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient

--- a/python/pyrogue/pydm/tools/generic_file_browser.py
+++ b/python/pyrogue/pydm/tools/generic_file_browser.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-# Title      : PyRogue PyDM Browse For Command Arg Tool
+# Title      : PyRogue PyDM Generic File Browser
 #-----------------------------------------------------------------------------
 # This file is part of the rogue software platform. It is subject to
 # the license terms in the LICENSE.txt file found in the top-level directory

--- a/python/pyrogue/pydm/tools/generic_file_browser.py
+++ b/python/pyrogue/pydm/tools/generic_file_browser.py
@@ -1,0 +1,72 @@
+#-----------------------------------------------------------------------------
+# Title      : PyRogue PyDM Browse For Command Arg Tool
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import logging
+from pydm.tools import ExternalTool
+from pydm.utilities.iconfont import IconFont
+from qtpy.QtWidgets import QVBoxLayout, QFileDialog, QDialog, QPushButton, QFormLayout, QLineEdit
+from qtpy.QtCore import Qt
+
+import pyrogue
+from pyrogue.interfaces import VirtualClient
+from pyrogue.pydm.data_plugins.rogue_plugin import parseAddress
+
+logger = logging.getLogger(__name__)
+
+
+class GenericFileBrowse(ExternalTool):
+
+    def __init__(self):
+        icon = IconFont().icon("cogs")
+        name = "File Browser"
+        group = "Rogue"
+        use_with_widgets = True
+        ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+
+    def call(self, channels, sender):
+        addr, port, path, mode = parseAddress(channels[0].address)
+        self._client = VirtualClient(addr, port)
+        node = self._client.root.getNode(path)
+
+        dlg = QFileDialog()
+
+        dataFile = dlg.getOpenFileName(caption='Select File', filter='YAML Files(*.yml);;Data Files(*.dat);;CSV Files(*.csv);;All Files(*.*)')
+        # Detect QT5 return
+        if isinstance(dataFile,tuple):
+            dataFile = dataFile[0]
+
+        if dataFile == '':
+            logger.warning(f"Skipping empty file name for node {node.name}")
+
+        if node.isinstance(pyrogue.BaseCommand):
+            node.call(dataFile)
+
+        elif node.isinstance(pyrogue.BaseVariable):
+            if node.mode == 'RO':
+                logger.warning(f"Can't set file to RO node: {node.name}")
+
+            else:
+                node.set(dataFile)
+
+        else:
+            logger.warning(f"File browser used with invalid node: {node.name}")
+
+    def to_json(self):
+        return ""
+
+    def from_json(self, content):
+        pass
+
+    def get_info(self):
+        ret = ExternalTool.get_info(self)
+        ret.update({'file': __file__})
+        return ret

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -353,6 +353,7 @@ class AxiVersion(pr.Device):
 
         @self.command(hidden=False,value='',retValue='')
         def TestCommand(arg):
+            print('Got {}'.format(arg))
             return('Got {}'.format(arg))
 
         @self.command(hidden=False,value='',retValue='')

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -101,7 +101,7 @@ def test_enum():
 
         # Test the undef enum case
         status = root.Dev.Status.getDisp()
-        if ( status != 'INVALID: 0x3'):
+        if ( status != 'INVALID: 3'):
             raise AssertionError( f'root.Dev.Status.getDisp()={status}' )
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a new tool tip item to allow the user to browse for a file name for any Rogue command or variable. If the node is a command the file name is passed as the arg. If the node is a variable the file is passed to the set() method.

This is accessible by right clicking on the node name. 

