### PR TITLE
Fix bug in start and stop recursion

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -238,7 +238,7 @@ class Device(pr.Node,rim.Hub):
         for intf in self._ifAndProto:
             if hasattr(intf,"_start"):
                 intf._start()
-        for d in self.deviceList:
+        for d in self.devices.values():
             d._start()
 
     def _stop(self):
@@ -246,7 +246,7 @@ class Device(pr.Node,rim.Hub):
         for intf in self._ifAndProto:
             if hasattr(intf,"_stop"):
                 intf._stop()
-        for d in self.deviceList:
+        for d in self.devices.values():
             d._stop()
 
     @property

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -234,7 +234,7 @@ class Device(pr.Node,rim.Hub):
         self._ifAndProto.extend(interfaces)
 
     def _start(self):
-        """ Called recursively from Root.stop when starting """
+        """ Called recursively from Root.start when starting """
         for intf in self._ifAndProto:
             if hasattr(intf,"_start"):
                 intf._start()


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
`Device._start()` and `Device._stop()` were calling `self.deviceList` to recurse. But this is the wrong call, as it returns a full recursion of every Device in the tree from that point. The effect was that `_start()` and `_stop()` were being called multiple times on each Device depending on the tree depth.

The updated methods use `self.devices.values()` to iterate through child `Devices`.

**There is a big inconsistency between `Node.nodeList`, `Node.variableList`, and `Node.deviceList`.
`nodeList` is not recursive. It just gets a list of the child Nodes. But `variableList` and `deviceList` are recursive.**

Currently `Root` is the only caller of `deviceList`. A few things call `variableList` (https://github.com/search?l=Python&q=org%3Aslaclab+variableList&type=Code). I can't find anything that calls `nodeList`.

We should decide what to do about this. I think I prefer these all to be non-recursive, or maybe even get rid of them entirely. Iterating of children should be done with the `nodes`, `commands`, `variables` or `devices` properties. I've created a new JIRA ticket for this issue, so we can merge this PR now and solve that problem later. https://jira.slac.stanford.edu/browse/ESROGUE-599