### PR TITLE
Add functions for operating on custom list of Blocks

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -34,28 +34,28 @@ def writeBlocks(blocks, force=False, checkEach=False, index=-1, **kwargs):
         Allows a custom list of blocks to be efficiently written,
         similar to Device.writeBlocks(). """
     for b in blocks:
-        b._startTransaction(type=rim.Write, forceWr=force, checkEach=checkEach, index=index)
+        startTransaction(b, type=rim.Write, forceWr=force, checkEach=checkEach, index=index, **kwargs)
 
 def verifyBlocks(blocks, checkEach=False, **kwargs):
     """ Helper function for verifying a list of blocks.
         Allows a custom list of blocks to be efficiently verified without blocking
         between each read, similar to Device.verifyBlocks(). """
     for b in blocks:
-        b._startTransaction(type=rim.Verify, checkEach=checkEach)
+        startTransaction(b, type=rim.Verify, checkEach=checkEach, **kwargs)
 
 def readBlocks(blocks, checkEach=False, **kwargs):
     """ Helper function for reading a list of blocks.
         Allows a custom list of blocks to be efficiently read without blocking
         between each read, similar to Device.readBlocks(). """
     for b in blocks:
-        b._startTransaction(type=rim.Read, checkEach=checkEach)
+        startTransaction(b, type=rim.Read, checkEach=checkEach, **kwargs)
 
 def checkBlocks(blocks, **kwargs):
     """ Helper function for waiting on block transactions for a list of blocks
         Allows a custom list of blocks to be efficiently operated on without blocking
         between each transaction, similar to  Device.checkBlocks(). """
     for b in blocks:
-        b._checkTransaction()
+        checkTransaction(b)
 
 def writeAndVerifyBlocks(blocks, force=False, checkEach=False, index=-1, **kwargs):
     """ Helper function for writing and verifying a list of blocks.
@@ -265,4 +265,3 @@ class LocalBlock(object):
             self.set(None, self.get(None) | other)
             if self._enable:
                 self._variable._queueUpdate()
-

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -18,6 +18,7 @@ import shlex
 import numpy as np
 import ast
 import sys
+import functools
 from collections import OrderedDict as odict
 from collections.abc import Iterable
 
@@ -1021,7 +1022,6 @@ class LocalVariable(BaseVariable):
         self._block._ior(other)
         return self
 
