### PR TITLE
Update epicsV4.py

### DIFF
--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -177,6 +177,10 @@ class EpicsPvHolder(object):
 
         # Get initial value
         varVal = var.getVariableValue(read=False)
+        
+        # Override LinkerVariables with init=None
+        if varVal.valueDisp is None:
+            varVal.valueDisp = ''
 
         # Detect array
         if self._var.isList:

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -177,7 +177,7 @@ class EpicsPvHolder(object):
 
         # Get initial value
         varVal = var.getVariableValue(read=False)
-        
+
         # Override LinkerVariables with init=None
         if varVal.valueDisp is None:
             varVal.valueDisp = ''


### PR DESCRIPTION
### Description
- Bug fix for when the LinkerVariables has an init=None
- Example from https://github.com/slaclab/surf/blob/master/python/surf/devices/transceivers/_Sfp.py:
```python
        self.add(pr.LinkVariable(
            name         = 'ManufactureDate',
            description  = 'Vendor\'s manufacturing date code (ASCII)',
            mode         = 'RO',
            linkedGet    = transceivers.getDate,
            dependencies = [self.DateCode[x] for x in range(6)],
        ))
```