### PR TITLE
Ensure that link variable errors are logged

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1004,19 +1004,32 @@ class LinkVariable(BaseVariable):
     @pr.expose
     def set(self, value, write=True, index=-1):
         if self._linkedSet is not None:
+            try:
 
-            # Possible args
-            pargs = {'dev' : self.parent, 'var' : self, 'value' : value, 'write' : write, 'index' : index}
+                # Possible args
+                pargs = {'dev' : self.parent, 'var' : self, 'value' : value, 'write' : write, 'index' : index}
 
-            pr.functionHelper(self._linkedSet,pargs,self._log,self.path)
+                pr.functionHelper(self._linkedSet,pargs,self._log,self.path)
+
+            except Exception as e:
+                pr.logException(self._log,e)
+                self._log.error("Error setting link variable '{}'".format(self.path))
+                raise e
 
     @pr.expose
     def get(self, read=True, index=-1):
         if self._linkedGet is not None:
+            try:
 
-            # Possible args
-            pargs = {'dev' : self.parent, 'var' : self, 'read' : read, 'index' : index}
+                # Possible args
+                pargs = {'dev' : self.parent, 'var' : self, 'read' : read, 'index' : index}
 
-            return pr.functionHelper(self._linkedGet,pargs,self._log,self.path)
+                return pr.functionHelper(self._linkedGet,pargs,self._log,self.path)
+
+            except Exception as e:
+                pr.logException(self._log,e)
+                self._log.error("Error getting link variable '{}'".format(self.path))
+                raise e
+
         else:
             return None

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -56,4 +56,3 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             return str(self._doOperation(json.loads(data)))
         except Exception as msg:
             return "EXCEPTION: " + str(msg)
-

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -13,6 +13,7 @@
 import rogue.interfaces
 import pickle
 import json
+import traceback
 
 
 class ZmqServer(rogue.interfaces.ZmqServer):
@@ -49,10 +50,22 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         try:
             return pickle.dumps(self._doOperation(pickle.loads(data)))
         except Exception as msg:
+            tb = traceback.format_exc()
+            print("----------------- ZMQ Server Exception ------------------")
+            print(msg)
+            print("----------------- ZMQ Server Traceback ------------------")
+            print(tb)
+            print("---------------------------------------------------------")
             return pickle.dumps(msg)
 
     def _doString(self,data):
         try:
             return str(self._doOperation(json.loads(data)))
         except Exception as msg:
+            print("----------------- ZMQ Server Exception ------------------")
+            print(msg)
+            print("----------------- ZMQ Server Traceback ------------------")
+            print(tb)
+            print("---------------------------------------------------------")
             return "EXCEPTION: " + str(msg)
+

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -13,7 +13,6 @@
 import rogue.interfaces
 import pickle
 import json
-import traceback
 
 
 class ZmqServer(rogue.interfaces.ZmqServer):
@@ -50,22 +49,11 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         try:
             return pickle.dumps(self._doOperation(pickle.loads(data)))
         except Exception as msg:
-            tb = traceback.format_exc()
-            print("----------------- ZMQ Server Exception ------------------")
-            print(msg)
-            print("----------------- ZMQ Server Traceback ------------------")
-            print(tb)
-            print("---------------------------------------------------------")
             return pickle.dumps(msg)
 
     def _doString(self,data):
         try:
             return str(self._doOperation(json.loads(data)))
         except Exception as msg:
-            print("----------------- ZMQ Server Exception ------------------")
-            print(msg)
-            print("----------------- ZMQ Server Traceback ------------------")
-            print(tb)
-            print("---------------------------------------------------------")
             return "EXCEPTION: " + str(msg)
 


### PR DESCRIPTION
In the previous version errors that occurred in the link variable set and get functions were not in the system log or properly displayed on the server console. This made debugging difficult.