### PR TITLE
ESROGUE-532: Bug fix for bad weak_ptr when calling shared_from_this()

### DIFF
--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -68,7 +68,7 @@ namespace rogue {
                std::shared_ptr<rogue::Logging> log_;
 
                //! Thread background
-               void runThread();
+               void runThread(std::weak_ptr<int>);
 
                //! Enable zero copy
                bool zeroCopyEn_;

--- a/include/rogue/hardware/pgp/PgpCard.h
+++ b/include/rogue/hardware/pgp/PgpCard.h
@@ -73,7 +73,7 @@ namespace rogue {
                std::shared_ptr<rogue::Logging> log_;
 
                //! Thread background
-               void runThread();
+               void runThread(std::weak_ptr<int>);
 
                //! Enable zero copy
                bool zeroCopyEn_;

--- a/include/rogue/protocols/udp/Client.h
+++ b/include/rogue/protocols/udp/Client.h
@@ -43,7 +43,7 @@ namespace rogue {
                uint16_t port_;
 
                //! Thread background
-               void runThread();
+               void runThread(std::weak_ptr<int>);
 
             public:
 

--- a/include/rogue/protocols/udp/Server.h
+++ b/include/rogue/protocols/udp/Server.h
@@ -43,7 +43,7 @@ namespace rogue {
                struct sockaddr_in locAddr_;
 
                //! Thread background
-               void runThread();
+               void runThread(std::weak_ptr<int>);
 
             public:
 

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -57,6 +57,9 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
    vc_         = vc;
    zeroCopyEn_ = true;
 
+   // Create a shared pointer to use as a lock for runThread()
+   std::shared_ptr<int> scopePtr = std::make_shared<int>(0);
+
    rogue::defaultTimeout(timeout_);
 
    rogue::GilRelease noGil;
@@ -82,7 +85,7 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
 
    // Start read thread
    threadEn_ = true;
-   thread_ = new std::thread(&rhp::PgpCard::runThread, this);
+   thread_ = new std::thread(&rhp::PgpCard::runThread, this, std::weak_ptr<int>(scopePtr));
 
    // Set a thread name
 #ifndef __MACH__
@@ -339,7 +342,7 @@ void rhp::PgpCard::retBuffer(uint8_t * data, uint32_t meta, uint32_t size) {
 }
 
 //! Run thread
-void rhp::PgpCard::runThread() {
+void rhp::PgpCard::runThread(std::weak_ptr<int> lockPtr) {
    ris::BufferPtr buff;
    ris::FramePtr  frame;
    fd_set         fds;
@@ -350,8 +353,11 @@ void rhp::PgpCard::runThread() {
    uint32_t       meta;
    struct timeval tout;
 
+   // Wait until constructor completes
+   while (!lockPtr.expired())
+      continue;
+
    log_->logThreadId();
-   usleep(1000);
 
    // Preallocate empty frame
    frame = ris::Frame::create();

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -182,6 +182,7 @@ void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
    struct timeval tout;
    uint32_t       avail;
 
+   // Wait until constructor completes
    while (!lockPtr.expired())
       continue;
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -187,7 +187,6 @@ void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
       continue;
 
    udpLog_->logThreadId();
-   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -59,6 +59,9 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    port_    = port;
    udpLog_  = rogue::Logging::create("udp.Client");
 
+   // Create a shared pointer to use as a lock for runThread()
+   std::shared_ptr<int> ctorShrdPtr = std::make_shared<int>(0);
+
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
       throw(rogue::GeneralError::create("Client::Client","Failed to create socket for port %i at address %s",port_,address_.c_str()));
@@ -87,7 +90,8 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Start rx thread
    threadEn_ = true;
-   thread_ = new std::thread(&rpu::Client::runThread, this);
+   std::weak_ptr<int> ctorWkdPtr = ctorShrdPtr;
+   thread_ = new std::thread(&rpu::Client::runThread, this, ctorWkdPtr);
 
    // Set a thread name
 #ifndef __MACH__
@@ -171,7 +175,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
 }
 
 //! Run thread
-void rpu::Client::runThread() {
+void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
    ris::BufferPtr buff;
    ris::FramePtr  frame;
    fd_set         fds;
@@ -179,8 +183,11 @@ void rpu::Client::runThread() {
    struct timeval tout;
    uint32_t       avail;
 
+   while (!lockPtr.expired())
+      continue;
+
    udpLog_->logThreadId();
-   usleep(1000);
+   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -60,7 +60,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    udpLog_  = rogue::Logging::create("udp.Client");
 
    // Create a shared pointer to use as a lock for runThread()
-   std::shared_ptr<int> ctorSharedPtr = std::make_shared<int>(0);
+   std::shared_ptr<int> scopePtr = std::make_shared<int>(0);
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
@@ -90,7 +90,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Start rx thread
    threadEn_ = true;
-   thread_ = new std::thread(&rpu::Client::runThread, this, std::weak_ptr<int>(ctorSharedPtr));
+   thread_ = new std::thread(&rpu::Client::runThread, this, std::weak_ptr<int>(scopePtr));
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -60,7 +60,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
    udpLog_  = rogue::Logging::create("udp.Client");
 
    // Create a shared pointer to use as a lock for runThread()
-   std::shared_ptr<int> ctorShrdPtr = std::make_shared<int>(0);
+   std::shared_ptr<int> ctorSharedPtr = std::make_shared<int>(0);
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
@@ -90,8 +90,8 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Start rx thread
    threadEn_ = true;
-   std::weak_ptr<int> ctorWkdPtr = ctorShrdPtr;
-   thread_ = new std::thread(&rpu::Client::runThread, this, ctorWkdPtr);
+   std::weak_ptr<int> ctorWeakPtr = ctorSharedPtr;
+   thread_ = new std::thread(&rpu::Client::runThread, this, ctorWeakPtr);
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -90,8 +90,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Start rx thread
    threadEn_ = true;
-   std::weak_ptr<int> ctorWeakPtr = ctorSharedPtr;
-   thread_ = new std::thread(&rpu::Client::runThread, this, ctorWeakPtr);
+   thread_ = new std::thread(&rpu::Client::runThread, this, std::weak_ptr<int>(ctorSharedPtr));
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -55,6 +55,9 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    port_    = port;
    udpLog_ = rogue::Logging::create("udp.Server");
 
+   // Create a shared pointer to use as a lock for runThread()
+   std::shared_ptr<int> ctorShrdPtr = std::make_shared<int>(0);
+
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
       throw(rogue::GeneralError::create("Server::Server","Failed to create socket for port %i",port_));
@@ -84,7 +87,8 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Start rx thread
    threadEn_ = true;
-   thread_ = new std::thread(&rpu::Server::runThread, this);
+   std::weak_ptr<int> ctorWkdPtr = ctorShrdPtr;
+   thread_ = new std::thread(&rpu::Server::runThread, this, ctorWkdPtr);
 
    // Set a thread name
 #ifndef __MACH__
@@ -173,7 +177,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
 }
 
 //! Run thread
-void rpu::Server::runThread() {
+void rpu::Server::runThread(std::weak_ptr<int> lockPtr) {
    ris::BufferPtr     buff;
    ris::FramePtr      frame;
    fd_set             fds;
@@ -183,8 +187,11 @@ void rpu::Server::runThread() {
    uint32_t           tmpLen;
    uint32_t           avail;
 
+   while (!lockPtr.expired())
+      continue;
+
    udpLog_->logThreadId();
-   usleep(1000);
+   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -87,8 +87,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Start rx thread
    threadEn_ = true;
-   std::weak_ptr<int> ctorWeakPtr = ctorSharedPtr;
-   thread_ = new std::thread(&rpu::Server::runThread, this, ctorWeakPtr);
+   thread_ = new std::thread(&rpu::Server::runThread, this, std::weak_ptr<int>(ctorSharedPtr));
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -191,7 +191,6 @@ void rpu::Server::runThread(std::weak_ptr<int> lockPtr) {
       continue;
 
    udpLog_->logThreadId();
-   //usleep(1000);
 
    // Preallocate frame
    frame = ris::Pool::acceptReq(maxPayload(),false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -186,6 +186,7 @@ void rpu::Server::runThread(std::weak_ptr<int> lockPtr) {
    uint32_t           tmpLen;
    uint32_t           avail;
 
+   // Wait until constructor completes
    while (!lockPtr.expired())
       continue;
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -56,7 +56,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    udpLog_ = rogue::Logging::create("udp.Server");
 
    // Create a shared pointer to use as a lock for runThread()
-   std::shared_ptr<int> ctorShrdPtr = std::make_shared<int>(0);
+   std::shared_ptr<int> ctorSharedPtr = std::make_shared<int>(0);
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
@@ -87,8 +87,8 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Start rx thread
    threadEn_ = true;
-   std::weak_ptr<int> ctorWkdPtr = ctorShrdPtr;
-   thread_ = new std::thread(&rpu::Server::runThread, this, ctorWkdPtr);
+   std::weak_ptr<int> ctorWeakPtr = ctorSharedPtr;
+   thread_ = new std::thread(&rpu::Server::runThread, this, ctorWeakPtr);
 
    // Set a thread name
 #ifndef __MACH__

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -56,7 +56,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    udpLog_ = rogue::Logging::create("udp.Server");
 
    // Create a shared pointer to use as a lock for runThread()
-   std::shared_ptr<int> ctorSharedPtr = std::make_shared<int>(0);
+   std::shared_ptr<int> scopePtr = std::make_shared<int>(0);
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
@@ -87,7 +87,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Start rx thread
    threadEn_ = true;
-   thread_ = new std::thread(&rpu::Server::runThread, this, std::weak_ptr<int>(ctorSharedPtr));
+   thread_ = new std::thread(&rpu::Server::runThread, this, std::weak_ptr<int>(scopePtr));
 
    // Set a thread name
 #ifndef __MACH__


### PR DESCRIPTION
### Description
The call to shared_from_this() from within a thread would fail due to the constructor launching that thread not completing in time.

### JIRA:
[ESROGUE-532](https://jira.slac.stanford.edu/browse/ESROGUE-532)

### Issues
#823