### PR TITLE
add missing headers when compiling with devtoolset-11

### DIFF
--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <rogue/EnableSharedFromThis.h>
 #include <memory>
+#include <string>
 
 #include <thread>
 

--- a/src/rogue/hardware/pgp/Info.cpp
+++ b/src/rogue/hardware/pgp/Info.cpp
@@ -22,6 +22,7 @@
 
 #include <rogue/hardware/pgp/Info.h>
 #include <memory>
+#include <string>
 
 namespace rhp = rogue::hardware::pgp;
 


### PR DESCRIPTION
`devtoolset-11` trips over missing `string` headers  not included. Interestingly enough when enabling `c++20` this is not required. `c++11` seems to take a different include path to expose this.

