### PR TITLE
Add default value for index parameter in get and set

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -89,7 +89,7 @@ class LocalBlock(object):
     def variables(self):
         return self._variables
 
-    def set(self, var, value, index):
+    def set(self, var, value, index=-1):
         with self._lock:
 
             if index < 0 and (isinstance(value, list) or isinstance(value,dict)):
@@ -112,7 +112,7 @@ class LocalBlock(object):
 
                 pr.functionHelper(self._localSet, pargs, self._log, self._variable.path)
 
-    def get(self, var, index):
+    def get(self, var, index=-1):
         if self._enable and self._localGet is not None:
             with self._lock:
 


### PR DESCRIPTION
This PR adds a default value of -1 to the `index` parameter of `Block.set()` and `Block.get()`.

The `_iadd()`, `_isub()` and friends all call both `get()` and `set()` without an index, so it seems easiest to provide a default.