### PR TITLE
Limit size of running SystemLog variable

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -61,13 +61,13 @@ class RootLogHandler(logging.Handler):
 
                 # System log is a running json encoded list
                 with self._root.SystemLog.lock:
-                    lst = jsonpickle.loads(self._root.SystemLog.value())
+                    lst = json.loads(self._root.SystemLog.value())
 
                     # Limit system log size
                     lst = lst[-1 * (self._root._maxLog-1):]
 
                     lst.append(se)
-                    self._root.SystemLog.set(jsonpickle.dumps(lst))
+                    self._root.SystemLog.set(json.dumps(lst))
 
                 # Log to database
                 if self._root._sqlLog is not None:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -60,17 +60,14 @@ class RootLogHandler(logging.Handler):
                         se['traceBack'].append(tb.rstrip())
 
                 # System log is a running json encoded list
-                # Need to remove list terminator ']' and add new entry + list terminator
                 with self._root.SystemLog.lock:
-                    msg =  self._root.SystemLog.value()[:-1]
+                    lst = jsonpickle.loads(self._root.SystemLog.value())
 
-                    # Only add a comma and return if list is not empty
-                    if len(msg) > 1:
-                        msg += ',\n'
+                    # Limit system log size
+                    lst = lst[-1 * (self._root._maxLog-1):]
 
-                    msg += json.dumps(se) + ']'
-                    self._root.SystemLog.set(msg)
-                    #print(f"Error: {msg}")
+                    lst.append(se)
+                    self._root.SystemLog.set(jsonpickle.dumps(lst))
 
                 # Log to database
                 if self._root._sqlLog is not None:
@@ -83,7 +80,6 @@ class RootLogHandler(logging.Handler):
                 print("-----------Original Error-----------------------")
                 print(self.format(record))
                 print("------------------------------------------------")
-
 
 class Root(rogue.interfaces.stream.Master,pr.Device):
     """
@@ -113,6 +109,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                  pollEn=True,
                  serverPort=0,  # 9099 is the default, 0 for auto
                  sqlUrl=None,
+                 maxLog=1000,
                  streamIncGroups=None,
                  streamExcGroups=['NoStream'],
                  sqlIncGroups=None,
@@ -127,6 +124,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._pollEn          = pollEn
         self._serverPort      = serverPort
         self._sqlUrl          = sqlUrl
+        self._maxLog          = maxLog
         self._streamIncGroups = streamIncGroups
         self._streamExcGroups = streamExcGroups
         self._sqlIncGroups    = sqlIncGroups


### PR DESCRIPTION
This limits the number of entries in the SystemLog variable to a configurable number of entries (default=1000). The number of entries can be changed using the MaxLog parameters in the Root class.

This also limits the number of displayed entries in the PyDm console to the last 20.