### PR TITLE
ESROGUE-536 - Fix negative values for file size in the GUI

### DIFF
--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -74,7 +74,7 @@ namespace rogue {
                uint64_t currSize_;
 
                //! Total file size in bytes
-               uint32_t totSize_;
+               uint64_t totSize_;
 
                //! Buffering size to cache file writes, zero if disabled
                uint32_t buffSize_;

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -97,7 +97,7 @@ class DataWriter(PyDMFrame):
         w.alarmSensitiveBorder  = True
         fl.addRow('File Open:',w)
 
-        w = PyDMLabel(parent=None, init_channel=self._path + '.CurrentSize')
+        w = PyDMLabel(parent=None, init_channel=self._path + '.CurrentSize/disp')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Current File Size:',w)
@@ -121,7 +121,7 @@ class DataWriter(PyDMFrame):
         w.alarmSensitiveBorder  = True
         fl.addRow('Frame Count:',w)
 
-        w = PyDMLabel(parent=None, init_channel=self._path + '.TotalSize')
+        w = PyDMLabel(parent=None, init_channel=self._path + '.TotalSize/disp')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
         fl.addRow('Total File Size:',w)


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->
Fix conversion of 64-bit values to strings.

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The current and total file sizes do not display correctly on the GUI, as they switch between positive and negative numbers.  The reason is that most likely PyDM is not converting the 64-bit values to strings correctly.  This fix bypasses the PyDM conversion and uses rogue functionality to convert the size to a string and then hands it off to the PyDM widget.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
ESROGUE-536

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->