### PR TITLE
ESROGUE-532: Bug fix for `Bad access to shared pointer when creating UDP client and server`

### DIFF
--- a/include/rogue/interfaces/stream/Pool.h
+++ b/include/rogue/interfaces/stream/Pool.h
@@ -73,6 +73,9 @@ namespace rogue {
 
             public:
 
+               //! Class creation
+               static std::shared_ptr<rogue::interfaces::stream::Pool> create();
+               
                // Class creator
                Pool();
 

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -36,6 +36,12 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 #endif
 
+//! Class creation
+ris::PoolPtr ris::Pool::create () {
+   ris::PoolPtr r = std::make_shared<ris::Pool>();
+   return(r);
+}
+
 //! Creator
 ris::Pool::Pool() {
    allocMeta_  = 0;

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -174,16 +174,24 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
 void rpu::Client::runThread() {
    ris::BufferPtr buff;
    ris::FramePtr  frame;
+   ris::PoolPtr   pool;
    fd_set         fds;
    int32_t        res;
    struct timeval tout;
    uint32_t       avail;
 
    udpLog_->logThreadId();
-   usleep(1000);
+   //usleep(1000);
+
+   // Allocate the frame pool
+   pool = ris::Pool::create();
+
+   // Fixed size buffer pool
+   pool->setFixedSize(maxPayload());
+   pool->setPoolSize(10000); // Initial value, 10K frames
 
    // Preallocate frame
-   frame = ris::Pool::acceptReq(maxPayload(),false);
+   frame = pool->acceptReq(maxPayload(),false);
 
    while(threadEn_) {
 
@@ -202,7 +210,7 @@ void rpu::Client::runThread() {
          }
 
          // Get new frame
-         frame = ris::Pool::acceptReq(maxPayload(),false);
+         frame = pool->acceptReq(maxPayload(),false);
       }
       else {
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -180,7 +180,7 @@ void rpu::Client::runThread() {
    uint32_t       avail;
 
    udpLog_->logThreadId();
-   //usleep(1000);
+   usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -82,8 +82,8 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    ((struct sockaddr_in *)(&remAddr_))->sin_port=htons(port_);
 
    // Fixed size buffer pool
-   setFixedSize(maxPayload());
-   setPoolSize(10000); // Initial value, 10K frames
+   //setFixedSize(maxPayload());
+   //setPoolSize(10000); // Initial value, 10K frames
 
    // Start rx thread
    threadEn_ = true;

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -180,7 +180,7 @@ void rpu::Client::runThread() {
    uint32_t       avail;
 
    udpLog_->logThreadId();
-   usleep(1000);
+   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -184,7 +184,7 @@ void rpu::Server::runThread() {
    uint32_t           avail;
 
    udpLog_->logThreadId();
-   usleep(1000);
+   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -184,7 +184,7 @@ void rpu::Server::runThread() {
    uint32_t           avail;
 
    udpLog_->logThreadId();
-   //usleep(1000);
+   usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -79,8 +79,8 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    }
 
    // Fixed size buffer pool
-   setFixedSize(maxPayload());
-   setPoolSize(10000); // Initial value, 10K frames
+   //setFixedSize(maxPayload());
+   //setPoolSize(10000); // Initial value, 10K frames
 
    // Start rx thread
    threadEn_ = true;


### PR DESCRIPTION
### Description
This fix bypasses the bad shared_ptr issue by creating a Pool object and then calling its member functions, instead of making direct calls to the functions in the un-instantiated class.  It seemed to me that's why shared_from_this() was failing before, as this call will work only with an object already owned by a shared_ptr.