### PR TITLE
ESROGUE-545: Disable Load and Save buttons in GUI when file text fields are blank

### DIFF
--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -190,7 +190,7 @@ class RootControl(PyDMFrame):
         if isinstance(saveFile,tuple):
             saveFile = saveFile[0]
 
-        if saveFile != '':
+        if len(saveFile) != 0:
             self._saveConfigValue.setText(saveFile)
             self._saveConfigCmd.setEnabled(True)
 
@@ -210,6 +210,6 @@ class RootControl(PyDMFrame):
         if isinstance(stateFile,tuple):
             stateFile = stateFile[0]
 
-        if stateFile != '':
+        if len(stateFile) != 0:
             self._saveStateValue.setText(stateFile)
             self._saveStateCmd.setEnabled(True)

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -160,6 +160,8 @@ class RootControl(PyDMFrame):
         self._loadConfigCmd.pressValue = value
         if not self._loadConfigValue.text():
             self._loadConfigCmd.setEnabled(False)
+        else:
+            self._loadConfigCmd.setEnabled(True)
 
     @Slot()
     def _loadConfigBrowse(self):

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -180,6 +180,10 @@ class RootControl(PyDMFrame):
     @Slot(str)
     def _saveConfigChanged(self,value):
         self._saveConfigCmd.pressValue = value
+        if not self._saveConfigValue.text():
+            self._saveConfigCmd.setEnabled(False)
+        else:
+            self._saveConfigCmd.setEnabled(True)
 
     @Slot()
     def _saveConfigBrowse(self):
@@ -200,6 +204,10 @@ class RootControl(PyDMFrame):
     @Slot(str)
     def _saveStateChanged(self,value):
         self._saveStateCmd.pressValue = value
+        if not self._saveStateValue.text():
+            self._saveStateCmd.setEnabled(False)
+        else:
+            self._saveStateCmd.setEnabled(True)
 
     @Slot()
     def _saveStateBrowse(self):

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -158,6 +158,8 @@ class RootControl(PyDMFrame):
     @Slot(str)
     def _loadConfigChanged(self,value):
         self._loadConfigCmd.pressValue = value
+        if not self._loadConfigValue.text():
+            self._loadConfigCmd.setEnabled(False)
 
     @Slot()
     def _loadConfigBrowse(self):
@@ -169,7 +171,7 @@ class RootControl(PyDMFrame):
         if isinstance(loadFile,tuple):
             loadFile = loadFile[0]
 
-        if loadFile != '':
+        if len(loadFile) != 0:
             self._loadConfigValue.setText(','.join(loadFile))
             self._loadConfigCmd.setEnabled(True)
 

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -100,6 +100,7 @@ class RootControl(PyDMFrame):
         self._loadConfigCmd = PyDMPushButton(label='Load Config',
                                              pressValue='',
                                              init_channel=self._path + '.LoadConfig')
+        self._loadConfigCmd.check_enable_state = lambda: None
 
         hb.addWidget(self._loadConfigCmd)
 
@@ -120,6 +121,7 @@ class RootControl(PyDMFrame):
         self._saveConfigCmd = PyDMPushButton(label='Save Config',
                                              pressValue='',
                                              init_channel=self._path + '.SaveConfig')
+        self._saveConfigCmd.check_enable_state = lambda: None
 
         hb.addWidget(self._saveConfigCmd)
 
@@ -140,6 +142,7 @@ class RootControl(PyDMFrame):
         self._saveStateCmd = PyDMPushButton(label='Save State ',
                                             pressValue='',
                                             init_channel=self._path + '.SaveState')
+        self._saveStateCmd.check_enable_state = lambda: None
 
         hb.addWidget(self._saveStateCmd)
 
@@ -168,6 +171,7 @@ class RootControl(PyDMFrame):
 
         if loadFile != '':
             self._loadConfigValue.setText(','.join(loadFile))
+            self._loadConfigCmd.setEnabled(True)
 
     @Slot(str)
     def _saveConfigChanged(self,value):
@@ -186,6 +190,8 @@ class RootControl(PyDMFrame):
 
         if saveFile != '':
             self._saveConfigValue.setText(saveFile)
+            self._saveConfigCmd.setEnabled(True)
+
 
     @Slot(str)
     def _saveStateChanged(self,value):
@@ -204,3 +210,4 @@ class RootControl(PyDMFrame):
 
         if stateFile != '':
             self._saveStateValue.setText(stateFile)
+            self._saveStateCmd.setEnabled(True)


### PR DESCRIPTION
### Description
Disable `Load Config`, `Save Config` and `Save State` buttons when the file path boxes are empty.

### JIRA
https://jira.slac.stanford.edu/browse/ESROGUE-545