### PR TITLE
ESROGUE-543: Hide max file size and buffer size if 0 and make them read only.

### DIFF
--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -90,7 +90,10 @@ class DataWriter(PyDMFrame):
         w = PyRogueLineEdit(parent=None, init_channel=self._path + '.BufferSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
-        fl.addRow('Buffer Size:',w)
+        w.check_enable_state = lambda: None
+        w.setReadOnly(True)
+        if w.text().isnumeric() and w.text() != '0':
+          fl.addRow('Buffer Size:',w)
 
         w = PyDMLabel(parent=None, init_channel=self._path + '.IsOpen/disp')
         w.alarmSensitiveContent = False
@@ -114,7 +117,10 @@ class DataWriter(PyDMFrame):
         w = PyRogueLineEdit(parent=None, init_channel=self._path + '.MaxFileSize')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
-        fl.addRow('Max Size:',w)
+        w.check_enable_state = lambda: None
+        w.setReadOnly(True)
+        if w.text().isnumeric() and w.text() != '0':
+          fl.addRow('Max Size:',w)
 
         w = PyDMLabel(parent=None, init_channel=self._path + '.FrameCount')
         w.alarmSensitiveContent = False

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -93,7 +93,7 @@ class DataWriter(PyDMFrame):
         w.check_enable_state = lambda: None
         w.setReadOnly(True)
         if w.text().isnumeric() and w.text() != '0':
-          fl.addRow('Buffer Size:',w)
+            fl.addRow('Buffer Size:',w)
 
         w = PyDMLabel(parent=None, init_channel=self._path + '.IsOpen/disp')
         w.alarmSensitiveContent = False
@@ -120,7 +120,7 @@ class DataWriter(PyDMFrame):
         w.check_enable_state = lambda: None
         w.setReadOnly(True)
         if w.text().isnumeric() and w.text() != '0':
-          fl.addRow('Max Size:',w)
+            fl.addRow('Max Size:',w)
 
         w = PyDMLabel(parent=None, init_channel=self._path + '.FrameCount')
         w.alarmSensitiveContent = False


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->
ESROGUE-543: Hide max file size and buffer size if 0 and make them read only.

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
Hide max file size and buffer size widgets if 0 and make them read only when not hidden.  Note that those were not made class instance attributes as described in the JIRA ticket.  I didn't see the need for that.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
ESROGUE-543.

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->