### PR TITLE
ESROGUE-569 - Add function to dump entire tree including Variable attributes to dict

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -206,7 +206,7 @@ class BaseCommand(pr.BaseVariable):
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
         pass
 
-    def _getDict(self,modes,incGroups,excGroups):
+    def _getDict(self,modes,incGroups,excGroups,properties):
         return None
 
     def get(self,read=True, index=-1):

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -92,7 +92,7 @@ class MemoryDevice(pr.Device):
             for offset, values in d.items():
                 self._setValues[offset] = [self._base.fromString(s) for s in values.split(',')]
 
-    def _getDict(self,modes,incGroups,excGroups):
+    def _getDict(self,modes,incGroups,excGroups,properties):
         return None
 
     def writeBlocks(self, force=False, recurse=True, variable=None, checkEach=False):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -72,12 +72,6 @@ def expose(item):
     item._rogueExposed = True
     return item
 
-def isExposed(item):
-    if inspect.isdatadescriptor(item):
-        return hasattr(item.fget, '_rogueExposed') and item.fget._rogueExposed
-    else:
-        return hasattr(item, '_rogueExposed') and item._rogueExposed
-
 
 class NodeError(Exception):
     """ Exception for node manipulation errors."""
@@ -128,6 +122,10 @@ class Node(object):
 
         if hidden is True:
             self.addToGroup('Hidden')
+
+    def __repr__(self):
+        return f'{self.__class__} - {self.path}'
+            
 
     @property
     def name(self):
@@ -531,7 +529,7 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
-    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None):
+    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
         """
         Get variable values in a dictionary starting from this level.
         Attributes that are Nodes are recursed.
@@ -540,7 +538,7 @@ class Node(object):
         data = odict()
         for key,value in self.nodes.items():
             if value.filterByGroup(incGroups,excGroups):
-                nv = value._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)
+                nv = value._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups, properties=properties)
             if nv is not None:
                 data[key] = nv
 
@@ -548,9 +546,6 @@ class Node(object):
             return None
         else:
             return data
-
-    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
-        return self._getDict(modes, incGroups, excGroups, properties)
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
 

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -124,8 +124,7 @@ class Node(object):
             self.addToGroup('Hidden')
 
     def __repr__(self):
-        return f'{self.__class__} - {self.path}'
-            
+        return f'{self.__class__} - {self.path}' 
 
     @property
     def name(self):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -124,7 +124,7 @@ class Node(object):
             self.addToGroup('Hidden')
 
     def __repr__(self):
-        return f'{self.__class__} - {self.path}' 
+        return f'{self.__class__} - {self.path}'
 
     @property
     def name(self):

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -531,7 +531,7 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
-    def _getDict(self,modes,incGroups,excGroups):
+    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None):
         """
         Get variable values in a dictionary starting from this level.
         Attributes that are Nodes are recursed.
@@ -548,6 +548,9 @@ class Node(object):
             return None
         else:
             return data
+
+    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
+        return self._getDict(modes, incGroups, excGroups, properties)
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
 

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -192,9 +192,6 @@ class Node(object):
     def guiGroup(self):
         return self._guiGroup
 
-    def __repr__(self):
-        return self.path
-
     def __getattr__(self, name):
         """Allow child Nodes with the 'name[key]' naming convention to be accessed as if they belong to a
         dictionary of Nodes with that 'name'.

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -72,6 +72,12 @@ def expose(item):
     item._rogueExposed = True
     return item
 
+def isExposed(item):
+    if inspect.isdatadescriptor(item):
+        return hasattr(item.fget, '_rogueExposed') and item.fget._rogueExposed
+    else:
+        return hasattr(item, '_rogueExposed') and item._rogueExposed
+
 
 class NodeError(Exception):
     """ Exception for node manipulation errors."""

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -858,6 +858,13 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._read()
         return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
 
+    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
+        d = super().treeDict(modes, incGroups, excGroups, properties)
+        return {self.name: d}
+
+    def treeYaml(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
+        return pr.dataToYaml(self.treeDict(modes, incGroups, excGroups, properties))
+
     def setYaml(self,yml,writeEach,modes,incGroups,excGroups):
         """
         Set variable values from a yaml file

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -597,7 +597,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                 data += "{}\t".format(v.maximum)
                 data += "{}\t".format(v.enum)
                 data += "{}\t".format(v.overlapEn)
