### PR TITLE
Update AxiStreamDma to use a single virtual memory mapping across multiple instances

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -21,7 +21,7 @@ on: [push]
 jobs:
   full_build_test:
     name: Full Build Test
-    runs-on: ubuntu-20.04.5
+    runs-on: ubuntu-20.04
 
     env:
       EPICS_BASE: /home/runner/packages/epics/base-7.0.3
@@ -153,7 +153,7 @@ jobs:
 
   small_build_test:
     name: Small Build Test
-    runs-on: ubuntu-20.04.5
+    runs-on: ubuntu-20.04
     steps:
 
       # This step checks out a copy of your repository.
@@ -176,7 +176,7 @@ jobs:
 
   gen_release:
     name: Generate Release
-    runs-on: ubuntu-20.04.5
+    runs-on: ubuntu-20.04
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04.5
+          - ubuntu-20.04
           - macos-10.15
         src:
           - conda-recipe
@@ -305,7 +305,7 @@ jobs:
 
   docker_build:
     name: Docker Build
-    runs-on: ubuntu-20.04.5
+    runs-on: ubuntu-20.04
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/pre-release'
     steps:

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev
+          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev libboost-python-dev
           pip install -r pip_requirements.txt
 
       # Flake 8 check

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: 'pip_requirements.txt'
 
@@ -187,7 +187,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Get Image Information
         id: get_image_info
@@ -230,7 +230,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Setup anaconda
         env:

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: 'pip_requirements.txt'
 
@@ -187,7 +187,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Get Image Information
         id: get_image_info
@@ -230,7 +230,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.8
 
       - name: Setup anaconda
         env:

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -21,7 +21,7 @@ on: [push]
 jobs:
   full_build_test:
     name: Full Build Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04.5
 
     env:
       EPICS_BASE: /home/runner/packages/epics/base-7.0.3
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev libboost-python-dev
+          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev
           pip install -r pip_requirements.txt
 
       # Flake 8 check
@@ -153,7 +153,7 @@ jobs:
 
   small_build_test:
     name: Small Build Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04.5
     steps:
 
       # This step checks out a copy of your repository.
@@ -176,7 +176,7 @@ jobs:
 
   gen_release:
     name: Generate Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04.5
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04.5
           - macos-10.15
         src:
           - conda-recipe
