### PR TITLE
Add context for rogue clients

### DIFF
--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -95,3 +95,9 @@ class SimpleClient(object):
 
     def exec(self,path,arg):
         return self._remoteAttr(path, '__call__', arg)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._stop()

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -322,4 +322,3 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.stop()
-

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -316,3 +316,10 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
+


### PR DESCRIPTION
This feature was missing. This adds the ability to use the clients in the following way:

with pyrogue.interfaces.VirtualClient(host,port) as client:
     client.variable.set()

