### PR TITLE
MemoryDevice now properly obeys enable on writeBlocks and verifyBlocks

### DIFF
--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -96,7 +96,7 @@ class MemoryDevice(pr.Device):
         return None
 
     def writeBlocks(self, force=False, recurse=True, variable=None, checkEach=False):
-        if not self.enable.get():
+        if self.enable.get() is not True:
             return
 
         with self._txnLock:
@@ -109,7 +109,7 @@ class MemoryDevice(pr.Device):
 
 
     def verifyBlocks(self, recurse=True, variable=None, checkEach=False):
-        if (not self._verify) or (not self.enable.get()):
+        if (not self._verify) or (self.enable.get() is not True):
             return
 
         with self._txnLock:


### PR DESCRIPTION
The enable check was not catching the `enable=='parent'` and similar cases.