### PR TITLE
Release Candidate v5.15.1

### DIFF
--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -526,7 +526,7 @@ class Node(object):
             self.addToGroup(grp)
 
     @expose
-    def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=False):
+    def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=True):
 
         """
         Get current values as yaml data.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -297,7 +297,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  function=lambda arg: self.getYaml(readFirst=arg,
                                                                    modes=['RW','WO'],
                                                                    incGroups=None,
-                                                                   excGroups='NoConfig'),
+                                                                   excGroups='NoConfig',
+                                                                   recurse=True),
                                  hidden=True,
                                  description='Get current configuration as YAML string. Pass read first arg.'))
 
@@ -305,7 +306,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                  function=lambda arg: self.getYaml(readFirst=arg,
                                                                    modes=['RW','RO','WO'],
                                                                    incGroups=None,
-                                                                   excGroups='NoState'),
+                                                                   excGroups='NoState',
+                                                                   recurse=True),
                                  hidden=True,
                                  description='Get current state as YAML string. Pass read first arg.'))
 
@@ -727,7 +729,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self._sendYamlFrame(self.getYaml(readFirst=False,
                                          modes=modes,
                                          incGroups=incGroups,
-                                         excGroups=excGroups))
+                                         excGroups=excGroups,
+                                         recurse=True))
 
     def _write(self):
         """Write all blocks"""
@@ -764,7 +767,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             if autoCompress:
                 name += '.zip'
 
-        yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups)
+        yml = self.getYaml(readFirst=readFirst,modes=modes,incGroups=incGroups,excGroups=excGroups, recurse=True)
 
         if name.split('.')[-1] == 'zip':
             with zipfile.ZipFile(name, 'w', compression=zipfile.ZIP_LZMA) as zf:

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -55,11 +55,16 @@ class DefaultTop(Display):
         self.tab = QTabWidget()
         vb.addWidget(self.tab)
 
+        # System Tab  (Tab Index=0)
         sys = SystemWindow(parent=None, init_channel=Channel)
         self.tab.addTab(sys,'System')
 
+        # Debug Tree Tab  (Tab Index=1)
         var = DebugTree(parent=None, init_channel=Channel)
         self.tab.addTab(var,'Debug Tree')
+
+        # Set the default Tab view
+        self.tab.setCurrentIndex(1)
 
         self.resize(self.sizeX, self.sizeY)
 

--- a/tests/test_config_in.yml
+++ b/tests/test_config_in.yml
@@ -1,0 +1,25 @@
+DummyTree:
+  enable: True
+  ForceWrite: False
+  InitAfterConfig: False
+  PollEn: False
+  SimpleDev:
+    enable: True
+    A : 1
+    B : 2
+    C : 3
+    SimpleDev:
+      enable: True
+      A : 4
+      B : 5
+      C : 6
+      SimpleDev:
+        enable: True
+        A : 7
+        B : 8
+        C : 9
+        SimpleDev:
+          enable: True
+          A : 10
+          B : 11
+          C : 12

--- a/tests/test_loadsave.py
+++ b/tests/test_loadsave.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Comment added by rherbst for demonstration purposes.
+import pyrogue as pr
+import pyrogue.interfaces.simulation
+import rogue.interfaces.memory
+
+import pathlib
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+#import logging
+#logger = logging.getLogger('pyrogue')
+#logger.setLevel(logging.DEBUG)
+
+class SimpleDev(pr.Device):
+
+    def __init__(self, depth, **kwargs):
+        print(f"Init SimpleDev with offset {kwargs['offset']:x} and {depth=}")
+
+        super().__init__(**kwargs)
+
+        print(self.offset)
+
+        self.add(pr.RemoteVariable(
+            name         = "A",
+            offset       =  0x00,
+            bitSize      =  32,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "B",
+            offset       =  0x04,
+            bitSize      =  32,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = "C",
+            offset       =  0x08,
+            bitSize      =  32,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        if depth > 0:
+            self.add(SimpleDev(
+                offset = self.offset >> 1,
+                depth = depth-1))
+
+
+class DummyTree(pr.Root):
+
+    def __init__(self):
+        pr.Root.__init__(self,
+                         name='DummyTree',
+                         description="Dummy tree for example",
+                         timeout=2.0,
+                         pollEn=False,
+                         serverPort=None)
+
+        # Use a memory space emulator
+        #sim = pr.interfaces.simulation.MemEmulate()
+        sim = rogue.interfaces.memory.Emulate(4,0x1000)
+        self.addInterface(sim)
+
+        # Add Device
+        self.add(SimpleDev(
+            offset     = 0x100000,
+            depth      = 3,
+            memBase    = sim,
+        ))
+
+
+def test_loadsave():
+
+    filepath = pathlib.Path(__file__).parent.resolve()
+    inputYaml = f'{filepath}/test_config_in.yml'
+    outputYaml = f'{filepath}/test_config_out.yml'
+
+    with DummyTree() as root:
+
+        root.LoadConfig(inputYaml)
+
+        inputDict = pr.yamlToData(fName=inputYaml)
+
+        root.SaveConfig(outputYaml)
+
+        outputDict = pr.yamlToData(fName=outputYaml)
+
+        if (inputDict != outputDict):
+            raise AssertionError('Configuration does not match input yaml after loading')
+
+
+if __name__ == "__main__":
+    test_loadsave()


### PR DESCRIPTION
# Pull Requests Since v5.15.0
### Bug
 1. #893 - Fix getYaml() recursion bug that affects Root.SaveState and Root.SaveConfig
### Enhancement
 1. #892 - pydmTop.py change in default tab view
# Pull Request Details
### pydmTop.py change in default tab view
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Oct 12 11:31:33 2022 -0700|
|**Pull:**|#892 (5 additions, 0 deletions, 1 files changed)|
|**Branch:**|slaclab/pydmTop-update|
|**Labels:**|enhancement|

**Notes:**
> ### Description
> - Make the debug tree the default tab that's open at start up

-------


### Fix getYaml() recursion bug that affects Root.SaveState and Root.SaveConfig
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Wed Oct 12 12:33:46 2022 -0700|
|**Pull:**|#893 (143 additions, 5 deletions, 4 files changed)|
|**Branch:**|slaclab/getYaml-recurse|
|**Issues:**|#859, #893|
|**Labels:**|bug|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> PR #859 introduced a bug where `Root` calls to `getYaml()` do not include the new `recurse` parameter. This parameter is `False` by default, so many functions such as `SaveState()` and `SaveConfig()` no longer recurse the tree.
> 
> `Root` calls to `getYaml()` now explicitly set the `recurse` parameter to `True`. Additionally, the `recurse` parameter now defaults to `True`, which seems like more common use case.
> 
> #### Testing
> A test case has also been added in `tests/` that loads a yaml config, saves a YAML config, and then compares them. This is far from a complete test of the YAML functionality, but can be expanded upon later.
> 
> 
> ### Related
> <!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
> #859

-------


