### PR TITLE
Update petalinux.rst

### DIFF
--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -28,7 +28,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
 
    SRC_URI = "https://github.com/slaclab/rogue/archive/v${ROGUE_VERSION}.tar.gz"
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
-   S = "${WORKDIR}/rogue-${ROGUE_VERSION}/"
+   S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
 
    DEPENDS += "python3 python3-numpy python3-native python3-numpy-native cmake boost zeromq bzip2"
    DEPENDS += "python3-pyzmq python3-parse python3-pyyaml python3-click python3-sqlalchemy python3-pyserial"
@@ -64,7 +64,7 @@ To enable compilation and installation of the rogue package in your petalinux pr
 
 .. code::
 
-   > petalinux-config rootfs
+   > petalinux-config -c rootfs
 
 and enable the rogue package under 'user packages'. Save and exit the menu configuration.
 

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -79,7 +79,13 @@ You can then build the rogue package with the following command:
 
 .. code::
 
+   # Try to let rogue build and let it assert the error about missing setup.py file
+   > petalinux-build -c rogue
+
+   # Copy the autogenerate setup.py from the 1st "petalinux-build -c rogue" to the correct directory (work around)
+   > cp build/tmp/work/cortexa72-cortexa53-xilinx-linux/rogue/1.0-r0/build/setup.py build/tmp/work/cortexa72-cortexa53-xilinx-linux/rogue/1.0-r0/rogue-<ROGUE_VERSION>/.
+
+   # Rebuild again
    > petalinux-build -c rogue
 
 You can then build the petalinux project as normal.
-


### PR DESCRIPTION
### Description
- newer petalinux versions does not allow trailing `/` when doing the `petalinux-build -c rogue` step
- newer petalinux requires the `-c` as part of the `petalinux-config` step