### PR TITLE
Add `running` flag to `Device` to check whether `_start()` has been called

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -64,10 +64,6 @@ class DataReceiver(pr.Device,ris.Slave):
         self.ByteCount.set(0)
         super().countReset()
 
-    def _start(self):
-        super()._start()
-        self.RxEnable.set(self._enableOnStart)
-
     def _acceptFrame(self, frame):
         # Do nothing if not yet started or enabled
         if self.running is False or self.RxEnable.value() is False:
@@ -110,7 +106,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
     def _start(self):
         super()._start()
-        self.RxEnable.set(value=True)
+        self.RxEnable.set(value=self._enableOnStart)
 
     def _stop(self):
         self.RxEnable.set(value=False)

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -21,6 +21,7 @@ class DataReceiver(pr.Device,ris.Slave):
                  typeStr='UInt8[np]',
                  hideData=True,
                  value=numpy.zeros(shape=1, dtype=numpy.uint8, order='C'),
+                 enableOnStart=True,
                  **kwargs):
 
         pr.Device.__init__(self, **kwargs)
@@ -61,8 +62,12 @@ class DataReceiver(pr.Device,ris.Slave):
         self.ByteCount.set(0)
         super().countReset()
 
+    def _start(self):
+        super()._start()
+        self.RxEnable.set(True)
+
     def _acceptFrame(self, frame):
-        if not self.RxEnable.get():
+        if not self.RxEnable.value():
             return
 
         # Lock frame

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -27,6 +27,8 @@ class DataReceiver(pr.Device,ris.Slave):
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)
 
+        self._enableOnStart = enableOnStart
+
         self.add(pr.LocalVariable(name='RxEnable',
                                   value=True,
                                   description='Frame Rx Enable'))
@@ -64,7 +66,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
     def _start(self):
         super()._start()
-        self.RxEnable.set(True)
+        self.RxEnable.set(self._enableOnStart)
 
     def _acceptFrame(self, frame):
         if not self.RxEnable.value():

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -69,7 +69,8 @@ class DataReceiver(pr.Device,ris.Slave):
         self.RxEnable.set(self._enableOnStart)
 
     def _acceptFrame(self, frame):
-        if not self.RxEnable.value():
+        # Do nothing if not yet started or enabled
+        if self.running is False or self.RxEnable.value() is False:
             return
 
         # Lock frame

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -249,7 +249,7 @@ class Device(pr.Node,rim.Hub):
         for d in self.deviceList:
             d._stop()
 
-    @proptery
+    @property
     def running(self):
         """ Check if Device._start() has been called """
         return self.root is not None and self.root.running

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -144,7 +144,6 @@ class Device(pr.Node,rim.Hub):
         self._memLock    = threading.RLock()
         self._size       = size
         self._defaults   = defaults if defaults is not None else {}
-        self._started    = False
 
         if size != 0:
             print("")
@@ -241,7 +240,6 @@ class Device(pr.Node,rim.Hub):
                 intf._start()
         for d in self.deviceList:
             d._start()
-        self._started = True
 
     def _stop(self):
         """ Called recursively from Root.stop when exiting """
@@ -250,11 +248,11 @@ class Device(pr.Node,rim.Hub):
                 intf._stop()
         for d in self.deviceList:
             d._stop()
-        self._started = False
 
-    def started(self):
+    @proptery
+    def running(self):
         """ Check if Device._start() has been called """
-        return self._started
+        return self.root is not None and self.root.running
 
 
     def addRemoteVariables(self, number, stride, pack=False, **kwargs):

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -144,6 +144,7 @@ class Device(pr.Node,rim.Hub):
         self._memLock    = threading.RLock()
         self._size       = size
         self._defaults   = defaults if defaults is not None else {}
+        self._started    = False
 
         if size != 0:
             print("")
@@ -240,6 +241,7 @@ class Device(pr.Node,rim.Hub):
                 intf._start()
         for d in self.deviceList:
             d._start()
+        self._started = True
 
     def _stop(self):
         """ Called recursively from Root.stop when exiting """
@@ -248,6 +250,11 @@ class Device(pr.Node,rim.Hub):
                 intf._stop()
         for d in self.deviceList:
             d._stop()
+        self._started = False
+
+    def started(self):
+        """ Check if Device._start() has been called """
+        return self._started
 
 
     def addRemoteVariables(self, number, stride, pack=False, **kwargs):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The `Device.running` property is useful inside Device methods that access Variables but might fire before `Device._start()` has been called.

One such example is in `DataReceiver` (or any Device that is also a stream receiver), where `_acceptFrame` might be called before the Device tree has been started.

`DataReceiver` now also allows an `enableOnStart` instantiation parameter to allow `RxEnable` to be optionally set True once the `Device` has been started.

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
The need for the `running` flag was noticed after implementing https://jira.slac.stanford.edu/browse/ESROGUE-548 - #832. Frames arriving before tree start caused errors when accessing `Variables`.