### PR TITLE
Change Github Actions CI workflow back to "on push"

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -16,7 +16,7 @@
 # secrets.DOCKERHUB_TOKEN
 
 name: Rogue Integration
-on: [pull_request]
+on: [push]
 
 jobs:
   full_build_test:


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The CI was changed to "on pull request" in #878. The purpose was to reduce unnecessary CI runs. But it turns out that this change stops CI from running on the pre-release branch until a Release Candidate PR is created. It probably also breaks the release actions when a release tag is generated. 

The CI workflow has not been changed back to "on push".

### JIRA
<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
https://jira.slac.stanford.edu/browse/ESROGUE-583
### Related
<!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
#878