### PR TITLE
Apply Fix For PyBuildValue errors when converting byte arrays In Python 10

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -2,7 +2,7 @@ channels:
   - tidair-packages
   - conda-forge
 dependencies:
-  - python=3.10
+  - python
   - gcc_linux-64
   - gxx_linux-64
   - make
@@ -23,6 +23,7 @@ dependencies:
   - sphinx_rtd_theme
   - breathe
   - pyserial
+  - p4p
   - sqlalchemy
   - pydm
   - matplotlib

--- a/conda.yml
+++ b/conda.yml
@@ -2,7 +2,7 @@ channels:
   - tidair-packages
   - conda-forge
 dependencies:
-  - python
+  - python=3.10
   - gcc_linux-64
   - gxx_linux-64
   - make
@@ -23,7 +23,6 @@ dependencies:
   - sphinx_rtd_theme
   - breathe
   - pyserial
-  - p4p
   - sqlalchemy
   - pydm
   - matplotlib

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -260,7 +260,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
    PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
 
    if ( val == NULL )
-      throw(rogue::GeneralError::create("ZmqServer::send","Failed to generate bytearray"));
+      throw(rogue::GeneralError::create("ZmqClient::send","Failed to generate bytearray"));
 
    zmq_msg_close(&rxMsg);
 

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -14,6 +14,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/ZmqClient.h>
 #include <rogue/GeneralError.h>
 #include <memory>
@@ -255,6 +258,10 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
    if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!", seconds);
 
    PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("ZmqServer::send","Failed to generate bytearray"));
+
    zmq_msg_close(&rxMsg);
 
    bp::handle<> handle(val);

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -14,6 +14,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/ZmqServer.h>
 #include <rogue/GeneralError.h>
 #include <memory>
@@ -268,6 +271,10 @@ void rogue::interfaces::ZmqServer::runThread() {
          Py_buffer valueBuf;
          rogue::ScopedGil gil;
          PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+
+         if ( val == NULL )
+            throw(rogue::GeneralError::create("ZmqServer::runThread","Failed to generate bytearray"));
+
          bp::handle<> handle(val);
 
          bp::object ret = this->doRequest(bp::object(handle));

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -16,6 +16,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/memory/Block.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Variable.h>
@@ -529,7 +532,7 @@ bp::object rim::Block::variablesPy() {
 void rim::Block::reverseBytes ( uint8_t *data, uint32_t byteSize ) {
    uint32_t x;
    uint8_t tmp;
-   
+
    for (x=0; x < byteSize/2; x++) {
       tmp = data[x];
       data[x] = data[byteSize-x-1];
@@ -718,6 +721,9 @@ bp::object rim::Block::getPyFunc ( rim::Variable *var, int32_t index ) {
       getBytes(getBuffer, var, index);
       PyObject *val = Py_BuildValue("y#",getBuffer,var->valueBytes_);
 
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getPyFunc","Failed to generate bytearray"));
+
       bp::handle<> handle(val);
       bp::object pass = bp::object(handle);
 
@@ -760,6 +766,9 @@ bp::object rim::Block::getByteArrayPy ( rim::Variable *var, int32_t index ) {
 
    getBytes(getBuffer, var,index);
    PyObject *val = Py_BuildValue("y#",getBuffer,var->valueBytes_);
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("Block::setByteArrayPy","Failed to generate bytearray"));
 
    bp::handle<> handle(val);
    return bp::object(handle);
@@ -890,6 +899,10 @@ bp::object rim::Block::getUIntPy (rim::Variable *var, int32_t index ) {
    }
    else {
       PyObject *val = Py_BuildValue("K",getUInt(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getUIntPy","Failed to generate UInt"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1031,6 +1044,10 @@ bp::object rim::Block::getIntPy ( rim::Variable *var, int32_t index ) {
    }
    else {
       PyObject *val = Py_BuildValue("L",getInt(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getIntPy","Failed to generate Int"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1216,6 +1233,10 @@ bp::object rim::Block::getStringPy ( rim::Variable *var, int32_t index ) {
 
    getString(var,strVal,index);
    PyObject *val = Py_BuildValue("s",strVal.c_str());
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("Block::getStringPy","Failed to generate String"));
+
    bp::handle<> handle(val);
    return bp::object(handle);
 }
@@ -1346,6 +1367,10 @@ bp::object rim::Block::getFloatPy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("f",getFloat(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getFloatPy","Failed to generate Float"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1470,6 +1495,10 @@ bp::object rim::Block::getDoublePy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("d",getDouble(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getDoublePy","Failed to generate Double"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1593,6 +1622,10 @@ bp::object rim::Block::getFixedPy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("d",getFixed(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getFixedPy","Failed to generate Fixed"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }


### PR DESCRIPTION
This resolves JIRA ESROGUE-602 which was seeing exceptions when running the gui with python 10.

It turns out this was generated by PyBuildValue returning a NULL value which was undetected. First I added checks for NULL returns on all instances of PyBuildValue.

Next I added an include at the start of each file which uses PyBuildValue per this note:

https://docs.python.org/3/c-api/arg.html

"Note For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python 3.9 and older, the type of the length argument is [Py_ssize_t](https://docs.python.org/3/c-api/intro.html#c.Py_ssize_t) if the PY_SSIZE_T_CLEAN macro is defined, or int otherwise."