### PR TITLE
Allow an iterable to be passed to Device.addInterface() and addProtocol()

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -214,14 +214,21 @@ class Device(pr.Node,rim.Hub):
             # Device does not have a membase
             if node._memBase is None:
                 node._setSlave(self)
-
+                
     def addInterface(self, interface):
-        """Add a rogue.interfaces.stream.Master or rogue.interfaces.memory.Master"""
-        self._ifAndProto.append(interface)
+        """Add a rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
+        Also accepts an iterable for adding multiple at once"""
+        if isinstance(interface, collections.abc.Iterable):
+            self._ifAndProto.extend(interface)
+        else:
+            self._ifAndProto.append(interface)
 
     def addProtocol(self, protocol):
         """Add a protocol entity"""
-        self._ifAndProto.append(protocol)
+        if isinstance(protocol, collections.abc.Iterable):
+            self._ifAndProto.extend(protocol)
+        else:
+            self._ifAndProto.append(protocol)
 
     def _start(self):
         """ Called recursively from Root.stop when starting """
@@ -238,6 +245,7 @@ class Device(pr.Node,rim.Hub):
                 intf._stop()
         for d in self.deviceList:
             d._stop()
+
 
     def addRemoteVariables(self, number, stride, pack=False, **kwargs):
         if pack:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -214,7 +214,7 @@ class Device(pr.Node,rim.Hub):
             # Device does not have a membase
             if node._memBase is None:
                 node._setSlave(self)
-                
+
     def addInterface(self, *interfaces):
         """Add one or more rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
         Also accepts iterables for adding multiple at once"""
@@ -227,7 +227,7 @@ class Device(pr.Node,rim.Hub):
     def addProtocol(self, *protocols):
         """Add a protocol entity.
         Also accepts iterables for adding multiple at once"""
-        for protocol in protocols:        
+        for protocol in protocols:
             if isinstance(protocol, collections.abc.Iterable):
                 self._ifAndProto.extend(protocol)
             else:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -215,20 +215,23 @@ class Device(pr.Node,rim.Hub):
             if node._memBase is None:
                 node._setSlave(self)
                 
-    def addInterface(self, interface):
-        """Add a rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
-        Also accepts an iterable for adding multiple at once"""
-        if isinstance(interface, collections.abc.Iterable):
-            self._ifAndProto.extend(interface)
-        else:
-            self._ifAndProto.append(interface)
+    def addInterface(self, *interfaces):
+        """Add one or more rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
+        Also accepts iterables for adding multiple at once"""
+        for interface in interfaces:
+            if isinstance(interface, collections.abc.Iterable):
+                self._ifAndProto.extend(interface)
+            else:
+                self._ifAndProto.append(interface)
 
-    def addProtocol(self, protocol):
-        """Add a protocol entity"""
-        if isinstance(protocol, collections.abc.Iterable):
-            self._ifAndProto.extend(protocol)
-        else:
-            self._ifAndProto.append(protocol)
+    def addProtocol(self, *protocols):
+        """Add a protocol entity.
+        Also accepts iterables for adding multiple at once"""
+        for protocol in protocols:        
+            if isinstance(protocol, collections.abc.Iterable):
+                self._ifAndProto.extend(protocol)
+            else:
+                self._ifAndProto.append(protocol)
 
     def _start(self):
         """ Called recursively from Root.stop when starting """


### PR DESCRIPTION
This change allows an number of lists (or any iterable) of interfaces or protocols to be passed to `addInterface()` and `addProtocol()`

I have a few Root subclasses where I instantiate several interfaces at once with a list comprehension.
It is then convenient to just call `addInterface()` on the whole list rather than iterating it manually.

```
febStreams = [ris.TcpClient(host, port) for port in postList]
self.addInterface(febStreams)
```

This change also allows
```
febStream = ris.TcpClient()
febSrp = SrpV3()
self.addInterface(febStream, febSrp)
```