### PR TITLE
Fifo: Expose status information to python (for version v4)

### DIFF
--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -64,6 +64,9 @@ namespace rogue {
                // Thread background
                void runThread();
 
+               // Drop frame counter
+               std::size_t dropFrameCnt_;
+
             public:
 
                //! Create a Fifo object and return as a FifoPtr
@@ -87,6 +90,12 @@ namespace rogue {
 
                // Return the number of elements in the fifo
                std::size_t size() { return queue_.size(); };
+
+               // Return the number of dropped frames
+               std::size_t dropCnt() const;
+
+               // Clear counters
+               void clearCnt();
 
                // Receive frame from Master
                void acceptFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );

--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -88,8 +88,8 @@ namespace rogue {
                // Destroy the Fifo
                ~Fifo();
 
-               // Return the number of elements in the fifo
-               std::size_t size() { return queue_.size(); };
+               // Return the number of elements in the Fifo
+               std::size_t size();
 
                // Return the number of dropped frames
                std::size_t dropCnt() const;

--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -50,22 +50,22 @@ namespace rogue {
                std::shared_ptr<rogue::Logging> log_;
 
                // Configurations
-               uint32_t trimSize_;
                uint32_t maxDepth_;
+               uint32_t trimSize_;
                bool     noCopy_;
+
+               // Drop frame counter
+               std::size_t dropFrameCnt_;
 
                // Queue
                rogue::Queue<std::shared_ptr<rogue::interfaces::stream::Frame>> queue_;
 
                // Transmission thread
-               std::thread* thread_;
                bool threadEn_;
+               std::thread* thread_;
 
                // Thread background
                void runThread();
-
-               // Drop frame counter
-               std::size_t dropFrameCnt_;
 
             public:
 

--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -85,6 +85,9 @@ namespace rogue {
                // Destroy the Fifo
                ~Fifo();
 
+               // Return the number of elements in the fifo
+               std::size_t size() { return queue_.size(); };
+
                // Receive frame from Master
                void acceptFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );
 

--- a/python/pyrogue/interfaces/stream/_Fifo.py
+++ b/python/pyrogue/interfaces/stream/_Fifo.py
@@ -21,6 +21,13 @@ class Fifo(pyrogue.Device):
         pyrogue.Device.__init__(self, name=name, description=description, **kwargs)
         self._fifo = rogue.interfaces.stream.Fifo(maxDepth, trimSize, noCopy)
 
+        # Maximum Depth
+        self.add(pyrogue.LocalVariable(
+            name='MaxDepth',
+            description='Maximum depth of the Fifo',
+            mode='RO',
+            value=maxDepth))
+
         # Number of elements in the Fifo
         self.add(pyrogue.LocalVariable(
             name='Size',

--- a/python/pyrogue/interfaces/stream/_Fifo.py
+++ b/python/pyrogue/interfaces/stream/_Fifo.py
@@ -18,7 +18,7 @@ import pyrogue
 
 class Fifo(pyrogue.Device):
     def __init__(self, name, description, maxDepth, trimSize, noCopy, **kwargs):
-        pyrogue.Device.__init__(self, **kwargs)
+        pyrogue.Device.__init__(self, name=name, description=description, **kwargs)
         self._fifo = rogue.interfaces.stream.Fifo(maxDepth, trimSize, noCopy)
 
         # Number of elements in the Fifo

--- a/python/pyrogue/interfaces/stream/_Fifo.py
+++ b/python/pyrogue/interfaces/stream/_Fifo.py
@@ -1,0 +1,54 @@
+#-----------------------------------------------------------------------------
+# Title      : AXI Stream FIFO
+#-----------------------------------------------------------------------------
+# Description:
+# Python wrapper for the AXI Stream FIFO C++ device.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import rogue
+import pyrogue
+
+class Fifo(pyrogue.Device):
+    def __init__(self, name, description, maxDepth, trimSize, noCopy, **kwargs):
+        pyrogue.Device.__init__(self, **kwargs)
+        self._fifo = rogue.interfaces.stream.Fifo(maxDepth, trimSize, noCopy)
+
+        # Number of elements in the Fifo
+        self.add(pyrogue.LocalVariable(
+            name='Size',
+            description='Number of elements in the Fifo',
+            mode='RO',
+            value=0,
+            typeStr='UInt64',
+            pollInterval=1,
+            localGet=self._fifo.size))
+
+        # Number of dropped frames
+        self.add(pyrogue.LocalVariable(
+            name='FrameDropCnt',
+            description='Number of dropped frames',
+            mode='RO',
+            value=0,
+            typeStr='UInt64',
+            pollInterval=1,
+            localGet=self._fifo.dropCnt))
+
+        # Command to clear all the counters
+        self.add(pyrogue.LocalCommand(
+            name='ClearCnt',
+            description='Clear all counters',
+            function=self._fifo.clearCnt))
+
+    def _getStreamSlave(self):
+        return self._fifo
+
+    def _getStreamMaster(self):
+        return self._fifo

--- a/python/pyrogue/interfaces/stream/__init__.py
+++ b/python/pyrogue/interfaces/stream/__init__.py
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+from pyrogue.interfaces.stream._Fifo import *

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -56,19 +56,19 @@ void ris::Fifo::setup_python() {
 }
 
 //! Creator with version constant
-ris::Fifo::Fifo(uint32_t maxDepth, uint32_t trimSize, bool noCopy ) : ris::Master(), ris::Slave() {
-   maxDepth_ = maxDepth;
-   trimSize_ = trimSize;
-   noCopy_   = noCopy;
-   dropFrameCnt_ = 0;
-
+ris::Fifo::Fifo(uint32_t maxDepth, uint32_t trimSize, bool noCopy )
+:
+   ris::Master   ( ),
+   ris::Slave    ( ),
+   log_          ( rogue::Logging::create("stream.Fifo") ),
+   maxDepth_     ( maxDepth ),
+   trimSize_     ( trimSize ),
+   noCopy_       ( noCopy ),
+   dropFrameCnt_ ( 0 ),
+   threadEn_     ( true ),
+   thread_       ( new std::thread(&ris::Fifo::runThread, this) )
+{
    queue_.setThold(maxDepth);
-
-   log_ = rogue::Logging::create("stream.Fifo");
-
-   // Start read thread
-   threadEn_ = true;
-   thread_ = new std::thread(&ris::Fifo::runThread, this);
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -80,6 +80,11 @@ ris::Fifo::~Fifo() {
    thread_->join();
 }
 
+//! Return the number of elements in the Fifo
+std::size_t ris::Fifo::size() {
+   return queue_.size();
+};
+
 //! Return the number of dropped frames
 std::size_t ris::Fifo::dropCnt() const {
    return dropFrameCnt_;

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -82,6 +82,7 @@ ris::Fifo::~Fifo() {
    rogue::GilRelease noGil;
    queue_.stop();
    thread_->join();
+   delete thread_;
 }
 
 //! Return the number of elements in the Fifo

--- a/src/rogue/interfaces/stream/Fifo.cpp
+++ b/src/rogue/interfaces/stream/Fifo.cpp
@@ -47,7 +47,11 @@ ris::FifoPtr ris::Fifo::create(uint32_t maxDepth, uint32_t trimSize, bool noCopy
 //! Setup class in python
 void ris::Fifo::setup_python() {
 #ifndef NO_PYTHON
-   bp::class_<ris::Fifo, ris::FifoPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Fifo",bp::init<uint32_t,uint32_t,bool>());
+   bp::class_<ris::Fifo, ris::FifoPtr, bp::bases<ris::Master,ris::Slave>, boost::noncopyable >("Fifo",bp::init<uint32_t,uint32_t,bool>())
+      .def("size",     &Fifo::size)
+      .def("dropCnt",  &Fifo::dropCnt)
+      .def("clearCnt", &Fifo::clearCnt)
+   ;
 #endif
 }
 


### PR DESCRIPTION
This PR exposes some useful status information from a Fifo device to python. The information exposed is:
- The maximum depth of the fifo,
- Current number of elements in the fifo, and
- The number of dropped frames, with a clear command.

Additionally, a python wrapper for the C++ class was added.

Finally, a couple of optimization were added as well:
- Use member initializer list for the Fifo C++ class, which offer a better performance when creating the objects, and 
- Add a missing `delete` to match the `new` operator, in order to avoid leaking the memory.

Same changes as https://github.com/slaclab/rogue/pull/776 but for rogue version v4.

https://jira.slac.stanford.edu/browse/ESROGUE-498