### PR TITLE
Fix stride bug in txnChunker

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -409,7 +409,7 @@ class Device(pr.Node,rim.Hub):
             if isinstance(data, bytearray):
                 ldata = data
             elif isinstance(data, collections.abc.Iterable):
-                ldata = b''.join(base.toBytes(word) for word in data)
+                ldata = b''.join(base.toBytes(word).rjust(stride, b'\0') for word in data)
             else:
                 ldata = base.toBytes(data)
 

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -173,7 +173,7 @@ class MemoryDevice(pr.Device):
             if isinstance(data, bytearray):
                 ldata = data
             elif isinstance(data, collections.abc.Iterable):
-                ldata = b''.join(base.toBytes(word) for word in data)
+                ldata = b''.join(base.toBytes(word).rjust(stride, b'\0') for word in data)
             else:
                 ldata = base.toBytes(data)
 


### PR DESCRIPTION
`MemoryDevice._txnChunker()` and `Device._rawTxnChunker()` were not calculating the stride correctly when `wordBitSize < 32` and data was passed in as a list of values.