### PR TITLE
PyDM GUI Enhancements

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -426,9 +426,11 @@ class BaseVariable(pr.Node):
         try:
 
             if isinstance(value,np.ndarray):
-                with np.printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize):
-                    ret = np.array2string(value, separator=', ')
-                return ret
+                return np.array2string(value,
+                                       separator=', ',
+                                       formatter={'all':self.disp.format},
+                                       threshold=sys.maxsize,
+                                       max_line_width=1000)
 
             elif self.disp == 'enum':
                 if value in self.enum:

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -178,9 +178,6 @@ def makeVariableViewWidget(parent):
         w.writeOnPress          = True
         w.installEventFilter(parent._top)
 
-    elif parent._var.mode == 'RO' and not parent._var.isCommand:
-        w = PyRogueLabel(parent=None, init_channel=parent._path + '/disp')
-
     else:
         w = PyRogueLineEdit(parent=None, init_channel=parent._path + '/disp')
 

--- a/python/pyrogue/pydm/widgets/label.py
+++ b/python/pyrogue/pydm/widgets/label.py
@@ -1,6 +1,6 @@
 from pydm.widgets import PyDMLabel
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QGridLayout
+from qtpy.QtWidgets import QHBoxLayout
 from pydm.widgets.base import str_types
 from pydm.widgets.display_format import parse_value_for_display
 
@@ -15,12 +15,11 @@ class PyRogueLabel(PyDMLabel):
         self._unitWidget.setAlignment(Qt.AlignRight)
         self._unitWidget.setText("")
 
-        grid = QGridLayout()
-        grid.addWidget(self._unitWidget, 0, 0)
-        grid.setVerticalSpacing(0)
-        grid.setHorizontalSpacing(0)
-        grid.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(grid)
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(self._unitWidget)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(hbox)
 
     def unit_changed(self, new_unit):
         if self._show_units:

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -43,6 +43,12 @@ class PyRogueLineEdit(PyDMLineEdit):
         super(PyRogueLineEdit, self).focusOutEvent(event)
         refresh_style(self)
 
+
+    def check_enable_state(self):
+        status = self._write_access and self._connected
+        self.setReadOnly(not status)
+        refresh_style(self)        
+
     @Property(bool)
     def dirty(self):
         return self._dirty

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -4,35 +4,36 @@ import ast
 import logging
 from pydm.widgets import PyDMLineEdit, PyDMLabel
 from qtpy.QtCore import Property, Qt
-from qtpy.QtWidgets import QGridLayout
+from qtpy.QtWidgets import QHBoxLayout
 from pydm.widgets.base import refresh_style, str_types
 from pydm.widgets.display_format import DisplayFormat, parse_value_for_display
 
 logger = logging.getLogger(__name__)
 
 class PyRogueLineEdit(PyDMLineEdit):
-    def __init__(self, parent, init_channel=None, show_units=True):
+    def __init__(self, parent, init_channel=None, show_units=True, read_only=False):
         super().__init__(parent, init_channel=init_channel)
 
         self._show_units = show_units
+
+        self.textEdited.connect(self.text_edited)
+        self._dirty = False
+        self.setStyleSheet("*[dirty='true']\
+                           {background-color: orange;}\
+                           *[readOnly='true'] { color: black; background-color: WhiteSmoke;}")
+
 
         self._unitWidget = PyDMLabel(parent)
         self._unitWidget.setStyleSheet("QLabel { color : DimGrey; }")
         self._unitWidget.setAlignment(Qt.AlignRight)
         self._unitWidget.setText("")
 
-        grid = QGridLayout()
-        grid.addWidget(self._unitWidget, 0, 0)
-        grid.setVerticalSpacing(0)
-        grid.setHorizontalSpacing(0)
-        grid.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(grid)
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(self._unitWidget)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(hbox)
 
-        self.textEdited.connect(self.text_edited)
-        self._dirty = False
-
-        self.setStyleSheet("*[dirty='true']\
-                           {background-color: orange;}")
 
     def text_edited(self):
         self._dirty = True
@@ -47,7 +48,7 @@ class PyRogueLineEdit(PyDMLineEdit):
     def check_enable_state(self):
         status = self._write_access and self._connected
         self.setReadOnly(not status)
-        refresh_style(self)        
+        refresh_style(self)
 
     @Property(bool)
     def dirty(self):


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
Adds several enhancements to Rogue's PyDM GUI widgets.

 - `debug_tree` now displays read-only variables with PyRogueLineEdit rather than PyRogueLabel
   - Allows for consistent borders around values and a cleaner look
   - Override `check_enable_state()` from `PyDMWritableWidget` so that entire widget is not disabled
     - Simply `setReadOnly()` instead, and adjust the styleSheet for grey background color
 - Use `QHBoxLayout` to position units overlay
   - `QGridLayout` was not rendering correctly in some environments
   - This is the more correct way to do it anyway
 - Prevent line breaks in array disp strings
   - Line breaks cause value to be truncated when displayed in `debug_tree`.

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/15825552/197260021-a6e23d98-f410-4bf6-8359-56a233b98429.png">
