### PR TITLE
Release Candidate v5.15.3

### DIFF
--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -220,7 +220,7 @@ class DebugHolder(QTreeWidgetItem):
         self.setToolTip(0,self._var.description)
 
         self.setText(1,self._var.mode)
-        self.setText(2,self._var.typeStr)
+        self.setText(2,f'{self._var.typeStr}   ') # Pad to look nicer
         self.setToolTip(0,self._var.description)
 
         w = makeVariableViewWidget(self)
@@ -268,9 +268,9 @@ class DebugTree(PyDMFrame):
 
         self._tree.setColumnCount(5)
         self._tree.setHeaderLabels(['Node','Mode','Type','Value', 'Command'])
-        self._tree.header().setStretchLastSection(False)
-        self._tree.header().setResizeMode(3, QHeaderView.Stretch) #ResizeToContents)
-
+        header = self._tree.header()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(3, QHeaderView.Stretch)
 
         self._tree.itemExpanded.connect(self._expandCb)
 


### PR DESCRIPTION
# Pull Requests Since v5.15.2
 1. #897 - Change pyqt4 setResizeMode() call to pyqt5 setSectionResize()
# Pull Request Details
### Change pyqt4 setResizeMode() call to pyqt5 setSectionResize()
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Thu Oct 20 11:11:10 2022 -0700|
|**Pull:**|#897 (4 additions, 4 deletions, 1 files changed)|
|**Branch:**|slaclab/pyqt5-fix|
|**Issues:**|#895|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> Fixes a bug introduced in v5.15.2 by #895. A deprecated method (`setResizeMode()`) was called. In pyqt5, the correct method is `setSectionResizeMode()`. This was not caught because some versions of pyqt5 seem to support the deprecated `setResizeMode()` method.
> 
> ### JIRA
> <!--- Optional. Provide a link to any relevant JIRA ticket here. Otherwise you can delete this section -->
> https://jira.slac.stanford.edu/browse/ESROGUE-606
> 
> ### Related
> <!--- Optional. Provide links to any related Pull Requests. Otherwise you can delete this section -->
> #895

-------
