### PR TITLE
ESROGUE-526: Use portable format specifiers when printing inttypes

### DIFF
--- a/include/rogue/interfaces/stream/FrameAccessor.h
+++ b/include/rogue/interfaces/stream/FrameAccessor.h
@@ -20,6 +20,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #include <stdint.h>
+#include <inttypes.h>
 #include <memory>
 #include <rogue/GeneralError.h>
 #include <rogue/interfaces/stream/FrameIterator.h>
@@ -58,7 +59,7 @@ namespace rogue {
                T & at(const uint32_t offset) {
 
                   if ( offset >= size_ )
-                     throw rogue::GeneralError::create("FrameAccessor","Attempt to access element %i with size %i",offset,size_);
+                     throw rogue::GeneralError::create("FrameAccessor","Attempt to access element %" PRIu32 " with size %" PRIu32, offset, size_);
 
                   return data_[offset];
                }

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -104,7 +104,7 @@ void rogue::Logging::intLog(uint32_t level, const char * fmt, va_list args) {
    char buffer[1000];
    vsnprintf(buffer,1000,fmt,args);
    gettimeofday(&tme,NULL);
-   printf("%li.%i:%s: %s\n",tme.tv_sec,tme.tv_usec,name_.c_str(),buffer);
+   printf("%" PRIuLEAST32 ".%" PRIuLEAST32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
 }
 
 void rogue::Logging::log(uint32_t level, const char * fmt, ...) {

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #if defined(__linux__)
 #include <sys/syscall.h>
@@ -75,7 +76,7 @@ rogue::Logging::Logging(std::string name, bool quiet) {
    }
    levelMtx_.unlock();
 
-   if ( ! quiet ) warning("Starting logger with level = %i",level_);
+   if ( ! quiet ) warning("Starting logger with level = %" PRIu32, level_);
 }
 
 rogue::Logging::~Logging() { }
@@ -103,7 +104,7 @@ void rogue::Logging::intLog(uint32_t level, const char * fmt, va_list args) {
    char buffer[1000];
    vsnprintf(buffer,1000,fmt,args);
    gettimeofday(&tme,NULL);
-   printf("%li.%li:%s: %s\n",tme.tv_sec,tme.tv_usec,name_.c_str(),buffer);
+   printf("%li.%i:%s: %s\n",tme.tv_sec,tme.tv_usec,name_.c_str(),buffer);
 }
 
 void rogue::Logging::log(uint32_t level, const char * fmt, ...) {
@@ -161,7 +162,7 @@ void rogue::Logging::logThreadId() {
    tid = 0;
 #endif
 
-   this->log(Thread, "PID=%i, TID=%i", getpid(), tid);
+   this->log(Thread, "PID=%" PRIu32 ", TID=%" PRIu32, getpid(), tid);
 }
 
 void rogue::Logging::setup_python() {

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -104,7 +104,7 @@ void rogue::Logging::intLog(uint32_t level, const char * fmt, va_list args) {
    char buffer[1000];
    vsnprintf(buffer,1000,fmt,args);
    gettimeofday(&tme,NULL);
-   printf("%" PRIuLEAST32 ".%" PRIuLEAST32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
+   printf("%" PRIuLEAST32 ".%06" PRIuLEAST32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
 }
 
 void rogue::Logging::log(uint32_t level, const char * fmt, ...) {

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <string>
 #include <sstream>
+#include <inttypes.h>
 
 #ifndef NO_PYTHON
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
@@ -42,14 +43,14 @@ void rogue::Version::init() {
    char     lead;
    int32_t  ret;
 
-   ret = sscanf(_version,"%c%i.%i.%i-%i-%s",&lead,&_major,&_minor,&_maint,&_devel,dump);
+   ret = sscanf(_version,"%c%" SCNu32 ".%" SCNu32 ".%" SCNu32 "-%" SCNu32 "-%s", &lead, &_major, &_minor, &_maint, &_devel, dump);
 
    if ( (ret != 4 && ret != 6) || (lead != 'v' && lead != 'V'))
       throw(rogue::GeneralError("Version:init","Invalid compiled version string"));
 }
 
 void rogue::Version::extract(std::string compare, uint32_t *major, uint32_t *minor, uint32_t *maint) {
-   if ( sscanf(compare.c_str(),"%i.%i.%i",major,minor,maint) != 3 )
+   if ( sscanf(compare.c_str(),"%" PRIu32 ".%" PRIu32 ".%" PRIu32, major, minor, maint) != 3 )
       throw(rogue::GeneralError("Version:extract","Invalid version string"));
 }
 

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -112,14 +112,14 @@ void rh::MemMap::runThread() {
          }
 
          if ( (tran->size() % 4) != 0 ) {
-            tran->error("Invalid transaction size %i, must be an integer number of 4 bytes",tran->size());
+            tran->error("Invalid transaction size %" PRIu32 ", must be an integer number of 4 bytes", tran->size());
             tran.reset();
             continue;
          }
 
          // Check that the address is legal
          if ( (tran->address() + tran->size()) > size_ ) {
-            tran->error("Request transaction to address 0x%x with size %i is out of bounds",tran->address(),tran->size());
+            tran->error("Request transaction to address 0x%" PRIx64 " with size %" PRIu32 " is out of bounds", tran->address(), tran->size());
             tran.reset();
             continue;
          }

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -140,7 +140,7 @@ void rh::MemMap::runThread() {
             count += 4;
          }
 
-         log_->debug("Transaction id=0x%" PRIx32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32, tran->id(), tran->address(), tran->size(), tran->type());
+         log_->debug("Transaction id=%" PRIu32 ", addr 0x%08" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32, tran->id(), tran->address(), tran->size(), tran->type());
          tran->done();
       }
    }

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <inttypes.h>
 
 namespace rh  = rogue::hardware;
 namespace rim = rogue::interfaces::memory;
@@ -59,7 +60,7 @@ rh::MemMap::MemMap(uint64_t base, uint32_t size) : rim::Slave(4,0xFFFFFFFF) {
    if ( (map_ = (uint8_t *)mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, base)) == (void *) -1)
       throw(rogue::GeneralError::create("MemMap::MemMap", "Failed to map memory to user space."));
 
-   log_->debug("Created map to 0x%x with size 0x%x", base, size);
+   log_->debug("Created map to 0x%" PRIx64 " with size 0x%" PRIx32, base, size);
 
    // Start read thread
    threadEn_ = true;
@@ -105,7 +106,7 @@ void rh::MemMap::runThread() {
          rim::TransactionLockPtr lock = tran->lock();
 
          if ( tran->expired() ) {
-            log_->warning("Transaction expired. Id=%i",tran->id());
+            log_->warning("Transaction expired. Id=%" PRIu32, tran->id());
             tran.reset();
             continue;
          }
@@ -139,7 +140,7 @@ void rh::MemMap::runThread() {
             count += 4;
          }
 
-         log_->debug("Transaction id=0x%08x, addr 0x%08x. Size=%i, type=%i",tran->id(),tran->address(),tran->size(),tran->type());
+         log_->debug("Transaction id=0x%" PRIx32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32, tran->id(), tran->address(), tran->size(), tran->type());
          tran->done();
       }
    }

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -118,7 +118,7 @@ void rha::AxiMemMap::runThread() {
          rim::TransactionLockPtr lock = tran->lock();
 
          if ( tran->expired() ) {
-            log_->warning("Transaction expired. Id=%i",tran->id());
+            log_->warning("Transaction expired. Id=%" PRIu32, tran->id());
             tran.reset();
             continue;
          }
@@ -140,7 +140,7 @@ void rha::AxiMemMap::runThread() {
             it += dataSize;
          }
 
-         log_->debug("Transaction id=0x%08x, addr 0x%016x. Size=%i, type=%i, data=0x%08x",tran->id(),tran->address(),tran->size(),tran->type(),data);
+         log_->debug("Transaction id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", data=0x%08x", tran->id(), tran->address(), tran->size(), tran->type(), data);
          if ( ret != 0 ) tran->error("Memory transaction failed with error code %i, see driver error codes",ret);
          else tran->done();
       }

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -108,7 +108,7 @@ void rha::AxiMemMap::runThread() {
       if ( (tran = queue_.pop()) != NULL ) {
 
          if ( (tran->size() % dataSize) != 0 ) {
-            tran->error("Invalid transaction size %i, must be an integer number of %i bytes",tran->size(),dataSize);
+            tran->error("Invalid transaction size %" PRIu32 ", must be an integer number of %" PRIu32 " bytes", tran->size(), dataSize);
             tran.reset();
             continue;
          }
@@ -142,7 +142,7 @@ void rha::AxiMemMap::runThread() {
          }
 
          log_->debug("Transaction id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", data=0x%08x", tran->id(), tran->address(), tran->size(), tran->type(), data);
-         if ( ret != 0 ) tran->error("Memory transaction failed with error code %i, see driver error codes",ret);
+         if ( ret != 0 ) tran->error("Memory transaction failed with error code %" PRIi32 ", see driver error codes", ret);
          else tran->done();
       }
    }

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -141,7 +141,7 @@ void rha::AxiMemMap::runThread() {
             it += dataSize;
          }
 
-         log_->debug("Transaction id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", data=0x%08x", tran->id(), tran->address(), tran->size(), tran->type(), data);
+         log_->debug("Transaction id=%" PRIu32 ", addr 0x%016" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", data=0x%08" PRIu32, tran->id(), tran->address(), tran->size(), tran->type(), data);
          if ( ret != 0 ) tran->error("Memory transaction failed with error code %" PRIi32 ", see driver error codes", ret);
          else tran->done();
       }

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -74,7 +74,7 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
       throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma",
-            "Failed to open device file %s with dest 0x%" PRIu32 "! Another process may already have it open!", path.c_str(), dest));
+            "Failed to open device file %s with dest 0x%" PRIx32 "! Another process may already have it open!", path.c_str(), dest));
 
    }
 
@@ -182,7 +182,7 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("AxiStreamDma::acceptReq: Timeout waiting for outbound buffer after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("AxiStreamDma::acceptReq: Timeout waiting for outbound buffer after %" PRIuLEAST32 ".%" PRIuLEAST32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -283,7 +283,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("AxiStreamDma::acceptFrame: Timeout waiting for outbound write after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("AxiStreamDma::acceptFrame: Timeout waiting for outbound write after %" PRIuLEAST32 ".%" PRIuLEAST32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -74,7 +74,7 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
       throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma",
-            "Failed to open device file %s with dest 0x%x! Another process may already have it open!",path.c_str(),dest));
+            "Failed to open device file %s with dest 0x%" PRIu32 "! Another process may already have it open!", path.c_str(), dest));
 
    }
 
