### PR TITLE
Bug fix to protocols/udp for non-RSSI applications

### DIFF
--- a/include/rogue/protocols/udp/Core.h
+++ b/include/rogue/protocols/udp/Core.h
@@ -27,11 +27,14 @@ namespace rogue {
    namespace protocols {
       namespace udp {
 
-         const uint32_t MaxJumboPayload = 8900;
-         const uint32_t MaxStdPayload   = 1400;
-
          const uint32_t JumboMTU = 9000;
          const uint32_t StdMTU   = 1500;
+
+          // IPv4 Header = 20B, UDP Header = 8B
+         const uint32_t HdrSize  = 20+8;
+
+         const uint32_t MaxJumboPayload = JumboMTU-HdrSize;
+         const uint32_t MaxStdPayload   = StdMTU-HdrSize;
 
          //! UDP Core
          class Core {
@@ -89,4 +92,3 @@ namespace rogue {
 };
 
 #endif
-


### PR DESCRIPTION
### Description
I am using the `rogue.protocols.udp.Server` has a UDP bridge between PGP lane and (Xilinx Virtual Cable) XVC UDP.  The Xilinx software for XVC can use the max MTU1500 UDP size.  When I try to connect to the XVC using non-jumbo frames with this bridge, the XVC software crash when it sends anything over 1400B.  
```
sendVec -- bits 1230, bytes 154, bytesTot 336
HSIZE 16, SIZE 154, got 170
sendVec -- bits 240, bytes 30, bytesTot 80
HSIZE 16, SIZE 30, got 46
sendVec -- bits 240, bytes 30, bytesTot 80
HSIZE 16, SIZE 30, got 46
sendVec -- bits 240, bytes 30, bytesTot 80
HSIZE 16, SIZE 30, got 46
sendVec -- bits 240, bytes 30, bytesTot 80
HSIZE 16, SIZE 30, got 46
sendVec -- bits 240, bytes 30, bytesTot 80
HSIZE 16, SIZE 30, got 46
sendVec -- bits 55, bytes 7, bytesTot 48
HSIZE 16, SIZE 7, got 23
sendVec -- bits 461, bytes 58, bytesTot 144
HSIZE 16, SIZE 58, got 74
sendVec -- bits 5760, bytes 720, bytesTot 1456
terminate called after throwing an instance of 'TimeoutErr'
  what():  Timeout error; too many retries failed
Aborted (core dumped)
```
If I sent it to JUMBO, it no longer crash but not the correct way to operate the software.