### PR TITLE
Release Candidate v5.13.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--- Provide a one sentence summary of your changes in the Title above -->
+
+### Description
+<!--- Describe your changes in detail. This could include code examples, etc. -->
+<!--- If you leave this blank your PR will not be accepted. -->
+<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
+
+### Details
+<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
+
+### JIRA
+<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
+
+### Related
+<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2021, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2022, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ The following is how you install the development version (pre-release) or Rogue 
    $ conda create -n rogue_pre -c tidair-dev -c tidair-packages -c conda-forge rogue
 
 ```
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -21,6 +21,7 @@ branch of Rogue. New documentation is being added incrementally over time.
    protocols/index
    logging/index
    custom_module/index
+   pydm/index
 
 Please email rherbst@slac.stanford.edu if you see any errors or have any
 questions about anything in the current documentation. We are still adding

--- a/docs/src/pydm/channel_urls.rst
+++ b/docs/src/pydm/channel_urls.rst
@@ -1,0 +1,27 @@
+.. _channel_urls
+
+============
+Channel URLS
+============
+
+When using the PyDM and Rogue widgets the user must associate the widget with a Rogue Device, Variable or Command using a channel URL. The URLs used by Rogue connected widgets are in the form:
+
+rogue://0/MyRoot.MyDevice.MyVariable
+
+The user can either use the real root name or simply the 'root' alias when referring to a Rogue root instance. This is usefull when creating generic debug tree associations. For example the URL used by a generic DebugTree widdget would be:
+
+rogue://0/root
+
+URL Suffix
+==========
+
+For some channels such as variables and commands a suffix can be added to the URL to direct PyDM on how to access the Rogue instance. An example suffix usage is:
+
+rogue://0/root.Device.Variable/disp
+
+The following suffixes are currently supported:
+
+   - name: The PyDM widget will display the Rogue instance name instead of its value. This is usefull for labels.
+   - path: The PyDM widget will display the full Rogue path of the instance.
+   - disp: The PyDM widget will use the getDisp() call instead of get() to display the string representation of the current value. This is usefull for line edit widgets.
+

--- a/docs/src/pydm/index.rst
+++ b/docs/src/pydm/index.rst
@@ -1,0 +1,26 @@
+.. _pydm:
+
+==================
+Using the PyDM Gui
+==================
+
+Rogue makes use of the PyDM platform for its GUI. While Rogue provides a default debug GUI that auto populates, the user should consider creating custom GUIs using the numerous PyDYM widgets and other features.
+
+Documentation on the PyDM platform can be found here:
+
+http://slaclab.github.io/pydm/
+
+Rogue provides a few custom features within the PyDM platform. First it supports its own custom channel driver using the URL prefix:
+
+rogue://
+
+Additionally Rogue provides a few custom widgets which can be used to visualize specific Rogue structures.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Rogue PyDM Features:
+
+   starting_gui
+   channel_urls
+   rogue_widgets
+

--- a/docs/src/pydm/rogue_widgets.rst
+++ b/docs/src/pydm/rogue_widgets.rst
@@ -1,0 +1,17 @@
+.. _rogue_widgets
+
+=============
+Rogue Widgets
+=============
+
+The following Rogue specific PyDM widgets are provided:
+
+   - system_window: System window included resets, config load, config save, the top level run control and data writer instances as well as  a system log window.
+   - root_control: A widget for reset and configuration file managment
+   - run_control: A widget for the Rogue run control device
+   - data_writer: A widget for the Rogue data writer device
+   - system_log: A widget to display the Rogue system log
+   - process: A widget for the Rogue Process device
+   - debug_tree: A widget containing a representation of the Rogue tree
+   - line_edit: A Rogue specific sub-class of PyDmLineEdit which stays yellow while the entered value is stale
+

--- a/docs/src/pydm/starting_gui.rst
+++ b/docs/src/pydm/starting_gui.rst
@@ -1,0 +1,60 @@
+.. _starting_gui
+
+===========================
+Starting The Rogue PyDM GUI
+===========================
+
+The Rogue PyDM GUI can be started either from the command line or within a python application.
+
+Using The Command Line
+======================
+
+You use the rogue module from the command line to start the GUI in the following way:
+
+.. code::
+
+   $ python -m pyrogue gui
+
+This will start the default Rogue debug GUI and connect to the first Rogue server it fines while scanning the typical server ports opened by a Rogue instance.
+
+You can also specify one or more Rogue server addresses on the command line:
+
+.. code::
+
+   $ python -m pyrogue --server localhost:9099 gui
+
+Or for connecting to multiple Rogue servers:
+
+.. code::
+
+   $ python -m pyrogue --server localhost:9099,otherhost1:9099,otherhost2:9099 gui
+
+The default GUI only supports a connection to one server at a time and will only display the debug GUI for the first server in the list. The additional servers are available in the PyDM session, but require a custom GUI to be created either programically or using the PyQT designer application.
+
+The PyDM channel prefix for each instance of Rogue to which is is connected is rogue://n/ where n is the 0 based serial number of the server instance passed on the command line.
+
+If you have created a custom PyDM display using the designer tool, you can start that display from the command line by passing the path to the created designer ui file:
+
+.. code::
+
+   $ python -m pyrogue --server localhost:9099,otherhost1:9099,otherhost2:9099 --ui path/to/file.ui gui
+
+Using A Python Script
+=====================
+
+The alternative way to start the PyDM GUI is to execute the Rogue helper function for starting PyDM from within a python script, using the Rogue Virtual Client, or directly with a local Rogue root:
+
+.. code::
+    import pyrogue.pydm
+
+    with MyRoot() as root:
+         pyrogue.pydm.runPyDM(root=root,title='MyTitle',sizeX=1000,sizeY=500)
+
+The possible args that can be passed to the runPyDm function are:
+
+   - serverList: A string list of Rogue servers to connect to. i.e. localhost:9099,server1:9099,server2:9099
+   - root: An existing Rogue root object using a virutal client or local root
+   - ui: The path to a UI file created with the PyQT designer tool
+   - title: The title of the main window
+   - sizeX: The GUI size in the X dimension
+   - sizeY: The GUI size in the Y dimension

--- a/include/rogue/LibraryBase.h
+++ b/include/rogue/LibraryBase.h
@@ -24,6 +24,8 @@
 #include <map>
 #include <set>
 #include <string>
+#include <fstream>
+#include <istream>
 #include <rogue/interfaces/stream/Master.h>
 #include <rogue/interfaces/stream/Slave.h>
 #include <rogue/interfaces/memory/Variable.h>
@@ -61,6 +63,8 @@ namespace rogue {
 
          // Parse memory map
          void parseMemMap (std::string map);
+		 void parseMemMap (const char * filePath, char delim = '\n');
+		 void parseMemMap (std::istream & fStream, char delim);
 
          static std::shared_ptr<rogue::LibraryBase> create();
 

--- a/include/rogue/protocols/srp/SrpV3.h
+++ b/include/rogue/protocols/srp/SrpV3.h
@@ -43,6 +43,8 @@ namespace rogue {
                static const uint32_t HeadLen = 20;
                static const uint32_t TailLen = 4;
 
+               uint8_t timeout_ = 0x0A;
+
                // Setup header, return write flag
                bool setupHeader(std::shared_ptr<rogue::interfaces::memory::Transaction> tran,
                                 uint32_t *header, uint32_t &frameLen, bool tx);
@@ -67,6 +69,8 @@ namespace rogue {
                //! Accept a frame from master
                void acceptFrame ( std::shared_ptr<rogue::interfaces::stream::Frame> frame );
 
+               // Set hardware timeout
+               void setHardwareTimeout( uint8_t val );
          };
 
          // Convenience

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -25,7 +25,6 @@ class DataReceiver(pr.Device,ris.Slave):
 
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
-        self._rxEnable = False
 
         self.add(pr.LocalVariable(name='RxEnable',
                                   value=True,
@@ -63,7 +62,7 @@ class DataReceiver(pr.Device,ris.Slave):
         super().countReset()
 
     def _acceptFrame(self, frame):
-        if not self._rxEnable:
+        if not self.RxEnable.get():
             return
 
         # Lock frame
@@ -103,10 +102,10 @@ class DataReceiver(pr.Device,ris.Slave):
 
     def _start(self):
         super()._start()
-        self._rxEnable = True
+        self.RxEnable.set(value=True)
 
     def _stop(self):
-        self._rxEnable = False
+        self.RxEnable.set(value=False)
         super()._stop()
 
     # source >> destination

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -388,8 +388,9 @@ class BaseVariable(pr.Node):
         try:
 
             if isinstance(value,np.ndarray):
-                np.set_printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize)
-                return np.array2string(value, separator=', ')
+                with np.printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize):
+                    ret = np.array2string(value, separator=', ')
+                return ret
 
             elif self.disp == 'enum':
                 if value in self.enum:

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -117,7 +117,10 @@ class RogueConnection(PyDMConnection):
         elif self._enum is not None:
             self.new_value_signal[int].emit(self._enum.index(varValue.valueDisp))
         else:
-            self.new_value_signal[type(varValue.value)].emit(varValue.value)
+            if isinstance(varValue.value, list):
+                self.new_value_signal[str].emit(varValue.valueDisp)
+            else:
+                self.new_value_signal[type(varValue.value)].emit(varValue.value)
 
         self.new_severity_signal.emit(AlarmToInt[varValue.severity])
 

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -58,18 +58,22 @@ class DataWriter(PyDMFrame):
         hb = QHBoxLayout()
         vb.addLayout(hb)
 
-        pb = QPushButton('Browse')
-        pb.clicked.connect(self._browse)
-        hb.addWidget(pb)
+        self._browsebutton = QPushButton('Browse')
+        self._browsebutton.clicked.connect(self._browse)
+        hb.addWidget(self._browsebutton)
 
-        w = PyDMPushButton(label='Auto Name',pressValue=1,init_channel=self._path + '.AutoName')
-        hb.addWidget(w)
+        self._autonamebutton = PyDMPushButton(label='Auto Name',pressValue=1,init_channel=self._path + '.AutoName')
+        hb.addWidget(self._autonamebutton)
 
-        w = PyDMPushButton(label='Open',pressValue=1,init_channel=self._path + '.Open')
-        hb.addWidget(w)
+        self._openbutton = PyDMPushButton(label='Open',pressValue=1,init_channel=self._path + '.Open')
+        self._openbutton.clicked.connect(self._openDataFile)
+        hb.addWidget(self._openbutton)
 
-        w = PyDMPushButton(label='Close',pressValue=1,init_channel=self._path + '.Close')
-        hb.addWidget(w)
+        self._closebutton = PyDMPushButton(label='Close',pressValue=1,init_channel=self._path + '.Close')
+        self._closebutton.check_enable_state = lambda: None
+        self._closebutton.clicked.connect(self._closeDataFile)
+        self._closebutton.setEnabled(False)
+        hb.addWidget(self._closebutton)
 
         hb = QHBoxLayout()
         vb.addLayout(hb)
@@ -121,6 +125,22 @@ class DataWriter(PyDMFrame):
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Total File Size:',w)
+
+    @Slot()
+    def _closeDataFile(self):
+        self._dataFile.setEnabled(True)
+        self._browsebutton.setEnabled(True)
+        self._openbutton.setEnabled(True)
+        self._autonamebutton.setEnabled(True)
+        self._closebutton.setEnabled(False)
+
+    @Slot()
+    def _openDataFile(self):
+        self._dataFile.setEnabled(False)
+        self._browsebutton.setEnabled(False)
+        self._openbutton.setEnabled(False)
+        self._autonamebutton.setEnabled(False)
+        self._closebutton.setEnabled(True)
 
     @Slot()
     def _browse(self):

--- a/python/pyrogue/utilities/hls/_RegInterfParser.py
+++ b/python/pyrogue/utilities/hls/_RegInterfParser.py
@@ -1,0 +1,283 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue library utilities. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of rogue, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Run this script as shown below:
+# python -m pyrogue.utilities.hls._RegInterfParser --memoryDevice
+# python -m pyrogue.utilities.hls._RegInterfParser --remoteVariable
+# python -m pyrogue.utilities.hls._RegInterfParser --remoteCommand
+
+import os
+import argparse
+import zipfile
+from collections import namedtuple
+from zipfile import ZipFile
+
+##############################################################################
+# Supported types of rogue devices and variables                             #
+##############################################################################
+# RemoteVariable type
+RemoteVariable = namedtuple('RemoteVariable', ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base',
+                                               'mode'], defaults=['VarName', 'description', 0x00000, 8, 0, 'pr.Int',
+                                                                  'RW'])
+
+# RemoteCommand type
+RemoteCommand = namedtuple('RemoteCommand', ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base',
+                                             'function'], defaults=['CmdName', 'description', 0x00000, 8, 0, 'pr.UInt',
+                                                                    'lambda cmd: cmd.post(1)'])
+
+# MemoryDevice type
+MemoryDevice = namedtuple('MemoryDevice', ['name', 'offset', 'size', 'wordBitSize', 'stride', 'base'],
+                          defaults=['DevName', 0x00000, 16, 8, 16, 'pr.Int'])
+##############################################################################
+
+vartype = ''
+maxwidth = 64
+
+def parse():
+    # Get the path to the zip file
+    zname = input('Enter the path to the zipfile: ')
+
+    if not os.path.exists(zname):
+        print('Zip file cannot be opened:', zname)
+        exit()
+
+    # Check if it's a valid zipfile
+    if not zipfile.is_zipfile(zname):
+        print('Not a valid zip file:', zname)
+        exit()
+
+    # Extract all the contents of the zip file in the current directory
+    with ZipFile(zname, 'r') as zipObj:
+        zipObj.extractall()
+
+    fname = ''
+
+    for root, dirs, files in os.walk("./"):
+        for file in files:
+            if file.endswith("_hw.h"):
+                fname = os.path.join(root, file)
+
+    try:
+        fhand = open(fname)
+    except FileNotFoundError:
+        print('Register file cannot be opened:', fname)
+        exit()
+
+    macrolines = []
+
+    # Parse the register interface file and extract macros
+    for line in fhand:
+        line = line.lstrip()
+        line = line.rstrip()
+        words = line.split()
+
+        # Look for the #define lines and save them off
+        if len(words) > 0 and words[0] == '#define':
+            if len(words) == 3:
+                words = words[1::]
+                macrolines.append((words[0], words[1]))
+
+    # Keep track of indices of processed macros
+    matchedIndices = []
+
+    # Group all macros for the same device or variable together by detecting name similarities
+    devs = []
+    for m1 in macrolines:
+        dev = []
+        for m2 in macrolines:
+            # Check macros differences and extract device/variable/command info
+            if macrolines.index(m2) not in matchedIndices and m1 != m2:
+                terms = ['ADDR', 'BASE', 'HIGH', 'BITS', 'WIDTH', 'DEPTH']
+                diffm1m2 = list((set(m1[0].split('_'))-set(m2[0].split('_'))))
+                diffm2m1 = list((set(m2[0].split('_'))-set(m1[0].split('_'))))
+                if len(diffm1m2) == 1 and len(diffm2m1) == 1 and diffm1m2[0] in terms and diffm2m1[0] in terms:
+                    dev.append(m1)
+                    dev.append(m2)
+                    matchedIndices.append(macrolines.index(m1))
+                    matchedIndices.append(macrolines.index(m2))
+
+                if (len(diffm1m2) == 2 and len(diffm2m1) == 1 and diffm2m1[0] in terms and 'ADDR' in diffm1m2 and ('BASE' in diffm1m2 or 'HIGH' in diffm1m2)) or \
+                   (len(diffm1m2) == 1 and len(diffm2m1) == 2 and diffm1m2[0] in terms and 'ADDR' in diffm2m1 and ('BASE' in diffm2m1 or 'HIGH' in diffm2m1)):
+                    dev.append(m1)
+                    dev.append(m2)
+                    matchedIndices.append(macrolines.index(m1))
+                    matchedIndices.append(macrolines.index(m2))
+
+        # Remove duplicates
+        dev = list(dict.fromkeys(dev))
+
+        # Save device macro to device list
+        if dev:
+            devs.append(dev)
+        else:
+            if macrolines.index(m1) not in matchedIndices:
+                dev.append(m1)
+                devs.append(dev)
+
+    # List to hold device names and parameters
+    params = []
+
+    # Extract device and variable parameters
+    for dev in devs:
+        # Identify parameters and save off in a list
+        dname = 'DevName'
+        addr = 0x00000
+        width = depth = 8
+        for macroline in dev:
+            macroname = macroline[0].split('_')
+            # Get word bit size
+            if 'BITS' in list(macroname):
+                width = macroline[1]
+            elif 'WIDTH' in list(macroname):
+                width = macroline[1]
+
+            # Ensure bit width is no larger than 64
+            if int(width) > maxwidth:
+                print('\n*********************************************************************')
+                print('*                               ERROR                               *')
+                print('*********************************************************************')
+                print('Bit widths larger than 64 were detected that Rogue does not support.')
+                print('Please ensure the correct bit widths are assigned in the header file.')
+                print('*********************************************************************\n')
+                print('Exiting ...')
+                exit()
+
+            # Get bit depth
+            if 'DEPTH' in list(macroname):
+                depth = macroline[1]
+
+            # Get address offset
+            if 'ADDR' in list(macroname) and 'BASE' in list(macroname):
+                addr = macroline[1]
+            elif 'ADDR' in list(macroname) and 'HIGH' in list(macroname):
+                pass
+            elif 'ADDR' in list(macroname):
+                addr = macroline[1]
+
+            # Get device name
+            if dname == 'DevName':
+                dname = macroline[0]
+            else:
+                if len(dname) > len(macroline[0]):
+                    dname = macroline[0]
+
+        # Modify dev/var name to its shortest and simplest form
+        terms = ['ADDR', 'BASE', 'HIGH', 'BITS', 'WIDTH', 'DEPTH']
+        for t in terms:
+            if t in dname.split('_'):
+                dname = dname.split('_')
+                dname.remove(t)
+                dname = "_".join(dname)
+
+        if vartype is RemoteVariable.__name__:
+            var = RemoteVariable(name=dname, description='remote variable', offset=addr, bitSize=width)
+            params.append(var)
+        elif vartype is MemoryDevice.__name__:
+            var = MemoryDevice(name=dname, offset=addr, size=depth, wordBitSize=width)
+            params.append(var)
+        elif vartype is RemoteCommand.__name__:
+            var = RemoteCommand(name=dname, description='remote command', offset=addr, bitSize=width)
+            params.append(var)
+
+    return params
+
+def write(parameters):
+    with open('application.py', 'w+') as fhand:
+
+        fhand.write('#-----------------------------------------------------------------------------\n')
+        fhand.write('# This file is part of the utilities for the rogue library. It is subject to\n')
+        fhand.write('# the license terms in the LICENSE.txt file found in the top-level directory\n')
+        fhand.write('# of this distribution and at:\n')
+        fhand.write('#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.\n')
+        fhand.write('# No part of the rogue, including this file, may be copied, modified,\n')
+        fhand.write('# propagated, or distributed except according to the terms\n')
+        fhand.write('# contained in the LICENSE.txt file.\n')
+        fhand.write('#-----------------------------------------------------------------------------\n')
+        fhand.write('\n')
+        fhand.write('import pyrogue as pr\n')
+        fhand.write('\n')
+        fhand.write('class Application(pr.Device):\n')
+        fhand.write('    def __init__(self, **kwargs):\n')
+        fhand.write('        super().__init__(**kwargs)\n')
+        fhand.write('\n')
+
+        print('\nCreating the following Rogue variables:\n')
+
+        for param in parameters:
+            print(param)
+            if vartype is RemoteVariable.__name__:
+                fhand.write('        pr.RemoteVariable(\n')
+                argline = \
+                    '                        name=' + '\'' + param.name + '\'' + ',\n' + \
+                    '                        description=' + '\'' + param.description + '\'' + ',\n' + \
+                    '                        offset=' + str(param.offset) + ',\n' + \
+                    '                        bitSize=' + str(param.bitSize) + ',\n' + \
+                    '                        bitOffset=' + str(param.bitOffset) + ',\n' + \
+                    '                        base=' + str(param.base) + ',\n' + \
+                    '                        mode=' + '\'' + str(param.mode) + '\'' + ',\n'
+                fhand.write(argline)
+                fhand.write('                       )\n\n')
+            elif vartype is MemoryDevice.__name__:
+                fhand.write('        pr.MemoryDevice(\n')
+                argline = \
+                    '                        name=' + '\'' + param.name + '\'' + ',\n' + \
+                    '                        offset=' + str(param.offset) + ',\n' + \
+                    '                        size=' + str(param.size) + ',\n' + \
+                    '                        wordBitSize=' + str(param.wordBitSize) + ',\n' + \
+                    '                        stride=' + str(param.stride) + ',\n' + \
+                    '                        base=' + str(param.base) + ',\n'
+                fhand.write(argline)
+                fhand.write('                       )\n\n')
+            elif vartype is RemoteCommand.__name__:
+                fhand.write('        self.add(pr.RemoteCommand(\n')
+                argline = \
+                    '                        name=' + '\'' + param.name + '\'' + ',\n' + \
+                    '                        description=' + '\'' + param.description + '\'' + ',\n' + \
+                    '                        offset=' + str(param.offset) + ',\n' + \
+                    '                        bitSize=' + str(param.bitSize) + ',\n' + \
+                    '                        bitOffset=' + str(param.bitOffset) + ',\n' + \
+                    '                        base=' + str(param.base) + ',\n' + \
+                    '                        function=' + str(param.function) + ',\n'
+                fhand.write(argline)
+                fhand.write('                       ))\n\n')
+
+        fhand.write('    # This function call occurs after loading YAML configuration\n')
+        fhand.write('    def initialize(self):\n')
+        fhand.write('        super().initialize()\n')
+        fhand.write('\n')
+        fhand.write('        # Add and execute the relevant commands below\n')
+        fhand.write('\n\n')
+
+def run():
+    # Read command line option (i.e. output type)
+    parser = argparse.ArgumentParser(description='Specify type of output.')
+    parser.add_argument('--remoteCommand', action='store_true', required=False, help='set up remote commands')
+    parser.add_argument('--remoteVariable', action='store_true', required=False, help='connect remote variables to register interface')
+    parser.add_argument('--memoryDevice', action='store_true', required=False, help='connect memory devices to register interface')
+    args = parser.parse_args()
+
+    global vartype
+
+    if args.memoryDevice:
+        vartype = 'MemoryDevice'
+    elif args.remoteVariable:
+        vartype = 'RemoteVariable'
+    elif args.remoteCommand:
+        vartype = 'RemoteCommand'
+    else:
+        print('Please provide type of output at the command line.  Run with --help for more info.')
+        exit(0)
+
+    dev_params = parse()
+    write(dev_params)
+
+# __main__ block
+if __name__ == '__main__':
+    run()

--- a/python/pyrogue/utilities/hls/__init__.py
+++ b/python/pyrogue/utilities/hls/__init__.py
@@ -1,0 +1,10 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+

--- a/src/rogue/LibraryBase.cpp
+++ b/src/rogue/LibraryBase.cpp
@@ -70,9 +70,23 @@ const std::map< std::string, rim::BlockPtr> rogue::LibraryBase::getBlockList() {
 
 // Parse memory map
 void rogue::LibraryBase::parseMemMap (std::string map) {
+   // Determine which delimiter we are using
+   char delim;
+   std::size_t found = map.find("|");
+   if (found!=std::string::npos) delim = '|';
+   else delim = '\n';
+   std::istringstream fStream(map);
+   parseMemMap( fStream, delim );
+}
+
+void rogue::LibraryBase::parseMemMap ( const char * filePath, char delim ) {
+   std::ifstream fStream(filePath);
+   parseMemMap( fStream, delim );
+}
+
+void rogue::LibraryBase::parseMemMap (std::istream & fStream,char delim){
    std::string line;
    std::string field;
-   std::istringstream fStream(map);
    std::vector<std::string> key;
 
    std::map< std::string, std::vector<rim::VariablePtr> > blockVars;
@@ -80,12 +94,6 @@ void rogue::LibraryBase::parseMemMap (std::string map) {
 
    uint32_t x;
    bool doKey=true;
-   char delim;
-
-   // Determine which delimiter we are using
-   std::size_t found = map.find("|");
-   if (found!=std::string::npos) delim = '|';
-   else delim = '\n';
 
    while(std::getline(fStream,line,delim)) {
       std::istringstream lStream(line);

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -52,6 +52,13 @@ rha::AxiMemMap::AxiMemMap(std::string path) : rim::Slave(4,0xFFFFFFFF) {
    log_ = rogue::Logging::create("axi.AxiMemMap");
    if ( fd_ < 0 )
       throw(rogue::GeneralError::create("AxiMemMap::AxiMemMap", "Failed to open device file: %s",path.c_str()));
+   
+   // Check driver version
+   if ( dmaCheckVersion(fd_) < 0 )
+      throw(rogue::GeneralError("AxiMemMap::AxiMemMap","Bad kernel driver version detected. Please re-compile kernel driver.\n \
+      Note that aes-stream-driver (v5.15.2 or earlier) and rogue (v5.11.1 or earlier) are compatible with the 32-bit address API. \
+      To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
+      \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
 
    // Start read thread
    threadEn_ = true;

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -62,7 +62,10 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
       throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", "Failed to open device file: %s",path.c_str()));
 
    if ( dmaCheckVersion(fd_) < 0 )
-      throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Bad kernel driver version detected. Please re-compile kernel driver"));
+      throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Bad kernel driver version detected. Please re-compile kernel driver.\n \
+      Note that aes-stream-driver (v5.15.2 or earlier) and rogue (v5.11.1 or earlier) are compatible with the 32-bit address API. \
+      To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
+      \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
 
    dmaInitMaskBytes(mask);
    dmaAddMaskBytes(mask,dest_);

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -67,7 +67,10 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
       throw(rogue::GeneralError::create("PgpCard::PgpCard", "Failed to open device file: %s",path.c_str()));
 
    if ( dmaCheckVersion(fd_) < 0 )
-      throw(rogue::GeneralError("PgpCard::PgpCard","Bad kernel driver version detected. Please re-compile kernel driver"));
+      throw(rogue::GeneralError("PgpCard::PgpCard","Bad kernel driver version detected. Please re-compile kernel driver.\n \
+      Note that aes-stream-driver (v5.15.2 or earlier) and rogue (v5.11.1 or earlier) are compatible with the 32-bit address API. \
+      To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
+      \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
 
    dmaInitMaskBytes(mask);
    dmaAddMaskBytes(mask,(lane_*4)+vc_);

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -55,9 +55,9 @@ rps::SrpV3Ptr rps::SrpV3::create () {
 //! Setup class in python
 void rps::SrpV3::setup_python() {
 #ifndef NO_PYTHON
-
-   bp::class_<rps::SrpV3, rps::SrpV3Ptr, bp::bases<ris::Master,ris::Slave,rim::Slave>,boost::noncopyable >("SrpV3",bp::init<>());
-
+   bp::class_<rps::SrpV3, rps::SrpV3Ptr, bp::bases<ris::Master,ris::Slave,rim::Slave>,boost::noncopyable >("SrpV3",bp::init<>())
+      .def("_setHardwareTimeout",           &rps::SrpV3::setHardwareTimeout)
+   ;
    bp::implicitly_convertible<rps::SrpV3Ptr, ris::MasterPtr>();
    bp::implicitly_convertible<rps::SrpV3Ptr, ris::SlavePtr>();
    bp::implicitly_convertible<rps::SrpV3Ptr, rim::SlavePtr>();
@@ -71,6 +71,11 @@ rps::SrpV3::SrpV3() : ris::Master(), ris::Slave(), rim::Slave(4,4096) {
 
 //! Deconstructor
 rps::SrpV3::~SrpV3() {}
+
+//! Set the hardware timeout
+void rps::SrpV3::setHardwareTimeout( uint8_t val ) { 
+   timeout_ = val; 
+}
 
 //! Setup header, return frame size
 bool rps::SrpV3::setupHeader(rim::TransactionPtr tran, uint32_t *header, uint32_t &frameLen, bool tx) {
@@ -90,7 +95,7 @@ bool rps::SrpV3::setupHeader(rim::TransactionPtr tran, uint32_t *header, uint32_
    // Bit 14 = ignore mem resp
    // Bit 23:15 = Unused
    // Bit 31:24 = timeout count
-   header[0] |= 0x0A000000;
+   header[0] |= (timeout_ << 24 | 0x00000000);
 
    // Header word 1, transaction ID
    header[1] = tran->id();

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -24,6 +24,7 @@ setup (
               'pyrogue.gui', 
               'pyrogue.utilities', 
               'pyrogue.utilities.fileio', 
+              'pyrogue.utilities.hls', 
               'pyrogue.interfaces', 
               'pyrogue.protocols', 
               'pyrogue.pydm', 


### PR DESCRIPTION
# Pull Requests Since v5.12.0
### Bug
 1. #829 - ESROGUE-533: Shutdown Rogue if DmaDriver version mismatch
 1. #832 - ESROGUE-548: Make DataReceiver.RxEnable work properly
 1. #837 - ESROGUE-528: Catch list case for variable values
 1. #833 - Reduce scope of printoptions when generating string for numpy array.
### Enhancement
 1. #830 - ESROGUE-518: Load and auto-populate registers based on Xilinx *_hw.h header
 1. #831 - ESROGUE-540: PyDM FileWriter - Prevent users from updating the "Data File" string while the file is opened
 1. #824 - Add new variants of parseMemMap() to allow parsing csv dump files
 1. #828 - ESROGUE-539: Add accessor to set the SRP hardware timeout
 1. #834 - Update LICENSE.txt
# Pull Request Details
### Add new variants of parseMemMap() to allow parsing csv dump files
|||
|---:|:---|
|**Author:**|Larry Ruckman <ruckman@slac.stanford.edu>|
|**Date:**|Tue Jan 11 13:37:10 2022 -0800|
|**Pull:**|#824 (19 additions, 7 deletions, 2 files changed)|
|**Branch:**|bhill-slac/parseMemMap-variants|
|**Labels:**|enhancement|

**Notes:**
> Allows easy reading of rogue address map from the file system during bootup.

-------


### ESROGUE-539: Add accessor to set the SRP hardware timeout
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Jan 25 12:03:59 2022 -0800|
|**Pull:**|#828 (13 additions, 4 deletions, 2 files changed)|
|**Branch:**|slaclab/esrogue_539|
|**Issues:**|#828|
|**Labels:**|enhancement|

**Notes:**
> The SRP timeout field can now be controlled via the `setHardwareTimeout()` method. This is exposed in python as well. 

-------


### ESROGUE-533: Shutdown Rogue if DmaDriver version mismatch
|||
|---:|:---|
|**Author:**|Larry Ruckman <ruckman@slac.stanford.edu>|
|**Date:**|Mon Jan 17 11:43:26 2022 -0800|
|**Pull:**|#829 (15 additions, 2 deletions, 3 files changed)|
|**Branch:**|slaclab/esrogue_533|
|**Issues:**|#829|
|**Labels:**|bug|

**Notes:**
> Rogue was not properly checking the DMA driver version for AxiMemMap instances. All checks now have a better error string.

-------


### ESROGUE-518: Load and auto-populate registers based on Xilinx *_hw.h header
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 1 13:07:17 2022 -0800|
|**Pull:**|#830 (294 additions, 0 deletions, 3 files changed)|
|**Branch:**|slaclab/esrogue_518|
|**Issues:**|#830|
|**Labels:**|enhancement|

**Notes:**
> A new script has been added that writes a python rogue tree based on HLS outputs.

-------


### ESROGUE-540: PyDM FileWriter - Prevent users from updating the "Data File" string while the file is opened
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 1 13:06:37 2022 -0800|
|**Pull:**|#831 (29 additions, 9 deletions, 1 files changed)|
|**Branch:**|slaclab/esrogue_540|
|**Labels:**|enhancement|

**Notes:**
> ### Description
> The "Data File" field is now greyed out whenever a file is open
> 
> ### JIRA
> https://jira.slac.stanford.edu/browse/ESROGUE-540

-------


### ESROGUE-548: Make DataReceiver.RxEnable work properly
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 1 12:15:48 2022 -0800|
|**Pull:**|#832 (3 additions, 4 deletions, 1 files changed)|
|**Branch:**|slaclab/esrogue_548|
|**Labels:**|bug|

**Notes:**
> The `RxEnable` `LocalVariable` is now used to control the behavior of `_acceptFrame()`.
> 
> Previously it was controlled by an internal instance variable `_rxEnable`, and not accessible via the Rogue API. The `RxEnable` rogue variable was confusingly left unused. This is now fixed.

-------


### Reduce scope of printoptions when generating string for numpy array.
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Mon Jan 31 10:14:13 2022 -0800|
|**Pull:**|#833 (3 additions, 2 deletions, 1 files changed)|
|**Branch:**|slaclab/numpy-print-fix|
|**Labels:**|bug|

**Notes:**
> When setting numpy print options for formatting a numpy array as a string, `Variable.getDisp()` was modifying the global numpy printoptions, and affecting the formatting of unrelated numpy arrays elsewhere in the code.
> 
> This fix uses the `np.printoptions` context manager to limit the scope of print options to each variable instance.

-------


### Update LICENSE.txt
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 1 13:07:41 2022 -0800|
|**Pull:**|#834 (1 additions, 1 deletions, 1 files changed)|
|**Branch:**|slaclab/ruck314-patch-1|
|**Labels:**|enhancement|

**Notes:**
> ### Description
> - Updating for year 2022

-------


### ESROGUE-528: Catch list case for variable values
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Feb 2 14:36:22 2022 -0800|
|**Pull:**|#837 (4 additions, 1 deletions, 1 files changed)|
|**Branch:**|slaclab/esrogue-528|
|**Labels:**|bug|

**Notes:**
> ### Description
> - This fixes the case where the config file variable has a list instead of a string.

-------


