### PR TITLE
bug fix for XVC.stop()

### DIFF
--- a/src/rogue/protocols/xilinx/Xvc.cpp
+++ b/src/rogue/protocols/xilinx/Xvc.cpp
@@ -102,8 +102,9 @@ void rpx::Xvc::stop()
    if (threadEn_)  
    {
       threadEn_ = false;
-      thread_->join();
+      thread_->detach();
       delete thread_;
+      thread_ = NULL;
    }
 }
 


### PR DESCRIPTION
### Description
- [Using the detach() instead of join() for stopping the thread]( https://stackoverflow.com/questions/37015775/what-is-different-between-join-and-detach-for-multi-threading-in-c)
- Setting `thread_ = NULL;` (same method as rssi.Controller.stop())