### PR TITLE
Rogue v5.15.0 Release Candidate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 <!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
 
 ### JIRA
-<!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
+<!--- Optional. Provide a link to any relevant JIRA ticket here. Otherwise you can delete this section -->
 
 ### Related
 <!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -247,6 +247,7 @@ jobs:
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh
           conda config --set always_yes yes
+          conda update -n base -c conda-forge conda
           conda install conda-build anaconda-client conda-verify
           if [ $OS_NAME == "macos-10.15" ]
           then

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -16,7 +16,7 @@
 # secrets.DOCKERHUB_TOKEN
 
 name: Rogue Integration
-on: [pull_request]
+on: [push]
 
 jobs:
   full_build_test:

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -16,27 +16,32 @@
 # secrets.DOCKERHUB_TOKEN
 
 name: Rogue Integration
-on: [push]
+on: [pull_request]
 
 jobs:
   full_build_test:
     name: Full Build Test
     runs-on: ubuntu-latest
+
+    env:
+      EPICS_BASE: /home/runner/packages/epics/base-7.0.3
+      EPICS_PCAS_ROOT: /home/runner/packages/pcas/pcas-4.13.2
+
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
+          cache: 'pip'
+          cache-dependency-path: 'pip_requirements.txt'
 
       - name: Setup Environment
         run: |
-          EPICS_BASE=${HOME}/packages/epics/base-7.0.3
-          EPICS_PCAS_ROOT=${HOME}/packages/pcas/pcas-4.13.2
           LD_LIBRARY_PATH=/usr/lib:${EPICS_BASE}/lib/linux-x86_64:${EPICS_PCAS_ROOT}/lib/linux-x86_64
           PATH=${EPICS_BASE}/bin/linux-x86_64:${PATH}
           echo "EPICS_BASE=$EPICS_BASE" >> $GITHUB_ENV
@@ -48,11 +53,27 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev
-          python -m pip install --upgrade pip
-          pip install setuptools
           pip install -r pip_requirements.txt
 
-      - name: Install EPICS Base
+      # Flake 8 check
+      - name: Flake8 Tests
+        run: |
+          python -m compileall -f ./python/
+          flake8 --count ./python/
+          python -m compileall -f ./tests
+          flake8 --count ./tests/
+
+      - name: Cache EPICS
+        uses: actions/cache@v3
+        id: epics-cache
+        with:
+          key: epics
+          path: |
+            ${{ env.EPICS_BASE }}/
+            ${{ env.EPICS_PCAS_ROOT }}/
+
+      - if: ${{ steps.epics-cache.outputs.cache-hit != 'true' }}
+        name: Install EPICS Base
         run: |
           mkdir -p ${EPICS_BASE}
           cd ${EPICS_BASE}
@@ -61,7 +82,8 @@ jobs:
           tar xzf base-7.0.3.tar.gz --strip 1
           make clean && make && make install
 
-      - name: Install EPICS PCAS
+      - if: ${{ steps.epics-cache.outputs.cache-hit != 'true' }}
+        name: Install EPICS PCAS
         run: |
           mkdir -p ${EPICS_PCAS_ROOT}
           cd ${EPICS_PCAS_ROOT}
@@ -84,14 +106,14 @@ jobs:
           source setup_rogue.sh
           python -m pytest --cov
 
-      # Flake 8 check
-      - name: Flake8 Tests
-        run: |
-          source setup_rogue.sh
-          python -m compileall -f ./python/
-          flake8 --count ./python/
-          python -m compileall -f ./tests
-          flake8 --count ./tests/          
+#       # Run test_rate.py
+# #       - name: Get test_rate.py output
+# #         uses: mathiasvr/command-output@v1
+# #         id: rates
+# #         with:
+# #           run: |
+# #             source setup rogue.sh
+# #             python -m test_rate.py
 
       # Code Coverage
       - name: Code Coverage
@@ -115,13 +137,27 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: docs/build/html
 
+#       # Set up for Comment PR
+#       - name: Checkout
+#         uses: actions/checkout@v3
+
+#       # Comment on PR
+#       - name: Comment PR
+#         uses: thollander/actions-comment-pull-request@v1
+#         with:
+#           message: |
+#             Rates -
+#             ${{steps.rates.outputs.stdout}}
+#           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+
   small_build_test:
     name: Small Build Test
     runs-on: ubuntu-latest
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -137,6 +173,7 @@ jobs:
           cmake .. -DROGUE_INSTALL=local -DNO_PYTHON=1 -DSTATIC_LIB=1
           make -j4 install
 
+
   gen_release:
     name: Generate Release
     runs-on: ubuntu-latest
@@ -144,11 +181,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -187,11 +224,11 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -273,7 +310,7 @@ jobs:
     steps:
 
       # This step checks out a copy of your repository.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/conda.yml
+++ b/conda.yml
@@ -27,3 +27,5 @@ dependencies:
   - sqlalchemy
   - pydm
   - matplotlib
+  - pytest
+  - pytest-cov

--- a/conda_mac.yml
+++ b/conda_mac.yml
@@ -23,3 +23,5 @@ dependencies:
   - pydm
   - pyserial
   - matplotlib
+  - pytest
+  - pytest-cov

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -18,8 +18,8 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
 
 .. code::
 
-   ROGUE_VERSION = "5.13.0"
-   ROGUE_MD5SUM  = "e7d8da39b2017e9a5ef05b7851fcabc7"
+   ROGUE_VERSION = "5.14.0"
+   ROGUE_MD5SUM  = "ba8146e03f60e463a2aa3d978c1dc46e"
 
    SUMMARY = "Rogue Application"
    SECTION = "PETALINUX/apps"
@@ -30,26 +30,27 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
 
-   DEPENDS += "python3 python3-numpy python3-native python3-numpy-native cmake boost zeromq bzip2"
-   DEPENDS += "python3-pyzmq python3-parse python3-pyyaml python3-click python3-sqlalchemy python3-pyserial"
+   DEPENDS += "python3 python3-numpy python3-native python3-numpy-native python3-pyzmq"
+   DEPENDS += "python3-parse python3-pyyaml python3-click python3-sqlalchemy python3-pyserial"
+   DEPENDS += "cmake boost zeromq bzip2 python3-jupyter"
 
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
 
-   inherit cmake python3native distutils3
+   inherit cmake python3native distutils3 xilinx-pynq setuptools3
 
    FILES_${PN}-dev += "/usr/include/rogue/*"
    FILES_${PN} += "/usr/lib/*"
 
    do_configure() {
       cmake_do_configure
+      bbplain $(cp -vH ${WORKDIR}/build/setup.py ${S}/.)
    }
 
    do_install() {
       cmake_do_install
       distutils3_do_install
    }
-
 
 Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
 
@@ -79,13 +80,6 @@ You can then build the rogue package with the following command:
 
 .. code::
 
-   # Try to let rogue build and let it assert the error about missing setup.py file
-   > petalinux-build -c rogue
-
-   # Copy the autogenerate setup.py from the 1st "petalinux-build -c rogue" to the correct directory (work around)
-   > cp build/tmp/work/cortexa72-cortexa53-xilinx-linux/rogue/1.0-r0/build/setup.py build/tmp/work/cortexa72-cortexa53-xilinx-linux/rogue/1.0-r0/rogue-<ROGUE_VERSION>/.
-
-   # Rebuild again
    > petalinux-build -c rogue
 
 You can then build the petalinux project as normal.

--- a/docs/src/pydm/index.rst
+++ b/docs/src/pydm/index.rst
@@ -21,6 +21,7 @@ Additionally Rogue provides a few custom widgets which can be used to visualize 
    :caption: Rogue PyDM Features:
 
    starting_gui
+   timeplot_gui
    channel_urls
    rogue_widgets
 

--- a/docs/src/pydm/rogue_widgets.rst
+++ b/docs/src/pydm/rogue_widgets.rst
@@ -14,4 +14,4 @@ The following Rogue specific PyDM widgets are provided:
    - process: A widget for the Rogue Process device
    - debug_tree: A widget containing a representation of the Rogue tree
    - line_edit: A Rogue specific sub-class of PyDmLineEdit which stays yellow while the entered value is stale
-
+   - time_plotter: A widget for plotting polled variables over time

--- a/docs/src/pydm/starting_gui.rst
+++ b/docs/src/pydm/starting_gui.rst
@@ -11,7 +11,7 @@ Using The Command Line
 
 You use the rogue module from the command line to start the GUI in the following way:
 
-.. code::
+.. code:: bash
 
    $ python -m pyrogue gui
 
@@ -19,13 +19,13 @@ This will start the default Rogue debug GUI and connect to the first Rogue serve
 
 You can also specify one or more Rogue server addresses on the command line:
 
-.. code::
+.. code:: bash
 
    $ python -m pyrogue --server localhost:9099 gui
 
 Or for connecting to multiple Rogue servers:
 
-.. code::
+.. code:: bash
 
    $ python -m pyrogue --server localhost:9099,otherhost1:9099,otherhost2:9099 gui
 
@@ -35,7 +35,7 @@ The PyDM channel prefix for each instance of Rogue to which is is connected is r
 
 If you have created a custom PyDM display using the designer tool, you can start that display from the command line by passing the path to the created designer ui file:
 
-.. code::
+.. code:: bash
 
    $ python -m pyrogue --server localhost:9099,otherhost1:9099,otherhost2:9099 --ui path/to/file.ui gui
 
@@ -44,7 +44,8 @@ Using A Python Script
 
 The alternative way to start the PyDM GUI is to execute the Rogue helper function for starting PyDM from within a python script, using the Rogue Virtual Client, or directly with a local Rogue root:
 
-.. code::
+.. code:: python
+
     import pyrogue.pydm
 
     with MyRoot() as root:

--- a/docs/src/pydm/timeplot_gui.rst
+++ b/docs/src/pydm/timeplot_gui.rst
@@ -1,0 +1,36 @@
+.. _timeplot_gui
+
+===========================
+Starting The Rogue PyDM Timeplot GUI
+===========================
+
+The Rogue PyDM Timeplot GUI can be started from the command line
+
+Using The Command Line
+======================
+
+You use the rogue module from the command line to start the GUI in the following way:
+
+.. code:: bash
+
+   $ python -m pyrogue timeplot
+
+This will start the Timeplot GUI and connect to the first Rogue server it fines while scanning the typical server ports opened by a Rogue instance.
+
+You can also specify one or more Rogue server addresses on the command line:
+
+.. code:: bash
+
+   $ python -m pyrogue --server localhost:9099 timeplot
+
+Or for connecting to multiple Rogue servers:
+
+.. code:: bash
+
+   $ python -m pyrogue --server localhost:9099,otherhost1:9099,otherhost2:9099 timeplot
+
+The default GUI only supports a connection to one server at a time and will only display the debug GUI for the first server in the list. The additional servers are available in the PyDM session, but require a custom GUI to be created either programically or using the PyQT designer application.
+
+The PyDM channel prefix for each instance of Rogue to which is is connected is rogue://n/ where n is the 0 based serial number of the server instance passed on the command line.
+
+

--- a/python/pyrogue/_DataWriter.py
+++ b/python/pyrogue/_DataWriter.py
@@ -114,15 +114,15 @@ class DataWriter(pr.Device):
 
     def _getCurrentSize(self):
         """get current file size. Override in sub-class"""
-        return(0)
+        return 0
 
     def _getTotalSize(self):
         """get total file size. Override in sub-class"""
-        return(0)
+        return 0
 
     def _getFrameCount(self):
         """get current file frame count. Override in sub-class"""
-        return(0)
+        return 0
 
     def _genFileName(self):
         """

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -234,11 +234,11 @@ class Device(pr.Node,rim.Hub):
         self._ifAndProto.extend(interfaces)
 
     def _start(self):
-        """ Called recursively from Root.stop when starting """
+        """ Called recursively from Root.start when starting """
         for intf in self._ifAndProto:
             if hasattr(intf,"_start"):
                 intf._start()
-        for d in self.deviceList:
+        for d in self.devices.values():
             d._start()
 
     def _stop(self):
@@ -246,7 +246,7 @@ class Device(pr.Node,rim.Hub):
         for intf in self._ifAndProto:
             if hasattr(intf,"_stop"):
                 intf._stop()
-        for d in self.deviceList:
+        for d in self.devices.values():
             d._stop()
 
     @property

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -450,10 +450,10 @@ class Fixed(Model):
     Parameters
     ----------
     bitSize : int
-        Number of bits being represented
+        Specifies the total number of bits, including the binary point bit width.
 
     binPoint : int
-        Huh?
+        Specifies the bit location of the binary point, where bit zero is the least significant bit.
     """
 
     pytype  = float
@@ -463,4 +463,26 @@ class Fixed(Model):
     def __init__(self, bitSize, binPoint):
         super().__init__(bitSize,binPoint)
         self.name = f'Fixed_{self.bitSize-self.binPoint-1}_{self.binPoint}'
+        self.ndType = np.dtype(np.float64)
+
+class UFixed(Model):
+    """
+    Model class for fixed point unsigned integers
+
+    Parameters
+    ----------
+    bitSize : int
+        Specifies the total number of bits, including the binary point bit width.
+
+    binPoint : int
+        Specifies the bit location of the binary point, where bit zero is the least significant bit.
+    """
+
+    pytype  = float
+    signed  = False
+    modelId = rim.Fixed
+
+    def __init__(self, bitSize, binPoint):
+        super().__init__(bitSize,binPoint)
+        self.name = f'UFixed_{self.bitSize-self.binPoint-1}_{self.binPoint}'
         self.ndType = np.dtype(np.float64)

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -210,7 +210,7 @@ class Node(object):
 
 
     def __dir__(self):
-        return(super().__dir__() + [k for k,v in self._nodes.items()])
+        return super().__dir__() + [k for k,v in self._nodes.items()]
 
     def __reduce__(self):
         attr = {}
@@ -341,7 +341,7 @@ class Node(object):
         """
         Get sub-nodes in a list
         """