-                data += "{}\t".format(v.verify)
+                data += "{}\t".format(v.verifyEn)
                 data += "{}\t".format(v._base.modelId)
                 data += "{}\t".format(v._base.isBigEndian)
                 data += "{}\t".format(v._base.bitReverse)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -858,8 +858,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self._read()
         return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
 
-    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
-        d = super().treeDict(modes, incGroups, excGroups, properties)
+    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None):
+        d = self._getDict(modes, incGroups, excGroups, properties=True)
         return {self.name: d}
 
     def treeYaml(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -107,7 +107,7 @@ class VariableListData(object):
 
     def __repr__(self):
         return f'{self.__class__}({self.__dict__})'
-    
+ 
 
 
 class BaseVariable(pr.Node):
@@ -200,7 +200,7 @@ class BaseVariable(pr.Node):
            (self._mode != 'WO'):
             raise VariableError(f'Invalid variable mode {self._mode}. Supported: RW, RO, WO')
 
-        
+ 
         # Call super constructor
         pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups, guiGroup=guiGroup)
 
@@ -306,7 +306,7 @@ class BaseVariable(pr.Node):
         d['value'] = self.value()
         d['valueDisp'] = self.valueDisp()
         d['class'] = self.__class__.__name__
-        
+ 
         for p in self.PROPS:
             d[p] = getattr(self, p)
         return d
@@ -533,13 +533,13 @@ class BaseVariable(pr.Node):
         elif self._mode in modes:
             self.setDisp(d,writeEach)
 
-            
+ 
     def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
         if self._mode in modes:
             if properties is False:
                 return VariableValue(self)
             else:
-                return self.properties()                
+                return self.properties()
         else:
             return None
 
@@ -702,6 +702,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
     ##############################
     # Properties held by C++ class
     ##############################
+    
     @property
     def numValues(self):
         return self._numValues()
@@ -732,7 +733,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
     @property
     def overlapEn(self):
         return self._overlapEn()
-    
+ 
     @pr.expose
     @property
     def bitSize(self):
@@ -752,6 +753,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
     ########################
     # Local Properties
     ########################
+    
     @pr.expose
     @property
     def address(self):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -105,7 +105,7 @@ class VariableListData(object):
 
 class BaseVariable(pr.Node):
 
-    PROPS = ['name', 'path', 'mode', 'typeStr', 'value', 'valueDisp', 'enum',
+    PROPS = ['name', 'path', 'mode', 'typeStr', 'enum',
              'disp', 'precision', 'units', 'minimum', 'maximum',
              'nativeType', 'ndType', 'updateNotify',
              'hasAlarm', 'lowWarning', 'highWarning', 'lowAlarm',
@@ -294,8 +294,18 @@ class BaseVariable(pr.Node):
         stat,sevr = self._alarmState(self.value())
         return sevr
 
-    def properties(self)
-        ret = {p:getattr(self, p) for p in self.PROPS}
+    def properties(self, props=None):
+        if props is None:
+            props = self.PROPS
+            
+        d = odict()
+        d['value'] = self.value()
+        d['valueDisp'] = self.valueDisp()
+        d['class'] = self.__class__.__name__
+        
+        for p in props:
+            d[p] = getattr(self, p)
+        return d
 
     def addDependency(self, dep):
         if dep not in self.__dependencies:
@@ -423,8 +433,8 @@ class BaseVariable(pr.Node):
         return(self.genDisp(self.get(read=read,index=index)))
 
     @pr.expose
-    def valueDisp(self, read=True, index=-1):
-        return self.getDisp(read=False,index=index)
+    def valueDisp(self): #, read=True, index=-1):
+        return self.getDisp(read=False,index=-1)
 
     @pr.expose
     def parseDisp(self, sValue):
@@ -519,11 +529,16 @@ class BaseVariable(pr.Node):
         elif self._mode in modes:
             self.setDisp(d,writeEach)
 
-    def _getDict(self,modes,incGroups,excGroups):
+            
+    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None):
         if self._mode in modes:
             return VariableValue(self)
         else:
             return None
+
+    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
+        return self.properties(properties)
+        
 
     def _queueUpdate(self):
         self._root._queueUpdates(self)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -95,12 +95,19 @@ class VariableValue(object):
 
         self.status, self.severity = var._alarmState(self.value)
 
+    def __repr__(self):
+        return f'{str(self.__class__)}({self.__dict__})'
+
 
 class VariableListData(object):
     def __init__(self, numValues, valueBits, valueStride):
         self.numValues   = numValues
         self.valueBits   = valueBits
         self.valueStride = valueStride
+
+    def __repr__(self):
+        return f'{self.__class__}({self.__dict__})'
+    
 
 
 class BaseVariable(pr.Node):
@@ -294,16 +301,13 @@ class BaseVariable(pr.Node):
         stat,sevr = self._alarmState(self.value())
         return sevr
 
-    def properties(self, props=None):
-        if props is None:
-            props = self.PROPS
-            
+    def properties(self):
         d = odict()
         d['value'] = self.value()
         d['valueDisp'] = self.valueDisp()
         d['class'] = self.__class__.__name__
         
-        for p in props:
+        for p in self.PROPS:
             d[p] = getattr(self, p)
         return d
 
@@ -530,15 +534,15 @@ class BaseVariable(pr.Node):
             self.setDisp(d,writeEach)
 
             
-    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None):
+    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
         if self._mode in modes:
