### PR TITLE
Add update period feature for the updateGroup context

### DIFF
--- a/include/rogue/GeneralError.h
+++ b/include/rogue/GeneralError.h
@@ -22,6 +22,7 @@
 #include <exception>
 #include <stdint.h>
 #include <string>
+#include <memory>
 
 #ifndef NO_PYTHON
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS

--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <vector>
 #include <string>
+#include <memory>
 
 namespace rogue {
 

--- a/include/rogue/hardware/MemMap.h
+++ b/include/rogue/hardware/MemMap.h
@@ -20,6 +20,7 @@
 #include <rogue/interfaces/memory/Transaction.h>
 #include <thread>
 #include <mutex>
+#include <memory>
 #include <stdint.h>
 #include <rogue/Logging.h>
 #include <rogue/Queue.h>

--- a/include/rogue/hardware/axi/AxiMemMap.h
+++ b/include/rogue/hardware/axi/AxiMemMap.h
@@ -19,6 +19,7 @@
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Transaction.h>
 #include <thread>
+#include <memory>
 #include <mutex>
 #include <stdint.h>
 #include <rogue/Queue.h>

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -16,6 +16,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <thread>
+#include <memory>
 #include <stdint.h>
 #include <rogue/Logging.h>
 

--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -17,6 +17,7 @@
 #ifndef __ROGUE_ZMQ_CLIENT_H__
 #define __ROGUE_ZMQ_CLIENT_H__
 #include <thread>
+#include <memory>
 #include <rogue/Logging.h>
 
 #ifndef NO_PYTHON

--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -18,6 +18,7 @@
 #define __ROGUE_ZMQ_SERVER_H__
 #include <thread>
 #include <rogue/Logging.h>
+#include <memory>
 
 #ifndef NO_PYTHON
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS

--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -23,6 +23,7 @@
 
 #include <rogue/interfaces/memory/Master.h>
 #include <thread>
+#include <memory>
 
 #ifndef NO_PYTHON
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS

--- a/include/rogue/interfaces/memory/Hub.h
+++ b/include/rogue/interfaces/memory/Hub.h
@@ -24,6 +24,7 @@
 #define __ROGUE_INTERFACES_MEMORY_HUB_H__
 #include <stdint.h>
 #include <vector>
+#include <memory>
 
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/interfaces/memory/Slave.h>

--- a/include/rogue/interfaces/memory/Master.h
+++ b/include/rogue/interfaces/memory/Master.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <map>
 #include <thread>
+#include <memory>
 #include <rogue/Logging.h>
 
 #ifndef NO_PYTHON

--- a/include/rogue/interfaces/memory/Slave.h
+++ b/include/rogue/interfaces/memory/Slave.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <vector>
 #include <map>
+#include <memory>
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/EnableSharedFromThis.h>
 

--- a/include/rogue/interfaces/memory/TcpClient.h
+++ b/include/rogue/interfaces/memory/TcpClient.h
@@ -21,6 +21,7 @@
 #define __ROGUE_INTERFACES_MEMORY_TCP_CLIENT_H__
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/Logging.h>
+#include <memory>
 #include <thread>
 #include <stdint.h>
 

--- a/include/rogue/interfaces/memory/TcpServer.h
+++ b/include/rogue/interfaces/memory/TcpServer.h
@@ -21,6 +21,7 @@
 #define __ROGUE_INTERFACES_MEMORY_TCP_SERVER_H__
 #include <rogue/interfaces/memory/Master.h>
 #include <rogue/Logging.h>
+#include <memory>
 #include <thread>
 #include <stdint.h>
 

--- a/include/rogue/interfaces/memory/TransactionLock.h
+++ b/include/rogue/interfaces/memory/TransactionLock.h
@@ -21,6 +21,7 @@
 #define __ROGUE_INTERFACES_MEMORY_TRANSACTION_LOCK_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -22,6 +22,7 @@
 #include <inttypes.h>
 #include <vector>
 #include <rogue/EnableSharedFromThis.h>
+#include <memory>
 
 #include <thread>
 

--- a/include/rogue/interfaces/stream/Buffer.h
+++ b/include/rogue/interfaces/stream/Buffer.h
@@ -21,6 +21,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_BUFFER_H__
 #define __ROGUE_INTERFACES_STREAM_BUFFER_H__
 #include <stdint.h>
+#include <memory>
 
 #include <rogue/interfaces/stream/Frame.h>
 

--- a/include/rogue/interfaces/stream/Fifo.h
+++ b/include/rogue/interfaces/stream/Fifo.h
@@ -22,6 +22,7 @@
 #define __ROGUE_INTERFACES_STREAM_FIFO_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>

--- a/include/rogue/interfaces/stream/Filter.h
+++ b/include/rogue/interfaces/stream/Filter.h
@@ -21,6 +21,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FILTER_H__
 #define __ROGUE_INTERFACES_STREAM_FILTER_H__
 #include <stdint.h>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>

--- a/include/rogue/interfaces/stream/FrameAccessor.h
+++ b/include/rogue/interfaces/stream/FrameAccessor.h
@@ -20,6 +20,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #include <stdint.h>
+#include <memory>
 #include <rogue/GeneralError.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 

--- a/include/rogue/interfaces/stream/FrameIterator.h
+++ b/include/rogue/interfaces/stream/FrameIterator.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <vector>
 #include <cstring>
+#include <memory>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/stream/FrameLock.h
+++ b/include/rogue/interfaces/stream/FrameLock.h
@@ -21,6 +21,7 @@
 #define __ROGUE_INTERFACES_MEMORY_FRAME_LOCK_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 
 namespace rogue {
    namespace interfaces {

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <thread>
 #include <mutex>
+#include <memory>
 #include <rogue/EnableSharedFromThis.h>
 
 #ifndef NO_PYTHON
@@ -141,7 +142,7 @@ namespace rogue {
                 *  Subclasses should override this method
                 */
                virtual void stop();
-    
+
 #ifndef NO_PYTHON
 
                //! Support == operator in python

--- a/include/rogue/interfaces/stream/RateDrop.h
+++ b/include/rogue/interfaces/stream/RateDrop.h
@@ -21,6 +21,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_RATE_DROP_H__
 #define __ROGUE_INTERFACES_STREAM_RATE_DROP_H__
 #include <stdint.h>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>

--- a/include/rogue/interfaces/stream/Slave.h
+++ b/include/rogue/interfaces/stream/Slave.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Pool.h>
 #include <rogue/Logging.h>
 #include <rogue/EnableSharedFromThis.h>

--- a/include/rogue/interfaces/stream/TcpClient.h
+++ b/include/rogue/interfaces/stream/TcpClient.h
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/TcpCore.h>
 #include <rogue/Logging.h>
 #include <thread>
+#include <memory>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/TcpCore.h
+++ b/include/rogue/interfaces/stream/TcpCore.h
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/Logging.h>
 #include <thread>
+#include <memory>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/interfaces/stream/TcpServer.h
+++ b/include/rogue/interfaces/stream/TcpServer.h
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/TcpCore.h>
 #include <rogue/Logging.h>
 #include <thread>
+#include <memory>
 #include <stdint.h>
 
 namespace rogue {

--- a/include/rogue/protocols/batcher/CoreV1.h
+++ b/include/rogue/protocols/batcher/CoreV1.h
@@ -22,6 +22,7 @@
 #define __ROGUE_PROTOCOLS_BATCHER_CORE_V1_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/Logging.h>
 

--- a/include/rogue/protocols/batcher/Data.h
+++ b/include/rogue/protocols/batcher/Data.h
@@ -22,6 +22,7 @@
 #define __ROGUE_PROTOCOLS_BATCHER_DATA_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
 

--- a/include/rogue/protocols/batcher/InverterV1.h
+++ b/include/rogue/protocols/batcher/InverterV1.h
@@ -22,6 +22,7 @@
 #define __ROGUE_PROTOCOLS_BATCHER_INVERTER_V1_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/batcher/SplitterV1.h
+++ b/include/rogue/protocols/batcher/SplitterV1.h
@@ -22,6 +22,7 @@
 #define __ROGUE_PROTOCOLS_BATCHER_SPLITTER_V1_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/Logging.h>

--- a/include/rogue/protocols/epicsV3/Command.h
+++ b/include/rogue/protocols/epicsV3/Command.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Master.h
+++ b/include/rogue/protocols/epicsV3/Master.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Pv.h
+++ b/include/rogue/protocols/epicsV3/Pv.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Server.h
+++ b/include/rogue/protocols/epicsV3/Server.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Slave.h
+++ b/include/rogue/protocols/epicsV3/Slave.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Value.h
+++ b/include/rogue/protocols/epicsV3/Value.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Variable.h
+++ b/include/rogue/protocols/epicsV3/Variable.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <thread>
+#include <memory>
 #include <casdef.h>
 #include <gdd.h>
 #include <gddApps.h>

--- a/include/rogue/protocols/epicsV3/Work.h
+++ b/include/rogue/protocols/epicsV3/Work.h
@@ -24,6 +24,7 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 #include <casdef.h>
+#include <memory>
 #include <gdd.h>
 #include <gddApps.h>
 #include <gddAppFuncTable.h>

--- a/include/rogue/protocols/packetizer/Application.h
+++ b/include/rogue/protocols/packetizer/Application.h
@@ -19,6 +19,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <stdint.h>
+#include <memory>
 #include <rogue/Queue.h>
 
 namespace rogue {

--- a/include/rogue/protocols/packetizer/Core.h
+++ b/include/rogue/protocols/packetizer/Core.h
@@ -18,6 +18,7 @@
 #define __ROGUE_PROTOCOLS_PACKETIZER_CORE_H__
 #include <thread>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/packetizer/CoreV2.h
+++ b/include/rogue/protocols/packetizer/CoreV2.h
@@ -21,6 +21,7 @@
 #define __ROGUE_PROTOCOLS_PACKETIZER_CORE_V2_H__
 #include <thread>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/packetizer/Transport.h
+++ b/include/rogue/protocols/packetizer/Transport.h
@@ -19,6 +19,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/rssi/Application.h
+++ b/include/rogue/protocols/rssi/Application.h
@@ -19,6 +19,7 @@
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -18,6 +18,7 @@
 #define __ROGUE_PROTOCOLS_RSSI_CLIENT_H__
 #include <thread>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -18,6 +18,7 @@
 #define __ROGUE_PROTOCOLS_RSSI_SERVER_H__
 #include <thread>
 #include <stdint.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/rssi/Transport.h
+++ b/include/rogue/protocols/rssi/Transport.h
@@ -20,6 +20,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <stdint.h>
 #include <rogue/Queue.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/srp/Cmd.h
+++ b/include/rogue/protocols/srp/Cmd.h
@@ -18,6 +18,7 @@
 #define __ROGUE_PROTOCOLS_SRP_CMD_H__
 #include <stdint.h>
 #include <thread>
+#include <memory>
 #include <rogue/interfaces/stream/Master.h>
 
 namespace rogue {

--- a/include/rogue/protocols/srp/SrpV0.h
+++ b/include/rogue/protocols/srp/SrpV0.h
@@ -22,6 +22,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/Logging.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/srp/SrpV3.h
+++ b/include/rogue/protocols/srp/SrpV3.h
@@ -22,6 +22,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/Logging.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/udp/Client.h
+++ b/include/rogue/protocols/udp/Client.h
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/udp/Core.h
+++ b/include/rogue/protocols/udp/Core.h
@@ -22,6 +22,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/protocols/udp/Server.h
+++ b/include/rogue/protocols/udp/Server.h
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
+#include <memory>
 
 namespace rogue {
    namespace protocols {

--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -20,6 +20,7 @@
 #include <thread>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
+#include <memory>
 
 namespace rogue {
    namespace utilities {

--- a/include/rogue/utilities/StreamUnZip.h
+++ b/include/rogue/utilities/StreamUnZip.h
@@ -22,6 +22,7 @@
 #include <thread>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
+#include <memory>
 
 namespace rogue {
    namespace utilities {

--- a/include/rogue/utilities/StreamZip.h
+++ b/include/rogue/utilities/StreamZip.h
@@ -23,6 +23,7 @@
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/stream/Master.h>
 
+#include <memory>
 namespace rogue {
    namespace utilities {
 

--- a/include/rogue/utilities/fileio/LegacyStreamReader.h
+++ b/include/rogue/utilities/fileio/LegacyStreamReader.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <map>
 #include <condition_variable>
+#include <memory>
 
 namespace rogue {
    namespace utilities {

--- a/include/rogue/utilities/fileio/StreamReader.h
+++ b/include/rogue/utilities/fileio/StreamReader.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <map>
+#include <memory>
 
 namespace rogue {
    namespace utilities {

--- a/include/rogue/utilities/fileio/StreamWriterChannel.h
+++ b/include/rogue/utilities/fileio/StreamWriterChannel.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <thread>
 #include <rogue/interfaces/stream/Slave.h>
+#include <memory>
 
 namespace rogue {
    namespace utilities {

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -109,6 +109,7 @@ class Process(pr.Device):
             self._process()
         except Exception as e:
             pr.logException(self._log,e)
+            self.Message.setDisp("Stopped after error!")
 
         self.Running.set(False)
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -31,10 +31,10 @@ from contextlib import contextmanager
 SystemLogInit = '[]'
 
 class UpdateTracker(object):
-    def __init__(self,period,q):
+    def __init__(self,q):
         self._count = 0
         self._list = {}
-        self._period = period
+        self._period = 0
         self._last = time.time()
         self._q = q
 
@@ -50,7 +50,8 @@ class UpdateTracker(object):
         self._check()
 
     def _check(self):
-        if len(self._list) != 0 and (self._count == 0 or (time.time() - self._last) > self._period):
+        if len(self._list) != 0 and (self._count == 0 or (self._period != 0 and (time.time() - self._last) > self._period)):
+            #print(f"Update fired {time.time()}")
             self._last = time.time()
             self._q.put(self._list)
             self._list = {}


### PR DESCRIPTION
This PR modifies the updateGroup context a bit. First I added a class to help manage this.

Second I added a feature allowing a period to be passed to the context. The period setting allows the updates to be posted after the passed period times out. This allows scripts to still allow GUI updates, but at a controlled rate. The default behavior is to defer all updates as in the past. 

This also fixes some missing include calls needed with later compilers. 

Example call:

    def _saTuneWrap(self):
        with self.root.updateGroup(0.25):
            ret = warm_tdm_api.saTune(group=self.parent,pctVar=self.Progress)
            self.SaTuneOutput.set(value=ret)