@@ -323,7 +323,7 @@ void rha::AxiStreamDma::retBuffer(uint8_t * data, uint32_t meta, uint32_t size) 
 
          // Bulk return
          if ( (count = retQueue_.size()) >= retThold_ ) {
-            printf("Return count=%i\n",count);
+            printf("Return count=%" PRIu32 "\n", count);
             if ( count > 100 ) count = 100;
             for (x=0; x < count; x++) ret[x] = retQueue_.pop() & 0x3FFFFFFF;
 

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;
 namespace ris = rogue::interfaces::stream;
@@ -181,7 +182,7 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("AxiStreamDma::acceptReq: Timeout waiting for outbound buffer after %i.%i seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("AxiStreamDma::acceptReq: Timeout waiting for outbound buffer after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -282,7 +283,7 @@ void rha::AxiStreamDma::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("AxiStreamDma::acceptFrame: Timeout waiting for outbound write after %i.%i seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("AxiStreamDma::acceptFrame: Timeout waiting for outbound write after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -222,7 +222,7 @@ ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("PgpCard::acceptReq: Timeout waiting for outbound buffer after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("PgpCard::acceptReq: Timeout waiting for outbound buffer after %" PRIuLEAST32 ".%" PRIuLEAST32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -304,7 +304,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("PgpCard::acceptFrame: Timeout waiting for outbound write after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("PgpCard::acceptFrame: Timeout waiting for outbound write after %" PRIuLEAST32 ".%" PRIuLEAST32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -78,7 +78,7 @@ rhp::PgpCard::PgpCard ( std::string path, uint32_t lane, uint32_t vc ) {
 
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
       ::close(fd_);
-      throw(rogue::GeneralError::create("PgpCard::PgpCard","Failed to acquire destination %i on device %s",(lane*4)+vc,path.c_str()));
+      throw(rogue::GeneralError::create("PgpCard::PgpCard","Failed to acquire destination %" PRIu32 " on device %s", (lane*4)+vc, path.c_str()));
    }
 
    // Result may be that rawBuff_ = NULL

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 namespace rhp = rogue::hardware::pgp;
 namespace ris = rogue::interfaces::stream;
@@ -221,7 +222,7 @@ ris::FramePtr rhp::PgpCard::acceptReq ( uint32_t size, bool zeroCopyEn) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("PgpCard::acceptReq: Timeout waiting for outbound buffer after %i.%i seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("PgpCard::acceptReq: Timeout waiting for outbound buffer after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = -1;
             }
             else {
@@ -303,7 +304,7 @@ void rhp::PgpCard::acceptFrame ( ris::FramePtr frame ) {
             tout = timeout_;
 
             if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-               log_->critical("PgpCard::acceptFrame: Timeout waiting for outbound write after %i.%i seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
+               log_->critical("PgpCard::acceptFrame: Timeout waiting for outbound write after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound back pressure.", timeout_.tv_sec, timeout_.tv_usec);
                res = 0;
             }
             else {

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -81,7 +81,7 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port, bool d
 
       if ( zmq_connect(this->zmqSub_,temp.c_str()) < 0 )
          throw(rogue::GeneralError::create("ZmqClient::ZmqClient",
-                  "Failed to connect to port %i at address %s",port,addr.c_str()));
+                  "Failed to connect to port %" PRIu16 " at address %s", port, addr.c_str()));
 
       reqPort = port + 1;
    }
@@ -111,7 +111,7 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port, bool d
 
    if ( zmq_connect(this->zmqReq_,temp.c_str()) < 0 )
       throw(rogue::GeneralError::create("ZmqClient::ZmqClient",
-               "Failed to connect to port %i at address %s",reqPort,addr.c_str()));
+               "Failed to connect to port %" PRIu32 " at address %s", reqPort, addr.c_str()));
 
    if ( doString_ ) {
       threadEn_ = false;
@@ -150,7 +150,7 @@ void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs, bool waitRetry) {
    waitRetry_ = waitRetry;
    timeout_ = msecs;
 
-   printf("ZmqClient::setTimeout: Setting timeout to %i msecs, waitRetry = %i\n",timeout_,waitRetry_);
+   printf("ZmqClient::setTimeout: Setting timeout to %" PRIu32 " msecs, waitRetry = %" PRIu8 "\n", timeout_, waitRetry_);
 
    if ( zmq_setsockopt (this->zmqReq_, ZMQ_RCVTIMEO, &timeout_, sizeof(int32_t)) != 0 )
          throw(rogue::GeneralError("ZmqClient::setTimeout","Failed to set socket timeout"));

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -22,6 +22,7 @@
 #include <rogue/GeneralError.h>
 #include <string>
 #include <zmq.h>
+#include <inttypes.h>
 
 #ifndef NO_PYTHON
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
@@ -114,10 +115,10 @@ rogue::interfaces::ZmqClient::ZmqClient (std::string addr, uint16_t port, bool d
 
    if ( doString_ ) {
       threadEn_ = false;
-      log_->info("Connected to Rogue server at port %i",reqPort);
+      log_->info("Connected to Rogue server at port %" PRIu32, reqPort);
    }
    else {
-      log_->info("Connected to Rogue server at ports %i:%i",port,reqPort);
+      log_->info("Connected to Rogue server at ports %" PRIu16 ":%" PRIu32, port, reqPort);
 
       threadEn_ = true;
       thread_ = new std::thread(&rogue::interfaces::ZmqClient::runThread, this);
@@ -181,7 +182,7 @@ std::string rogue::interfaces::ZmqClient::sendString(std::string path, std::stri
       if ( zmq_recvmsg(this->zmqReq_,&msg,0) <= 0 ) {
          seconds += (float)timeout_ / 1000.0;
          if ( waitRetry_ ) {
-            log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...",seconds);
+            log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...", seconds);
             zmq_msg_close(&msg);
          }
          else
@@ -190,7 +191,7 @@ std::string rogue::interfaces::ZmqClient::sendString(std::string path, std::stri
       else break;
    }
 
-   if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!",seconds);
+   if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!", seconds);
 
    data = std::string((const char *)zmq_msg_data(&msg),zmq_msg_size(&msg));
    zmq_msg_close(&msg);
@@ -241,7 +242,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
          if ( zmq_recvmsg(this->zmqReq_,&rxMsg,0) <= 0 ) {
             seconds += (float)timeout_ / 1000.0;
             if ( waitRetry_ ) {
-               log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...",seconds);
+               log_->error("Timeout waiting for response after %f Seconds, server may be busy! Waiting...", seconds);
                zmq_msg_close(&rxMsg);
             }
             else
@@ -251,7 +252,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
       }
    }
 
-   if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!",seconds);
+   if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!", seconds);
 
    PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
    zmq_msg_close(&rxMsg);

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
+#include <inttypes.h>
 #include <string>
 #include <zmq.h>
 
@@ -77,7 +78,7 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
             "Failed to bind server to port %i on interface %s. Another process may be using this port.",port+1,addr.c_str()));
    }
 
-   log_->info("Started Rogue server at ports %i:%i",this->basePort_,this->basePort_+1);
+   log_->info("Started Rogue server at ports %" PRIu16 ":%" PRIu16, this->basePort_, this->basePort_+1);
 
    threadEn_ = true;
    rThread_ = new std::thread(&rogue::interfaces::ZmqServer::runThread, this);
@@ -115,7 +116,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
    std::string temp;
    uint32_t opt;
 
-   log_->debug("Trying to serve on ports %i:%i:%i",this->basePort_,this->basePort_+1,this->basePort_+2);
+   log_->debug("Trying to serve on ports %" PRIu16 ":%" PRIu16 ":%" PRIu16, this->basePort_, this->basePort_+1, this->basePort_+2);
 
    this->zmqPub_ = zmq_socket(this->zmqCtx_,ZMQ_PUB);
    this->zmqRep_ = zmq_socket(this->zmqCtx_,ZMQ_REP);
@@ -148,7 +149,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
       zmq_close(this->zmqStr_);
-      log_->debug("Failed to bind publish to port %i",this->basePort_);
+      log_->debug("Failed to bind publish to port %" PRIu16, this->basePort_);
       return false;
    }
 
@@ -162,7 +163,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
       zmq_close(this->zmqStr_);
-      log_->debug("Failed to bind resp to port %i",this->basePort_+1);
+      log_->debug("Failed to bind resp to port %" PRIu16, this->basePort_+1);
       return false;
    }
 
@@ -176,7 +177,7 @@ bool rogue::interfaces::ZmqServer::tryConnect() {
       zmq_close(this->zmqPub_);
       zmq_close(this->zmqRep_);
       zmq_close(this->zmqStr_);
-      log_->debug("Failed to bind str resp to port %i",this->basePort_+2);
+      log_->debug("Failed to bind str resp to port %" PRIu16, this->basePort_+2);
       return false;
    }
 

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -75,7 +75,7 @@ rogue::interfaces::ZmqServer::ZmqServer (std::string addr, uint16_t port) {
             "Failed to auto bind server on interface %s.",addr.c_str()));
       else
          throw(rogue::GeneralError::create("ZmqServer::ZmqServer",
-            "Failed to bind server to port %i on interface %s. Another process may be using this port.",port+1,addr.c_str()));
+            "Failed to bind server to port %" PRIu16 " on interface %s. Another process may be using this port.", port+1, addr.c_str()));
    }
 
    log_->info("Started Rogue server at ports %" PRIu16 ":%" PRIu16, this->basePort_, this->basePort_+1);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -350,7 +350,7 @@ bool rim::Block::checkTransaction() {
          for (x=verifyBase_; x < verifyBase_ + verifySize_; x++) {
             if ((verifyData_[x] & verifyMask_[x]) != (blockData_[x] & verifyMask_[x])) {
                throw(rogue::GeneralError::create("Block::checkTransaction",
-                  "Verify error for block %s with address 0x%.8x. Byte: %i. Got: 0x%.2x, Exp: 0x%.2x, Mask: 0x%.2x",
+                  "Verify error for block %s with address 0x%" PRIx64 ". Byte: %" PRIu32 ". Got: 0x%" PRIx8 ", Exp: 0x%" PRIx8 ", Mask: 0x%" PRIx8,
                   path_.c_str(), address(), x, verifyData_[x], blockData_[x], verifyMask_[x]));
             }
          }
@@ -542,7 +542,7 @@ void rim::Block::setBytes ( const uint8_t *data, rim::Variable *var, uint32_t in
 
       // Verify range
       if ( index < 0 || index >= var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setBytes","Index %i is out of range for %s",index, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setBytes","Index %" PRIu32 " is out of range for %s", index, var->name_.c_str()));
 
       // Fast copy
       if ( var->fastByte_ != NULL ) memcpy(blockData_+var->fastByte_[index],buff,var->valueBytes_);
@@ -596,7 +596,7 @@ void rim::Block::getBytes( uint8_t *data, rim::Variable *var, uint32_t index ) {
 
       // Verify range
       if ( index < 0 || index >= var->numValues_ )
-         throw(rogue::GeneralError::create("Block::getBytes","Index %i is out of range for %s",index, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::getBytes","Index %" PRIu32 " is out of range for %s", index, var->name_.c_str()));
 
       // Fast copy
       if ( var->fastByte_ != NULL ) memcpy(data,blockData_+var->fastByte_[index],var->valueBytes_);
@@ -652,7 +652,7 @@ void rim::Block::setPyFunc ( bp::object &value, rim::Variable *var, int32_t inde
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setPyFunc","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setPyFunc","Overflow error for passed array with length %" PRIu32 " at index %" PRIu32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          tmp = vl[x];
@@ -777,10 +777,10 @@ void rim::Block::setUIntPy ( bp::object &value, rim::Variable *var, int32_t inde
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setUIntPy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setUIntPy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setUIntPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setUIntPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIu32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_UINT64 ) {
           uint64_t *src = reinterpret_cast<uint64_t *>(PyArray_DATA (arr));
@@ -801,7 +801,7 @@ void rim::Block::setUIntPy ( bp::object &value, rim::Variable *var, int32_t inde
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setUIntPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setUIntPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<uint64_t> tmp(vl[x]);
@@ -918,10 +918,10 @@ void rim::Block::setIntPy ( bp::object &value, rim::Variable *var, int32_t index
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setIntPy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setIntPy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setIntPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setIntPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_INT64 ) {
           int64_t *src = reinterpret_cast<int64_t *>(PyArray_DATA (arr));
@@ -942,7 +942,7 @@ void rim::Block::setIntPy ( bp::object &value, rim::Variable *var, int32_t index
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setIntPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setIntPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<int64_t> tmp(vl[x]);
@@ -1063,10 +1063,10 @@ void rim::Block::setBoolPy ( bp::object &value, rim::Variable *var, int32_t inde
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setBoolPy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setBoolPy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setBoolPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setBoolPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_BOOL ) {
           bool *src = reinterpret_cast<bool *>(PyArray_DATA (arr));
@@ -1083,7 +1083,7 @@ void rim::Block::setBoolPy ( bp::object &value, rim::Variable *var, int32_t inde
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setBoolPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setBoolPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<bool> tmp(vl[x]);
@@ -1252,10 +1252,10 @@ void rim::Block::setFloatPy ( bp::object &value, rim::Variable *var, int32_t ind
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setFloatPy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFloatPy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setFloatPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFloatPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_FLOAT32 ) {
           float *src = reinterpret_cast<float *>(PyArray_DATA (arr));
@@ -1271,7 +1271,7 @@ void rim::Block::setFloatPy ( bp::object &value, rim::Variable *var, int32_t ind
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setFloatPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFloatPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<float> tmp(vl[x]);
@@ -1375,10 +1375,10 @@ void rim::Block::setDoublePy ( bp::object &value, rim::Variable *var, int32_t in
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setDoublePy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setDoublePy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setDoublePy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setDoublePy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_FLOAT64 ) {
           double *src = reinterpret_cast<double *>(PyArray_DATA (arr));
@@ -1395,7 +1395,7 @@ void rim::Block::setDoublePy ( bp::object &value, rim::Variable *var, int32_t in
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setDoublePy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setDoublePy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<double> tmp(vl[x]);
@@ -1498,10 +1498,10 @@ void rim::Block::setFixedPy ( bp::object &value, rim::Variable *var, int32_t ind
       npy_intp * dims = PyArray_SHAPE(arr);
 
       if ( ndims != 1 )
-         throw(rogue::GeneralError::create("Block::setFixedPy","Invalid number of dimensions (%i) for passed ndarray for %s", ndims, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFixedPy","Invalid number of dimensions (%" PRIu32 ") for passed ndarray for %s", ndims, var->name_.c_str()));
 
       if ( (index + dims[0]) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setFixedPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", dims[0], index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFixedPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", dims[0], index, var->numValues_, var->name_.c_str()));
 
       if ( PyArray_TYPE(arr) == NPY_FLOAT64 ) {
           double *src = reinterpret_cast<double *>(PyArray_DATA (arr));
@@ -1518,7 +1518,7 @@ void rim::Block::setFixedPy ( bp::object &value, rim::Variable *var, int32_t ind
       uint32_t vlen = len(vl);
 
       if ( (index + vlen) > var->numValues_ )
-         throw(rogue::GeneralError::create("Block::setFixedPy","Overflow error for passed array with length %i at index %i. Variable length = %i for %s", vlen, index, var->numValues_, var->name_.c_str()));
+         throw(rogue::GeneralError::create("Block::setFixedPy","Overflow error for passed array with length %" PRIu32 " at index %" PRIi32 ". Variable length = %" PRIu32 " for %s", vlen, index, var->numValues_, var->name_.c_str()));
 
       for (x=0; x < vlen; x++) {
          bp::extract<double> tmp(vl[x]);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -350,7 +350,7 @@ bool rim::Block::checkTransaction() {
          for (x=verifyBase_; x < verifyBase_ + verifySize_; x++) {
             if ((verifyData_[x] & verifyMask_[x]) != (blockData_[x] & verifyMask_[x])) {
                throw(rogue::GeneralError::create("Block::checkTransaction",
-                  "Verify error for block %s with address 0x%" PRIx64 ". Byte: %" PRIu32 ". Got: 0x%" PRIx8 ", Exp: 0x%" PRIx8 ", Mask: 0x%" PRIx8,
+                  "Verify error for block %s with address 0x%.8" PRIx64 ". Byte: %" PRIu32 ". Got: 0x%.2" PRIx8 ", Exp: 0x%.2" PRIx8 ", Mask: 0x%.2" PRIx8,
                   path_.c_str(), address(), x, verifyData_[x], blockData_[x], verifyMask_[x]));
             }
          }
@@ -459,7 +459,7 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
          }
       }
 
-      bLog_->debug("Adding variable %s to block %s at offset 0x%" PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_);
+      bLog_->debug("Adding variable %s to block %s at offset 0x%.8" PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_);
    }
 
    // Init overlap enable before check, block level overlap enable flag will be removed in the future

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -247,7 +247,7 @@ void rim::Block::intStartTransaction(uint32_t type, bool forceWr, bool check, ri
       }
       doUpdate_ = updateEn_;
 
-      bLog_->debug("Start transaction type = %i, Offset=0x%x, lByte=%i, hByte=%i, tOff=0x%x, tSize=%i",type,offset_,lowByte,highByte,tOff,tSize);
+      bLog_->debug("Start transaction type = %" PRIu32 ", Offset=0x%" PRIx64 ", lByte=%" PRIu32 ", hByte=%" PRIu32 ", tOff=0x%" PRIx32 ", tSize=%" PRIu32, type, offset_, lowByte, highByte, tOff, tSize);
 
       // Start transaction
       reqTransaction(offset_+tOff, tSize, tData, type);
@@ -274,7 +274,7 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
 
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
+         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
       }
    }
@@ -307,7 +307,7 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
 
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %i out of %i: %s",(count+1),(retryCount_+1),err.what());
+         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
       }
    }
@@ -343,7 +343,7 @@ bool rim::Block::checkTransaction() {
 
       // Check verify data if verifyInp is set
       if ( verifyInp_ ) {
-         bLog_->debug("Verfying data. Base=0x%x, size=%i",verifyBase_,verifySize_);
+         bLog_->debug("Verfying data. Base=0x%" PRIx32 ", size=%" PRIu32, verifyBase_, verifySize_);
          verifyReq_ = false;
          verifyInp_ = false;
 
@@ -459,7 +459,7 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
          }
       }
 
-      bLog_->debug("Adding variable %s to block %s at offset 0x%.8x",(*vit)->name_.c_str(),path_.c_str(),offset_);
+      bLog_->debug("Adding variable %s to block %s at offset 0x%" PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_);
    }
 
    // Init overlap enable before check, block level overlap enable flag will be removed in the future
@@ -1605,7 +1605,7 @@ double rim::Block::getFixed ( rim::Variable *var, int32_t index ) {
 
    getBytes((uint8_t *)&fPoint,var,index);
    // Do two-complement if negative
-   if ((fPoint & (1 << var->valueBits_-1)) != 0) {
+   if ((fPoint & (1 << (var->valueBits_-1))) != 0) {
      fPoint = fPoint - (1 << var->valueBits_);
    }
 

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <string.h>
+#include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;
 
@@ -62,7 +63,7 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
    uint64_t addr = tran->address();
    uint8_t * ptr = tran->begin();
 
-   //printf("Got transaction address=0x%x, size=%i, type = %i\n",addr,size,type);
+   //printf("Got transaction address=0x%" PRIx64 ", size=%" PRIu32 ", type = %" PRIu32 "\n", addr, size, type);
 
    rogue::interfaces::memory::TransactionLockPtr lock = tran->lock();
    {
@@ -84,13 +85,13 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
          if ( tran->type() == rogue::interfaces::memory::Write ||
               tran->type() == rogue::interfaces::memory::Post ) {
 
-               //printf("Write data to 4k=0x%x, offset=0x%x, size=%i\n",addr4k,off4k,size4k);
+               //printf("Write data to 4k=0x%" PRIx64 ", offset=0x%" PRIx64 ", size=%" PRIu64 "\n", addr4k, off4k, size4k);
                memcpy(memMap_[addr4k]+off4k,ptr,size4k);
          }
 
          // Read or verify
          else {
-            //printf("Read data from 4k=0x%x, offset=0x%x, size=%i\n",addr4k,off4k,size4k);
+            //printf("Read data from 4k=0x%" PRIx64 ", offset=0x%" PRIx64 ", size=%" PRIu64 "\n", addr4k, off4k, size4k);
             memcpy(ptr,memMap_[addr4k]+off4k,size4k);
          }
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -208,7 +208,7 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
    }
 
    log_->debug("Request transaction type=%" PRIu32 " id=%" PRIu32, tran->type_, tran->id_);
-   tran->log_->debug("Created transaction type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ,
+   tran->log_->debug("Created transaction type=%" PRIu32 " id=%" PRIu32 ", address=0x%016" PRIx64 ", size=%" PRIu32 ,
          tran->type_,tran->id_,tran->address_,tran->size_);
    slave->doTransaction(tran);
    tran->refreshTimer(tran);

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;
 

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -206,8 +206,8 @@ uint32_t rim::Master::intTransaction(rim::TransactionPtr tran) {
       tranMap_[tran->id_] = tran;
    }
 
-   log_->debug("Request transaction type=%i id=%i",tran->type_,tran->id_);
-   tran->log_->debug("Created transaction type=%i id=%i, address=0x%016x, size=0x%x",
+   log_->debug("Request transaction type=%" PRIu32 " id=%" PRIu32, tran->type_, tran->id_);
+   tran->log_->debug("Created transaction type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ,
          tran->type_,tran->id_,tran->address_,tran->size_);
    slave->doTransaction(tran);
    tran->refreshTimer(tran);

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -181,8 +181,8 @@ uint32_t rim::Master::reqTransactionPy(uint64_t address, boost::python::object p
    if ( (tran->size_ + offset) > tran->pyBuf_.len ) {
       PyBuffer_Release(&(tran->pyBuf_));
       throw(rogue::GeneralError::create("Master::reqTransactionPy",
-               "Attempt to access %i bytes in python buffer with size %i at offset %i",
-               tran->size_,tran->pyBuf_.len,offset));
+               "Attempt to access %" PRIu32 " bytes in python buffer with size %" PRIu32 " at offset %" PRIu32,
+               tran->size_, tran->pyBuf_.len, offset));
    }
 
    tran->pyValid_ = true;
@@ -295,7 +295,7 @@ void rim::Master::copyBitsPy(boost::python::object dst, uint32_t dstLsb, boost::
    if ( (dstLsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
       throw(rogue::GeneralError::create("Master::copyBits",
-               "Attempt to copy %i bits starting from bit %i from dest array with bitSize %i",
+               "Attempt to copy %" PRIu32 " bits starting from bit %" PRIu32 " from dest array with bitSize %" PRIu32,
                size, dstLsb, dstBuf.len*8));
    }
 
@@ -308,7 +308,7 @@ void rim::Master::copyBitsPy(boost::python::object dst, uint32_t dstLsb, boost::
       PyBuffer_Release(&srcBuf);
       PyBuffer_Release(&dstBuf);
       throw(rogue::GeneralError::create("Master::copyBits",
-               "Attempt to copy %i bits starting from bit %i from source array with bitSize %i",
+               "Attempt to copy %" PRIu32 " bits starting from bit %" PRIu32 " from source array with bitSize %" PRIu32,
                size, srcLsb, srcBuf.len*8));
    }
 
@@ -363,7 +363,7 @@ void rim::Master::setBitsPy(boost::python::object dst, uint32_t lsb, uint32_t si
    if ( (lsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
       throw(rogue::GeneralError::create("Master::setBits",
-               "Attempt to set %i bits starting from bit %i in array with bitSize %i",
+               "Attempt to set %" PRIu32 " bits starting from bit %" PRIu32 " in array with bitSize %" PRIu32,
                size, lsb, dstBuf.len*8));
    }
 
@@ -424,7 +424,7 @@ bool rim::Master::anyBitsPy(boost::python::object dst, uint32_t lsb, uint32_t si
    if ( (lsb + size) > (dstBuf.len*8) ) {
       PyBuffer_Release(&dstBuf);
       throw(rogue::GeneralError::create("Master::anyBits",
-               "Attempt to access %i bits starting from bit %i from array with bitSize %i",
+               "Attempt to access %" PRIu32 " bits starting from bit %" PRIu32 " from array with bitSize %" PRIu32,
                size, lsb, dstBuf.len*8));
    }
 

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -90,13 +90,13 @@ rim::TcpClient::TcpClient (std::string addr, uint16_t port) : rim::Slave(4,0xFFF
 
    if ( zmq_connect(this->zmqResp_,this->respAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpClient::TcpClient",
-               "Failed to connect to remote port %i at address %s",port+1,addr.c_str()));
+               "Failed to connect to remote port %" PRIu16 " at address %s", port+1, addr.c_str()));
 
    this->bridgeLog_->debug("Creating request client port: %s",this->reqAddr_.c_str());
 
    if ( zmq_connect(this->zmqReq_,this->reqAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpClient::TcpClient",
-               "Failed to connect to remote port %i at address %s",port,addr.c_str()));
+               "Failed to connect to remote port %" PRIu16 " at address %s", port, addr.c_str()));
 
    // Start rx thread
    threadEn_ = true;

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -83,13 +83,13 @@ rim::TcpServer::TcpServer (std::string addr, uint16_t port) {
 
    if ( zmq_bind(this->zmqResp_,this->respAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpServer::TcpServer",
-               "Failed to bind server to port %i at address %s, another process may be using this port",port+1,addr.c_str()));
+               "Failed to bind server to port %" PRIu16 " at address %s, another process may be using this port", port+1, addr.c_str()));
 
    this->bridgeLog_->debug("Creating request client port: %s",this->reqAddr_.c_str());
 
    if ( zmq_bind(this->zmqReq_,this->reqAddr_.c_str()) < 0 )
       throw(rogue::GeneralError::create("memory::TcpServer::TcpServer",
-               "Failed to bind server to port %i at address %s, another process may be using this port",port,addr.c_str()));
+               "Failed to bind server to port %" PRIu16 " at address %s, another process may be using this port", port, addr.c_str()));
 
    // Start rx thread
    threadEn_ = true;

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -188,7 +188,7 @@ void rim::TcpServer::runThread() {
             // Data pointer
             data = (uint8_t *)zmq_msg_data(&(msg[4]));
 
-            bridgeLog_->debug("Starting transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32,id,addr,size,type);
+            bridgeLog_->debug("Starting transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32, id, addr, size, type);
 
             // Execute transaction and wait for result
             this->clearError();
@@ -196,7 +196,7 @@ void rim::TcpServer::runThread() {
             waitTransaction(0);
             result = getError();
 
-            bridgeLog_->debug("Done transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32 ", result=(%s)",id,addr,size,type,result.c_str());
+            bridgeLog_->debug("Done transaction id=%" PRIu32 ", addr=0x%" PRIx64 ", size=%" PRIu32 ", type=%" PRIu32 ", result=(%s)", id, addr, size, type, result.c_str());
 
             // Result message, at least one char needs to be sent
             if ( result.length() == 0 ) result = "OK";

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -122,7 +122,7 @@ uint32_t rim::Transaction::type() { return type_; }
 //! Complete transaction without error, lock must be held
 void rim::Transaction::done() {
 
-   log_->debug("Transaction done. type=%i id=%i, address=0x%016x, size=0x%x",
+   log_->debug("Transaction done. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ,
          type_,id_,address_,size_);
 
    error_ = "";
@@ -135,7 +135,7 @@ void rim::Transaction::errorPy(std::string error) {
    error_ = error;
    done_  = true;
 
-   log_->debug("Transaction error. type=%i id=%i, address=0x%016x, size=0x%x, error=%s",
+   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ", error=%s",
          type_,id_,address_,size_,error_.c_str());
 
    cond_.notify_all();
@@ -153,7 +153,7 @@ void rim::Transaction::error(const char * fmt, ...) {
    error_ = buffer;
    done_  = true;
 
-   log_->debug("Transaction error. type=%i id=%i, address=0x%016x, size=0x%x, error=%s",
+   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ", error=%s",
          type_,id_,address_,size_,error_.c_str());
 
    cond_.notify_all();
@@ -175,7 +175,7 @@ std::string rim::Transaction::wait() {
          done_  = true;
          error_ = "Timeout waiting for register transaction " + std::to_string(id_) + " message response.";
 
-         log_->debug("Transaction timeout. type=%i id=%i, address=0x%016x, size=0x%x",
+         log_->debug("Transaction timeout. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32,
                type_,id_,address_,size_);
       }
       else cond_.wait_for(lock,std::chrono::microseconds(1000));
@@ -208,7 +208,7 @@ void rim::Transaction::refreshTimer(rim::TransactionPtr ref) {
 
       if ( warnTime_.tv_sec == 0 && warnTime_.tv_usec == 0 ) warnTime_ = endTime_;
       else if ( timercmp(&warnTime_,&currTime,>=) ) {
-            log_->warning("Transaction timer refresh! Possible slow link! type=%i id=%i, address=0x%016x, size=0x%x",
+            log_->warning("Transaction timer refresh! Possible slow link! type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32,
                   type_,id_,address_,size_);
          warnTime_ = endTime_;
       }

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -123,7 +123,7 @@ uint32_t rim::Transaction::type() { return type_; }
 //! Complete transaction without error, lock must be held
 void rim::Transaction::done() {
 
-   log_->debug("Transaction done. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ,
+   log_->debug("Transaction done. type=%" PRIu32 " id=%" PRIu32 ", address=0x%016" PRIx64 ", size=%" PRIu32 ,
          type_,id_,address_,size_);
 
    error_ = "";
@@ -136,7 +136,7 @@ void rim::Transaction::errorPy(std::string error) {
    error_ = error;
    done_  = true;
 
-   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ", error=%s",
+   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%016" PRIx64 ", size=%" PRIu32 ", error=%s",
          type_,id_,address_,size_,error_.c_str());
 
    cond_.notify_all();
@@ -154,7 +154,7 @@ void rim::Transaction::error(const char * fmt, ...) {
    error_ = buffer;
    done_  = true;
 
-   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32 ", error=%s",
+   log_->debug("Transaction error. type=%" PRIu32 " id=%" PRIu32 ", address=0x%016" PRIx64 ", size=%" PRIu32 ", error=%s",
          type_,id_,address_,size_,error_.c_str());
 
    cond_.notify_all();
@@ -209,7 +209,7 @@ void rim::Transaction::refreshTimer(rim::TransactionPtr ref) {
 
       if ( warnTime_.tv_sec == 0 && warnTime_.tv_usec == 0 ) warnTime_ = endTime_;
       else if ( timercmp(&warnTime_,&currTime,>=) ) {
-            log_->warning("Transaction timer refresh! Possible slow link! type=%" PRIu32 " id=%" PRIu32 ", address=0x%" PRIx64 ", size=%" PRIu32,
+            log_->warning("Transaction timer refresh! Possible slow link! type=%" PRIu32 " id=%" PRIu32 ", address=0x%016" PRIx64 ", size=%" PRIu32,
                   type_,id_,address_,size_);
          warnTime_ = endTime_;
       }

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -29,6 +29,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -242,7 +242,7 @@ void rim::Transaction::setData ( boost::python::object p, uint32_t offset ) {
    if ( (offset + count) > size_ ) {
       PyBuffer_Release(&pyBuf);
       throw(rogue::GeneralError::create("Transaction::setData",
-               "Attempt to set %i bytes at offset %i to python buffer with size %i",
+               "Attempt to set %" PRIu32 " bytes at offset %" PRIu32 " to python buffer with size %" PRIu32,
                count,offset,size_));
    }
 
@@ -262,8 +262,8 @@ void rim::Transaction::getData ( boost::python::object p, uint32_t offset ) {
    if ( (offset + count) > size_ ) {
       PyBuffer_Release(&pyBuf);
       throw(rogue::GeneralError::create("Transaction::getData",
-               "Attempt to get %i bytes from offset %i to python buffer with size %i",
-               count,offset,size_));
+               "Attempt to get %" PRIu32 " bytes from offset %" PRIu32 " to python buffer with size %" PRIu32,
+               count, offset, size_));
    }
 
    std::memcpy((uint8_t *)pyBuf.buf, begin()+offset, count);

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -26,6 +26,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 
@@ -82,12 +83,12 @@ void ris::Buffer::adjustHeader(int32_t value) {
    // Decreasing header size
    if ( value < 0 && (uint32_t)abs(value) > headRoom_ )
          throw(rogue::GeneralError::create("Buffer::adjustHeader",
-                  "Attempt to reduce header with size %i by %i",headRoom_,value));
+                  "Attempt to reduce header with size %" PRIu32 " by %" PRIi32, headRoom_, value));
 
    // Increasing header size
    if ( value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)) )
          throw(rogue::GeneralError::create("Buffer::adjustHeader",
-                  "Attempt to increase header by %i in buffer with size %i",
+                  "Attempt to increase header by %" PRIi32 " in buffer with size %" PRIu32,
                   value, (rawSize_ - (headRoom_ + tailRoom_))));
 
    // Make adjustment
@@ -114,12 +115,12 @@ void ris::Buffer::adjustTail(int32_t value) {
    // Decreasing tail size
    if ( value < 0 && (uint32_t)abs(value) > tailRoom_ )
          throw(rogue::GeneralError::create("Buffer::adjustTail",
-                  "Attempt to reduce tail with size %i by %i",tailRoom_,value));
+                  "Attempt to reduce tail with size %" PRIu32 " by %" PRIi32, tailRoom_, value));
 
    // Increasing tail size
    if ( value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)) )
          throw(rogue::GeneralError::create("Buffer::adjustTail",
-                  "Attempt to increase header by %i in buffer with size %i",
+                  "Attempt to increase header by %" PRIi32 " in buffer with size %" PRIu32,
                   value, (rawSize_ - (headRoom_ + tailRoom_))));
 
    // Make adjustment
@@ -202,7 +203,7 @@ uint32_t ris::Buffer::getPayload() {
 void ris::Buffer::setPayload(uint32_t size) {
    if ( size > (rawSize_ - (headRoom_ + tailRoom_) ) )
       throw(rogue::GeneralError::create("Buffer::setPayload",
-               "Attempt to set payload to size %i in buffer with size %i",
+               "Attempt to set payload to size %" PRIu32 " in buffer with size %" PRIu32,
                size, (rawSize_ - (headRoom_ + tailRoom_))));
 
    payload_ = size + headRoom_;
@@ -223,7 +224,7 @@ void ris::Buffer::minPayload(uint32_t size) {
 void ris::Buffer::adjustPayload(int32_t value) {
    if ( value < 0 && (uint32_t)abs(value) > getPayload())
       throw(rogue::GeneralError::create("Buffer::adjustPayload",
-               "Attempt to decrease payload by %i in buffer with size %i",
+               "Attempt to decrease payload by %" PRIi32 " in buffer with size %" PRIu32,
                value, getPayload()));
 
    setPayload(getPayload() + value);
@@ -247,7 +248,7 @@ void ris::Buffer::setPayloadEmpty() {
 
 //! Debug buffer
 void ris::Buffer::debug(uint32_t idx) {
-   printf("    Buffer: %i, AllocSize: %i, RawSize: %i, HeadRoom: %i, TailRoom: %i, Payload: %i\n",
+   printf("    Buffer: %" PRIu32 ", AllocSize: %" PRIu32 ", RawSize: %" PRIu32 ", HeadRoom: %" PRIu32 ", TailRoom: %" PRIu32 ", Payload: %" PRIu32 "\n",
          idx, allocSize_, rawSize_, headRoom_, tailRoom_, payload_);
 }
 

--- a/src/rogue/interfaces/stream/Filter.cpp
+++ b/src/rogue/interfaces/stream/Filter.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/Filter.h>
 #include <rogue/Logging.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 
@@ -66,7 +67,7 @@ void ris::Filter::acceptFrame ( ris::FramePtr frame ) {
 
    // Drop errored frames
    if ( dropErrors_ && (frame->getError() != 0) ) {
-      log_->debug("Dropping errored frame: Channel=%i, Error=0x%x",channel_, frame->getError());
+      log_->debug("Dropping errored frame: Channel=%" PRIu8 ", Error=0x%" PRIx8, channel_, frame->getError());
       return;
    }
 

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -220,7 +220,7 @@ void ris::Frame::adjustPayload(int32_t value) {
 
    if ( value < 0 && (uint32_t)abs(value) > size)
       throw(rogue::GeneralError::create("Frame::adjustPayload",
-               "Attempt to reduce payload by %" PRId32 " in frame with size %" PRIu32,
+               "Attempt to reduce payload by %" PRIi32 " in frame with size %" PRIu32,
                value, size));
 
    setPayload(size + value);

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#include <inttypes.h>
 
 namespace ris  = rogue::interfaces::stream;
 
@@ -196,8 +197,8 @@ void ris::Frame::setPayload(uint32_t pSize) {
 
    if ( lSize != 0 )
       throw(rogue::GeneralError::create("Frame::setPayload",
-               "Attempt to set payload to size %i in frame with size %i",
-               pSize,size_));
+               "Attempt to set payload to size %" PRIu32 " in frame with size %" PRIu32,
+               pSize, size_));
 
    // Refresh
    payload_ = pSize;
@@ -219,8 +220,8 @@ void ris::Frame::adjustPayload(int32_t value) {
 
    if ( value < 0 && (uint32_t)abs(value) > size)
       throw(rogue::GeneralError::create("Frame::adjustPayload",
-               "Attempt to reduce payload by %i in frame with size %i",
-               value,size));
+               "Attempt to reduce payload by %" PRId32 " in frame with size %" PRIu32,
+               value, size));
 
    setPayload(size + value);
 }
@@ -355,7 +356,7 @@ void ris::Frame::readPy ( boost::python::object p, uint32_t offset ) {
    if ( (offset + count) > size ) {
       PyBuffer_Release(&pyBuf);
       throw(rogue::GeneralError::create("Frame::readPy",
-               "Attempt to read %i bytes from frame at offset %i with size %i",count,offset,size));
+               "Attempt to read %" PRIu32 " bytes from frame at offset %" PRIu32 " with size %" PRIu32, count, offset, size));
    }
 
    ris::FrameIterator beg = this->begin() + offset;
@@ -378,7 +379,7 @@ void ris::Frame::writePy ( boost::python::object p, uint32_t offset ) {
    if ( (offset + count) > size ) {
       PyBuffer_Release(&pyBuf);
       throw(rogue::GeneralError::create("Frame::writePy",
-               "Attempt to write %i bytes to frame at offset %i with size %i",count,offset,size));
+               "Attempt to write %" PRIu32 " bytes to frame at offset %" PRIu32 " with size %" PRIu32, count, offset, size));
    }
 
    minPayload(offset+count);
@@ -396,7 +397,7 @@ boost::python::object ris::Frame::getNumpy (uint32_t offset, uint32_t count)
    // Check this does not request data past the EOF
    if ( (offset + count) > size ) {
       throw(rogue::GeneralError::create("Frame::getNumpy",
-               "Attempt to read %i bytes from frame at offset %i with size %i",count,offset,size));
+               "Attempt to read %" PRIu32 " bytes from frame at offset %" PRIu32 " with size %" PRIu32, count, offset, size));
    }
 
    // Create a numpy array to receive it and locate the destination data buffer
@@ -446,7 +447,7 @@ void ris::Frame::putNumpy ( boost::python::object p, uint32_t offset ) {
    // Check this does not request data past the EOF
    if ( end > size ) {
       throw(rogue::GeneralError::create("Frame::putNumpy",
-               "Attempt to write %i bytes to frame at offset %i with size %i",count,offset,size));
+               "Attempt to write %" PRIu32 " bytes to frame at offset %" PRIu32 " with size %" PRIu32, count, offset, size));
    }
 
    uint8_t *src = reinterpret_cast<uint8_t *>(PyArray_DATA (arr));
@@ -501,7 +502,7 @@ void ris::Frame::debug() {
    ris::Frame::BufferIterator it;
    uint32_t idx = 0;
 
-   printf("Frame Info. BufferCount: %i, Size: %i, Available: %i, Payload: %i, Channel: %i, Error: 0x%x, Flags: 0x%x\n",
+   printf("Frame Info. BufferCount: %" PRIu32 ", Size: %" PRIu32 ", Available: %" PRIu32 ", Payload: %" PRIu32 ", Channel: %" PRIu8 ", Error: 0x%" PRIx8 ", Flags: 0x%" PRIx16 "\n",
          bufferCount(), getSize(), getAvailable(), getPayload(), getChannel(), getError(), getFlags());
 
    for (it = buffers_.begin(); it != buffers_.end(); ++it) {

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -27,6 +27,7 @@
 #include <rogue/GeneralError.h>
 #include <memory>
 #include <rogue/GilRelease.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 
@@ -153,7 +154,7 @@ ris::BufferPtr ris::Pool::allocBuffer ( uint32_t size, uint32_t *total ) {
       dataQ_.pop();
    }
    else if ( (data = (uint8_t *)malloc(bAlloc)) == NULL )
-      throw(rogue::GeneralError::create("Pool::allocBuffer","Failed to allocate buffer with size = %i",bAlloc));
+      throw(rogue::GeneralError::create("Pool::allocBuffer","Failed to allocate buffer with size = %" PRIu32, bAlloc));
 
    // Only use lower 24 bits of meta.
    // Upper 8 bits may have special meaning to sub-class

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -33,6 +33,7 @@
 #include <rogue/ScopedGil.h>
 #include <rogue/Logging.h>
 #include <string.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 
@@ -83,7 +84,7 @@ void ris::Slave::acceptFrame ( ris::FramePtr frame ) {
    if ( debug_ > 0 ) {
       char buffer[1000];
 
-      log_->critical("Got Size=%i, Error=%i, Data:",frame->getPayload(),frame->getError());
+      log_->critical("Got Size=%" PRIu32 ", Error=%" PRIu8 ", Data:", frame->getPayload(), frame->getError());
       sprintf(buffer,"     ");
 
       count = 0;

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -93,13 +93,13 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
 
       if ( zmq_bind(this->zmqPull_,this->pullAddr_.c_str()) < 0 )
          throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
-                  "Failed to bind server to port %i at address %s, another process may be using this port",port,addr.c_str()));
+                  "Failed to bind server to port %" PRIu16 " at address %s, another process may be using this port", port, addr.c_str()));
 
       this->bridgeLog_->debug("Creating push server port: %s",this->pushAddr_.c_str());
 
       if ( zmq_bind(this->zmqPush_,this->pushAddr_.c_str()) < 0 )
          throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
-                  "Failed to bind server to port %i at address %s, another process may be using this port",port+1,addr.c_str()));
+                  "Failed to bind server to port %" PRIu16 " at address %s, another process may be using this port", port+1, addr.c_str()));
    }
 
    // Client mode
@@ -111,13 +111,13 @@ ris::TcpCore::TcpCore (std::string addr, uint16_t port, bool server) {
 
       if ( zmq_connect(this->zmqPull_,this->pullAddr_.c_str()) < 0 )
          throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
-                  "Failed to connect to remote port %i at address %s",port+1,addr.c_str()));
+                  "Failed to connect to remote port %" PRIu16 " at address %s", port+1, addr.c_str()));
 
       this->bridgeLog_->debug("Creating push client port: %s",this->pushAddr_.c_str());
 
       if ( zmq_connect(this->zmqPush_,this->pushAddr_.c_str()) < 0 )
          throw(rogue::GeneralError::create("stream::TcpCore::TcpCore",
-                  "Failed to connect to remote port %i at address %s",port,addr.c_str()));
+                  "Failed to connect to remote port %" PRIu16 " at address %s", port, addr.c_str()));
    }
 
    // Start rx thread

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
 #include <zmq.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 
@@ -171,7 +172,7 @@ void ris::TcpCore::acceptFrame ( ris::FramePtr frame ) {
    }
 
    if ( zmq_msg_init_size (&(msg[3]), frame->getPayload()) < 0 ) {
-      bridgeLog_->warning("Failed to init message with size %i",frame->getPayload());
+      bridgeLog_->warning("Failed to init message with size %" PRIu32,frame->getPayload());
       return;
    }
 
@@ -192,9 +193,9 @@ void ris::TcpCore::acceptFrame ( ris::FramePtr frame ) {
    // Send data
    for (x=0; x < 4; x++) {
       if ( zmq_sendmsg(this->zmqPush_,&(msg[x]),(x==3)?0:ZMQ_SNDMORE) < 0 )
-        bridgeLog_->warning("Failed to push message with size %i on %s",frame->getPayload(), this->pushAddr_.c_str());
+        bridgeLog_->warning("Failed to push message with size %" PRIu32 " on %s", frame->getPayload(), this->pushAddr_.c_str());
    }
-   bridgeLog_->debug("Pushed TCP frame with size %i on %s",frame->getPayload(), this->pushAddr_.c_str());
+   bridgeLog_->debug("Pushed TCP frame with size %" PRIu32 " on %s", frame->getPayload(), this->pushAddr_.c_str());
 }
 
 //! Run thread
@@ -266,7 +267,7 @@ void ris::TcpCore::runThread() {
          frame->setChannel(chan);
          frame->setError(err);
 
-         bridgeLog_->debug("Pulled frame with size %i",frame->getPayload());
+         bridgeLog_->debug("Pulled frame with size %" PRIu32, frame->getPayload());
          sendFrame(frame);
       }
 

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -112,7 +112,7 @@ uint32_t rpb::CoreV1::tailSize() {
 ris::FrameIterator rpb::CoreV1::beginTail(uint32_t index) {
    if ( index >= tails_.size() )
       throw(rogue::GeneralError::create("bather::CoreV1::beginTail",
-               "Attempt to get tail index %i in message with %i tails",index,tails_.size()));
+               "Attempt to get tail index %" PRIu32 " in message with %" PRIu32 " tails", index, tails_.size()));
 
    // Invert order on return
    return tails_[(tails_.size()-1) - index];
@@ -122,7 +122,7 @@ ris::FrameIterator rpb::CoreV1::beginTail(uint32_t index) {
 ris::FrameIterator rpb::CoreV1::endTail(uint32_t index) {
    if ( index >= tails_.size() )
       throw rogue::GeneralError::create("batcher::CoreV1::tail",
-            "Attempt to access tail %i in frame with %i tails", index, tails_.size());
+            "Attempt to access tail %" PRIu32 " in frame with %" PRIu32 " tails", index, tails_.size());
 
    // Invert order on return
    return tails_[(tails_.size()-1) - index] + tailSize_;
@@ -132,7 +132,7 @@ ris::FrameIterator rpb::CoreV1::endTail(uint32_t index) {
 rpb::DataPtr & rpb::CoreV1::record(uint32_t index) {
    if ( index >= list_.size() )
       throw rogue::GeneralError::create("batcher::CoreV1::record",
-            "Attempt to access record %i in frame with %i records", index, tails_.size());
+            "Attempt to access record %" PRIu32 " in frame with %" PRIu32 " records", index, tails_.size());
 
    // Invert order on return
    return list_[(list_.size()-1) - index];

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -51,6 +51,7 @@
 #include <rogue/protocols/batcher/Data.h>
 #include <rogue/GeneralError.h>
 #include <math.h>
+#include <inttypes.h>
 
 namespace rpb = rogue::protocols::batcher;
 namespace ris = rogue::interfaces::stream;
@@ -161,13 +162,13 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
 
    // Drop errored frames
    if ( (frame->getError()) ) {
-      log_->warning("Dropping frame due to error: 0x%x",frame->getError());
+      log_->warning("Dropping frame due to error: 0x%" PRIx8, frame->getError());
       return false;
    }
 
    // Drop small frames
    if ( (rem = frame->getPayload()) < 16)  {
-      log_->warning("Dropping small frame size = %i",frame->getPayload());
+      log_->warning("Dropping small frame size = %" PRIu32, frame->getPayload());
       return false;
    }
 
@@ -188,7 +189,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
 
    // Check version, convert width
    if ( (temp & 0xF) != 1 ) {
-      log_->error("Version mismatch. Got %i",(temp&0xF));
+      log_->error("Version mismatch. Got %" PRIu8, (temp&0xF));
       return false;
    }
 
@@ -203,7 +204,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
      case 3: headerSize_ = 16; break;// If WIDTH=0x3 (TYPE = 128-bit AXI stream), then appended header is 16 bytes.
      case 4: headerSize_ = 32; break;// If WIDTH=0x4 (TYPE = 256-bit AXI stream), then appended header is 32 bytes.
      case 5: headerSize_ = 64; break;// If WIDTH=0x5 (TYPE = 512-bit AXI stream), then appended header is 64 bytes.
-     default: log_->error("Invalid AXIS Type Detected. Got %i",((temp >> 4) & 0xF)); return false;
+     default: log_->error("Invalid AXIS Type Detected. Got %" PRIu8, ((temp >> 4) & 0xF)); return false;
    }
 
    // Set tail size, min 64-bits
@@ -214,7 +215,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
 
    // Frame needs to large enough for header + 1 tail
    if ( rem < (headerSize_ + tailSize_)) {
-      log_->error("Not enough space (%i) for tail (%i) + header (%i)",rem,headerSize_,tailSize_);
+      log_->error("Not enough space (%" PRIu32 ") for tail (%" PRIu32 ") + header (%" PRIu32 ")", rem, headerSize_, tailSize_);
       reset();
       return false;
    }
@@ -231,7 +232,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
 
       // sanity check
       if ( rem < tailSize_ ) {
-         log_->error("Not enough space (%i) for tail (%i)",rem,tailSize_);
+         log_->error("Not enough space (%" PRIu32 ") for tail (%" PRIu32 ")", rem, tailSize_);
          reset();
          return false;
       }
@@ -256,7 +257,7 @@ bool rpb::CoreV1::processFrame ( ris::FramePtr frame ) {
 
       // Not enough data for rewind value
       if ( fJump > rem ) {
-         log_->error("Not enough space (%i) for frame (%i)",rem,fJump);
+         log_->error("Not enough space (%" PRIu32 ") for frame (%" PRIu32 ")", rem, fJump);
          reset();
          return false;
       }

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/GeneralError.h>
 #include <fdManager.h>
+#include <inttypes.h>
 
 namespace rpe = rogue::protocols::epicsV3;
 
@@ -72,7 +73,7 @@ void rpe::Server::start() {
    uint32_t x;
    //this->setDebugLevel(10);
 
-   log_->info("Starting epics server with %i workers",workCnt_);
+   log_->info("Starting epics server with %" PRIu32 " workers",workCnt_);
 
    threadEn_ = true;
    thread_ = new std::thread(&rpe::Server::runThread, this);

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -152,8 +152,8 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
       else { epicsType_ = aitEnumString; }
 
-      log_->info("Detected Rogue Int with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue Int with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
    }
 
    // Signed Int types, > 32-bits treated as string

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -124,7 +124,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    else if ( forceStr ) epicsType_ = aitEnumString;
 
    // Unsigned Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"UInt%" PRIu32, &bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"UInt%" SCNu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8;}
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
@@ -135,7 +135,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
   }
 
    // Unsigned Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"uint%" PRIu32,&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"uint%" SCNu32,&bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8;}
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
@@ -146,7 +146,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
   }
 
    // Signed Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"Int%" PRIu32, &bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"Int%" SCNu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; }
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; }
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
@@ -157,7 +157,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Signed Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"int%" PRIu32, &bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"int%" SCNu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; }
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; }
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
@@ -176,7 +176,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Floats with size included
-   else if ( sscanf(typeStr.c_str(),"float%" PRIu32, &bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"float%" SCNu32, &bitSize) == 1 ) {
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 
@@ -185,7 +185,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Floats with size included
-   else if ( sscanf(typeStr.c_str(),"Float%" PRIu32, &bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"Float%" SCNu32, &bitSize) == 1 ) {
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -124,7 +124,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    else if ( forceStr ) epicsType_ = aitEnumString;
 
    // Unsigned Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"UInt%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"UInt%" PRIu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8;}
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
@@ -135,7 +135,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
   }
 
    // Unsigned Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"uint%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"uint%" PRIu32,&bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumUint8;}
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumUint16; }
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
@@ -146,7 +146,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
   }
 
    // Signed Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"Int%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"Int%" PRIu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; }
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; }
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
@@ -157,7 +157,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Signed Int types, > 32-bits treated as string
-   else if ( sscanf(typeStr.c_str(),"int%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"int%" PRIu32, &bitSize) == 1 ) {
       if ( bitSize <=  8 ) { fSize_ = 1; epicsType_ = aitEnumInt8; }
       else if ( bitSize <= 16 ) { fSize_ = 2; epicsType_ = aitEnumInt16; }
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
@@ -176,7 +176,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Floats with size included
-   else if ( sscanf(typeStr.c_str(),"float%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"float%" PRIu32, &bitSize) == 1 ) {
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 
@@ -185,7 +185,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    }
 
    // Floats with size included
-   else if ( sscanf(typeStr.c_str(),"Float%i",&bitSize) == 1 ) {
+   else if ( sscanf(typeStr.c_str(),"Float%" PRIu32, &bitSize) == 1 ) {
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <memory>
 #include <aitTypes.h>
+#include <inttypes.h>
 
 #ifdef __MACH__
 #include <mach/clock.h>
@@ -107,8 +108,8 @@ rpe::Value::~Value () {
 void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool forceStr) {
    uint32_t bitSize;
 
-   log_->info("Init GDD for %s typeStr=%s, isEnum=%i, count=%i",
-         epicsName_.c_str(),typeStr.c_str(),isEnum,count);
+   log_->info("Init GDD for %s typeStr=%s, isEnum=%" PRIu8 ", count=%" PRIu32,
+         epicsName_.c_str(), typeStr.c_str(), isEnum, count);
 
    // Save current type
    typeStr_ = typeStr;
@@ -116,7 +117,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
    // Enum type
    if ( isEnum ) {
       epicsType_ = aitEnumEnum16;
-      log_->info("Detected enum for %s typeStr=%s", epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected enum for %s typeStr=%s", epicsName_.c_str(), typeStr.c_str());
    }
 
    // Force to string
@@ -129,8 +130,8 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
       else { epicsType_ = aitEnumString; }
 
-      log_->info("Detected Rogue Uint with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue Uint with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
   }
 
    // Unsigned Int types, > 32-bits treated as string
@@ -140,8 +141,8 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       else if ( bitSize <= 32) { fSize_ = 4; epicsType_ = aitEnumUint32; }
       else { epicsType_ = aitEnumString; }
 
-      log_->info("Detected Rogue uint with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue uint with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
   }
 
    // Signed Int types, > 32-bits treated as string
@@ -162,15 +163,15 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       else if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumInt32; }
       else { epicsType_ = aitEnumString; }
 
-      log_->info("Detected Rogue int with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue int with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
    }
 
    // Python int
    else if ( typeStr.find("int") == 0 ) {
       fSize_ = 4;
       epicsType_ = aitEnumInt32;
-      log_->info("Detected python int with size %i for %s typeStr=%s",
+      log_->info("Detected python int with size %" PRIu32 " for %s typeStr=%s",
             bitSize, epicsName_.c_str(),typeStr.c_str());
    }
 
@@ -179,8 +180,8 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 
-      log_->info("Detected Rogue float with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue float with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
    }
 
    // Floats with size included
@@ -188,20 +189,20 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
       if ( bitSize <= 32 ) { fSize_ = 4; epicsType_ = aitEnumFloat32; }
       else { fSize_ = 8; epicsType_ = aitEnumFloat64; }
 
-      log_->info("Detected Rogue Float with size %i for %s typeStr=%s",
-            bitSize, epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected Rogue Float with size %" PRIu32 " for %s typeStr=%s",
+            bitSize, epicsName_.c_str(), typeStr.c_str());
    }
 
    // Treat other floats as 64-bit
    else if ( (typeStr.find("float") == 0) || ( typeStr.find("Double") == 0 ) || ( typeStr.find("Float") == 0 )) {
-      log_->info("Detected 64-bit float %s: typeStr=%s", epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected 64-bit float %s: typeStr=%s", epicsName_.c_str(), typeStr.c_str());
       epicsType_ = aitEnumFloat64;
       fSize_ = 8;
    }
 
    // Unknown type maps to string
    if ( epicsType_ == aitEnumInvalid ) {
-      log_->info("Detected unknown type for %s typeStr=%s. It will be mapped to a string.", epicsName_.c_str(),typeStr.c_str());
+      log_->info("Detected unknown type for %s typeStr=%s. It will be mapped to a string.", epicsName_.c_str(), typeStr.c_str());
       epicsType_ = aitEnumString;
    }
 
@@ -212,7 +213,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
          log_->info("Vector of string not supported in EPICS. Treating as string: %s\n", epicsName_.c_str());
          count = 0;
       }
-      log_->info("Treating String as waveform of chars for %s typeStr=%s\n", epicsName_.c_str(),typeStr.c_str());
+      log_->info("Treating String as waveform of chars for %s typeStr=%s\n", epicsName_.c_str(), typeStr.c_str());
       epicsType_ = aitEnumUint8;
       count      = 300;
       isString_  = true;
@@ -220,7 +221,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
 
    // Vector
    if ( count != 0 ) {
-      log_->info("Create vector GDD for %s epicsType_=%i, size=%i",epicsName_.c_str(),epicsType_,count);
+      log_->info("Create vector GDD for %s epicsType_=%" PRIu32 ", size=%" PRIu32, epicsName_.c_str(), epicsType_, count);
       pValue_ = new gddAtomic (gddAppType_value, epicsType_, 1u, count);
       size_   = count;
       max_    = count;
@@ -229,7 +230,7 @@ void rpe::Value::initGdd(std::string typeStr, bool isEnum, uint32_t count, bool 
 
    // Scalar
    else {
-      log_->info("Create scalar GDD for %s epicsType_=%i",epicsName_.c_str(),epicsType_);
+      log_->info("Create scalar GDD for %s epicsType_=%" PRIu32, epicsName_.c_str(), epicsType_);
       pValue_ = new gddScalar(gddAppType_value, epicsType_);
    }
 

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <math.h>
+#include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
@@ -106,7 +107,7 @@ ris::FramePtr rpp::Controller::reqFrame ( uint32_t size ) {
       // Buffer should support our header/tail plus at least one payload byte
       if ( buff->getAvailable() < (headSize_ + tailSize_ + 1) )
          throw(rogue::GeneralError::create("packetizer::Controller::reqFrame",
-                  "Buffer size %i is less than min size required %i",
+                  "Buffer size %" PRIu32 " is less than min size required %" PRIu32,
                   buff->getAvailable(), (headSize_ + tailSize_ + 1)));
 
       // Add 8 bytes to head and tail reservation

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -99,7 +99,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
 
    log_->debug("transportRx: Raw header: 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8,
          data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
-   log_->debug("transportRx: Raw footer: 0x%x",
+   log_->debug("transportRx: Raw footer: 0x%" PRIx8,
          data[size-1]);
    log_->debug("transportRx: Got frame: Fuser=0x%" PRIx8 ", Dest=0x%" PRIx8 ", Id=0x%" PRIx32 ", Count=%" PRIx32 ", Luser=0x%" PRIx8 ", Eof=%" PRIu8 ", size=%" PRIu32,
          tmpFuser, tmpDest, tmpIdx, tmpCount, tmpLuser, tmpEof, size);

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;
 namespace ris = rogue::interfaces::stream;
@@ -77,7 +78,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
       ( frame->bufferCount() != 1 ) || // Incoming frame can only have one buffer
       (size < 10) ||                   // Check for min. size (64-bit header + 8-bit min. payload + 8-bit tail)
       ((data[0] & 0xF) != 0) ) {       // Check for invalid version only
-      log_->warning("Dropping frame due to contents: error=0x%x, payload=%i, buffers=%i, Version=0x%x",frame->getError(),size,frame->bufferCount(),data[0]&0xF);
+      log_->warning("Dropping frame due to contents: error=0x%" PRIx8 ", payload=%" PRIu32 ", buffers=%" PRIu32 ", Version=0x%" PRIx8, frame->getError(), size, frame->bufferCount(), data[0]&0xF);
       dropCount_++;
       return;
    }
@@ -96,11 +97,11 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    tmpLuser = data[size-1] & 0x7F;
    tmpEof   = data[size-1] & 0x80;
 
-   log_->debug("transportRx: Raw header: 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x, 0x%x",
-         data[0],data[1],data[2],data[3],data[4],data[5],data[6],data[7]);
+   log_->debug("transportRx: Raw header: 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8 ", 0x%" PRIx8,
+         data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
    log_->debug("transportRx: Raw footer: 0x%x",
          data[size-1]);
-   log_->debug("transportRx: Got frame: Fuser=0x%x, Dest=0x%x, Id=0x%x, Count=%i, Luser=0x%x, Eof=%i, size=%i",
+   log_->debug("transportRx: Got frame: Fuser=0x%" PRIx8 ", Dest=0x%" PRIx8 ", Id=0x%" PRIx32 ", Count=%" PRIx32 ", Luser=0x%" PRIx8 ", Eof=%" PRIu8 ", size=%" PRIu32,
          tmpFuser, tmpDest, tmpIdx, tmpCount, tmpLuser, tmpEof, size);
 
    // Shorten message by one byte (before adjusting tail)
@@ -112,7 +113,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
 
    // Drop frame and reset state if mismatch
    if ( tmpCount > 0  && ( tmpIdx != tranIndex_ || tmpCount != tranCount_[0] ) ) {
-      log_->warning("Dropping frame due to state mismatch: expIdx=%i, gotIdx=%i, expCount=%i, gotCount=%i",tranIndex_,tmpIdx,tranCount_[0],tmpCount);
+      log_->warning("Dropping frame due to state mismatch: expIdx=%" PRIu32 ", gotIdx=%" PRIu32 ", expCount=%" PRIu32 ", gotCount=%" PRIu32, tranIndex_, tmpIdx, tranCount_[0], tmpCount);
       dropCount_++;
       tranCount_[0] = 0;
       tranFrame_[0].reset();
@@ -123,7 +124,7 @@ void rpp::ControllerV1::transportRx( ris::FramePtr frame ) {
    if ( tmpCount == 0 ) {
 
       if ( tranCount_[0] != 0 )
-         log_->warning("Dropping frame due to new incoming frame: expIdx=%i, expCount=%i",tranIndex_,tranCount_[0]);
+         log_->warning("Dropping frame due to new incoming frame: expIdx=%" PRIu32 ", expCount=%" PRIu32, tranIndex_, tranCount_[0]);
 
       tranFrame_[0] = ris::Frame::create();
       tranIndex_    = tmpIdx;
@@ -180,7 +181,7 @@ void rpp::ControllerV1::applicationRx ( ris::FramePtr frame, uint8_t tDest ) {
       usleep(10);
       gettimeofday(&currTime,NULL);
       if ( timercmp(&currTime,&endTime,>)) {
-         log_->critical("ControllerV1::applicationRx: Timeout waiting for outbound queue after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
+         log_->critical("ControllerV1::applicationRx: Timeout waiting for outbound queue after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
          gettimeofday(&startTime,NULL);
          timeradd(&startTime,&timeout_,&endTime);
       }

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -173,7 +173,7 @@ ris::FramePtr rpr::Controller::reqFrame ( uint32_t size ) {
    // Make sure there is enough room the buffer for our header
    if ( buffer->getAvailable() < rpr::Header::HeaderSize )
       throw(rogue::GeneralError::create("rssi::Controller::reqFrame",
-               "Buffer size %i is less than min header size %i",
+               "Buffer size %" PRId32 " is less than min header size %" PRIu32,
                rpr::Header::HeaderSize,buffer->getAvailable()));
 
    // Update buffer to include our header space.
@@ -202,7 +202,7 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
       return;
    }
 
-   log_->debug("RX frame: state=%i server=%" PRIu32 " size=%" PRIu32 " syn=%" PRIu32 " ack=%" PRIu32 " nul=%" PRIu32 ", bst=%" PRIu32 ", rst=%" PRIu32 ", ack#=%" PRIu32 " seq=%" PRIu32 ", nxt=%" PRIu32,
+   log_->debug("RX frame: state=%" PRIu32 " server=%" PRIu32 " size=%" PRIu32 " syn=%" PRIu32 " ack=%" PRIu32 " nul=%" PRIu32 ", bst=%" PRIu32 ", rst=%" PRIu32 ", ack#=%" PRIu32 " seq=%" PRIu32 ", nxt=%" PRIu32,
          state_, server_,frame->getPayload(),head->syn,head->ack,head->nul,head->busy,head->rst,
          head->acknowledge,head->sequence,nextSeqRx_);
 
@@ -243,7 +243,7 @@ void rpr::Controller::transportRx( ris::FramePtr frame ) {
    else if ( state_ == StOpen && ( head->nul || frame->getPayload() > rpr::Header::HeaderSize ) ) {
 
       if ( head->sequence == nextSeqRx_ ) {
-         // log_->warning("Data or NULL in the correct sequence go to application: nextSeqRx_=0x%x", nextSeqRx_);
+         // log_->warning("Data or NULL in the correct sequence go to application: nextSeqRx_=0x%" PRIx8, nextSeqRx_);
 
          lastSeqRx_ = nextSeqRx_;
          nextSeqRx_ = nextSeqRx_ + 1;
@@ -429,7 +429,7 @@ uint32_t rpr::Controller::getRemBusyCnt() {
 void rpr::Controller::setLocTryPeriod(uint32_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocTryPeriod",
-                                            "Invalid LocTryPeriod Value = %i",val);
+                                            "Invalid LocTryPeriod Value = %" PRIu32, val);
    locTryPeriod_ = val;
    convTime(tryPeriodD1_,  locTryPeriod_);
    convTime(tryPeriodD4_,  locTryPeriod_ / 4);
@@ -442,7 +442,7 @@ uint32_t rpr::Controller::getLocTryPeriod() {
 void rpr::Controller::setLocMaxBuffers(uint8_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocMaxBuffers",
-                                            "Invalid LocMaxBuffers Value = %i",val);
+                                            "Invalid LocMaxBuffers Value = %" PRIu8,val);
 
    locMaxBuffers_ = val;
 }
@@ -454,7 +454,7 @@ uint8_t rpr::Controller::getLocMaxBuffers() {
 void rpr::Controller::setLocMaxSegment(uint16_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocMaxSegment",
-                                            "Invalid LocMaxSegment Value = %i",val);
+                                            "Invalid LocMaxSegment Value = %" PRIu16, val);
    locMaxSegment_ = val;
 }
 
@@ -465,7 +465,7 @@ uint16_t rpr::Controller::getLocMaxSegment() {
 void rpr::Controller::setLocCumAckTout(uint16_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocCumAckTout",
-                                            "Invalid LocCumAckTout Value = %i",val);
+                                            "Invalid LocCumAckTout Value = %" PRIu16, val);
    locCumAckTout_ = val;
 }
 
@@ -476,7 +476,7 @@ uint16_t rpr::Controller::getLocCumAckTout() {
 void rpr::Controller::setLocRetranTout(uint16_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocRetranTout",
-                                            "Invalid LocRetranTout Value = %i",val);
+                                            "Invalid LocRetranTout Value = %" PRIu16,val);
    locRetranTout_ = val;
 }
 
@@ -487,7 +487,7 @@ uint16_t rpr::Controller::getLocRetranTout() {
 void rpr::Controller::setLocNullTout(uint16_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocNullTout",
-                                            "Invalid LocNullTout Value = %i",val);
+                                            "Invalid LocNullTout Value = %" PRIu16, val);
    locNullTout_ = val;
 }
 
@@ -498,7 +498,7 @@ uint16_t rpr::Controller::getLocNullTout() {
 void rpr::Controller::setLocMaxRetran(uint8_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocMaxRetran",
-                                            "Invalid LocMaxRetran Value = %i",val);
+                                            "Invalid LocMaxRetran Value = %" PRIu8,val);
    locMaxRetran_ = val;
 }
 
@@ -509,7 +509,7 @@ uint8_t rpr::Controller::getLocMaxRetran() {
 void rpr::Controller::setLocMaxCumAck(uint8_t val) {
    if ( val == 0 )
       throw rogue::GeneralError::create("Rssi::Controller::setLocMaxAck",
-                                            "Invalid LocMaxAck Value = %i",val);
+                                            "Invalid LocMaxAck Value = %" PRIu8, val);
    locMaxCumAck_ = val;
 }
 

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <string.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 namespace rpr = rogue::protocols::rssi;
 namespace ris = rogue::interfaces::stream;
@@ -162,7 +163,7 @@ void rpr::Header::update() {
 
    if ( buff->getSize() < size )
       throw(rogue::GeneralError::create("rssi::Header::update",
-               "Buffer size %i is less size indicated in header %i",
+               "Buffer size %" PRIu32 " is less size indicated in header %" PRIu8,
                buff->getSize(), size));
 
    buff->minPayload(size);

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -120,7 +120,7 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    }
 
    if (tran->size() > max()) {
-      tran->error("Transaction size 0x%" PRIx32 " exceeds max size %" PRIu32, tran->size(), min());
+      tran->error("Transaction size %" PRIu32 " exceeds max size %" PRIu32, tran->size(), max());
       return;
    }
 
@@ -150,9 +150,9 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    if ( tran->type() == rim::Post ) tran->done();
    else addTransaction(tran);
 
-   log_->debug("Send frame for id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", doWrite=%" PRIu8,
+   log_->debug("Send frame for id=%" PRIu32 ", addr 0x%0.8" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", doWrite=%" PRIu8,
                tran->id(), tran->address(), tran->size(), tran->type(), doWrite);
-   log_->debug("Send frame for id=%" PRIu32 ", header: 0x%" PRIx32" 0x%" PRIx32 " 0x%" PRIx32,
+   log_->debug("Send frame for id=%" PRIu32 ", header: 0x%0.8" PRIx32" 0x%0.8" PRIx32 " 0x%0.8" PRIx32,
                tran->id(), header[0], header[1], header[2]);
 
    sendFrame(frame);
@@ -195,7 +195,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract id from frame
    id = header[0];
-   log_->debug("Got frame id=%" PRIu32 " header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32,
+   log_->debug("Got frame id=%" PRIu32 " header: 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32,
                id, header[0], header[1], header[2]);
 
    // Find Transaction
@@ -236,7 +236,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
       if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
       else if ( tail[0] & 0x10000 ) tran->error("Axi bus returned fail status in hardware");
       else tran->error("Non zero status message returned on axi bus in hardware: 0x%" PRIu32, tail[0]);
-      log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%" PRIu32, id, tail[0]);
+      log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%0.8" PRIu32, id, tail[0]);
       return;
    }
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -109,18 +109,18 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
 
    // Size error
    if ((tran->address() % min()) != 0 ) {
-      tran->error("Transaction address 0x%x is not aligned to min size %i",tran->address(),min());
+      tran->error("Transaction address 0x%" PRIx64 " is not aligned to min size %" PRIu32, tran->address(), min());
       return;
    }
 
    // Size error
    if ((tran->size() % min()) != 0 || tran->size() < min()) {
-      tran->error("Transaction size 0x%x is not aligned to min size %i",tran->size(),min());
+      tran->error("Transaction size 0x%" PRIx32 " is not aligned to min size %" PRIu32, tran->size(), min());
       return;
    }
 
    if (tran->size() > max()) {
-      tran->error("Transaction size 0x%x exceeds max size %i",tran->size(),min());
+      tran->error("Transaction size 0x%" PRIx32 " exceeds max size %" PRIu32, tran->size(), min());
       return;
    }
 
@@ -209,7 +209,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      log_->warning("Transaction expired. Id=%i",id);
+      log_->warning("Transaction expired. Id=%" PRIu32, id);
       return;
    }
    tIter = tran->begin();
@@ -235,7 +235,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
    if ( tail[0] != 0 ) {
       if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
       else if ( tail[0] & 0x10000 ) tran->error("Axi bus returned fail status in hardware");
-      else tran->error("Non zero status message returned on axi bus in hardware: 0x%x",tail[0]);
+      else tran->error("Non zero status message returned on axi bus in hardware: 0x%" PRIu32, tail[0]);
       log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%" PRIu32, id, tail[0]);
       return;
    }

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -35,6 +35,7 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 #include <string.h>
+#include <inttypes.h>
 
 namespace rps = rogue::protocols::srp;
 namespace rim = rogue::interfaces::memory;
@@ -149,10 +150,10 @@ void rps::SrpV0::doTransaction(rim::TransactionPtr tran) {
    if ( tran->type() == rim::Post ) tran->done();
    else addTransaction(tran);
 
-   log_->debug("Send frame for id=%i, addr 0x%0.8x. Size=%i, type=%i, doWrite=%i",
-               tran->id(),tran->address(),tran->size(),tran->type(),doWrite);
-   log_->debug("Send frame for id=%i, header: 0x%0.8x 0x%0.8x 0x%0.8x",
-               tran->id(),header[0],header[1],header[2]);
+   log_->debug("Send frame for id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32 ", doWrite=%" PRIu8,
+               tran->id(), tran->address(), tran->size(), tran->type(), doWrite);
+   log_->debug("Send frame for id=%" PRIu32 ", header: 0x%" PRIx32" 0x%" PRIx32 " 0x%" PRIx32,
+               tran->id(), header[0], header[1], header[2]);
 
    sendFrame(frame);
 }
@@ -176,13 +177,13 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Drop errored frames
    if ( frame->getError() ) {
-      log_->warning("Got errored frame = 0x%i",frame->getError());
+      log_->warning("Got errored frame = 0x%" PRIx8, frame->getError());
       return; // Invalid frame, drop it
    }
 
    // Check frame size
    if ( (fSize = frame->getPayload()) < 16 ) {
-      log_->warning("Got undersized frame size = %i",fSize);
+      log_->warning("Got undersized frame size = %" PRIu32, fSize);
       return; // Invalid frame, drop it
    }
 
@@ -194,12 +195,12 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract id from frame
    id = header[0];
-   log_->debug("Got frame id=%i header: 0x%0.8x 0x%0.8x 0x%0.8x",
-               id, header[0],header[1],header[2]);
+   log_->debug("Got frame id=%" PRIu32 " header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32,
+               id, header[0], header[1], header[2]);
 
    // Find Transaction
    if ( (tran = getTransaction(id)) == NULL ) {
-     log_->warning("Invalid ID frame for id=%i",id);
+     log_->warning("Invalid ID frame for id=%" PRIu32,id);
      return; // Bad id or post, drop frame
    }
 
@@ -218,13 +219,13 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
 
    // Check frame size
    if ( fSize != expFrameLen ) {
-      log_->warning("Bad receive length for %i exp=%i, got=%i",id,expFrameLen,fSize);
+      log_->warning("Bad receive length for %" PRIu32 " exp=%" PRIu32 ", got=%" PRIu32, id, expFrameLen, fSize);
       return;
    }
 
    // Check header
    if ( memcmp(header,expHeader,RxHeadLen) != 0 ) {
-     log_->warning("Bad header for %i",id);
+     log_->warning("Bad header for %" PRIu32, id);
      return;
    }
 
@@ -235,7 +236,7 @@ void rps::SrpV0::acceptFrame ( ris::FramePtr frame ) {
       if ( tail[0] & 0x20000 ) tran->error("Axi bus timeout detected in hardware");
       else if ( tail[0] & 0x10000 ) tran->error("Axi bus returned fail status in hardware");
       else tran->error("Non zero status message returned on axi bus in hardware: 0x%x",tail[0]);
-      log_->warning("Error detected for ID id=%i, tail=0x%0.8x",id,tail[0]);
+      log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%" PRIu32, id, tail[0]);
       return;
    }
 

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -139,12 +139,12 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
 
    // Size error
    if ((tran->size() % min()) != 0 || tran->size() < min()) {
-      tran->error("Transaction size 0x%" PRIu32 " is not aligned to min size %" PRIu32, tran->size(), min());
+      tran->error("Transaction size 0x%" PRIx32 " is not aligned to min size %" PRIu32, tran->size(), min());
       return;
    }
 
    if (tran->size() > max()) {
-      tran->error("Transaction size 0x%" PRIu32 " exceeds max size %" PRIu32, tran->size(), min());
+      tran->error("Transaction size %" PRIu32 " exceeds max size %" PRIu32, tran->size(), max());
       return;
    }
 
@@ -170,9 +170,9 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
    if ( tran->type() == rim::Post ) tran->done();
    else addTransaction(tran);
 
-   log_->debug("Send frame for id=%" PRIu32 ", addr 0x%" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32,
+   log_->debug("Send frame for id=%" PRIu32 ", addr 0x%0.8" PRIx64 ". Size=%" PRIu32 ", type=%" PRIu32,
                tran->id(),tran->address(),tran->size(),tran->type());
-   log_->debug("Send frame for id=%" PRIu32 ", header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32,
+   log_->debug("Send frame for id=%" PRIu32 ", header: 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32,
                tran->id(), header[0], header[1], header[2], header[3], header[4]);
 
    sendFrame(frame);
@@ -195,7 +195,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    ris::FrameLockPtr frLock = frame->lock();
 
    if ( frame->getError() ) {
-      log_->warning("Got errored frame = 0x%" PRIu8, frame->getError());
+      log_->warning("Got errored frame = 0x%" PRIx8, frame->getError());
       return; // Invalid frame, drop it
    }
 
@@ -215,7 +215,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract the id
    id = header[1];
-   log_->debug("Got frame id=%" PRIu32 ", header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " tail: 0x%" PRIx32,
+   log_->debug("Got frame id=%" PRIu32 ", header: 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " 0x%0.8" PRIx32 " tail: 0x%0.8" PRIx32,
                id, header[0], header[1], header[2], header[3], header[4], tail[0]);
 
    // Find Transaction
@@ -251,7 +251,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
       if ( tail[0] & 0x2000 ) tran->error("FPGA register bus lockup detected in hardware. Power cycle required.");
       else if ( tail[0] & 0x0100 ) tran->error("FPGA register bus timeout detected in hardware");
       else tran->error("Non zero status message returned on fpga register bus in hardware: 0x%" PRIx32, tail[0]);
-      log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%" PRIx32, id, tail[0]);
+      log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%0.8" PRIx32, id, tail[0]);
       return;
    }
 

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -133,18 +133,18 @@ void rps::SrpV3::doTransaction(rim::TransactionPtr tran) {
 
    // Size error
    if ((tran->address() % min()) != 0 ) {
-      tran->error("Transaction address 0x%x is not aligned to min size %i",tran->address(),min());
+      tran->error("Transaction address 0x%" PRIx64 " is not aligned to min size %" PRIu32, tran->address(), min());
       return;
    }
 
    // Size error
    if ((tran->size() % min()) != 0 || tran->size() < min()) {
-      tran->error("Transaction size 0x%x is not aligned to min size %i",tran->size(),min());
+      tran->error("Transaction size 0x%" PRIu32 " is not aligned to min size %" PRIu32, tran->size(), min());
       return;
    }
 
    if (tran->size() > max()) {
-      tran->error("Transaction size 0x%x exceeds max size %i",tran->size(),min());
+      tran->error("Transaction size 0x%" PRIu32 " exceeds max size %" PRIu32, tran->size(), min());
       return;
    }
 
@@ -215,7 +215,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Extract the id
    id = header[1];
-   log_->debug("Got frame id=%i, header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " tail: 0x%" PRIx32,
+   log_->debug("Got frame id=%" PRIu32 ", header: 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " 0x%" PRIx32 " tail: 0x%" PRIx32,
                id, header[0], header[1], header[2], header[3], header[4], tail[0]);
 
    // Find Transaction
@@ -229,7 +229,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
 
    // Transaction expired
    if ( tran->expired() ) {
-      tran->error("Transaction expired: Id=%i (increase root->timeout value if this ID matches a previous timeout message)",id);
+      tran->error("Transaction expired: Id=%" PRIu32 " (increase root->timeout value if this ID matches a previous timeout message)", id);
       return;
    }
    tIter = tran->begin();
@@ -250,7 +250,7 @@ void rps::SrpV3::acceptFrame ( ris::FramePtr frame ) {
    if ( tail[0] != 0 ) {
       if ( tail[0] & 0x2000 ) tran->error("FPGA register bus lockup detected in hardware. Power cycle required.");
       else if ( tail[0] & 0x0100 ) tran->error("FPGA register bus timeout detected in hardware");
-      else tran->error("Non zero status message returned on fpga register bus in hardware: 0x%x",tail[0]);
+      else tran->error("Non zero status message returned on fpga register bus in hardware: 0x%" PRIx32, tail[0]);
       log_->warning("Error detected for ID id=%" PRIu32 ", tail=0x%" PRIx32, id, tail[0]);
       return;
    }

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;
 namespace ris = rogue::interfaces::stream;
@@ -158,7 +159,7 @@ void rpu::Client::acceptFrame ( ris::FramePtr frame ) {
          tout = timeout_;
 
          if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-            udpLog_->critical("Client::acceptFrame: Timeout waiting for outbound transmit after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
+            udpLog_->critical("Client::acceptFrame: Timeout waiting for outbound transmit after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
             res = 0;
          }
          else if ( (res = sendmsg(fd_,&msg,0)) < 0 )

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -62,7 +62,7 @@ rpu::Client::Client ( std::string host, uint16_t port, bool jumbo) : rpu::Core(j
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
-      throw(rogue::GeneralError::create("Client::Client","Failed to create socket for port %i at address %s",port_,address_.c_str()));
+      throw(rogue::GeneralError::create("Client::Client","Failed to create socket for port %" PRIu16 " at address %s", port_, address_.c_str()));
 
    // Lookup host address
    bzero(&aiHints, sizeof(aiHints));

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -22,6 +22,7 @@
 #include <rogue/GeneralError.h>
 #include <rogue/Helpers.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;
 
@@ -59,7 +60,7 @@ bool rpu::Core::setRxBufferCount(uint32_t count) {
    if(size > rwin) {
       udpLog_->critical("----------------------------------------------------------");
       udpLog_->critical("Error setting rx buffer size.");
-      udpLog_->critical("Wanted %i (%i * %i) Got %i",size,count,per,rwin);
+      udpLog_->critical("Wanted %" PRIu32 " (%" PRIu32 " * %" PRIu32 ") Got %" PRIu32, size, count, per, rwin);
       udpLog_->critical("sysctl -w net.core.rmem_max=size to increase in kernel");
       udpLog_->critical("----------------------------------------------------------");
       return(false);

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -58,7 +58,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
    // Create socket
    if ( (fd_ = socket(AF_INET,SOCK_DGRAM,0)) < 0 )
-      throw(rogue::GeneralError::create("Server::Server","Failed to create socket for port %i",port_));
+      throw(rogue::GeneralError::create("Server::Server","Failed to create socket for port %" PRIu16, port_));
 
    // Setup Remote Address
    memset(&locAddr_,0,sizeof(struct sockaddr_in));
@@ -69,7 +69,7 @@ rpu::Server::Server (uint16_t port, bool jumbo) : rpu::Core(jumbo) {
    memset(&remAddr_,0,sizeof(struct sockaddr_in));
 
    if (bind(fd_, (struct sockaddr *) &locAddr_, sizeof(locAddr_))<0)
-      throw(rogue::GeneralError::create("Server::Server","Failed to bind to local port %i. Another process may be using it",port_));
+      throw(rogue::GeneralError::create("Server::Server","Failed to bind to local port %" PRIu16 ". Another process may be using it", port_));
 
    // Kernel assigns port
    if ( port_ == 0 ) {

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -161,7 +161,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
          tout = timeout_;
 
          if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-            udpLog_->critical("Server::acceptFrame: Timeout waiting for outbound transmit after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
+            udpLog_->critical("Server::acceptFrame: Timeout waiting for outbound transmit after %" PRIuLEAST32 ".%" PRIuLEAST32 " seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
             res = 0;
          }
          else if ( (res = sendmsg(fd_,&msg,0)) < 0 )

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;
 namespace ris = rogue::interfaces::stream;
@@ -160,7 +161,7 @@ void rpu::Server::acceptFrame ( ris::FramePtr frame ) {
          tout = timeout_;
 
          if ( select(fd_+1,NULL,&fds,NULL,&tout) <= 0 ) {
-            udpLog_->critical("Server::acceptFrame: Timeout waiting for outbound transmit after %i.%i seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
+            udpLog_->critical("Server::acceptFrame: Timeout waiting for outbound transmit after %" PRIu32 ".%" PRIu32 " seconds! May be caused by outbound backpressure.", timeout_.tv_sec, timeout_.tv_usec);
             res = 0;
          }
          else if ( (res = sendmsg(fd_,&msg,0)) < 0 )

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -470,9 +470,9 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
          flfsr(expData);
 
          if ( ! std::equal(frIter,frIter+byteWidth_,expData ) ) {
-            sprintf(debugA,"Bad value at index %i. count=%i, size=%i",pos,rxCount_,(size/byteWidth_)-1);
+            sprintf(debugA,"Bad value at index %" PRIu32 ". count=%" PRIu32 ", size=%" PRIu32, pos, rxCount_, (size/byteWidth_)-1);
             for (x=0; x < byteWidth_; x++) {
-               sprintf(debugB,"\n   %i:%i Got=0x%x Exp=0x%x",pos,x,*(frIter+x),*(expData+x));
+               sprintf(debugB,"\n   %" PRIu32 ":%" PRIu32 " Got=0x%" PRIx8 " Exp=0x%" PRIx8, pos, x, *(frIter+x), *(expData+x));
                strcat(debugA,debugB);
             }
             rxLog_->warning(debugA);

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -35,6 +35,7 @@
 #include <rogue/GeneralError.h>
 #include <sys/time.h>
 #include <string.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
@@ -426,14 +427,14 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
 
    // Check for frame errors
    if ( frame->getError() ) {
-      rxLog_->warning("Frame error field is set: 0x%x",frame->getError());
+      rxLog_->warning("Frame error field is set: 0x%" PRIx8, frame->getError());
       rxErrCount_++;
       return;
    }
 
    // Verify size
    if ((( size % byteWidth_ ) != 0) || size < minSize_ ) {
-      rxLog_->warning("Size violation size=%i, count=%i",size,rxCount_);
+      rxLog_->warning("Size violation size=%" PRIu32 ", count=%" PRIu32, size, rxCount_);
       rxErrCount_++;
       return;
    }
@@ -451,8 +452,8 @@ void ru::Prbs::acceptFrame ( ris::FramePtr frame ) {
    // Accept any sequence if our local count is zero
    // incoming frames with seq = 0 never cause errors and treated as a restart
    if ( ( expSize != size ) || ( frSeq[0] != 0 && expSeq != 0 && frSeq[0] != expSeq ) ) {
-      rxLog_->warning("Bad header. expSize=%u gotSize=%u expSeq=%u gotSeq=%u nxtSeq=%u count=%i",
-            expSize,size,expSeq,frSeq[0],rxSeq_,rxCount_);
+      rxLog_->warning("Bad header. expSize=%" PRIu32 " gotSize=%" PRIu32 " expSeq=%" PRIu32 " gotSeq=%" PRIu32 " nxtSeq=%" PRIu32 " count=%" PRIu32,
+            expSize, size, expSeq, frSeq[0], rxSeq_, rxCount_);
       rxErrCount_++;
       return;
    }

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
@@ -69,7 +70,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
    strm.opaque  = NULL;
 
    if ( (ret = BZ2_bzDecompressInit(&strm,0,0)) != BZ_OK )
-      throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Error initializing decompressor. ret=%i",ret));
+      throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Error initializing decompressor. ret=%" PRIi32, ret));
 
    // Setup decompression pointers
    rBuff = frame->beginBuffer();
@@ -86,7 +87,7 @@ void ru::StreamUnZip::acceptFrame ( ris::FramePtr frame ) {
       ret = BZ2_bzDecompress(&strm);
 
       if ( (ret != BZ_STREAM_END) && (ret != BZ_OK) )
-         throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Decompression runtime error %i",ret));
+         throw(rogue::GeneralError::create("StreamUnZip::acceptFrame","Decompression runtime error %" PRIi32, ret));
 
       if ( ret == BZ_STREAM_END ) break;
 

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ru  = rogue::utilities;
@@ -70,7 +71,7 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    strm.opaque  = NULL;
 
    if ( (ret = BZ2_bzCompressInit(&strm,1,0,30)) != BZ_OK )
-      throw(rogue::GeneralError::create("StreamZip::acceptFrame","Error initializing compressor. ret=%i",ret));
+      throw(rogue::GeneralError::create("StreamZip::acceptFrame","Error initializing compressor. ret=%" PRIi32, ret));
 
    // Setup decompression pointers
    rBuff = frame->beginBuffer();
@@ -86,7 +87,7 @@ void ru::StreamZip::acceptFrame ( ris::FramePtr frame ) {
    do {
 
       if ( (ret = BZ2_bzCompress(&strm,(done)?BZ_FINISH:BZ_RUN)) == BZ_SEQUENCE_ERROR )
-         throw(rogue::GeneralError::create("StreamZip::acceptFrame","Compression runtime error %i",ret));
+         throw(rogue::GeneralError::create("StreamZip::acceptFrame","Compression runtime error %" PRIi32, ret));
 
       // Update read buffer if necessary
       if ( strm.avail_in == 0 && (!done)) {

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
@@ -178,9 +179,9 @@ void ruf::LegacyStreamReader::runThread() {
          }
 
          //cout << "Frame with size" << size << "and channel" << chan;
-         log.info("Got frame with header %x, size %i and channel %i", header, size, chan);
+         log.info("Got frame with header %" PRIx32 ", size %" PRIu32 " and channel %" PRIu8, header, size, chan);
          if ( size == 0 ) {
-            log.warning("Bad size read %i",size);
+            log.warning("Bad size read %" PRIu32, size);
             err = true;
             break;
          }
@@ -201,7 +202,7 @@ void ruf::LegacyStreamReader::runThread() {
             if ( bSize > (*it)->getSize() ) bSize = (*it)->getSize();
 
             if ( (ret = read(fd_,(*it)->begin(),bSize)) != bSize) {
-               log.warning("Short read. Ret = %i Req = %i after %i bytes",ret,bSize,frame->getPayload());
+               log.warning("Short read. Ret = %" PRId32 " Req = %" PRIu32 " after %" PRIu32 " bytes", ret, bSize, frame->getPayload());
                ::close(fd_);
                fd_ = -1;
                frame->setError(0x1);

--- a/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
@@ -44,6 +44,7 @@
 #include <fcntl.h>
 #include <rogue/GilRelease.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
@@ -116,7 +117,7 @@ void ruf::LegacyStreamWriter::writeFile ( uint8_t channel, std::shared_ptr<rogue
      // Data count is number of 32-bit words
      if ( channel == RawData ) {
         if ( (size % 4) != 0 )
-           throw(rogue::GeneralError::create("LegacyStreamWriter::writeFile", "FrameSize %i is not 32-bit aligned.",size));
+           throw(rogue::GeneralError::create("LegacyStreamWriter::writeFile", "FrameSize %" PRIu32 " is not 32-bit aligned.", size));
         size = size/4;
      }
 

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <fcntl.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
@@ -179,7 +180,7 @@ void ruf::StreamReader::runThread() {
       // Read size of each frame
       while ( (fd_ >= 0) && (read(fd_,&size,4) == 4) ) {
          if ( size == 0 ) {
-            log.warning("Bad size read %i",size);
+            log.warning("Bad size read %" PRIu32, size);
             err = true;
             break;
          }
@@ -214,7 +215,7 @@ void ruf::StreamReader::runThread() {
             if ( bSize > (*it)->getSize() ) bSize = (*it)->getSize();
 
             if ( (ret = read(fd_,(*it)->begin(),bSize)) != bSize) {
-               log.warning("Short read. Ret = %i Req = %i after %i bytes",ret,bSize,frame->getPayload());
+               log.warning("Short read. Ret = %" PRId32 " Req = %" PRIu32 " after %" PRIu32 " bytes", ret, bSize, frame->getPayload());
                ::close(fd_);
                fd_ = -1;
                frame->setError(0x1);

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -47,6 +47,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <cstring>
+#include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;
 namespace ruf = rogue::utilities::fileio;
@@ -173,7 +174,7 @@ void ruf::StreamWriter::setBufferSize(uint32_t size) {
 
          // Create new buffer
          if ( (buffer_ = (uint8_t *)malloc(size)) == NULL )
-            throw(rogue::GeneralError::create("StreamWriter::setBufferSize","Failed to allocate buffer with size = %i",size));
+            throw(rogue::GeneralError::create("StreamWriter::setBufferSize","Failed to allocate buffer with size = %" PRIu32, size));
          buffSize_ = size;
       }
    }


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

Replace all `"%i"` and related format specifiers with portable equivalents specified in `<inttypes.h>`.

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->

[ESROGUE 526](https://jira.slac.stanford.edu/browse/ESROGUE-526)

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->