@@ -305,7 +305,7 @@ jobs:
 
   docker_build:
     name: Docker Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04.5
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/pre-release'
     steps:

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -30,6 +30,8 @@ namespace rogue {
          class AxiStreamDmaShared {
             public:
 
+               AxiStreamDmaShared(std::string path);
+
                //! Shared FD
                int32_t  fd;
 

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -18,12 +18,39 @@
 #include <thread>
 #include <memory>
 #include <stdint.h>
+#include <map>
 #include <rogue/Logging.h>
 
 
 namespace rogue {
    namespace hardware {
       namespace axi {
+
+         //! Storage class for shared memory buffers
+         class AxiStreamDmaShared {
+            public:
+
+               //! Shared FD
+               int32_t  fd;
+
+               //! Path
+               std::string path;
+
+               //! Instance Counter
+               int32_t  openCount;
+
+               //! Pointer to zero copy buffers
+               void  ** rawBuff;
+
+               //! Number of buffers available for zero copy
+               uint32_t bCount;
+
+               //! Size of buffers in hardware
+               uint32_t bSize;
+         };
+
+         //! Alias for using shared pointer as AxiStreamDmaSharedPtr
+         typedef std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared> AxiStreamDmaSharedPtr;
 
          //! AXI Stream DMA Class
          /** This class provides a bridge between the Rogue stream interface and one
@@ -37,29 +64,23 @@ namespace rogue {
          class AxiStreamDma : public rogue::interfaces::stream::Master,
                               public rogue::interfaces::stream::Slave {
 
+               //! Shared memory buffer tracking
+               static std::map<std::string, std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared> > sharedBuffers_;
+
                //! Max number of buffers to receive at once
                static const uint32_t RxBufferCount = 100;
 
                //! AxiStreamDma file descriptor
-               int32_t  fd_;
+               std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared> desc_;
 
                //! Open Dest
                uint32_t dest_;
-
-               //! Number of buffers available for zero copy
-               uint32_t bCount_;
-
-               //! Size of buffers in hardware
-               uint32_t bSize_;
 
                //! Timeout for frame transmits
                struct timeval timeout_;
 
                //! ssi insertion enable
                bool enSsi_;
-
-               //! Pointer to zero copy buffers
-               void  ** rawBuff_;
 
                std::thread* thread_;
                bool threadEn_;
@@ -78,6 +99,13 @@ namespace rogue {
 
                //! Return thold
                uint32_t retThold_;
+
+               //! Open shared buffer space
+               static std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared>
+                  openShared(std::string path);
+
+               //! Close shared buffer space
+               static void closeShared(std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared>);
 
             public:
 

--- a/include/rogue/hardware/axi/AxiStreamDma.h
+++ b/include/rogue/hardware/axi/AxiStreamDma.h
@@ -75,6 +75,9 @@ namespace rogue {
                //! AxiStreamDma file descriptor
                std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared> desc_;
 
+               //! Process specific FD
+               int32_t fd_;
+
                //! Open Dest
                uint32_t dest_;
 
@@ -104,7 +107,7 @@ namespace rogue {
 
                //! Open shared buffer space
                static std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared>
-                  openShared(std::string path);
+                  openShared(std::string path, std::shared_ptr<rogue::Logging> log);
 
                //! Close shared buffer space
                static void closeShared(std::shared_ptr<rogue::hardware::axi::AxiStreamDmaShared>);

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -38,13 +38,15 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 #endif
 
+std::map<std::string, std::shared_ptr<rha::AxiStreamDmaShared> > rha::AxiStreamDma::sharedBuffers_;
+
 rha::AxiStreamDmaShared::AxiStreamDmaShared(std::string path) {
-   fd = -1;
-   path = path;
-   openCount = 1;
-   rawBuff = NULL;
-   bCount = 0;
-   bSize = 0;
+   this->fd = -1;
+   this->path = path;
+   this->openCount = 1;
+   this->rawBuff = NULL;
+   this->bCount = 0;
+   this->bSize = 0;
 }
 
 //! Open shared buffer space

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -38,6 +38,15 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 #endif
 
+rha::AxiStreamDmaShared::AxiStreamDmaShared(std::string path) {
+   fd = -1;
+   path = path;
+   openCount = 1;
+   rawBuff = NULL;
+   bCount = 0;
+   bSize = 0;
+}
+
 //! Open shared buffer space
 rha::AxiStreamDmaSharedPtr rha::AxiStreamDma::openShared (std::string path) {
    std::map<std::string, rha::AxiStreamDmaSharedPtr>::iterator it;
@@ -49,7 +58,7 @@ rha::AxiStreamDmaSharedPtr rha::AxiStreamDma::openShared (std::string path) {
    }
 
    // Create new record
-   rha::AxiStreamDmaSharedPtr ret = std::make_shared<rha::AxiStreamDmaShared>();
+   rha::AxiStreamDmaSharedPtr ret = std::make_shared<rha::AxiStreamDmaShared>(path);
 
    // We need to open device and create shared buffers
    if ( (ret->fd = ::open(path.c_str(), O_RDWR)) < 0 )
@@ -62,13 +71,6 @@ rha::AxiStreamDmaSharedPtr rha::AxiStreamDma::openShared (std::string path) {
       To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
       \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
    }
-
-   // Init
-   ret->path = path;
-   ret->openCount = 1;
-   ret->rawBuff = NULL;
-   ret->bCount = 0;
-   ret->bSize = 0;
 
    // Result may be that rawBuff = NULL
    // Should this just be a warning?


### PR DESCRIPTION
This PR allows multiple instances of AxiStreamDma to use a common virtual memory mapping of the DMA buffers in order to reduce the virtual memory footprint.

This PR also changes the error message to recommend a virtual memory map size based upon the number of buffers needed instead of the previous value which came from a online suggestion.

This addresses ESROGUE-607