### PR TITLE
Fix E275 Flake8 Errors

### DIFF
--- a/python/pyrogue/_DataWriter.py
+++ b/python/pyrogue/_DataWriter.py
@@ -114,15 +114,15 @@ class DataWriter(pr.Device):
 
     def _getCurrentSize(self):
         """get current file size. Override in sub-class"""
-        return(0)
+        return 0
 
     def _getTotalSize(self):
         """get total file size. Override in sub-class"""
-        return(0)
+        return 0
 
     def _getFrameCount(self):
         """get current file frame count. Override in sub-class"""
-        return(0)
+        return 0
 
     def _genFileName(self):
         """

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -210,7 +210,7 @@ class Node(object):
 
 
     def __dir__(self):
-        return(super().__dir__() + [k for k,v in self._nodes.items()])
+        return super().__dir__() + [k for k,v in self._nodes.items()]
 
     def __reduce__(self):
         attr = {}
@@ -341,7 +341,7 @@ class Node(object):
         """
         Get sub-nodes in a list
         """
-        return([k for k,v in self._nodes.items()])
+        return [k for k,v in self._nodes.items()]
 
     def getNodes(self,typ,excTyp=None,incGroups=None,excGroups=None):
         """

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -434,7 +434,7 @@ class BaseVariable(pr.Node):
 
     @pr.expose
     def getDisp(self, read=True, index=-1):
-        return(self.genDisp(self.get(read=read,index=index)))
+        return self.genDisp(self.get(read=read,index=index))
 
     @pr.expose
     def valueDisp(self, index=-1): #, read=True, index=-1):

--- a/python/pyrogue/examples/_AxiVersion.py
+++ b/python/pyrogue/examples/_AxiVersion.py
@@ -369,7 +369,7 @@ class AxiVersion(pr.Device):
         @self.command(hidden=False,value='',retValue='')
         def TestCommand(arg):
             print('Got {}'.format(arg))
-            return('Got {}'.format(arg))
+            return 'Got {}'.format(arg)
 
         @self.command(hidden=False,value='',retValue='')
         def TestMemoryException(arg):
@@ -385,11 +385,11 @@ class AxiVersion(pr.Device):
 
         @self.command(hidden=False,value='',retValue='')
         def TestGeneralException(arg):
-            return(rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0,True))
+            return rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0,True)
 
         @self.command(hidden=False,value='',retValue='')
         def TestOtherError(arg):
-            return(rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0))
+            return rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0)
 
         @self.command(hidden=False,value='blah blah',retValue='')
         def TestCmdString(arg):

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -322,7 +322,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             raise Exception(f"ZMQ Interface Exception: {e}")
 
         if isinstance(ret,Exception):
-            raise(ret)
+            raise ret
 
         return ret
 

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -141,10 +141,10 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         return 0
 
     def _doMaxAccess(self):
-        return(self._maxSize)
+        return self._maxSize
 
     def _doMinAccess(self):
-        return(self._minWidth)
+        return self._minWidth
 
     def _doTransaction(self,transaction):
         address = transaction.address()

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -284,7 +284,7 @@ class UdpRssiPack(pr.Device):
         ))
 
     def application(self,dest):
-        return(self._pack.application(dest))
+        return self._pack.application(dest)
 
     def countReset(self):
         self._rssi.resetCounters()

--- a/python/pyrogue/utilities/cpsw.py
+++ b/python/pyrogue/utilities/cpsw.py
@@ -18,7 +18,7 @@ import math
 
 def exportRemoteVariable(variable,indent):
 
-    if variable.ndType is not None or not('Bool' in variable.typeStr or 'String' in variable.typeStr or 'Int' in variable.typeStr):
+    if variable.ndType is not None or not ('Bool' in variable.typeStr or 'String' in variable.typeStr or 'Int' in variable.typeStr):
         print(f"Error: Found variable {variable.path} with unsupported type {variable.typeStr}, error exporting")
         return ""
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -85,17 +85,17 @@ class HubTestDev(pr.Device):
     # Return the command field from the read data
     @classmethod
     def cmd_address(cls, data): # returns address data
-        return((data & 0x7FFF0000) >> 20)
+        return (data & 0x7FFF0000) >> 20
 
     # Return the data field from the read data
     @classmethod
     def cmd_data(cls, data):  # returns data
-        return(data & 0xFFFFF)
+        return (data & 0xFFFFF)
 
     # Build the data field for a write command
     @classmethod
     def cmd_make(cls, read, address, data):
-        return((read << 31) | ((address << 20) & 0x7FF00000) | (data & 0xFFFFF))
+        return ((read << 31) | ((address << 20) & 0x7FF00000) | (data & 0xFFFFF))
 
     # Helper function to initiate outbound write transactions and wait for the result
     # Returns error string or "" for no error
@@ -200,10 +200,10 @@ class TestEmulate(rogue.interfaces.memory.Slave):
         return 0
 
     def _doMaxAccess(self):
-        return(self._maxSize)
+        return self._maxSize
 
     def _doMinAccess(self):
-        return(self._minWidth)
+        return self._minWidth
 
     def _doTransaction(self,transaction):
         address = transaction.address()


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This fixes all instances of the new E275 "Missing whitespace after keyword" flake8 error. This error is checked by default in the newest version of flake8.
