### PR TITLE
Memory retry test improvements

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -28,3 +28,4 @@ dependencies:
   - pydm
   - matplotlib
   - pytest
+  - pytest-cov

--- a/conda.yml
+++ b/conda.yml
@@ -27,3 +27,4 @@ dependencies:
   - sqlalchemy
   - pydm
   - matplotlib
+  - pytest

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -23,3 +23,4 @@ dependencies:
   - pydm
   - pyserial
   - matplotlib
+  - pytest

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -24,3 +24,4 @@ dependencies:
   - pyserial
   - matplotlib
   - pytest
+  - pytest-cov

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -152,7 +152,6 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         type    = transaction.type()
 
         if self._count < self._dropCount:
-            print(f'Dropping transaction {self._count}')
             self._count += 1
             return
 

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -151,11 +151,12 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         size    = transaction.size()
         type    = transaction.type()
 
-        self._count += 1
-
-        if self._dropCount != 0 and self._count == self._dropCount:
-            self._count = 0
+        if self._count < self._dropCount:
+            print(f'Dropping transaction {self._count}')
+            self._count += 1
             return
+
+        self._count = 0
 
         if (address % self._minWidth) != 0:
             transaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -283,7 +283,7 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
 
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+         bLog_->warning("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
       }
    }
@@ -316,7 +316,7 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
 
       } catch ( rogue::GeneralError err ) {
          if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+         bLog_->warning("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
       }
    }

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -118,7 +118,7 @@ def test_memory():
             root.SimpleDev.SimpleTestBB.set(0x42 + i)
             root.SimpleDev.SimpleTestBC.set(0x43 + i)
             root.SimpleDev.SimpleTestBD.set(0x44 + i)
-            
+
             retAA = root.SimpleDev.SimpleTestAA.get()
             retAB = root.SimpleDev.SimpleTestAB.get()
             retBA = root.SimpleDev.SimpleTestBA.get()

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -13,7 +13,8 @@ import pyrogue as pr
 import pyrogue.interfaces.simulation
 
 # We expect Errors with this test, so turn off logging of them
-#rogue.Logging.setLevel(rogue.Logging.Critical)
+#import rogue
+#rogue.Logging.setLevel(rogue.Logging.Warning)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -9,7 +9,6 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-import rogue
 import pyrogue as pr
 import pyrogue.interfaces.simulation
 

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -9,10 +9,14 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import rogue
 import pyrogue as pr
 import pyrogue.interfaces.simulation
 
-#rogue.Logging.setLevel(rogue.Logging.Debug)
+import pytest
+
+# We expect Errors with this test, so turn off logging of them
+#rogue.Logging.setLevel(rogue.Logging.Critical)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
@@ -30,7 +34,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -40,7 +44,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -50,7 +54,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -60,7 +64,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -70,7 +74,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -80,7 +84,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
 
@@ -90,7 +94,7 @@ class DummyTree(pr.Root):
         pr.Root.__init__(self,
                          name='dummyTree',
                          description="Dummy tree for example",
-                         timeout=2.0,
+                         timeout=.01,
                          pollEn=False,
                          serverPort=None)
 
@@ -116,7 +120,7 @@ def test_memory():
             root.SimpleDev.SimpleTestBB.set(0x42 + i)
             root.SimpleDev.SimpleTestBC.set(0x43 + i)
             root.SimpleDev.SimpleTestBD.set(0x44 + i)
-
+            
             retAA = root.SimpleDev.SimpleTestAA.get()
             retAB = root.SimpleDev.SimpleTestAB.get()
             retBA = root.SimpleDev.SimpleTestBA.get()

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -13,8 +13,6 @@ import rogue
 import pyrogue as pr
 import pyrogue.interfaces.simulation
 
-import pytest
-
 # We expect Errors with this test, so turn off logging of them
 #rogue.Logging.setLevel(rogue.Logging.Critical)
 #import logging


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
 - pytest and pytest-cov are now conda dependencies so they can be run locally
 - Fix bug in `pyrogue.simulation.MemEmulate that miscounted dropped transactions.
 - Reduced retry timeout in test_retry_memory.py so that script runs much faster.