-        return([k for k,v in self._nodes.items()])
+        return [k for k,v in self._nodes.items()]
 
     def getNodes(self,typ,excTyp=None,incGroups=None,excGroups=None):
         """

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -77,14 +77,14 @@ class PollQueue(object):
 
     def updatePollInterval(self, var):
         with self._condLock:
-            self._log.debug(f'updatePollInterval {var} - {var.pollInterval}')
+            self._log.debug(f'updatePollInterval {var} - {var._pollInterval}')
             # Special case: Variable has no block and just depends on other variables
             # Then do update on each dependency instead
             if not hasattr(var, '_block') or var._block is None:
                 if len(var.dependencies) > 0:
                     for dep in var.dependencies:
-                        if var.pollInterval != 0 and (dep.pollInterval == 0 or var.pollInterval < dep.pollInterval):
-                            dep.pollInterval = var.pollInterval
+                        if var._pollInterval != 0 and (dep.pollInterval == 0 or var._pollInterval < dep.pollInterval):
+                            dep.setPollInterval(var._pollInterval)
 
                 return
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -209,7 +209,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             description='Configuration Flag To Execute Initialize after LoadConfig or setYaml'))
 
         self.add(pr.LocalVariable(name='Time', value=0.0, mode='RO', hidden=True,
-                 description='Current Time In Seconds Since EPOCH UTC'))
+                                  description='Current Time In Seconds Since EPOCH UTC', groups=['NoSql']))
 
         self.add(pr.LinkVariable(name='LocalTime', value='', mode='RO', groups=['NoStream','NoSql','NoState'],
                  linkedGet=lambda: time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime(self.Time.value())),
@@ -940,7 +940,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             # Process list
             elif len(uvars) > 0:
                 self._log.debug(F'Process update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}')
-
                 for p,v in uvars.items():
                     try:
                         val = v._doUpdate()
@@ -960,6 +959,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
                         # Log to database
                         if self._sqlLog is not None and v.filterByGroup(self._sqlIncGroups, self._sqlExcGroups):
+                            #print('sql log:',p, val)
                             self._sqlLog.logVariable(p, val)
 
                     except Exception as e:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -323,8 +323,20 @@ class BaseVariable(pr.Node):
 
     @pollInterval.setter
     def pollInterval(self, interval):
+        print()
+        print('=========== Deprecation Warming ===============')
+        print(f'Called {self.path}.pollInterval = {interval}')
+        print('This way of setting the poll interval is deprecated')
+        print(f'Use {self.path}.setPollInterval({interval}) instead')
         self._pollInterval = interval
         self._updatePollInterval()
+
+    @pr.expose
+    def setPollInterval(self, interval):
+        print(f'{self.path}.setPollInterval({interval})')
+        self._pollInterval = interval
+        self._updatePollInterval()
+
 
     @pr.expose
     @property
@@ -1112,3 +1124,13 @@ class LinkVariable(BaseVariable):
     def depBlocks(self):
         """ Return a list of Blocks that this LinkVariable depends on """
         return self.__depBlocks
+
+    @pr.expose
+    @property
+    def pollInterval(self):
+
+        depIntervals = [dep.pollInterval for dep in self.dependencies if dep.pollInterval > 0]
+        if len(depIntervals) == 0:
+            return 0
+        else:
+            return min(depIntervals)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -434,7 +434,7 @@ class BaseVariable(pr.Node):
 
     @pr.expose
     def getDisp(self, read=True, index=-1):
-        return(self.genDisp(self.get(read=read,index=index)))
+        return self.genDisp(self.get(read=read,index=index))
 
     @pr.expose
     def valueDisp(self, index=-1): #, read=True, index=-1):

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -32,7 +32,7 @@ parser.add_argument('--details',
 
 parser.add_argument('cmd',
                     type=str,
-                    choices=['gui','syslog','monitor','get','value','set','exec','path'],
+                    choices=['gui','timeplot','syslog','monitor','get','value','set','exec','path'],
                     help='Client command to issue')
 
 parser.add_argument('path',
@@ -66,6 +66,11 @@ if args.cmd == 'gui':
     import pyrogue.gui
     import pyrogue.pydm
     pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui)
+
+elif args.cmd == 'timeplot':
+    import pyrogue.pydm
+    ui=os.path.dirname(os.path.abspath(__file__))+'/pydm/TimePlotTop.py'
+    pyrogue.pydm.runPyDM(serverList=args.server, ui=ui)
 
 # System log
 elif args.cmd == 'syslog':

--- a/python/pyrogue/examples/_AxiVersion.py
+++ b/python/pyrogue/examples/_AxiVersion.py
@@ -369,7 +369,7 @@ class AxiVersion(pr.Device):
         @self.command(hidden=False,value='',retValue='')
         def TestCommand(arg):
             print('Got {}'.format(arg))
-            return('Got {}'.format(arg))
+            return 'Got {}'.format(arg)
 
         @self.command(hidden=False,value='',retValue='')
         def TestMemoryException(arg):
@@ -385,11 +385,11 @@ class AxiVersion(pr.Device):
 
         @self.command(hidden=False,value='',retValue='')
         def TestGeneralException(arg):
-            return(rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0,True))
+            return rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0,True)
 
         @self.command(hidden=False,value='',retValue='')
         def TestOtherError(arg):
-            return(rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0))
+            return rogue.hardware.axi.AxiStreamDma('/dev/not_a_device',0)
 
         @self.command(hidden=False,value='blah blah',retValue='')
         def TestCmdString(arg):

--- a/python/pyrogue/interfaces/_SqlLogging.py
+++ b/python/pyrogue/interfaces/_SqlLogging.py
@@ -21,31 +21,34 @@ class SqlLogger(object):
     def __init__(self, url):
         self._log = pr.logInit(cls=self,name="SqlLogger",path=None)
         self._url = url
-        self._conn   = None
+        self._engine   = None
         self._thread = None
         self._queue  = queue.Queue()
         self._thread = threading.Thread(target=self._worker)
         self._thread.start()
         try:
-            conn = sqlalchemy.create_engine(self._url)
+            engine = sqlalchemy.create_engine(self._url) #, isolation_level="AUTOCOMMIT")
             self._log.info("Opened database connection to {}".format(self._url))
         except Exception as e:
             self._log.error("Failed to open database connection to {}: {}".format(self._url,e))
             return
 
-        self._metadata = sqlalchemy.MetaData(conn)
+        self._metadata = sqlalchemy.MetaData(engine)
 
-        self._varTable = sqlalchemy.Table('variables', self._metadata,
+        self._varTable = sqlalchemy.Table(
+            'variables', self._metadata,
             sqlalchemy.Column('id',        sqlalchemy.Integer, primary_key=True),
             sqlalchemy.Column('timestamp', sqlalchemy.DateTime(timezone=True), server_default=sqlalchemy.func.now()),
             sqlalchemy.Column('path',      sqlalchemy.String),
             sqlalchemy.Column('enum',      sqlalchemy.String),
             sqlalchemy.Column('disp',      sqlalchemy.String),
             sqlalchemy.Column('value',     sqlalchemy.String),
+            sqlalchemy.Column('valueDisp', sqlalchemy.String),
             sqlalchemy.Column('severity',  sqlalchemy.String),
             sqlalchemy.Column('status',    sqlalchemy.String))
 
-        self._logTable = sqlalchemy.Table('syslog', self._metadata,
+        self._logTable = sqlalchemy.Table(
+            'syslog', self._metadata,
             sqlalchemy.Column('id',          sqlalchemy.Integer, primary_key=True),
             sqlalchemy.Column('timestamp',   sqlalchemy.DateTime(timezone=True), server_default=sqlalchemy.func.now()),
             sqlalchemy.Column('name',        sqlalchemy.String),
@@ -54,16 +57,16 @@ class SqlLogger(object):
             sqlalchemy.Column('levelName',   sqlalchemy.String),
             sqlalchemy.Column('levelNumber', sqlalchemy.Integer))
 
-        self._varTable.create(conn, checkfirst=True)
-        self._logTable.create(conn, checkfirst=True)
-        self._conn = conn
+        self._varTable.create(engine, checkfirst=True)
+        self._logTable.create(engine, checkfirst=True)
+        self._engine = engine
 
     def logVariable(self, path, varValue):
-        if self._conn is not None:
+        if self._engine is not None:
             self._queue.put((path,varValue))
 
     def logSyslog(self, syslogData):
-        if self._conn is not None:
+        if self._engine is not None:
             self._queue.put((None,syslogData))
 
     def _stop(self):
@@ -71,39 +74,84 @@ class SqlLogger(object):
             print("Waiting for sql logger to finish...")
         self._queue.put(None)
         self._thread.join()
+        print('Sql logger stopped')
+
+
+    def insert_from_q(self, entry, conn):
+
+        # Variable
+        if entry[0] is not None:
+
+            # Handle corner cases
+            value = entry[1].value
+            if isinstance(value, int) and value.bit_length() > 64:
+                # Support >64 bit ints
+                value = entry[1].valueDisp
+            elif isinstance(value, tuple):
+                # Support tuples
+                value = str(value)
+
+            ins = self._varTable.insert().values(
+                path=entry[0],
+                enum=str(entry[1].enum),
+                disp=entry[1].disp,
+                value=value,
+                valueDisp=entry[1].valueDisp,
+                severity=entry[1].severity,
+                status=entry[1].status)
+
+        # Syslog
+        else:
+            ins = self._logTable.insert().values(
+                name=entry[1]['name'],
+                message=entry[1]['message'],
+                exception=entry[1]['exception'],
+                levelName=entry[1]['levelName'],
+                levelNumber=entry[1]['levelNumber'])
+
+        conn.execute(ins)
+
 
     def _worker(self):
         while True:
-            ent = self._queue.get()
+            # Block and wait for a queue entry to arrive
+            entry = self._queue.get()
 
-            # Done
-            if ent is None:
+            # Exit thread if None entry received
+            if entry is None:
                 return
 
-            if self._conn is not None:
-                try:
+            # Do nothing with the data if db connection not present
+            if self._engine is None:
+                continue
 
-                    # Variable
-                    if ent[0] is not None:
-                        ins = self._varTable.insert().values(path=ent[0],
-                                                             enum=str(ent[1].enum),
-                                                             disp=ent[1].disp,
-                                                             value=ent[1].valueDisp,
-                                                             severity=ent[1].severity,
-                                                             status=ent[1].status)
-                    # Syslog
-                    else:
-                        ins = self._logTable.insert().values(name=ent[1]['name'],
-                                                             message=ent[1]['message'],
-                                                             exception=ent[1]['exception'],
-                                                             levelName=ent[1]['levelName'],
-                                                             levelNumber=ent[1]['levelNumber'])
+            # If there are multiple entries in the queue
+            # write them to the DB in a single transaction
+            try:
+                with self._engine.begin() as conn:
+                    while True:
+                        #Need to check for null again from loop
+                        if entry is None:
+                            return
 
-                    self._conn.execute(ins)
-                except Exception as e:
-                    self._conn = None
-                    pr.logException(self._log,e)
-                    self._log.error("Lost database connection to {}".format(self._url))
+                        # Insert the entry
+                        self.insert_from_q(entry, conn)
+
+                        # Break from loop and close the transaction
+                        # when queue has been emptied
+                        if self._queue.qsize() == 0:
+                            break
+
+                        # Read the next queue entry and loop
+                        entry = self._queue.get()
+
+
+            except Exception as e:
+                self._engine = None
+                pr.logException(self._log,e)
+                self._log.error("Lost database connection to {}".format(self._url))
+
+
 
 
 class SqlReader(object):
@@ -111,20 +159,20 @@ class SqlReader(object):
     def __init__(self, url):
         self._log = pr.logInit(cls=self,name="SqlReader",path=None)
         self._url = url
-        self._conn = None
+        self._engine = None
 
         try:
-            conn = sqlalchemy.create_engine(self._url)
+            engine = sqlalchemy.create_engine(self._url)
             self._log.info("Opened database connection to {}".format(self._url))
         except Exception as e:
             self._log.error("Failed to open database connection to {}: {}".format(self._url,e))
             return
 
-        self._metadata = sqlalchemy.MetaData(conn)
+        self._metadata = sqlalchemy.MetaData(engine)
 
         self._varTable = sqlalchemy.Table('variables', self._metadata, autoload=True)
         self._logTable = sqlalchemy.Table('syslog', self._metadata, autoload=True)
-        self._conn = conn
+        self._engine = engine
 
     # Make this more useful
     def getVariable(self):

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -322,7 +322,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             raise Exception(f"ZMQ Interface Exception: {e}")
 
         if isinstance(ret,Exception):
-            raise(ret)
+            raise ret
 
         return ret
 

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -141,10 +141,10 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         return 0
 
     def _doMaxAccess(self):
-        return(self._maxSize)
+        return self._maxSize
 
     def _doMinAccess(self):
-        return(self._minWidth)
+        return self._minWidth
 
     def _doTransaction(self,transaction):
         address = transaction.address()

--- a/python/pyrogue/interfaces/simulation.py
+++ b/python/pyrogue/interfaces/simulation.py
@@ -151,11 +151,11 @@ class MemEmulate(rogue.interfaces.memory.Slave):
         size    = transaction.size()
         type    = transaction.type()
 
-        self._count += 1
-
-        if self._dropCount != 0 and self._count == self._dropCount:
-            self._count = 0
+        if self._count < self._dropCount:
+            self._count += 1
             return
+
+        self._count = 0
 
         if (address % self._minWidth) != 0:
             transaction.error("Transaction address {address:#x} is not aligned to min width {self._minWidth:#x}")

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -284,7 +284,7 @@ class UdpRssiPack(pr.Device):
         ))
 
     def application(self,dest):
-        return(self._pack.application(dest))
+        return self._pack.application(dest)
 
     def countReset(self):
         self._rssi.resetCounters()

--- a/python/pyrogue/pydm/TimePlotTop.py
+++ b/python/pyrogue/pydm/TimePlotTop.py
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# Title      : PyRogue PyDM Top Level GUI
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import os
+
+from pyrogue.pydm.widgets import TimePlotter
+
+from pydm import Display
+
+from qtpy.QtWidgets import QVBoxLayout
+
+
+Channel = 'rogue://0/root'
+
+class TimePlotTop(Display):
+    def __init__(self, parent=None, args=[], macros=None):
+        super().__init__(parent=parent, args=args, macros=None)
+
+        self.sizeX  = None
+        self.sizeY  = None
+        self.title  = None
+
+        for a in args:
+            if 'sizeX=' in a:
+                self.sizeX = int(a.split('=')[1])
+            if 'sizeY=' in a:
+                self.sizeY = int(a.split('=')[1])
+            if 'title=' in a:
+                self.title = a.split('=')[1]
+
+        if self.title is None:
+            self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
+
+        if self.sizeX is None:
+            self.sizeX = 800
+        if self.sizeY is None:
+            self.sizeY = 1000
+
+        self.setWindowTitle(self.title)
+
+        vb = QVBoxLayout()
+        self.setLayout(vb)
+
+        tp = TimePlotter(parent=None, init_channel=Channel)
+        vb.addWidget(tp)
+
+
+        self.resize(self.sizeX, self.sizeY)
+
+    def ui_filepath(self):
+        # No UI file is being used
+        return None

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -11,12 +11,14 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-from pyrogue.pydm.widgets.line_edit     import PyRogueLineEdit
-from pyrogue.pydm.widgets.data_writer   import DataWriter
-from pyrogue.pydm.widgets.root_control  import RootControl
-from pyrogue.pydm.widgets.run_control   import RunControl
-from pyrogue.pydm.widgets.system_log    import SystemLog
-from pyrogue.pydm.widgets.system_window import SystemWindow
-from pyrogue.pydm.widgets.debug_tree    import DebugTree
-from pyrogue.pydm.widgets.process       import Process
-from pyrogue.pydm.widgets.plot          import Plotter
+from pyrogue.pydm.widgets.line_edit            import PyRogueLineEdit
+from pyrogue.pydm.widgets.line_edit            import PyRogueVariableLineEdit
+from pyrogue.pydm.widgets.line_edit            import PyRogueVariableLabel
+from pyrogue.pydm.widgets.data_writer          import DataWriter
+from pyrogue.pydm.widgets.root_control         import RootControl
+from pyrogue.pydm.widgets.run_control          import RunControl
+from pyrogue.pydm.widgets.system_log           import SystemLog
+from pyrogue.pydm.widgets.system_window        import SystemWindow
+from pyrogue.pydm.widgets.debug_tree           import DebugTree
+from pyrogue.pydm.widgets.process              import Process
+from pyrogue.pydm.widgets.plot                 import Plotter

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -22,3 +22,4 @@ from pyrogue.pydm.widgets.system_window        import SystemWindow
 from pyrogue.pydm.widgets.debug_tree           import DebugTree
 from pyrogue.pydm.widgets.process              import Process
 from pyrogue.pydm.widgets.plot                 import Plotter
+from pyrogue.pydm.widgets.time_plotter         import TimePlotter

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -223,34 +223,7 @@ class DebugHolder(QTreeWidgetItem):
         self.setText(2,self._var.typeStr)
         self.setToolTip(0,self._var.description)
 
-        if self._var.isCommand and not self._var.arg:
-            w = PyDMPushButton(label='Exec',
-                               pressValue=1,
-                               init_channel=self._path + '/disp')
-
-
-        elif self._var.disp == 'enum' and self._var.enum is not None and (self._var.mode != 'RO' or self._var.isCommand) and self._var.typeStr != 'list':
-            w = PyDMEnumComboBox(parent=None, init_channel=self._path)
-            w.alarmSensitiveContent = False
-            w.alarmSensitiveBorder  = True
-            w.installEventFilter(self._top)
-
-        elif self._var.minimum is not None and self._var.maximum is not None and self._var.disp == '{}' and (self._var.mode != 'RO' or self._var.isCommand):
-            w = PyDMSpinbox(parent=None, init_channel=self._path)
-            w.precision             = 0
-            w.showUnits             = False
-            w.precisionFromPV       = False
-            w.alarmSensitiveContent = False
-            w.alarmSensitiveBorder  = True
-            w.showStepExponent      = False
-            w.writeOnPress          = True
-            w.installEventFilter(self._top)
-
-        elif self._var.mode == 'RO' and not self._var.isCommand:
-            w = PyRogueVariableLabel(parent=None, init_channel=self._path + '/disp') #, units=self._var.units)
-
-        else:
-            w = PyRogueVariableLineEdit(parent=None, init_channel=self._path + '/disp') #, units=self._var.units)
+        w = makeVariableViewWidget(self)
 
         if self._var.isCommand:
             self._top._tree.setItemWidget(self,4,w)

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -9,13 +9,14 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-
 import pyrogue
 import pyrogue.pydm.widgets
+from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
+from pyrogue.pydm.widgets import PyRogueVariableLabel, PyRogueVariableLineEdit
+
 from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
-from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from pyrogue.pydm.widgets import PyRogueLineEdit
+
 from qtpy.QtCore import Property, Slot, QEvent
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout
 from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel
@@ -47,6 +48,14 @@ class DebugDev(QTreeWidgetItem):
         self._top._tree.setItemWidget(self,0,w)
         self.setToolTip(0,self._dev.description)
 
+        w = PyDMPushButton(
+            label='Read',
+            pressValue=True,
+            init_channel=self._path + '.ReadDevice')
+
+        self._top._tree.setItemWidget(self, 4, w)
+
+
         if self._top._node == dev:
             self._parent.addTopLevelItem(self)
             self.setExpanded(True)
@@ -72,7 +81,6 @@ class DebugDev(QTreeWidgetItem):
 
         # First create variables/commands
         for key,val in lst.items():
-
             if val.guiGroup is not None:
                 if val.guiGroup not in self._groups:
                     self._groups[val.guiGroup] = DebugGroup(path=self._path, top=self._top, parent=self, name=val.guiGroup)
@@ -81,7 +89,6 @@ class DebugDev(QTreeWidgetItem):
 
             else:
                 DebugHolder(path=self._path + '.' + val.name, top=self._top, parent=self, variable=val)
-
         # Then create devices
         for key,val in self._dev.devicesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups).items():
 
@@ -125,14 +132,12 @@ class DebugGroup(QTreeWidgetItem):
 
         # Create variables
         for n in self._list:
-
             if n.isDevice:
                 DebugDev(path=self._path + '.' + n.name,
                          top=self._top,
                          parent=self,
                          dev=n,
                          noExpand=True)
-
             elif n.isVariable or n.isCommand:
                 DebugHolder(path=self._path + '.' + n.name,
                             top=self._top,
@@ -150,6 +155,37 @@ class DebugGroup(QTreeWidgetItem):
     def addNode(self,node):
         self._list.append(node)
 
+def makeVariableViewWidget(parent):
+    if parent._var.isCommand and not parent._var.arg:
+        w = PyDMPushButton(label='Exec',
+                           pressValue=1,
+                           init_channel=parent._path + '/disp')
+
+    elif parent._var.disp == 'enum' and parent._var.enum is not None and (parent._var.mode != 'RO' or parent._var.isCommand) and parent._var.typeStr != 'list':
+        w = PyDMEnumComboBox(parent=None, init_channel=parent._path)
+        w.alarmSensitiveContent = False
+        w.alarmSensitiveBorder  = True
+        w.installEventFilter(parent._top)
+
+    elif parent._var.minimum is not None and parent._var.maximum is not None and parent._var.disp == '{}' and (parent._var.mode != 'RO' or parent._var.isCommand):
+        w = PyDMSpinbox(parent=None, init_channel=parent._path)
+        w.precision             = 0
+        w.showUnits             = False
+        w.precisionFromPV       = False
+        w.alarmSensitiveContent = False
+        w.alarmSensitiveBorder  = True
+        w.showStepExponent      = False
+        w.writeOnPress          = True
+        w.installEventFilter(parent._top)
+
+    elif parent._var.mode == 'RO' and not parent._var.isCommand:
+        w = PyRogueVariableLabel(parent=None, init_channel=parent._path + '/disp')
+
+    else:
+        w = PyRogueVariableLineEdit(parent=None, init_channel=parent._path + '/disp')
+
+    return w
+
 
 class DebugHolder(QTreeWidgetItem):
 
@@ -160,15 +196,20 @@ class DebugHolder(QTreeWidgetItem):
         self._var    = variable
         self._path   = path
         self._depth  = parent._depth+1
+        self._isCommand = False
+
+        w = None
 
         w = PyDMLabel(parent=None, init_channel=self._path + '/name')
         w.showUnits             = False
         w.precisionFromPV       = False
+
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
 
         fm = QFontMetrics(w.font())
-        width = int(fm.width(self._path.split('.')[-1]) * 1.1)
+        label = self._path.split('.')[-1]
+        width = int(fm.width(label) * 1.1)
 
         rightEdge = width + (self._top._tree.indentation() * self._depth)
 
@@ -183,10 +224,10 @@ class DebugHolder(QTreeWidgetItem):
         self.setToolTip(0,self._var.description)
 
         if self._var.isCommand and not self._var.arg:
-
             w = PyDMPushButton(label='Exec',
                                pressValue=1,
                                init_channel=self._path + '/disp')
+
 
         elif self._var.disp == 'enum' and self._var.enum is not None and (self._var.mode != 'RO' or self._var.isCommand) and self._var.typeStr != 'list':
             w = PyDMEnumComboBox(parent=None, init_channel=self._path)
@@ -206,37 +247,21 @@ class DebugHolder(QTreeWidgetItem):
             w.installEventFilter(self._top)
 
         elif self._var.mode == 'RO' and not self._var.isCommand:
-            w = PyDMLabel(parent=None, init_channel=self._path + '/disp')
-            w.showUnits             = False
-            w.precisionFromPV       = True
-            w.alarmSensitiveContent = False
-            w.alarmSensitiveBorder  = True
+            w = PyRogueVariableLabel(parent=None, init_channel=self._path + '/disp') #, units=self._var.units)
+
         else:
-            w = PyRogueLineEdit(parent=None, init_channel=self._path + '/disp')
-            w.showUnits             = False
-            w.precisionFromPV       = True
-            w.alarmSensitiveContent = False
-            w.alarmSensitiveBorder  = True
-            #w.displayFormat         = 'String'
+            w = PyRogueVariableLineEdit(parent=None, init_channel=self._path + '/disp') #, units=self._var.units)
 
         if self._var.isCommand:
             self._top._tree.setItemWidget(self,4,w)
             width = fm.width('0xAAAAAAAA    ')
-
             if width > self._top._colWidths[4]:
                 self._top._colWidths[4] = width
-
-
-
         else:
             self._top._tree.setItemWidget(self,3,w)
             width = fm.width('0xAAAAAAAA    ')
-
             if width > self._top._colWidths[3]:
                 self._top._colWidths[3] = width
-
-        if self._var.units:
-            self.setText(5,str(self._var.units))
 
 
 class DebugTree(PyDMFrame):
@@ -250,7 +275,7 @@ class DebugTree(PyDMFrame):
         self._excGroups = excGroups
         self._tree      = None
 
-        self._colWidths = [250,50,75,200,200,50]
+        self._colWidths = [250,50,75,200,200]
 
     def connection_changed(self, connected):
         build = (self._node is None) and (self._connected != connected and connected is True)
@@ -269,7 +294,7 @@ class DebugTree(PyDMFrame):
         vb.addWidget(self._tree)
 
         self._tree.setColumnCount(5)
-        self._tree.setHeaderLabels(['Node','Mode','Type','Variable','Command','Units'])
+        self._tree.setHeaderLabels(['Node','Mode','Type','Value', 'Command'])
 
         self._tree.itemExpanded.connect(self._expandCb)
 
@@ -290,18 +315,16 @@ class DebugTree(PyDMFrame):
         DebugDev(path = self._path, top=self, parent=self._tree, dev=self._node, noExpand=False)
         self.setUpdatesEnabled(True)
 
+
     @Slot(QTreeWidgetItem)
     def _expandCb(self,item):
         self.setUpdatesEnabled(False)
         item._expand()
-
         self._tree.setColumnWidth(0,self._colWidths[0])
         self._tree.resizeColumnToContents(1)
         self._tree.resizeColumnToContents(2)
         self._tree.setColumnWidth(3,self._colWidths[3])
         self._tree.setColumnWidth(4,self._colWidths[4])
-        self._tree.resizeColumnToContents(5)
-
         self.setUpdatesEnabled(True)
 
     @Property(str)

--- a/python/pyrogue/pydm/widgets/designer.py
+++ b/python/pyrogue/pydm/widgets/designer.py
@@ -21,6 +21,7 @@ from pyrogue.pydm.widgets import SystemWindow
 from pyrogue.pydm.widgets import Process
 from pyrogue.pydm.widgets import PyRogueLineEdit
 from pyrogue.pydm.widgets import Plotter
+from pyrogue.pydm.widgets import TimePlotter
 
 LineEdit     = qtplugin_factory(PyRogueLineEdit, group="Rogue Widgets")
 DebugTree    = qtplugin_factory(DebugTree,       group="Rogue Widgets")
@@ -31,3 +32,4 @@ DataWriter   = qtplugin_factory(DataWriter,      group="Rogue Widgets")
 SystemWindow = qtplugin_factory(SystemWindow,    group="Rogue Widgets")
 Procsss      = qtplugin_factory(Process,         group="Rogue Widgets")
 Plotter      = qtplugin_factory(Plotter,         group="Rogue Widgets")
+TimePlotter  = qtplugin_factory(TimePlotter,     group="Rogue Widgets")

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -1,6 +1,6 @@
-
-from pydm.widgets import PyDMLineEdit
-from qtpy.QtCore import Property
+from pydm.widgets import PyDMLineEdit, PyDMLabel
+from qtpy.QtCore import Property, Qt
+from qtpy.QtWidgets import QWidget, QGridLayout
 from pydm.widgets.base import refresh_style
 
 class PyRogueLineEdit(PyDMLineEdit):
@@ -25,3 +25,44 @@ class PyRogueLineEdit(PyDMLineEdit):
     @Property(bool)
     def dirty(self):
         return self._dirty
+
+class PyRogueVariableDisplay(QWidget):
+    def __init__(self, parent, init_channel, widget):
+        QWidget.__init__(self, parent)
+
+        self._valueWidget = widget(parent, init_channel = init_channel)
+        self._valueWidget.precisionFromPV       = True
+        self._valueWidget.alarmSensitiveContent = False
+        self._valueWidget.alarmSensitiveBorder  = True
+        self._valueWidget.setStyleSheet("* { background-color: rgba(0, 0, 0, 0); }")
+
+
+        self._unitWidget = widget(parent, init_channel = None)
+        self._unitWidget.precisionFromPV       = True
+        self._unitWidget.alarmSensitiveContent = False
+        self._unitWidget.alarmSensitiveBorder  = True
+        self._unitWidget.set_opacity(0.7)
+        self._unitWidget.setAlignment(Qt.AlignRight)
+        self._unitWidget.setText("")
+
+        # Monkey patch!
+        def unit_changed(new_unit):
+            self._unitWidget.setText(new_unit)
+        self._valueWidget.unit_changed = unit_changed
+
+        grid = QGridLayout()
+        grid.addWidget(self._unitWidget, 0, 0)
+        grid.addWidget(self._valueWidget, 0, 0)
+        grid.setVerticalSpacing(0)
+        grid.setHorizontalSpacing(0)
+        grid.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(grid)
+
+
+class PyRogueVariableLineEdit(PyRogueVariableDisplay):
+    def __init__(self, parent, init_channel):
+        super().__init__(parent, init_channel, PyRogueLineEdit)
+
+class PyRogueVariableLabel(PyRogueVariableDisplay):
+    def __init__(self, parent, init_channel):
+        super().__init__(parent, init_channel, PyDMLabel)

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -1,0 +1,588 @@
+#-----------------------------------------------------------------------------
+# Title      : PyRogue PyDM Debug Tree Widget
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue
+from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
+from pyrogue.pydm.widgets.debug_tree import makeVariableViewWidget
+
+from pydm import Display
+from pydm.widgets.frame import PyDMFrame
+from pydm.widgets import PyDMLabel, PyDMPushButton
+import pydm.widgets.timeplot as pwt
+
+from qtpy import QtCore
+from qtpy.QtCore import Property, Slot, QEvent
+from qtpy.QtGui import QFontMetrics
+from qtpy.QtWidgets import (
+    QVBoxLayout, QHBoxLayout, QTreeWidgetItem, QTreeWidget, QLabel,
+    QGroupBox, QLineEdit, QPushButton, QScrollArea, QFrame, QWidget)
+
+from pyqtgraph import ViewBox
+
+from PyQt5.QtWidgets import QSplitter
+from PyQt5.QtCore import Qt
+
+import random
+
+
+class DebugDev(QTreeWidgetItem):
+
+    def __init__(self,main,*, path, top, parent, dev, noExpand):
+        QTreeWidgetItem.__init__(self,parent)
+        self._main=main
+        self._top      = top
+        self._parent   = parent
+        self._dev      = dev
+        self._dummy    = None
+        self._path     = path
+        self._groups   = {}
+
+        if isinstance(parent,DebugDev):
+            self._depth = parent._depth+1
+        else:
+            self._depth = 1
+
+        w = PyDMLabel(parent=None, init_channel=self._path + '/name')
+        w.showUnits             = False
+        w.precisionFromPV       = False
+        w.alarmSensitiveContent = False
+        w.alarmSensitiveBorder  = False
+
+        self._top._tree.setItemWidget(self,0,w)
+        self.setToolTip(0,self._dev.description)
+
+        if self._top._node == dev:
+            self._parent.addTopLevelItem(self)
+            self.setExpanded(True)
+            self._setup(False)
+
+        elif (not noExpand) and self._dev.expand:
+            self._dummy = None
+            self.setExpanded(True)
+            self._setup(False)
+        else:
+            self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
+            self.setExpanded(False)
+
+    def _setup(self,noExpand):
+
+        # Get dictionary of variables followed by commands
+        lst = self._dev.variablesByGroup(incGroups=self._top._incGroups,
+                                         excGroups=self._top._excGroups)
+
+
+#         lst.update(self._dev.commandsByGroup(incGroups=self._top._incGroups,
+#                                              excGroups=self._top._excGroups))
+
+        # First create variables/commands
+        for key,val in lst.items():
+
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = DebugGroup(path=self._path, top=self._top, parent=self, name=val.guiGroup)
+
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
+                DebugHolder(main=self._main,path=self._path + '.' + val.name, top=self._top, parent=self, variable=val)
+
+        # Then create devices
+        for key,val in self._dev.devicesByGroup(incGroups=self._top._incGroups, excGroups=self._top._excGroups).items():
+
+            if val.guiGroup is not None:
+                if val.guiGroup not in self._groups:
+                    self._groups[val.guiGroup] = DebugGroup(path=self._path, top=self._top, parent=self, name=val.guiGroup)
+
+                self._groups[val.guiGroup].addNode(val)
+
+            else:
+                DebugDev(main = self._main,path=self._path + '.' + val.name, top=self._top, parent=self, dev=val, noExpand=noExpand)
+
+    def _expand(self):
+        if self._dummy is None:
+            return
+
+        self.removeChild(self._dummy)
+        self._dummy = None
+        self._setup(True)
+
+
+class DebugGroup(QTreeWidgetItem):
+
+    def __init__(self,main,*, path, top, parent, name):
+        QTreeWidgetItem.__init__(self,parent)
+        self._main = main
+        self._top      = top
+        self._parent   = parent
+        self._name     = name
+        self._dummy    = None
+        self._path     = path
+        self._list     = []
+        self._depth    = parent._depth+1
+
+        self._lab = QLabel(parent=None, text=self._name)
+
+        self._top._tree.setItemWidget(self,0,self._lab)
+        self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
+        self.setExpanded(False)
+
+    def _setup(self):
+
+        # Create variables
+        for n in self._list:
+
+            if n.isDevice:
+                DebugDev(main=self._main,
+                         path=self._path + '.' + n.name,
+                         top=self._top,
+                         parent=self,
+                         dev=n,
+                         noExpand=True)
+
+            elif n.isVariable or n.isCommand:
+                DebugHolder(main=self._main,
+                            path=self._path + '.' + n.name,
+                            top=self._top,
+                            parent=self,
+                            variable=n)
+
+    def _expand(self):
+        if self._dummy is None:
+            return
+
+        self.removeChild(self._dummy)
+        self._dummy = None
+        self._setup()
+
+    def addNode(self,node):
+        self._list.append(node)
+
+
+class DebugHolder(QTreeWidgetItem):
+
+    def __init__(self,main,*,path,top,parent,variable):
+        QTreeWidgetItem.__init__(self,parent)
+        self._main   = main
+        self._top    = top
+        self._parent = parent
+        self._var    = variable
+        self._path   = path
+        self._depth  = parent._depth+1
+
+        # print(f'DebugHolder: {self._var=}, {self._var.name=}, {self._var.path=}, {self._var.pollInterval=}')
+
+        w = PyDMLabel(parent=None, init_channel=self._path + '/name')
+        w.showUnits             = False
+        w.precisionFromPV       = False
+        w.alarmSensitiveContent = False
+        w.alarmSensitiveBorder  = True
+
+        fm = QFontMetrics(w.font())
+        width = int(fm.width(self._path.split('.')[-1]) * 1.1)
+
+        rightEdge = width + (self._top._tree.indentation() * self._depth)
+
+        if rightEdge > self._top._colWidths[0]:
+            self._top._colWidths[0] = rightEdge
+
+        self._top._tree.setItemWidget(self,0,w)
+        self.setToolTip(0,self._var.description)
+
+        w = makeVariableViewWidget(self)
+        self._top._tree.setItemWidget(self, 1, w)
+
+        pe = QLineEdit(parent=None)
+
+        def _makeSetPoll(le):
+            def _setPoll():
+                print(self._var)
+                print(le.text())
+                self._var.setPollInterval(float(le.text()))
+            return _setPoll
+
+        pe.returnPressed.connect(_makeSetPoll(pe))
+        pe.setText(str(self._var.pollInterval))
+
+        self._top._tree.setItemWidget(self, 3, pe)
+        #self.setText(3,str(self._var.pollInterval))
+        # self.setText(4,str(self._var._value))
+
+
+        def funcgen(str):
+            def ret():
+                #calls the button's toggle method, and also changes the state of DefaultTop so that the correct color will be used in the plot
+                if w._state is True:
+                    self._main.do_remove(str)
+                else:
+                    self._main.do_add(str)
+                w.toggle()
+            return ret
+
+        f = funcgen(self._path)
+        w = ToggleButton(main=self._main, state=False, path=self._path)
+        w.setText('Add')
+        w.clicked.connect(f)
+
+
+        self._top._tree.setItemWidget(self,2,w)
+        width = fm.width('0xAAAAAAAA    ')
+
+        if width > self._top._colWidths[1]:
+            self._top._colWidths[1] = width
+
+
+
+class SelectionTree(PyDMFrame):
+    def __init__(self,main, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+        PyDMFrame.__init__(self, parent, init_channel)
+
+        self._main = main
+        self._node = None
+        self._path = None
+
+        self._incGroups = incGroups
+        self._excGroups = excGroups
+        self._tree      = None
+
+        self._colWidths = [250,50,150,50,50]
+
+    def connection_changed(self, connected):
+        build = (self._node is None) and (self._connected != connected and connected is True)
+        super(SelectionTree, self).connection_changed(connected)
+
+        if not build:
+            return
+
+        self._node = nodeFromAddress(self.channel)
+        self._path = self.channel
+
+        vb = QVBoxLayout()
+        self.setLayout(vb)
+
+        self._tree = QTreeWidget()
+        vb.addWidget(self._tree)
+
+        self._tree.setColumnCount(4)
+        self._tree.setHeaderLabels(['Node','Value','Plot','Poll Interval'])
+
+
+        self._tree.itemExpanded.connect(self._expandCb)
+
+        hb = QHBoxLayout()
+        vb.addLayout(hb)
+
+        if self._node.isinstance(pyrogue.Root):
+            hb.addWidget(PyDMPushButton(label='Read All',
+                                        pressValue=True,
+                                        init_channel=self._path + '.ReadAll'))
+        else:
+            hb.addWidget(PyDMPushButton(label='Read Recursive',
+                                        pressValue=True,
+                                        init_channel=self._path + '.ReadDevice'))
+
+
+        self.setUpdatesEnabled(False)
+        DebugDev(main = self._main, path = self._path, top=self, parent=self._tree, dev=self._node, noExpand=False)
+        self.setUpdatesEnabled(True)
+
+    @Slot(QTreeWidgetItem)
+    def _expandCb(self,item):
+        self.setUpdatesEnabled(False)
+        item._expand()
+
+        self._tree.setColumnWidth(0,self._colWidths[0])
+        self._tree.setColumnWidth(1,self._colWidths[1])
+        # self._tree.resizeColumnToContents(1)
+        # self._tree.resizeColumnToContents(2)
+        self._tree.setColumnWidth(2,self._colWidths[2])
+        self._tree.setColumnWidth(3,self._colWidths[3])
+        self._tree.setColumnWidth(4,self._colWidths[4])
+        # self._tree.setColumnWidth(4,self._colWidths[4])
+        # self._tree.resizeColumnToContents(5)
+
+        self.setUpdatesEnabled(True)
+
+    @Property(str)
+    def incGroups(self):
+        if self._incGroups is None or len(self._incGroups) == 0:
+            return ''
+        else:
+            return ','.join(self._incGroups)
+
+    @incGroups.setter
+    def incGroups(self, value):
+        if value == '':
+            self._incGroups = None
+        else:
+            self._incGroups = value.split(',')
+
+    @Property(str)
+    def excGroups(self):
+        if self._excGroups is None or len(self._excGroups) == 0:
+            return ''
+        else:
+            return ','.join(self._excGroups)
+
+    @excGroups.setter
+    def excGroups(self, value):
+        if value == '':
+            self._excGroups = None
+        else:
+            self._excGroups = value.split(',')
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
+
+class ToggleButton(QPushButton):
+    def __init__(self,main,state,path):
+        super().__init__()
+        self._main = main
+        self._state = state
+        self._path = path
+        self.styleSheet = 'QPushButton {background-color: %s;\
+                                          color: black;\
+                                          border: none;\
+                                          font: bold}'
+
+        self.setStyleSheet(self.styleSheet%self._main._addColor)
+
+    def toggle(self):
+        if self._state is True:
+            self.setText('Add')
+            self._state = False
+            self.setStyleSheet(self.styleSheet%self._main._addColor)
+        else:
+            self.setText('Remove')
+            self._state = True
+            self.setStyleSheet(self.styleSheet%self._main._colorSelector.current_color())
+
+
+    def setStyle(self,color):
+        self.setStyleSheet(self.styleSheet%color)
+
+class TimePlotter(PyDMFrame):
+    def __init__(self, parent=None, init_channel=None):
+        super().__init__(parent, init_channel)
+        self._node = None
+
+        self._addColor = '#dddddd'
+        self._colorSelector = ColorSelector()
+
+
+        self.setup_ui()
+
+
+    def setup_ui(self):
+
+        vb = QVBoxLayout()
+        self.setLayout(vb)
+
+        main_layout = QHBoxLayout()
+        main_box = QGroupBox(parent=self)
+        main_box.setLayout(main_layout)
+
+        buttons_layout = QHBoxLayout()
+        buttons_box = QGroupBox(parent=self)
+        buttons_box.setLayout(buttons_layout)
+
+        self.width_edit = QLineEdit()
+        apply_btn = QPushButton()
+        apply_btn.setText("Set width")
+        apply_btn.clicked.connect(self.do_setwidth)
+
+        auto_axis_btn = QPushButton()
+        auto_axis_btn.setText("Auto height")
+        auto_axis_btn.clicked.connect(self.do_autoheight)
+
+        # Create the legend layout
+        self.legend_layout = QVBoxLayout()
+        self.legend_layout.setContentsMargins(10, 10, 10, 10)
+
+        # Create a Frame to host the items in the legend
+        self.frm_legend = QFrame(parent=self)
+        self.frm_legend.setLayout(self.legend_layout)
+
+
+        # Create a ScrollArea
+        self.scroll_area = QScrollArea(parent=self)
+        self.scroll_area.setMinimumHeight(200)
+        self.scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+        self.scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setAlignment(QtCore.Qt.AlignTop)
+
+        # Add the Frame to the scroll area
+        self.scroll_area.setWidget(self.frm_legend)
+
+        buttons_layout.addWidget(self.width_edit)
+        buttons_layout.addWidget(apply_btn)
+        buttons_layout.addWidget(auto_axis_btn)
+
+        plots_layout = QHBoxLayout()
+        plots_box = QGroupBox(parent=self)
+        plots_box.setLayout(plots_layout)
+
+        self.plots = pwt.PyDMTimePlot(parent=None, background = '#f6f6f6', plot_by_timestamps = True)
+        self.plots.setShowLegend(False)
+        self.plots.setShowXGrid(True)
+        self.plots.setShowYGrid(True)
+        self.plots.setTitle('Plots')
+        self.plots.setTimeSpan(100)
+
+        plots_layout.addWidget(self.plots)
+        plots_layout.addWidget(buttons_box)
+
+        selection_layout = QVBoxLayout()
+        self.selection_tree = SelectionTree(main=self,parent=None,init_channel=self.channel)
+        self.selection_tree.setMinimumWidth(718)
+        selection_layout.addWidget(self.selection_tree)
+        selection_layout.addWidget(self.scroll_area)
+        selection_box = QGroupBox()
+        selection_box.setLayout(selection_layout)
+
+        selection_splitter = QSplitter(Qt.Vertical)
+        selection_splitter.addWidget(self.selection_tree)
+        selection_splitter.addWidget(self.scroll_area)
+
+        graphs_layout = QVBoxLayout()
+        graphs_layout.addWidget(self.plots)
+        graphs_layout.addWidget(buttons_box)
+        graphs_box = QGroupBox()
+        graphs_box.setLayout(graphs_layout)
+
+        main_splitter = QSplitter(Qt.Horizontal)
+
+        main_splitter.addWidget(selection_splitter)
+        main_splitter.addWidget(graphs_box)
+        main_layout.addWidget(main_splitter)
+
+        vb.addWidget(main_box)
+
+    def do_add(self,path):
+        self.plots.addYChannel(y_channel=path,
+                color = self._colorSelector.take_color(path),
+                lineWidth = 5)
+        self.plots.setShowLegend(False)
+
+        disp = LegendRow(parent = self,path=path,main = self)
+        disp.setMaximumHeight(50)
+        self.legend_layout.addWidget(disp)
+
+
+    def do_remove(self,path):
+        curve = self.plots.findCurve(path)
+        self.plots.removeYChannel(curve)
+        for widget in self.frm_legend.findChildren(QWidget):
+            if isinstance(widget,LegendRow) and widget._path == path:
+                widget.setParent(None)
+                widget.deleteLater()
+
+    def do_setwidth(self):
+        text = self.width_edit.text()
+
+        try:
+            val = float(text)
+            self.plots.setTimeSpan(val)
+        except Exception:
+            pass
+
+    def do_autoheight(self):
+        print('setting')
+        # self.plots.setAutoRangeY(True)
+        # self.plots.autoRangeY = True
+        self.plots.plotItem.enableAutoRange(ViewBox.YAxis, enable=True)
+
+    def minimumSizeHint(self):
+        return QtCore.QSize(1500, 1000)
+
+    def ui_filepath(self):
+        return None
+
+class LegendRow(Display):
+    def __init__(self, parent=None, args=[], macros=None,path=None,main=None):
+        super(LegendRow, self).__init__(parent=parent, args=args, macros=None)
+
+        self._path = path
+        self.sizeX = 40
+        self.sizeY = 40
+        self._main = main
+
+        self.setMaximumHeight(50)
+        self.setup_ui()
+
+    def setup_ui(self):
+
+        #setup main layout
+        main_layout = QHBoxLayout()
+        main_box = QGroupBox(parent=self)
+        main_box.setLayout(main_layout)
+
+
+        #Add widgets to layout
+        main_layout.addWidget(QLabel(self._path))
+        button = ToggleButton(main=self._main, state = True, path = self._path)
+        button.setStyle(self._main._colorSelector.current_color())
+        button.setMaximumWidth(150)
+        button.setMaximumHeight(50)
+        button.setText('Remove')
+
+        def legendbuttonfuncgen(path):
+            def f():
+                self._main.do_remove(path)
+                for widget in self._main.selection_tree.findChildren(QWidget):
+                    if isinstance(widget,ToggleButton) and widget._path == path:
+                        widget.toggle()
+            return f
+
+        button.clicked.connect(legendbuttonfuncgen(self._path))
+        main_layout.addWidget(button)
+
+        self.setLayout(main_layout)
+
+    def ui_filepath(self):
+        # No UI file is being used
+        return None
+
+class ColorSelector():
+
+    def __init__(self):
+        self._colorList = ['#F94144', '#F3722C', '#F8961E', '#F9844A', '#F9C74F', '#90BE6D', '#43AA8B', '#4D908E', '#577590', '#277DA1','#f70a0a','#f75d0a','#f7a00a','#f7f30a','#98f70a','#1af70a','#0af7c0','#0accf7','#0a75f7','#0a1ef7','#710af7','#e70af7','#f70a71','#8a2d06','#838a06''#188a06','#188a06','#188a06']
+        self._currentDict = {}
+        self._currentColor = None
+
+    def take_color(self,channel):
+
+        if len(self._colorList) == 0:
+            self._colorList.append(self.generate_new_color())
+
+        random.shuffle(self._colorList)
+        color = self._colorList.pop()
+        self._currentDict[channel] = color
+        self._currentColor = color
+        return color
+
+    def give_back_color(self,channel):
+
+        color = self.currentDict.pop(channel)
+        self._colorList.append(color)
+        random.shuffle(self._colorList)
+
+    def current_color(self):
+
+        return self._currentColor
+
+    def generate_new_color(self):
+
+        return '#' + hex(random.randint(0x100000,0xffffff))[2:] #<----------Change this

--- a/python/pyrogue/utilities/cpsw.py
+++ b/python/pyrogue/utilities/cpsw.py
@@ -18,7 +18,7 @@ import math
 
 def exportRemoteVariable(variable,indent):
 
-    if variable.ndType is not None or not('Bool' in variable.typeStr or 'String' in variable.typeStr or 'Int' in variable.typeStr):
+    if variable.ndType is not None or not ('Bool' in variable.typeStr or 'String' in variable.typeStr or 'Int' in variable.typeStr):
         print(f"Error: Found variable {variable.path} with unsupported type {variable.typeStr}, error exporting")
         return ""
 

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -282,9 +282,15 @@ void rim::Block::startTransaction(uint32_t type, bool forceWr, bool check, rim::
          count = retryCount_;
 
       } catch ( rogue::GeneralError err ) {
-         if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
+
+         // Rethrow the error if this is the final retry, else log warning
+         if ( (count+1) > retryCount_ ) {
+             bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+             throw err;
+         } else {
+             bLog_->warning("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+         }
       }
    }
    while (count++ < retryCount_);
@@ -315,9 +321,15 @@ void rim::Block::startTransactionPy(uint32_t type, bool forceWr, bool check, rim
          count = retryCount_;
 
       } catch ( rogue::GeneralError err ) {
-         if ( (count+1) >= retryCount_ ) throw err;
-         bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
          fWr = true; // Stale state is now lost
+
+         // Rethrow the error if this is the final retry, else log warning
+         if ( (count+1) > retryCount_ ) {
+             bLog_->error("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+             throw err;
+         } else {
+             bLog_->warning("Error on try %" PRIu32 " out of %" PRIu32 ": %s", (count+1), (retryCount_+1), err.what());
+         }
       }
    }
    while (count++ < retryCount_);
@@ -1675,4 +1687,3 @@ void rim::Block::rateTest() {
 
    printf("\nBlock c++ raw: Wrote %" PRIu64 " times in %f seconds. Rate = %f\n",count,durr,rate);
 }
-

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -528,12 +528,12 @@ bp::object rim::Block::variablesPy() {
 // byte reverse
 void rim::Block::reverseBytes ( uint8_t *data, uint32_t byteSize ) {
    uint32_t x;
-   uint32_t tmp;
-
+   uint8_t tmp;
+   
    for (x=0; x < byteSize/2; x++) {
       tmp = data[x];
-      data[x] = data[byteSize-x];
-      data[byteSize-x] = tmp;
+      data[x] = data[byteSize-x-1];
+      data[byteSize-x-1] = tmp;
    }
 }
 

--- a/tests/test_fifo.py
+++ b/tests/test_fifo.py
@@ -31,10 +31,17 @@ def fifo_path():
     # Client stream
     prbsTx >> fifo >> prbsRx
 
+    prbsRx.checkPayload(True)
+
     print("Generating Frames")
     for _ in range(FrameCount):
         prbsTx.genFrame(FrameSize)
-    time.sleep(30)
+
+    # Wait at least 30 seconds for frames to go through
+    for i in range(300):
+        if prbsRx.getRxCount() == FrameCount:
+            break
+        time.sleep(.1)
 
     if prbsRx.getRxErrors() != 0:
         raise AssertionError('PRBS Frame errors detected! Errors = {}'.format(prbsRx.getRxErrors()))

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -85,17 +85,17 @@ class HubTestDev(pr.Device):
     # Return the command field from the read data
     @classmethod
     def cmd_address(cls, data): # returns address data
-        return((data & 0x7FFF0000) >> 20)
+        return (data & 0x7FFF0000) >> 20
 
     # Return the data field from the read data
     @classmethod
     def cmd_data(cls, data):  # returns data
-        return(data & 0xFFFFF)
+        return (data & 0xFFFFF)
 
     # Build the data field for a write command
     @classmethod
     def cmd_make(cls, read, address, data):
-        return((read << 31) | ((address << 20) & 0x7FF00000) | (data & 0xFFFFF))
+        return ((read << 31) | ((address << 20) & 0x7FF00000) | (data & 0xFFFFF))
 
     # Helper function to initiate outbound write transactions and wait for the result
     # Returns error string or "" for no error
@@ -200,10 +200,10 @@ class TestEmulate(rogue.interfaces.memory.Slave):
         return 0
 
     def _doMaxAccess(self):
-        return(self._maxSize)
+        return self._maxSize
 
     def _doMinAccess(self):
-        return(self._minWidth)
+        return self._minWidth
 
     def _doTransaction(self,transaction):
         address = transaction.address()

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -12,7 +12,9 @@
 import pyrogue as pr
 import pyrogue.interfaces.simulation
 
-#rogue.Logging.setLevel(rogue.Logging.Debug)
+# We expect Errors with this test, so turn off logging of them
+#import rogue
+#rogue.Logging.setLevel(rogue.Logging.Warning)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
@@ -30,7 +32,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -40,7 +42,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -50,7 +52,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -60,7 +62,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -70,7 +72,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
         self.add(pr.RemoteVariable(
@@ -80,7 +82,7 @@ class SimpleDev(pr.Device):
             bitOffset    =  0x00,
             base         = pr.UInt,
             mode         = "RW",
-            retryCount   = 2
+            retryCount   = 3
         ))
 
 
@@ -90,7 +92,7 @@ class DummyTree(pr.Root):
         pr.Root.__init__(self,
                          name='dummyTree',
                          description="Dummy tree for example",
-                         timeout=2.0,
+                         timeout=.01,
                          pollEn=False,
                          serverPort=None)
 

--- a/tests/test_streamBridge.py
+++ b/tests/test_streamBridge.py
@@ -37,12 +37,18 @@ def data_path():
     # Server stream
     prbsRx << client
 
-    time.sleep(5)
+    prbsRx.checkPayload(True)
 
     print("Generating Frames")
     for _ in range(FrameCount):
         prbsTx.genFrame(FrameSize)
-    time.sleep(20)
+
+    # Wait at least 20 seconds for frames to go through
+    for i in range(200):
+        if prbsRx.getRxCount() == FrameCount:
+            break
+        time.sleep(.1)
+
 
     if prbsRx.getRxCount() != FrameCount:
         raise AssertionError('Frame count error. Got = {} expected = {}'.format(prbsRx.getRxCount(),FrameCount))


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

# Pull Requests Since v5.14.0
### Bug
 1. #883 - Memory retry test improvements
 1. #875 - Bug fix in Block.cpp
 1. #888 - Fix off by one error in big endian swaps
 1. #881 - Fix bug in start and stop recursion
 1. #887 - Temporary fix to build with python 3.10
### Enhancement
 1. #877 - Add timeplot GUI for plotting polled Variables in a tree.
 1. #885 - Enhancements to DebugTree GUI
 1. #884 - SQL Logging Enhancements
 1. #878 - ESROGUE-583 - Optimize github actions
 1. #883 - Memory retry test improvements
 1. #876 - Update _Model.py
### Unlabeled
 1. #882 - Fix E275 Flake8 Errors
 1. #879 - Update petalinux.rst
 1. #874 - Fix typo in PR template
# Pull Request Details
### Fix typo in PR template
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Jul 22 22:22:58 2022 -0700|
|**Pull:**|#874 (2 additions, 2 deletions, 1 files changed)|
|**Branch:**|slaclab/bengineerd-patch-1|
|**Labels:**|documentation|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> Fix relevate->relevant
> 

-------


### Bug fix in Block.cpp
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Jul 22 22:25:59 2022 -0700|
|**Pull:**|#875 (16 additions, 5 deletions, 1 files changed)|
|**Branch:**|slaclab/ESROGUE-504|
|**Issues:**|#875|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-504|
|**Labels:**|bug|

**Notes:**
> ### Description
> - fixed the Block's retry behavior and error print statements

-------


### Update _Model.py
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Jul 22 22:23:26 2022 -0700|
|**Pull:**|#876 (24 additions, 2 deletions, 1 files changed)|
|**Branch:**|slaclab/ESROGUE-591|
|**Issues:**|#876|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-591|
|**Labels:**|enhancement|

**Notes:**
> #### Description
> - Adding UFixed model
> - Updated Fixed model's comments for "bitSize" and "binPoint"

-------


### Add timeplot GUI for plotting polled Variables in a tree.
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Sep 14 13:39:41 2022 -0700|
|**Pull:**|#877 (835 additions, 79 deletions, 13 files changed)|
|**Branch:**|slaclab/time-plot|
|**Issues:**|#877|
|**Labels:**|enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> The new GUI can be run as a rogue client and connect to an existing server with
> ```
> > python -m pyrogue timeplot
> ```
> 
> Additionally, the `pyrogue.pydm.widgets.TimePlotter` widget can be added to an application GUI
> 
> There are still some quirks, but overall it is ready for users.
> 
> <img width="893" alt="image" src="https://user-images.githubusercontent.com/15825552/189739382-508eb4f8-dc3b-465d-8a4b-ffe1d06af6bd.png">
> 
> 
> ### Details
> <!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
> 
> Some changes have been made to the pollInterval functionality.
> - The `pollInterval` setter decorator method in `BaseVariable` has been deprecated. 
>   - These setters cannot be called from the Virtual classes in a client. 
>   - A `BaseVariable.setPollInterval()` method has been added that is exposed to the client side. 
>   - This allows the poll intervals to be changed from by a `client`.
> - The `LinkVariable.pollInterval` property method now returns the smallest poll interval of all the linked dependancies.
> 
> ### JIRA
> <!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
> https://jira.slac.stanford.edu/browse/ESROGUE-597

-------


### ESROGUE-583 - Optimize github actions
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Sep 9 11:10:12 2022 -0700|
|**Pull:**|#878 (76 additions, 26 deletions, 3 files changed)|
|**Branch:**|slaclab/james-test|
|**Issues:**|#883, #878|
|**Labels:**|enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> This PR makes several optimizations in order to reduce the Github Actions CI runtime.
> 
>  - The CI workflow now only runs on branches that have a pull request.
>  - `actions/checkout` upgraded to v3
>    - Probably not much effect on run time
>  - `actions/setup-python` upgraded to v4
>    - Allows installed `pip` packages to be cached between runs
>    - ~20 seconds speedup
>  - Cache EPICS install between runs
>    - ~4 minute speedup
>  - Run python linter before building rogue
>    - Catches python errors before wasting time on building and testing rogue
>  - Test script enhancements
>    - `test_fifo.py` and `test_streamBridge.py` were waiting 30 and 20 seconds for frames that take a fraction of that time
>    - These two scripts now finish as soon as the frames have arrived
>    - ~ 1 minute total speedup
> 
> Overall, these changes (plus #883) reduce the runtime from ~15 minutes to ~5 minutes.
> 
> ### JIRA
> <!--- Optional. Provide a link to any relevate JIRA ticket here. Otherwise you can delete this section -->
> https://jira.slac.stanford.edu/browse/ESROGUE-583
> 

-------


### Update petalinux.rst
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Jul 27 10:05:39 2022 -0700|
|**Pull:**|#879 (7 additions, 13 deletions, 1 files changed)|
|**Branch:**|slaclab/ESROGUE-523|
|**Issues:**|#879|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-523|
|**Labels:**|documentation|

**Notes:**
> ### Description
> - updated the bitbake example such that the setup.py file doesn't have to be manually copied
> - Adding python3-jupyter and xilinx-pynq packages to the bitbake receipt

-------


### Fix bug in start and stop recursion
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Sep 13 13:20:54 2022 -0700|
|**Pull:**|#881 (3 additions, 3 deletions, 1 files changed)|
|**Branch:**|slaclab/start-stop-fix|
|**Issues:**|#881|
|**Labels:**|bug|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> `Device._start()` and `Device._stop()` were calling `self.deviceList` to recurse. But this is the wrong call, as it returns a full recursion of every Device in the tree from that point. The effect was that `_start()` and `_stop()` were being called multiple times on each Device depending on the tree depth.
> 
> The updated methods use `self.devices.values()` to iterate through child `Devices`.
> 
> **There is a big inconsistency between `Node.nodeList`, `Node.variableList`, and `Node.deviceList`.
> `nodeList` is not recursive. It just gets a list of the child Nodes. But `variableList` and `deviceList` are recursive.**
> 
> Currently `Root` is the only caller of `deviceList`. A few things call `variableList` (https://github.com/search?l=Python&q=org%3Aslaclab+variableList&type=Code). I can't find anything that calls `nodeList`.
> 
> We should decide what to do about this. I think I prefer these all to be non-recursive, or maybe even get rid of them entirely. Iterating of children should be done with the `nodes`, `commands`, `variables` or `devices` properties. I've created a new JIRA ticket for this issue, so we can merge this PR now and solve that problem later. https://jira.slac.stanford.edu/browse/ESROGUE-599

-------


### Fix E275 Flake8 Errors
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Thu Sep 1 15:21:39 2022 -0700|
|**Pull:**|#882 (19 additions, 19 deletions, 9 files changed)|
|**Branch:**|slaclab/flake8-fix|
|**Labels:**|whitespace|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> This fixes all instances of the new E275 "Missing whitespace after keyword" flake8 error. This error is checked by default in the newest version of flake8.

-------


### Memory retry test improvements
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Sep 2 14:22:15 2022 -0700|
|**Pull:**|#883 (18 additions, 12 deletions, 4 files changed)|
|**Branch:**|slaclab/memory-retry-test|
|**Labels:**|bug, enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
>  - pytest and pytest-cov are now conda dependencies so they can be run locally
>  - Fix bug in `pyrogue.simulation.MemEmulate that miscounted dropped transactions.
>  - Reduced retry timeout in test_retry_memory.py so that script runs much faster.

-------


### SQL Logging Enhancements
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Sep 9 10:09:53 2022 -0700|
|**Pull:**|#884 (91 additions, 43 deletions, 2 files changed)|
|**Branch:**|slaclab/sql-logging-dev|
|**Labels:**|enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> SQL row writes are now batched, so that if multiple updates are queued, they are written to the DB in a single transaction.
> 
> This greatly increases the write efficiency. Before this change, the database write thread was unable to keep up.
> 
> The Root.Time variable has been given the `'NoSql'` group, since SQL logging this is rather useless.
> 

-------


### Enhancements to DebugTree GUI
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Mon Sep 12 16:21:12 2022 -0700|
|**Pull:**|#885 (111 additions, 45 deletions, 3 files changed)|
|**Branch:**|slaclab/debug-widget|
|**Issues:**|#885|
|**Labels:**|enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> - Variable units are now shown right-justified in the same column as the value, rather than in their own column. This is much cleaner.
> - Each Device has a "Read" command button to recursively read that Device.
> - Column auto-expand works a bit better. Still could use some more work.
> 
> ### Details
> <!-- Optional. Use if for anything that is relevant to discussion of the change, but too detailed to belong in the release notes. Otherwise you can delete this section -->
> Here is a picture of the new GUI.
> <img width="881" alt="image" src="https://user-images.githubusercontent.com/15825552/189404813-67950966-f83e-4d55-9498-8a35b4b12e99.png">

-------


### Temporary fix to build with python 3.10
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Sep 14 13:37:51 2022 -0700|
|**Pull:**|#887 (1 additions, 0 deletions, 1 files changed)|
|**Branch:**|slaclab/merge-bugfix|
|**Labels:**|bug|

**Notes:**
> Using the conda package from conda-forge avoid the "merge bug" when building rogue for python 3.10
> This is temporary workaround and should be removed when this bug is fixed: https://github.com/conda/conda/issues/11442

-------


### Fix off by one error in big endian swaps
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Fri Sep 16 12:06:09 2022 -0700|
|**Pull:**|#888 (4 additions, 4 deletions, 1 files changed)|
|**Branch:**|slaclab/big-endian-fix|
|**Issues:**|#888|
|**Labels:**|bug|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> This fixes a buffer index off-by-one error in the function that reverses the bytes for big-endian numbers.

-------
