### PR TITLE
Reduce scope of printoptions when generating string for numpy array.

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -388,8 +388,9 @@ class BaseVariable(pr.Node):
         try:
 
             if isinstance(value,np.ndarray):
-                np.set_printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize)
-                return np.array2string(value, separator=', ')
+                with np.printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize):
+                    ret = np.array2string(value, separator=', ')
+                return ret
 
             elif self.disp == 'enum':
                 if value in self.enum:


### PR DESCRIPTION
When setting numpy print options for formatting a numpy array as a string, `Variable.getDisp()` was modifying the global numpy printoptions, and affecting the formatting of unrelated numpy arrays elsewhere in the code.

This fix uses the `np.printoptions` context manager to limit the scope of print options to each variable instance.