### PR TITLE
Add value and valueDisp to node information

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -380,6 +380,11 @@ class BaseVariable(pr.Node):
         return VariableValue(self,read=read)
 
     @pr.expose
+    @property
+    def val(self):
+        return self.value
+
+    @pr.expose
     def value(self):
         return self.get(read=False, index=-1)
 
@@ -409,6 +414,11 @@ class BaseVariable(pr.Node):
     @pr.expose
     def getDisp(self, read=True, index=-1):
         return(self.genDisp(self.get(read=read,index=index)))
+
+    @pr.expose
+    @property
+    def valDisp(self):
+        return self.valueDisp
 
     @pr.expose
     def valueDisp(self, read=True, index=-1):

--- a/python/pyrogue/pydm/tools/node_info_tool.py
+++ b/python/pyrogue/pydm/tools/node_info_tool.py
@@ -46,7 +46,7 @@ class NodeInformation(ExternalTool):
             self._command(node,channels[0])
 
     def _variable(self, node, channel):
-        attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum',
+        attrs = ['name', 'val', 'valDisp', 'path', 'description', 'hidden', 'groups', 'enum',
                  'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum',
                  'maximum', 'lowWarning', 'lowAlarm', 'highWarning',
                  'highAlarm', 'alarmStatus', 'alarmSeverity', 'pollInterval']


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->
Added val (i.e. value) and valDisp (i.e. valueDisp) to the node information list for a variable.

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
Since there were already accessor methods (without the @property decorator) used to get value and valueDisp and because changing those kept breaking the code, I decided (at least temporarily) to create new accessors in _Variable.py to get value and valueDisp that I called val and valDisp respectively.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
ESROGUE-506

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->