### PR TITLE
Defer pydm import

### DIFF
--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -11,8 +11,6 @@
 import argparse
 import pyrogue
 import pyrogue.interfaces
-import pyrogue.gui
-import pyrogue.pydm
 import time
 import os
 
@@ -65,6 +63,8 @@ print("Connecting to {}".format(args.server))
 
 # GUI Client
 if args.cmd == 'gui':
+    import pyrogue.gui
+    import pyrogue.pydm
     pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui)
 
 # System log


### PR DESCRIPTION
Needed when we use rogue on a linuxRT system as we don't have QT support there.
However, we still need to use the non-gui parts of rogue w/o triggering an exception.