### PR TITLE
ESROGUE-508: Reset RSSI counters in UdpRssiPack on Root.CountReset() Command

### DIFF
--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -116,6 +116,8 @@ namespace rogue {
                uint8_t  curMaxRetran();
                uint8_t  curMaxCumAck();
 
+               void resetCounters();
+
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 

--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -224,6 +224,8 @@ namespace rogue {
                uint8_t  curMaxRetran();
                uint8_t  curMaxCumAck();
 
+               void resetCounters();
+
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -116,6 +116,8 @@ namespace rogue {
                uint8_t  curMaxRetran();
                uint8_t  curMaxCumAck();
 
+               void resetCounters();
+
                //! Set timeout in microseconds for frame transmits
                void setTimeout(uint32_t timeout);
 

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -286,6 +286,9 @@ class UdpRssiPack(pr.Device):
     def application(self,dest):
         return(self._pack.application(dest))
 
+    def countReset(self):
+        self._rssi.resetCounters()
+
     def _stop(self):
         self._rssi._stop()
 

--- a/src/rogue/protocols/rssi/Client.cpp
+++ b/src/rogue/protocols/rssi/Client.cpp
@@ -78,6 +78,7 @@ void rpr::Client::setup_python() {
       .def("curNullTout",      &rpr::Client::curNullTout)
       .def("curMaxRetran",     &rpr::Client::curMaxRetran)
       .def("curMaxCumAck",     &rpr::Client::curMaxCumAck)
+      .def("resetCounters",    &rpr::Client::resetCounters)
       .def("setTimeout",       &rpr::Client::setTimeout)
       .def("_stop",            &rpr::Client::stop)
       .def("_start",           &rpr::Client::start)
@@ -240,6 +241,10 @@ uint8_t  rpr::Client::curMaxRetran() {
 
 uint8_t  rpr::Client::curMaxCumAck() {
    return cntl_->curMaxCumAck();
+}
+
+void rpr::Client::resetCounters() {
+  cntl_->resetCounters();
 }
 
 //! Set timeout for frame transmits in microseconds

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -544,6 +544,14 @@ uint8_t  rpr::Controller::curMaxCumAck() {
    return curMaxCumAck_;
 }
 
+void rpr::Controller::resetCounters() {
+  dropCount_ = 0;
+  downCount_ = 0;
+  retranCount_ = 0;
+  locBusyCnt_ = 0;
+  remBusyCnt_ = 0;
+}
+
 // Method to transit a frame with proper updates
 void rpr::Controller::transportTx(rpr::HeaderPtr head, bool seqUpdate, bool txReset) {
    std::unique_lock<std::mutex> lock(txMtx_);

--- a/src/rogue/protocols/rssi/Server.cpp
+++ b/src/rogue/protocols/rssi/Server.cpp
@@ -74,6 +74,7 @@ void rpr::Server::setup_python() {
       .def("curNullTout",      &rpr::Server::curNullTout)
       .def("curMaxRetran",     &rpr::Server::curMaxRetran)
       .def("curMaxCumAck",     &rpr::Server::curMaxCumAck)
+      .def("resetCounters",    &rpr::Server::resetCounters)
       .def("setTimeout",       &rpr::Server::setTimeout)
       .def("_stop",            &rpr::Server::stop)
       .def("_start",           &rpr::Server::start)
@@ -236,6 +237,10 @@ uint8_t  rpr::Server::curMaxRetran() {
 
 uint8_t  rpr::Server::curMaxCumAck() {
    return cntl_->curMaxCumAck();
+}
+
+void rpr::Server::resetCounters() {
+  cntl_->resetCounters();
 }
 
 //! Set timeout for frame transmits in microseconds


### PR DESCRIPTION
### Descriptions
The various counters in the RSSI server now get reset by the Rogue CountReset() command.