### PR TITLE
Apply style sheet rule centrally on RogueLineEdit

### DIFF
--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -24,8 +24,8 @@ class DefaultTop(Display):
     def __init__(self, parent=None, args=[], macros=None):
         super(DefaultTop, self).__init__(parent=parent, args=args, macros=None)
 
-        self.setStyleSheet("*[dirty='true']\
-                           {background-color: orange;}")
+        #self.setStyleSheet("*[dirty='true']\
+        #                   {background-color: orange;}")
 
         self.sizeX  = None
         self.sizeY  = None

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -10,6 +10,9 @@ class PyRogueLineEdit(PyDMLineEdit):
         self.textEdited.connect(self.text_edited)
         self._dirty = False
 
+        self.setStyleSheet("*[dirty='true']\
+                           {background-color: orange;}")
+
     def text_edited(self):
         self._dirty = True
         refresh_style(self)


### PR DESCRIPTION
In the previous code we applied the "go orange when dirty" style rule in the pyDmTop.py file. This does not apply when the user creates their own ui file, or top level application code.

Instead I now apply this style rule in the only widget which currently is using the dirty flag.
