### PR TITLE
Make conda activate and deactivate directories first

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh
-          conda build $CONDA_SRC --debug --output-folder bld-dir -c tidair-packages -c conda-forge
+          conda build $CONDA_SRC --output-folder bld-dir -c tidair-packages -c conda-forge
 
       - name: Upload
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,9 @@ if (NOT (${ROGUE_INSTALL} STREQUAL "local"))
 endif()
 
 # Conda activate and deactivate functions
-if ((${ROGUE_INSTALL} STREQUAL "conda"))
+if (${ROGUE_INSTALL} STREQUAL "conda")
+   install(CODE "execute_process(COMMAND mkdir -p ${ROGUE_DIR}/etc/conda/activate.d)")
+   install(CODE "execute_process(COMMAND mkdir -p ${ROGUE_DIR}/etc/conda/deactivate.d)")
    install(CODE "execute_process(COMMAND scp ${PROJECT_SOURCE_DIR}/templates/activate-rogue.sh
                                              ${ROGUE_DIR}/etc/conda/activate.d/rogue.sh)")
    install(CODE "execute_process(COMMAND scp ${PROJECT_SOURCE_DIR}/templates/deactivate-rogue.sh


### PR DESCRIPTION
Build was failing because the anaconda activate.d and deactivate.d directories were no previously created by other packages. 