### PR TITLE
Temporary fix to build with python 3.10

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -210,6 +210,7 @@ jobs:
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh
           conda config --set always_yes yes
+          conda update -n base -c conda-forge conda
           conda install conda-build anaconda-client conda-verify
           if [ $OS_NAME == "macos-10.15" ]
           then


### PR DESCRIPTION
Using the conda package from conda-forge avoid the "merge bug" when building rogue for python 3.10.:

https://github.com/conda/conda/issues/11442

I could build rogue for python 3.10 this way. I think this should be reverted when the bug above is closed