### PR TITLE
ESROGUE-578 - Delete thread created with new

### DIFF
--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -134,7 +134,7 @@ void rpr::Controller::stop() {
       rogue::GilRelease noGil;
       threadEn_ = false;
       thread_->join();
-      thread_ = NULL;
+      delete thread_;
       state_ = StClosed;
    }
 }


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
In `rpr::Controller::start` a thread was created using new, but never freed. The `stop` method now calls `delete thread_` to make sure it gets freed.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->

### JIRA
<!--- Optional. Provide a link to any relavent JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESROGUE-578

### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
https://github.com/slaclab/rogue/issues/862