-
 class LinkVariable(BaseVariable):
 
     def __init__(self, *,
@@ -1091,3 +1091,14 @@ class LinkVariable(BaseVariable):
             pr.logException(self._log,e)
             self._log.error("Error getting link variable '{}'".format(self.path))
             raise e
+
+    @functools.cache
+    def getBlocks(self):
+        b = [] # list of blocks
+        for d in self.dependencies:
+            if isinstance(d, LinkVariable):
+                b.extend(d.getBlocks())
+            if hasattr(d, '_block') and d._block is not None:
+                b.append(d._block)
+
+        return b

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1092,7 +1092,7 @@ class LinkVariable(BaseVariable):
             self._log.error("Error getting link variable '{}'".format(self.path))
             raise e
 
-    @functools.lru_cache
+
     def getBlocks(self):
         b = [] # list of blocks
         for d in self.dependencies:
@@ -1102,3 +1102,10 @@ class LinkVariable(BaseVariable):
                 b.append(d._block)
 
         return b
+
+    def _finishInit(self):
+        self._depBlocks = self.getBlocks()
+
+    @property
+    def depBlocks(self):
+        return self._depBlocks

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1098,7 +1098,7 @@ class LinkVariable(BaseVariable):
         for d in self.dependencies:
             if isinstance(d, LinkVariable):
                 b.extend(d.getBlocks())
-            if hasattr(d, '_block') and d._block is not None:
+            elif hasattr(d, '_block') and d._block is not None:
                 b.append(d._block)
 
         return b

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -18,7 +18,6 @@ import shlex
 import numpy as np
 import ast
 import sys
-import functools
 from collections import OrderedDict as odict
 from collections.abc import Iterable
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1093,19 +1093,21 @@ class LinkVariable(BaseVariable):
             raise e
 
 
-    def getBlocks(self):
+    def _getBlocks(self):
         b = [] # list of blocks
         for d in self.dependencies:
             if isinstance(d, LinkVariable):
-                b.extend(d.getBlocks())
+                b.extend(d._getBlocks())
             elif hasattr(d, '_block') and d._block is not None:
                 b.append(d._block)
 
         return b
 
     def _finishInit(self):
-        self._depBlocks = self.getBlocks()
+        super()._finishInit()        
+        self._depBlocks = self._getBlocks()
 
     @property
     def depBlocks(self):
+        """ Return a list of Blocks that this LinkVariable depends on """
         return self._depBlocks

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1092,7 +1092,7 @@ class LinkVariable(BaseVariable):
             self._log.error("Error getting link variable '{}'".format(self.path))
             raise e
 
-    @functools.cache
+    @functools.lru_cache
     def getBlocks(self):
         b = [] # list of blocks
         for d in self.dependencies:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1070,6 +1070,8 @@ class LinkVariable(BaseVariable):
             for d in dependencies:
                 self.addDependency(d)
 
+        self.__depBlocks = []
+
     def __getitem__(self, key):
         # Allow dependencies to be accessed as indices of self
         return self.dependencies[key]
@@ -1093,21 +1095,21 @@ class LinkVariable(BaseVariable):
             raise e
 
 
-    def _getBlocks(self):
-        b = [] # list of blocks
+    def __getBlocks(self):
+        b = []
         for d in self.dependencies:
             if isinstance(d, LinkVariable):
-                b.extend(d._getBlocks())
+                b.extend(d.__getBlocks())
             elif hasattr(d, '_block') and d._block is not None:
                 b.append(d._block)
 
         return b
 
     def _finishInit(self):
-        super()._finishInit()        
-        self._depBlocks = self._getBlocks()
+        super()._finishInit()
+        self.__depBlocks = self.__getBlocks()
 
     @property
     def depBlocks(self):
         """ Return a list of Blocks that this LinkVariable depends on """
-        return self._depBlocks
+        return self.__depBlocks


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This change allows write, verify, read, and check to be performed on a custom list of Blocks.
It also provides a LinkVarable.getBlocks() method to get a list of all Blocks held by the LinkVariable dependencies.
You can then use the new Block functions to efficiently operate on this list of Blocks.

### Details
<!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
This change is particularly useful for LinkVariables that aggregate a group of RemoteVariables. It allows for those RemoteVariables to be accessed efficiently without blocking (`checkBlocks()`) between each RemoteVariable read/write/verify.

Example:
```python
class GroupLinkVariable(pr.LinkVariable):
    def __init__(self, **kwargs):
        super().__init__(
            linkedSet=self._set,
            linkedGet=self._get,
            **kwargs)
        
    def _set(self, *, value, index, write):
        # Dependencies represent each index in order
        # So just use those references to do the set accesses
        with self.parent.root.updateGroup():
            if index != -1:
                # Individual index writes happen as normal
                self.dependencies[index].set(value=value, write=write)
            else:
                for idx, (var, val) in enumerate(zip(self.dependencies, value)):
                    # Set shadow values without writing to hardware
                    var.set(value=val, write=False)

                if write is True:
                    pr.writeAndVerifyBlocks(self.depBlocks)

    def _get(self, *, index, read):
        # Dependencies represent each index in order
        # So just use those references to do the get accesses
        with self.parent.root.updateGroup():
            if index != -1:
                return self.dependencies[index].get(read=read)
            else:
                if read is True:
                    # Do a hardware read on all the dependency Blocks
                    pr.readAndCheckBlocks(self.depBlocks)
                    
                # Assign results to return variable
                ret = np.zeros(len(self.dependencies), np.float)
                for idx, var in enumerate(self.dependencies):
                    ret[idx] = var.get(read=False)

                return ret
```
