### PR TITLE
Only add LocalVariables to update queue if they have been changed

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -141,7 +141,7 @@ class LocalBlock(object):
             with self._lock:
                 doUpdate = self._doUpdate
                 self._doUpdate = False
-                self._changed = False                
+                self._changed = False
 
             # Update variables outside of lock
             if doUpdate:


### PR DESCRIPTION
`LocalVariables` were being added to the `updateQueue` every time they were read, regardless of whether they had been updated. This was a problem for very large array variables, as it would slow the `ReadAll` operation to a crawl.
`LocalBlock` now tracks whether a change has occurred when when `set()` is called, and later only sends the variable to the updateQueue if the `changed` flag is true.