### PR TITLE
pydmTop.py change in default tab view

### DIFF
--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -65,7 +65,7 @@ class DefaultTop(Display):
 
         # Set the default Tab view
         self.tab.setCurrentIndex(1)
-        
+
         self.resize(self.sizeX, self.sizeY)
 
     def ui_filepath(self):

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -55,12 +55,17 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
+        # System Tab  (Tab Index=0)
         sys = SystemWindow(parent=None, init_channel=Channel)
         self.tab.addTab(sys,'System')
 
+        # Debug Tree Tab  (Tab Index=1)
         var = DebugTree(parent=None, init_channel=Channel)
         self.tab.addTab(var,'Debug Tree')
 
+        # Set the default Tab view
+        self.tab.setCurrentIndex(1)
+        
         self.resize(self.sizeX, self.sizeY)
 
     def ui_filepath(self):


### PR DESCRIPTION
### Description
- Make the debug tree the default tab that's open at start up