-            return VariableValue(self)
+            if properties is False:
+                return VariableValue(self)
+            else:
+                return self.properties()                
         else:
             return None
 
-    def treeDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=None):
-        return self.properties(properties)
-        
 
     def _queueUpdate(self):
         self._root._queueUpdates(self)
@@ -577,6 +581,7 @@ class BaseVariable(pr.Node):
 
         else:
             return 'Good','Good'
+
 
 
 class RemoteVariable(BaseVariable,rim.Variable):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -107,7 +107,7 @@ class VariableListData(object):
 
     def __repr__(self):
         return f'{self.__class__}({self.__dict__})'
- 
+
 
 
 class BaseVariable(pr.Node):
@@ -200,7 +200,7 @@ class BaseVariable(pr.Node):
            (self._mode != 'WO'):
             raise VariableError(f'Invalid variable mode {self._mode}. Supported: RW, RO, WO')
 
- 
+
         # Call super constructor
         pr.Node.__init__(self, name=name, description=description, hidden=hidden, groups=groups, guiGroup=guiGroup)
 
@@ -306,7 +306,7 @@ class BaseVariable(pr.Node):
         d['value'] = self.value()
         d['valueDisp'] = self.valueDisp()
         d['class'] = self.__class__.__name__
- 
+
         for p in self.PROPS:
             d[p] = getattr(self, p)
         return d
@@ -533,7 +533,7 @@ class BaseVariable(pr.Node):
         elif self._mode in modes:
             self.setDisp(d,writeEach)
 
- 
+
     def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
         if self._mode in modes:
             if properties is False:
@@ -702,7 +702,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
     ##############################
     # Properties held by C++ class
     ##############################
-    
+
+
     @property
     def numValues(self):
         return self._numValues()
@@ -733,7 +734,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
     @property
     def overlapEn(self):
         return self._overlapEn()
- 
+
     @pr.expose
     @property
     def bitSize(self):
@@ -753,7 +754,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
     ########################
     # Local Properties
     ########################
-    
+
+
     @pr.expose
     @property
     def address(self):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
A new `treeDict()` method has been added to `Root` to get the entire tree, including Variable attributes, as a recursive dict.
A new `properties()` method has been added to `BaseVariable` that returns a dictionary of all the `Variable`'s relevant properties.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
The new method works by calling `_getDict()` underneath. A new `properties` parameter has been added to `_getDict()` to determine whether the dictionary has all the Variable properties or just a `VariableValue`.

This might not be a great way to implement this, and we should discuss it.


### JIRA
<!--- Optional. Provide a link to any relevant JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESROGUE-569
### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->