### PR TITLE
Fix off by one error in big endian swaps

### DIFF
--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -533,7 +533,7 @@ void rim::Block::reverseBytes ( uint8_t *data, uint32_t byteSize ) {
    for (x=0; x < byteSize/2; x++) {
       tmp = data[x];
       data[x] = data[byteSize-x-1];
-      data[byteSize-1-x] = tmp;
+      data[byteSize-x-1] = tmp;
    }
 }
 

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -528,12 +528,12 @@ bp::object rim::Block::variablesPy() {
 // byte reverse
 void rim::Block::reverseBytes ( uint8_t *data, uint32_t byteSize ) {
    uint32_t x;
-   uint32_t tmp;
-
+   uint8_t tmp;
+   
    for (x=0; x < byteSize/2; x++) {
       tmp = data[x];
-      data[x] = data[byteSize-x];
-      data[byteSize-x] = tmp;
+      data[x] = data[byteSize-x-1];
+      data[byteSize-1-x] = tmp;
    }
 }
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This fixes a buffer index off-by-one error in the function that reverses the bytes for big-endian numbers.
