### PR TITLE
Add per node yaml dump

### DIFF
--- a/notebooks/ExampleRoot.ipynb
+++ b/notebooks/ExampleRoot.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "id": "aff0a06c",
    "metadata": {},
    "outputs": [
@@ -22,7 +22,7 @@
        "0"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -31,13 +31,6 @@
      "output_type": "stream",
      "text": [
       "xterm: cannot load font \"-misc-fixed-medium-r-semicondensed--13-120-75-75-c-60-iso10646-1\"\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:pyrogue.VirtualClient.VirtualClient:I have finally heard from ExampleRoot. All is good!\n"
      ]
     }
    ],
@@ -96,17 +89,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "id": "0d52d2f5",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to ExampleRoot at localhost:9099\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "'2022-03-15 17:24:30 PDT'"
+       "'2022-03-25 13:45:05 PDT'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1730d87",
+   "id": "f1011203",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -526,7 +526,7 @@ class Node(object):
             self.addToGroup(grp)
 
     @expose
-    def getYaml(self,readFirst=False,modes=['RW','RO','WO'],incGroups=None,excGroups=None):
+    def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
 
         """
         Get current values as yaml data.
@@ -535,20 +535,28 @@ class Node(object):
         """
         if readFirst:
             self.root._read()
-        return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
+        return pr.dataToYaml({self.name:self._getDict(modes=modes, incGroups=incGroups, excGroups=excGroups, recurse=recurse)})
 
-    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
+    def printYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
+        print(self.getYaml(readFirst=readFirst, modes=modes, incGroups=incGroups, excGroups=excGroups, recurse=recurse))
+
+    def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False, recurse=True):
         """
         Get variable values in a dictionary starting from this level.
         Attributes that are Nodes are recursed.
         modes is a list of variable modes to include.
         """
         data = odict()
-        for key,value in self.nodes.items():
-            if value.filterByGroup(incGroups,excGroups):
-                nv = value._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups, properties=properties)
+        for key,value in self.variablesByGroup(incGroups, excGroups).items():
+            nv = value._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups, properties=properties)
             if nv is not None:
                 data[key] = nv
+
+        if recurse:
+            for key, value in self.devicesByGroup(incGroups, excGroups).items():
+                nv = value._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups, properties=properties)
+                if nv is not None:
+                    data[key] = nv
 
         if len(data) == 0:
             return None

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -525,6 +525,17 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
+    @expose
+    def getYaml(self,readFirst=False,modes=['RW','RO','WO'],incGroups=None,excGroups=None):
+        """
+        Get current values as yaml data.
+        modes is a list of variable modes to include.
+        If readFirst=True a full read from hardware is performed.
+        """
+        if readFirst:
+            self.root._read()
+        return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
+
     def _getDict(self,modes,incGroups,excGroups):
         """
         Get variable values in a dictionary starting from this level.

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -525,7 +525,7 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
-    @expose
+    @pr.expose
     def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
 
         """

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -525,7 +525,7 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
-    @pr.expose
+    @expose
     def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
 
         """

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -527,7 +527,7 @@ class Node(object):
 
     @expose
     def getYaml(self,readFirst=False,modes=['RW','RO','WO'],incGroups=None,excGroups=None):
-    
+
         """
         Get current values as yaml data.
         modes is a list of variable modes to include.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -753,7 +753,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._log.info("Done root read")
         return True
 
-    @expose
+    @pr.expose
     def saveYaml(self,name,readFirst,modes,incGroups,excGroups,autoPrefix,autoCompress):
         """Save YAML configuration/status to a file. Called from command"""
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -850,16 +850,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         return True
 
-    def getYaml(self,readFirst,modes,incGroups,excGroups):
-        """
-        Get current values as yaml data.
-        modes is a list of variable modes to include.
-        If readFirst=True a full read from hardware is performed.
-        """
-        if readFirst:
-            self._read()
-        return pr.dataToYaml({self.name:self._getDict(modes=modes,incGroups=incGroups,excGroups=excGroups)})
-
     def setYaml(self,yml,writeEach,modes,incGroups,excGroups):
         """
         Set variable values from a yaml file
@@ -880,7 +870,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         if self.InitAfterConfig.value():
             self.initialize()
-
 
     def remoteVariableDump(self,name,modes,readFirst):
         """Dump remote variable values to a file."""

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -753,6 +753,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._log.info("Done root read")
         return True
 
+    @expose
     def saveYaml(self,name,readFirst,modes,incGroups,excGroups,autoPrefix,autoCompress):
         """Save YAML configuration/status to a file. Called from command"""
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -185,6 +185,9 @@ class VirtualNode(pr.Node):
     def _setDict(self,*args,**kwargs):
         raise pr.NodeError('_setDict not supported in VirtualNode')
 
+    def printYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
+        print(self.getYaml(readFirst=readFirst, modes=modes, incGroups=incGroups, excGroups=excGroups, recurse=recurse))
+
     def _doUpdate(self, val):
         for func in self._functions:
             func(self.path,val)


### PR DESCRIPTION
Moves the getYaml function to the node so that you can dump the configuration at deeper levels. 