### PR TITLE
Fix syntax error

### DIFF
--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -79,7 +79,7 @@ class StreamWriter(pyrogue.DataWriter):
 
 class LegacyStreamWriter(StreamWriter):
     def __init__(self, **kwargs):
-        super().__init__(self, writer=rogue.utilities.fileio.LegacyStreamWriter(), **kwargs)
+        super().__init__(writer=rogue.utilities.fileio.LegacyStreamWriter(), **kwargs)
 
     def getDataChannel(self):
         return self._writer.getDataChannel()


### PR DESCRIPTION
Fix syntax error in `LegacyStreamWriter` init.