### PR TITLE
bug fix for Logging.cpp warning message

### DIFF
--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -104,7 +104,7 @@ void rogue::Logging::intLog(uint32_t level, const char * fmt, va_list args) {
    char buffer[1000];
    vsnprintf(buffer,1000,fmt,args);
    gettimeofday(&tme,NULL);
-   printf("%" PRIuLEAST32 ".%06" PRIuLEAST32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
+   printf("%l" PRIi32 ".%06l" PRIi32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
 }
 
 void rogue::Logging::log(uint32_t level, const char * fmt, ...) {


### PR DESCRIPTION
### Description
- Removes a warning message when building from source (instead of anaconda)
```
/u/re/ruckman/projects/rogue/src/rogue/Logging.cpp: In member function ‘void rogue::Logging::intLog(uint32_t, const char*, __va_list_tag*)’:
/u/re/ruckman/projects/rogue/src/rogue/Logging.cpp:107:11: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 2 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
  107 |    printf("%" PRIuLEAST32 ".%06" PRIuLEAST32 ":%s: %s\n", tme.tv_sec, tme.tv_usec, name_.c_str(), buffer);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~
      |                                                               |
      |                                                               __time_t {aka long int}
/u/re/ruckman/projects/rogue/src/rogue/Logging.cpp:107:11: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘__suseconds_t’ {aka ‘long int’} [-Wformat=]
```