### PR TITLE
Release Candidate v5.16.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,34 +1,59 @@
 [flake8]
-exclude = __init__.py, rogue_plugin.py
 #############################################################
-# Note: Command to remove white space at the end of lines
+# Note: Comamnd to remove white space at the end of lines
 # $ find . -type f -name "*.py" -print0 | xargs -0 sed -i 's/\s*$//g'
 #############################################################
-# E116 unexpected indentation (comment)
-# E128 continuation line under-indented for visual indent
-# E131 continuation line unaligned for hanging indent
-# E201 whitespace after '('
-# E202 whitespace before ')'
-# E203 whitespace before ':'
-# E211 whitespace before '('
-# E221 multiple spaces before operator
-# E222 multiple spaces after operator
-# E225 missing whitespace around operator
-# E226 missing whitespace around arithmetic operator
-# E227 missing whitespace around bitwise or shift operator
-# E228 missing whitespace around modulo operator
-# E231 missing whitespace after ','
-# E241 multiple spaces after ','
-# E251 unexpected spaces around keyword / parameter equals
-# E261 at least two spaces before inline comment
-# E262 inline comment should start with '# '
-# E265 block comment should start with '# '
-# E266 too many leading '#' for block comment
-# E272 multiple spaces before keyword
-# E302 expected 2 blank lines, found 1
-# E303 too many blank lines
-# E305 expected 2 blank lines after class or function definition
-# E306 expected 1 blank line before a nested definition, found 0
-# E501 line too long
-#############################################################
-ignore = E116,E128,E131,E201,E202,E203,E211,E221,E222,E225,E226,E227,E228,E231,E241,E251,E261,E262,E265,E266,E272,E302,E303,E305,E306,E501
+exclude = __init__.py, rogue_plugin.py
+extend-ignore =
+   # E116: unexpected indentation (comment)
+   E116,
+   # E128: continuation line under-indented for visual indent
+   E128,
+   # E131: continuation line unaligned for hanging indent
+   E131,
+   # E201: whitespace after '('
+   E201,
+   # E202: whitespace before ')'
+   E202,
+   # E203: whitespace before ':'
+   E203,
+   # E211: whitespace before '('
+   E211,
+   # E221: multiple spaces before operator
+   E221,
+   # E222: multiple spaces after operator
+   E222,
+   # E225: missing whitespace around operator
+   E225,
+   # E226: missing whitespace around arithmetic operator
+   E226,
+   # E227: missing whitespace around bitwise or shift operator
+   E227,
+   # E228: missing whitespace around modulo operator
+   E228,
+   # E231: missing whitespace after ','
+   E231,
+   # E241: multiple spaces after ','
+   E241,
+   # E251: unexpected spaces around keyword / parameter equals
+   E251,
+   # E261: at least two spaces before inline comment
+   E261,
+   # E262: inline comment should start with '# '
+   E262,
+   # E265: block comment should start with '# '
+   E265,
+   # E266: too many leading '#' for block comment
+   E266,
+   # E272: multiple spaces before keyword
+   E272,
+   # E302: expected 2 blank lines, found 1
+   E302,
+   # E303: too many blank lines
+   E303,
+   # E305: expected 2 blank lines after class or function definition
+   E305,
+   # E306: expected 1 blank line before a nested definition, found 0
+   E306,
+   # E501: line too long
+   E501

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -21,7 +21,7 @@ on: [push]
 jobs:
   full_build_test:
     name: Full Build Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       EPICS_BASE: /home/runner/packages/epics/base-7.0.3
@@ -153,7 +153,7 @@ jobs:
 
   small_build_test:
     name: Small Build Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
       # This step checks out a copy of your repository.
@@ -176,7 +176,7 @@ jobs:
 
   gen_release:
     name: Generate Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -215,7 +215,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-10.15
         src:
           - conda-recipe
@@ -305,7 +305,7 @@ jobs:
 
   docker_build:
     name: Docker Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [full_build_test, small_build_test]
     if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/pre-release'
     steps:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ The following is how you install the development version (pre-release) or Rogue 
 
 ```
 
+#hello?

--- a/docs/src/device_tree/_Node.py
+++ b/docs/src/device_tree/_Node.py
@@ -1,0 +1,3 @@
+.. autoclass:: pyrogue.interfaces.VirtualClient
+   :members:
+   :member-order: bysource

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -17,16 +17,54 @@ import rogue.interfaces.memory as rim
 
 
 def startTransaction(block, *, type, forceWr=False, checkEach=False, variable=None, index=-1, **kwargs):
-    """ Helper function for calling the startTransaction function in a block. This helper
+    """
+    Helper function for calling the startTransaction function in a block. This helper
         function ensures future changes to the API do not break custom code in a Device's
-        writeBlocks, readBlocks and checkBlocks functions. """
+        writeBlocks, readBlocks and checkBlocks functions.
+
+    Parameters2
+    ----------
+    block :
+
+    * :
+
+    type :
+
+    forceWr :
+         (Default value = False)
+    checkEach :
+         (Default value = False)
+    variable :
+         (Default value = None)
+    index :
+         (Default value = -1)
+    **kwargs :
+
+
+    Returns
+    -------
+
+    """
     block._startTransaction(type, forceWr, checkEach, variable, index)
 
 
 def checkTransaction(block, **kwargs):
-    """ Helper function for calling the checkTransaction function in a block. This helper
+    """
+    Helper function for calling the checkTransaction function in a block. This helper
         function ensures future changes to the API do not break custom code in a Device's
-        writeBlocks, readBlocks and checkBlocks functions. """
+        writeBlocks, readBlocks and checkBlocks functions.
+
+    Parameters
+    ----------
+    block :
+
+    **kwargs :
+
+
+    Returns
+    -------
+
+    """
     block._checkTransaction()
 
 def writeBlocks(blocks, force=False, checkEach=False, index=-1, **kwargs):
@@ -76,7 +114,9 @@ def readAndCheckBlocks(blocks, checkEach=False, **kwargs):
 
 
 class MemoryError(Exception):
-    """ Exception for memory access errors."""
+    """
+    Exception for memory access errors.
+    """
 
     def __init__(self, *, name, address, msg=None, size=0):
 
@@ -90,6 +130,7 @@ class MemoryError(Exception):
 
 
 class LocalBlock(object):
+    """ """
     def __init__(self, *, variable, localSet, localGet, value):
         self._path      = variable.path
         self._mode      = variable.mode
@@ -115,31 +156,76 @@ class LocalBlock(object):
 
     @property
     def path(self):
+        """ """
         return self._path
 
     @property
     def mode(self):
+        """ """
         return self._mode
 
     @property
     def bulkOpEn(self):
+        """ """
         return True
 
     def forceStale(self):
+        """ """
         pass
 
     def setEnable(self,value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self._enable = value
 
     def _setTimeout(self,value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         pass
 
     @property
     def variables(self):
+        """ """
         return self._variables
 
     def set(self, var, value, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        var :
+
+        value :
+
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         with self._lock:
 
             if index < 0 and (isinstance(value, list) or isinstance(value,dict)):
@@ -159,6 +245,20 @@ class LocalBlock(object):
                 self._localSetWrap(function=self._localSet, dev=self._device, var=self._variable, value=self._value, changed=changed)
 
     def get(self, var, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        var :
+
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         if self._enable and self._localGet is not None:
             with self._lock:
                 self._value = self._localGetWrap(function=self._localGet, dev=self._device, var=self._variable)
@@ -170,6 +270,23 @@ class LocalBlock(object):
     def _startTransaction(self, type, forceWr, checkEach, variable, index):
         """
         Start a transaction.
+
+        Parameters
+        ----------
+        type :
+
+        forceWr :
+
+        checkEach :
+
+        variable :
+
+        index :
+
+
+        Returns
+        -------
+
         """
         if self._enable:
             with self._lock:
@@ -179,6 +296,13 @@ class LocalBlock(object):
         """
         Check status of block.
         If update=True notify variables if read
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         if self._enable:
             with self._lock:
@@ -190,77 +314,233 @@ class LocalBlock(object):
                 self._variable._queueUpdate()
 
     def _iadd(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) + other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _isub(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) - other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imul(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) * other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imatmul(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) @ other)
             self._variable._queueUpdate()
 
     def _itruediv(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) / other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ifloordiv(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) // other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imod(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) % other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ipow(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) ** other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ilshift(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) << other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _irshift(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) >> other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _iand(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) & other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ixor(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) ^ other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ior(self, other):
+        """
+
+
+        Parameters
+        ----------
+        other :
+
+
+        Returns
+        -------
+
+        """
         with self._lock:
             self.set(None, self.get(None) | other)
             if self._enable:

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -16,11 +16,14 @@ import threading
 
 
 class CommandError(Exception):
-    """ Exception for command errors."""
+    """
+    Exception for command errors.
+    """
     pass
 
 
 class BaseCommand(pr.BaseVariable):
+    """ """
 
     def __init__(self, *,
                  name=None,
@@ -78,11 +81,13 @@ class BaseCommand(pr.BaseVariable):
     @pr.expose
     @property
     def arg(self):
+        """ """
         return self._arg
 
     @pr.expose
     @property
     def retTypeStr(self):
+        """ """
         return self._retTypeStr
 
     def __call__(self,arg=None):
@@ -100,7 +105,18 @@ class BaseCommand(pr.BaseVariable):
             return self._doFunc(arg)
 
     def _doFunc(self,arg):
-        """Execute command: TODO: Update comments"""
+        """
+        Execute command: TODO: Update comments
+
+        Parameters
+        ----------
+        arg :
+
+
+        Returns
+        -------
+
+        """
         if (self.parent.enable.value() is not True):
             return
 
@@ -127,22 +143,75 @@ class BaseCommand(pr.BaseVariable):
 
     @pr.expose
     def call(self,arg=None):
+        """
+
+
+        Parameters
+        ----------
+        arg : str
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         return self.__call__(arg)
 
     @staticmethod
     def nothing():
+        """ """
         pass
 
     @staticmethod
     def read(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.get(read=True)
 
     @staticmethod
     def setArg(cmd, arg):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+        arg :
+
+
+        Returns
+        -------
+
+        """
         cmd.set(arg)
 
     @staticmethod
     def setAndVerifyArg(cmd, arg):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+        arg :
+
+
+        Returns
+        -------
+
+        """
         cmd.set(arg)
         ret = cmd.get()
         if ret != arg:
@@ -150,24 +219,98 @@ class BaseCommand(pr.BaseVariable):
 
     @staticmethod
     def createToggle(sets):
+        """
+
+
+        Parameters
+        ----------
+        sets :
+
+
+        Returns
+        -------
+
+        """
         def toggle(cmd):
+            """
+
+
+            Parameters
+            ----------
+            cmd :
+
+
+            Returns
+            -------
+
+            """
             for s in sets:
                 cmd.set(s)
         return toggle
 
     @staticmethod
     def toggle(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.set(1)
         cmd.set(0)
 
     @staticmethod
     def createTouch(value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         def touch(cmd):
+            """
+
+
+            Parameters
+            ----------
+            cmd :
+
+
+            Returns
+            -------
+
+            """
             cmd.set(value)
         return touch
 
     @staticmethod
     def touch(cmd, arg):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+        arg :
+
+
+        Returns
+        -------
+
+        """
         if arg is not None:
             cmd.set(arg)
         else:
@@ -175,48 +318,227 @@ class BaseCommand(pr.BaseVariable):
 
     @staticmethod
     def touchZero(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.set(0)
 
     @staticmethod
     def touchOne(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.set(1)
 
     @staticmethod
     def createPostedTouch(value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         def postedTouch(cmd):
+            """
+
+
+            Parameters
+            ----------
+            cmd :
+
+
+            Returns
+            -------
+
+            """
             cmd.post(value)
         return postedTouch
 
     @staticmethod
     def postedTouch(cmd, arg):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+        arg :
+
+
+        Returns
+        -------
+
+        """
         cmd.post(arg)
 
     @staticmethod
     def postedTouchOne(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.post(1)
 
     @staticmethod
     def postedTouchZero(cmd):
+        """
+
+
+        Parameters
+        ----------
+        cmd :
+
+
+        Returns
+        -------
+
+        """
         cmd.post(0)
 
     def replaceFunction(self, function):
+        """
+
+
+        Parameters
+        ----------
+        function :
+
+
+        Returns
+        -------
+
+        """
         self._function = function
         self._functionWrap = pr.functionWrapper(function=self._function, callArgs=['root', 'dev', 'cmd', 'arg'])
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
+        """
+
+
+        Parameters
+        ----------
+        d :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+        keys :
+
+
+        Returns
+        -------
+
+        """
         pass
 
     def _getDict(self,modes,incGroups,excGroups,properties):
+        """
+
+
+        Parameters
+        ----------
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
         return None
 
     def get(self,read=True, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         return self._default
+
+    def _genDocs(self,file):
+        """
+
+
+        Parameters
+        ----------
+        file :
+
+
+        Returns
+        -------
+
+        """
+        print(f".. topic:: {self.path}",file=file)
+
+        print('',file=file)
+        print(pr.genDocDesc(self.description,4),file=file)
+        print('',file=file)
+
+        print(pr.genDocTableHeader(['Field','Value'],4,100),file=file)
+
+        for a in ['name', 'path', 'enum', 'typeStr', 'disp']:
+            astr = str(getattr(self,a))
+
+            if astr != 'None':
+                print(pr.genDocTableRow([a,astr],4,100),file=file)
+
 
 # LocalCommand is the same as BaseCommand
 LocalCommand = BaseCommand
 
 
 class RemoteCommand(BaseCommand, pr.RemoteVariable):
+    """ """
 
     def __init__(self, *,
                  name,
@@ -265,6 +587,24 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             guiGroup=guiGroup)
 
     def set(self, value, *,  index=-1, write=True):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+        * :
+
+        index : int
+             (Default value = -1)
+        write : bool
+             (Default value = True)
+
+        Returns
+        -------
+
+        """
         self._log.debug("{}.set({})".format(self, value))
         try:
             self._set(value,index)
@@ -278,6 +618,22 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
 
 
     def get(self, *, index=-1, read=True):
+        """
+
+
+        Parameters
+        ----------
+        * :
+
+        index : int
+             (Default value = -1)
+        read : bool
+             (Default value = True)
+
+        Returns
+        -------
+
+        """
         try:
             if read:
                 pr.startTransaction(self._block, type=rogue.interfaces.memory.Read, forceWr=False, checkEach=True, variable=self, index=index)
@@ -287,6 +643,29 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         except Exception as e:
             pr.logException(self._log,e)
             raise e
+
+    def _genDocs(self,file):
+        """
+
+
+        Parameters
+        ----------
+        file :
+
+
+        Returns
+        -------
+
+        """
+        BaseCommand._genDocs(self,file)
+
+        for a in ['offset', 'bitSize', 'bitOffset', 'varBytes']:
+            astr = str(getattr(self,a))
+
+            if astr != 'None':
+                print(pr.genDocTableRow([a,astr],4,100),file=file)
+
+
 
 # Alias, this should go away
 Command = BaseCommand

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -59,12 +59,25 @@ class DataReceiver(pr.Device,ris.Slave):
                                   description='Data Frame Container'))
 
     def countReset(self):
+        """ """
         self.FrameCount.set(0)
         self.ErrorCount.set(0)
         self.ByteCount.set(0)
         super().countReset()
 
     def _acceptFrame(self, frame):
+        """
+
+
+        Parameters
+        ----------
+        frame :
+
+
+        Returns
+        -------
+
+        """
         # Do nothing if not yet started or enabled
         if self.running is False or self.RxEnable.value() is False:
             return
@@ -94,6 +107,15 @@ class DataReceiver(pr.Device,ris.Slave):
         The user can use this method to process the data, by default a byte numpy array is generated
         This may include separating data, header and other payload sub-fields
         This all occurs with the frame lock held
+
+        Parameters
+        ----------
+        frame :
+
+
+        Returns
+        -------
+
         """
 
         # Get data from frame
@@ -105,10 +127,12 @@ class DataReceiver(pr.Device,ris.Slave):
         self.Updated.set(True,write=True)
 
     def _start(self):
+        """ """
         super()._start()
         self.RxEnable.set(value=self._enableOnStart)
 
     def _stop(self):
+        """ """
         self.RxEnable.set(value=False)
         super()._stop()
 

--- a/python/pyrogue/_DataWriter.py
+++ b/python/pyrogue/_DataWriter.py
@@ -17,20 +17,37 @@ class DataWriter(pr.Device):
     """Special base class to control data files. TODO: Update comments"""
 
     def __init__(self, *, hidden=True, **kwargs):
-        """Initialize device class"""
+        """
+        Initialize device class
+        Parameters
+        ----------
+        * :
 
-        pr.Device.__init__(self, hidden=hidden, **kwargs)
+        hidden=True :
+
+        **kwargs :
+
+        Returns
+        -------
+
+        """
+
+        pr.Device.__init__(self,
+                           hidden=hidden,
+                           description = 'Class which stores received data to a file.',
+                           **kwargs)
 
         self.add(pr.LocalVariable(
             name='DataFile',
             mode='RW',
             value='',
-            description='Data file for storing frames for connected streams.'))
+            description='Data file for storing frames for connected streams.'
+                        'This is the file opened when the Open command is executed.'))
 
         self.add(pr.LocalCommand(
             name='Open',
             function=self._open,
-            description='Open data file.'))
+            description='Open data file. The new file name will be the contents of the DataFile variable.'))
 
         self.add(pr.LocalCommand(
             name='Close',
@@ -42,7 +59,7 @@ class DataWriter(pr.Device):
             mode='RO',
             value=False,
             localGet=self._isOpen,
-            description='Data file is open.'))
+            description='Status field which is True when the Data file is open.'))
 
         self.add(pr.LocalVariable(
             name='BufferSize',
@@ -67,7 +84,7 @@ class DataWriter(pr.Device):
             typeStr='UInt64',
             pollInterval=1,
             localGet=self._getCurrentSize,
-            description='Size of current data files(s) for current open session in bytes.'))
+            description='Size of current data files in bytes.'))
 
         self.add(pr.LocalVariable(
             name='TotalSize',
@@ -76,7 +93,7 @@ class DataWriter(pr.Device):
             typeStr='UInt64',
             pollInterval=1,
             localGet=self._getTotalSize,
-            description='Size of all data sub-files(s) for current open session in bytes.'))
+            description='Total bytes written.'))
 
         self.add(pr.LocalVariable(
             name='FrameCount',
@@ -85,7 +102,7 @@ class DataWriter(pr.Device):
             typeStr='UInt32',
             pollInterval=1,
             localGet=self._getFrameCount,
-            description='Frame in data file(s) for current open session in bytes.'))
+            description='Total frames received and written.'))
 
         self.add(pr.LocalCommand(
             name='AutoName',
@@ -105,11 +122,33 @@ class DataWriter(pr.Device):
         pass
 
     def _setBufferSize(self,value):
-        """Set buffer size. Override in sub-class"""
+        """
+        Set buffer size. Override in sub-class
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         pass
 
     def _setMaxFileSize(self,value):
-        """Set max file size. Override in sub-class"""
+        """
+        Set max file size. Override in sub-class
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         pass
 
     def _getCurrentSize(self):
@@ -128,6 +167,13 @@ class DataWriter(pr.Device):
         """
         Auto create data file name based upon date and time.
         Preserve file's location in path.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+
         """
         idx = self.DataFile.value().rfind('/')
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -17,6 +17,7 @@ import threading
 
 
 class EnableVariable(pr.BaseVariable):
+    """ """
     def __init__(self, *, enabled, deps=None):
         pr.BaseVariable.__init__(
             self,
@@ -42,6 +43,21 @@ class EnableVariable(pr.BaseVariable):
 
     @pr.expose
     def get(self, read=False, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = False)
+        index : int
+             (Default value = -1)
+
+        Returns
+             ret :
+        -------
+
+        """
         ret = self._value
 
         with self._lock:
@@ -62,6 +78,22 @@ class EnableVariable(pr.BaseVariable):
 
     @pr.expose
     def set(self, value, write=True, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        value :
+             (Default value = enabled)
+        write : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         if value != 'parent' and value != 'deps':
             old = self.value()
 
@@ -84,6 +116,7 @@ class EnableVariable(pr.BaseVariable):
             #    var._doUpdate()
 
     def _doUpdate(self):
+        """ """
         if len(self._deps) != 0:
             oldEn = (self.value() is True)
 
@@ -99,6 +132,20 @@ class EnableVariable(pr.BaseVariable):
         return super()._doUpdate()
 
     def _rootAttached(self,parent,root):
+        """
+
+
+        Parameters
+        ----------
+        parent :
+
+        root :
+
+
+        Returns
+        -------
+
+        """
         pr.Node._rootAttached(self,parent,root)
 
         if parent is not root:
@@ -106,7 +153,7 @@ class EnableVariable(pr.BaseVariable):
 
 
 class DeviceError(Exception):
-    """ Exception for device manipulation errors."""
+    """ """
     pass
 
 
@@ -185,23 +232,50 @@ class Device(pr.Node,rim.Hub):
     @pr.expose
     @property
     def address(self):
+        """ """
         return self._getAddress()
 
     @pr.expose
     @property
     def offset(self):
+        """ """
         return self._getOffset()
 
     @pr.expose
     @property
     def size(self):
+        """ """
         return self._size
 
     def addCustomBlock(self, block):
+        """
+
+
+        Parameters
+        ----------
+        block :
+
+
+        Returns
+        -------
+
+        """
         self._custBlocks.append(block)
         self._custBlocks.sort(key=lambda x: (x.offset, x.size))
 
     def add(self,node):
+        """
+
+
+        Parameters
+        ----------
+        node :
+
+
+        Returns
+        -------
+
+        """
         # Call node add
         pr.Node.add(self,node)
 
@@ -213,8 +287,19 @@ class Device(pr.Node,rim.Hub):
                 node._setSlave(self)
 
     def addInterface(self, *interfaces):
-        """Add one or more rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
-        Also accepts iterables for adding multiple at once"""
+        """
+        Add one or more rogue.interfaces.stream.Master or rogue.interfaces.memory.Master
+        Also accepts iterables for adding multiple at once
+
+        Parameters
+        ----------
+        *interfaces :
+
+
+        Returns
+        -------
+
+        """
         for interface in interfaces:
             if isinstance(interface, collections.abc.Iterable):
                 self._ifAndProto.extend(interface)
@@ -222,8 +307,19 @@ class Device(pr.Node,rim.Hub):
                 self._ifAndProto.append(interface)
 
     def addProtocol(self, *protocols):
-        """Add a protocol entity.
-        Also accepts iterables for adding multiple at once"""
+        """
+        Add a protocol entity.
+        Also accepts iterables for adding multiple at once
+
+        Parameters
+        ----------
+        *protocols :
+
+
+        Returns
+        -------
+
+        """
         for protocol in protocols:
             if isinstance(protocol, collections.abc.Iterable):
                 self._ifAndProto.extend(protocol)
@@ -231,6 +327,18 @@ class Device(pr.Node,rim.Hub):
                 self._ifAndProto.append(protocol)
 
     def manage(self, *interfaces):
+        """
+
+
+        Parameters
+        ----------
+        *interfaces :
+
+
+        Returns
+        -------
+
+        """
         self._ifAndProto.extend(interfaces)
 
     def _start(self):
@@ -242,7 +350,7 @@ class Device(pr.Node,rim.Hub):
             d._start()
 
     def _stop(self):
-        """ Called recursively from Root.stop when exiting """
+        """Called recursively from Root.stop when exiting"""
         for intf in self._ifAndProto:
             if hasattr(intf,"_stop"):
                 intf._stop()
@@ -256,6 +364,24 @@ class Device(pr.Node,rim.Hub):
 
 
     def addRemoteVariables(self, number, stride, pack=False, **kwargs):
+        """
+
+
+        Parameters
+        ----------
+        number :
+
+        stride :
+
+        pack : bool
+             (Default value = False)
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         if pack:
             hidden=True
         else:
@@ -268,6 +394,24 @@ class Device(pr.Node,rim.Hub):
             varList = getattr(self, kwargs['name']).values()
 
             def linkedSet(dev, var, val, write):
+                """
+
+
+                Parameters
+                ----------
+                dev :
+
+                var :
+
+                val :
+
+                write :
+
+
+                Returns
+                -------
+
+                """
                 if val == '':
                     return
                 values = reversed(val.split('_'))
@@ -275,6 +419,22 @@ class Device(pr.Node,rim.Hub):
                     variable.setDisp(value, write=write)
 
             def linkedGet(dev, var, read):
+                """
+
+
+                Parameters
+                ----------
+                dev :
+
+                var :
+
+                read :
+
+
+                Returns
+                -------
+
+                """
                 values = [v.getDisp(read=read) for v in varList]
                 return '_'.join(reversed(values))
 
@@ -285,9 +445,22 @@ class Device(pr.Node,rim.Hub):
             self.add(lv)
 
     def setPollInterval(self, interval, variables=None):
-        """Set the poll interval for a group of variables.
+        """
+        Set the poll interval for a group of variables.
         The variables param is an Iterable of strings
-        If variables=None, set interval for all variables that currently have nonzero pollInterval"""
+        If variables=None, set interval for all variables that currently have nonzero pollInterval
+
+        Parameters
+        ----------
+        interval :
+
+        variables : str
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         if variables is None:
             variables = [k for k,v in self.variables.items() if v.pollInterval != 0]
 
@@ -295,7 +468,20 @@ class Device(pr.Node,rim.Hub):
             self.node(x).pollInterval = interval
 
     def hideVariables(self, hidden, variables=None):
-        """Hide a list of Variables (or Variable names)"""
+        """
+        Hide a list of Variables (or Variable names)
+
+        Parameters
+        ----------
+        hidden :
+
+        variables : str
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         if variables is None:
             variables=self.variables.values()
 
@@ -306,18 +492,33 @@ class Device(pr.Node,rim.Hub):
                 self.variables[v].hidden = hidden
 
     def initialize(self):
+        """ """
         for key,value in self.devices.items():
             value.initialize()
 
     def hardReset(self):
+        """ """
         for key,value in self.devices.items():
             value.hardReset()
 
     def countReset(self):
+        """ """
         for key,value in self.devices.items():
             value.countReset()
 
     def enableChanged(self,value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         pass
 
         #if value is True:
@@ -326,6 +527,27 @@ class Device(pr.Node,rim.Hub):
     def writeBlocks(self, *, force=False, recurse=True, variable=None, checkEach=False, index=-1, **kwargs):
         """
         Write all of the blocks held by this Device to memory
+
+        Parameters
+        ----------
+        * :
+
+        force : bool
+             (Default value = False)
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+        index : int
+             (Default value = -1)
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
         checkEach = checkEach or self.forceCheckEach
 
@@ -344,6 +566,23 @@ class Device(pr.Node,rim.Hub):
     def verifyBlocks(self, *, recurse=True, variable=None, checkEach=False, **kwargs):
         """
         Perform background verify
+
+        Parameters
+        ----------
+              * :
+
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
         checkEach = checkEach or self.forceCheckEach
 
@@ -362,6 +601,25 @@ class Device(pr.Node,rim.Hub):
     def readBlocks(self, *, recurse=True, variable=None, checkEach=False, index=-1, **kwargs):
         """
         Perform background reads
+
+        Parameters
+        ----------
+              * :
+
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+        index : int
+             (Default value = -1)
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
         checkEach = checkEach or self.forceCheckEach
 
@@ -378,7 +636,24 @@ class Device(pr.Node,rim.Hub):
                     value.readBlocks(recurse=True, checkEach=checkEach, **kwargs)
 
     def checkBlocks(self, *, recurse=True, variable=None, **kwargs):
-        """Check errors in all blocks and generate variable update notifications"""
+        """
+        Check errors in all blocks and generate variable update notifications
+
+        Parameters
+        ----------
+              * :
+
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         if variable is not None:
             pr.checkTransaction(variable._block, **kwargs)
 
@@ -391,17 +666,50 @@ class Device(pr.Node,rim.Hub):
                     value.checkBlocks(recurse=True, **kwargs)
 
     def writeAndVerifyBlocks(self, force=False, recurse=True, variable=None, checkEach=False):
-        """Perform a write, verify and check. Useful for committing any stale variables"""
+        """
+        Perform a write, verify and check. Useful for committing any stale variables
+
+        Parameters
+        ----------
+        force : bool
+             (Default value = False)
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         self.writeBlocks(force=force, recurse=recurse, variable=variable, checkEach=checkEach)
         self.verifyBlocks(recurse=recurse, variable=variable, checkEach=checkEach)
         self.checkBlocks(recurse=recurse, variable=variable)
 
     def readAndCheckBlocks(self, recurse=True, variable=None, checkEach=False):
-        """Perform a read and check."""
+        """
+        Perform a read and check.
+
+        Parameters
+        ----------
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         self.readBlocks(recurse=recurse, variable=variable, checkEach=checkEach)
         self.checkBlocks(recurse=recurse, variable=variable)
 
     def _updateBlockEnable(self):
+        """ """
         for block in self._blocks:
             block.setEnable(self.enable.value() is True)
 
@@ -409,6 +717,30 @@ class Device(pr.Node,rim.Hub):
             value._updateBlockEnable()
 
     def _rawTxnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):
+        """
+
+
+        Parameters
+        ----------
+        offset :
+
+        data :
+
+        base : str
+             (Default value = pr.UInt)
+        stride : int
+             (Default value = 4)
+        wordBitSize : int
+             (Default value = 32)
+        txnType : str
+             (Default value = rim.Write)
+        numWords : int
+             (Default value = 1)
+
+        Returns
+        -------
+
+        """
 
         if not isinstance(base, pr.Model):
             base = base(wordBitSize)
@@ -445,6 +777,30 @@ class Device(pr.Node,rim.Hub):
             return ldata
 
     def _rawWrite(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, tryCount=1, posted=False):
+        """
+
+
+        Parameters
+        ----------
+        offset :
+
+        data :
+
+        base : str
+             (Default value = pr.UInt)
+        stride : int
+             (Default value = 4)
+        wordBitSize : int
+             (Default value = 32)
+        tryCount : int
+             (Default value = 1)
+        posted : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
 
         if not isinstance(base, pr.Model):
             base = base(wordBitSize)
@@ -471,6 +827,30 @@ class Device(pr.Node,rim.Hub):
             raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
 
     def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=32, data=None, tryCount=1):
+        """
+
+
+        Parameters
+        ----------
+        offset :
+
+        numWords : int
+             (Default value = 1)
+        base : str
+             (Default value = pr.UInt)
+        stride : int
+             (Default value = 4)
+        wordBitSize : int
+             (Default value = 32)
+        data : str
+             (Default value = None)
+        tryCount : int
+             (Default value = 1)
+
+        Returns
+        -------
+
+        """
 
         if not isinstance(base, pr.Model):
             base = base(wordBitSize)
@@ -492,6 +872,7 @@ class Device(pr.Node,rim.Hub):
             raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
 
     def _buildBlocks(self):
+        """ """
         remVars = []
 
         # Use min block size, larger blocks can be pre-created
@@ -581,6 +962,20 @@ class Device(pr.Node,rim.Hub):
             newBlock.setEnable(self.enable.value() is True)
 
     def _rootAttached(self, parent, root):
+        """
+
+
+        Parameters
+        ----------
+        parent :
+
+        root :
+
+
+        Returns
+        -------
+
+        """
         pr.Node._rootAttached(self, parent, root)
 
         for key,value in self._nodes.items():
@@ -604,6 +999,15 @@ class Device(pr.Node,rim.Hub):
     def _setTimeout(self,timeout):
         """
         Set timeout value on all devices & blocks
+
+        Parameters
+        ----------
+        timeout :
+
+
+        Returns
+        -------
+
         """
 
         for block in self._blocks:
@@ -616,8 +1020,31 @@ class Device(pr.Node,rim.Hub):
                 value._setTimeout(timeout)
 
     def command(self, **kwargs):
-        """A Decorator to add inline constructor functions as commands"""
+        """
+        A Decorator to add inline constructor functions as commands
+
+        Parameters
+        ----------
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         def _decorator(func):
+            """
+
+
+            Parameters
+            ----------
+            func :
+
+
+            Returns
+            -------
+
+            """
             if 'name' not in kwargs:
                 kwargs['name'] = func.__name__
 
@@ -627,8 +1054,31 @@ class Device(pr.Node,rim.Hub):
         return _decorator
 
     def linkVariableGet(self, **kwargs):
-        """ Decorator to add inline constructor functions as LinkVariable.linkedGet functions"""
+        """
+        Decorator to add inline constructor functions as LinkVariable.linkedGet functions
+
+        Parameters
+        ----------
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         def _decorator(func):
+            """
+
+
+            Parameters
+            ----------
+            func :
+
+
+            Returns
+            -------
+
+            """
             if 'name' not in kwargs:
                 kwargs['name'] = func.__name__
 
@@ -637,8 +1087,104 @@ class Device(pr.Node,rim.Hub):
             return func
         return _decorator
 
+    def genDocuments(self,path,incGroups, excGroups):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
+
+        with open(path + '/' + self.path.replace('.','_') + '.rst','w') as file:
+
+            print("****************************",file=file)
+            print(self.name,file=file)
+            print("****************************",file=file)
+
+            print('',file=file)
+            print(pr.genDocDesc(self.description,0),file=file)
+            print('',file=file)
+
+            plist = self.getNodes(typ=pr.Process,incGroups=incGroups,excGroups=excGroups)
+            dlist = self.devicesByGroup(incGroups=incGroups,excGroups=excGroups)
+            vlist = self.variablesByGroup(incGroups=incGroups,excGroups=excGroups)
+            clist = self.commandsByGroup(incGroups=incGroups,excGroups=excGroups)
+
+            tlist = {k:v for k,v in dlist.items() if k not in plist}
+
+            if len(tlist) > 0:
+                print(".. toctree::",file=file)
+                print("   :maxdepth: 1",file=file)
+                print("   :caption: Sub Devices:",file=file)
+                print('',file=file)
+                for k,v in tlist.items():
+                    print('   ' + v.path.replace('.','_'),file=file)
+                    v.genDocuments(path,incGroups,excGroups)
+                print('',file=file)
+
+            if len(plist) > 0:
+                print(".. toctree::",file=file)
+                print("   :maxdepth: 1",file=file)
+                print("   :caption: Processes:",file=file)
+                print('',file=file)
+                for k,v in plist.items():
+                    print('   ' + v.path.replace('.','_'),file=file)
+                    v.genDocuments(path,incGroups,excGroups)
+                print('',file=file)
+
+            print("Summary",file=file)
+            print("#######",file=file)
+            print('',file=file)
+
+            if len(vlist):
+                print("Variable List",file=file)
+                print("*************",file=file)
+                print('',file=file)
+                for k,v in vlist.items():
+                    print(f"* {k}",file=file)
+                print('',file=file)
+
+            if len(clist):
+                print("Command List",file=file)
+                print("*************",file=file)
+                print('',file=file)
+                for k,v in clist.items():
+                    print(f"* {k}",file=file)
+                print('',file=file)
+
+            print("Details",file=file)
+            print("#######",file=file)
+            print('',file=file)
+
+            if len(vlist):
+                print("Variables",file=file)
+                print("*********",file=file)
+                print('',file=file)
+                for k,v in vlist.items():
+                    v._genDocs(file=file)
+                    print('',file=file)
+
+            if len(clist):
+                print("Commands",file=file)
+                print("********",file=file)
+                print('',file=file)
+                for k,v in clist.items():
+                    v._genDocs(file=file)
+                    print('',file=file)
+
 
 class ArrayDevice(Device):
+    """ """
     def __init__(self, *, arrayClass, number, stride=0, arrayArgs=None, **kwargs):
         if 'name' not in kwargs:
             kwargs['name'] = f'{arrayClass.__name__}Array'

--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -27,6 +27,15 @@ def addLibraryPath(path):
     Append the past string or list of strings to the python library path.
     Passed strings can either be relative: ../path/to/library
     or absolute: /path/to/library
+
+    Parameters
+    ----------
+    path :
+
+
+    Returns
+    -------
+
     """
     if len(sys.argv) == 0:
         base = os.path.dirname(os.path.realpath(__file__))
@@ -72,10 +81,25 @@ def waitCntrlC():
     """Helper Function To Wait For Cntrl-c"""
 
     class monitorSignal(object):
+        """ """
+
         def __init__(self):
+            """ """
             self.runEnable = True
 
         def receiveSignal(self,*args):
+            """
+
+
+            Parameters
+            ----------
+            *args :
+
+
+            Returns
+            -------
+
+            """
             print("Got SIGTERM, exiting")
             self.runEnable = False
 
@@ -99,6 +123,17 @@ def streamConnect(source, dest):
     the _getStreamMaster call to return a contained master.
     Similarly dest is either a stream slave sub class or implements
     the _getStreamSlave call to return a contained slave.
+
+    Parameters
+    ----------
+    source :
+
+    dest :
+
+
+    Returns
+    -------
+
     """
 
     # Is object a native master or wrapped?
@@ -119,6 +154,17 @@ def streamConnect(source, dest):
 def streamTap(source, tap):
     """
     DEPRECATED!
+
+    Parameters
+    ----------
+    source :
+
+    tap :
+
+
+    Returns
+    -------
+
     """
     #print("******** Stream TAP is deprecated. Use streamConnect instead. ********")
     streamConnect(source,tap)
@@ -132,6 +178,17 @@ def streamConnectBiDir(deviceA, deviceB):
     the _getStreamMaster call to return a contained master.
     Similarly dest is either a stream slave sub class or implements
     the _getStreamSlave call to return a contained slave.
+
+    Parameters
+    ----------
+    deviceA :
+
+    deviceB :
+
+
+    Returns
+    -------
+
     """
 
     """
@@ -153,6 +210,17 @@ def busConnect(source,dest):
     the _getMemoryMaster call to return a contained master.
     Similarly dest is either a memory slave sub class or implements
     the _getMemorySlave call to return a contained slave.
+
+    Parameters
+    ----------
+    source :
+
+    dest :
+
+
+    Returns
+    -------
+
     """
 
     # Is object a native master or wrapped?
@@ -174,14 +242,40 @@ def yamlToData(stream='',fName=None):
     """
     Load yaml to data structure.
     A yaml string or file path may be passed.
+
+    Parameters
+    ----------
+    stream :
+         (Default value = '')
+    fName :
+         (Default value = None)
+
+    Returns
+    -------
+
     """
 
     log = pr.logInit(name='yamlToData')
 
     class PyrogueLoader(yaml.Loader):
+        """ """
         pass
 
     def include_mapping(loader, node):
+        """
+
+
+        Parameters
+        ----------
+        loader :
+
+        node :
+
+
+        Returns
+        -------
+
+        """
         rel = loader.construct_scalar(node)
 
         # Filename starts with absolute path
@@ -200,6 +294,20 @@ def yamlToData(stream='',fName=None):
         return yamlToData(fName=os.path.abspath(filename))
 
     def construct_mapping(loader, node):
+        """
+
+
+        Parameters
+        ----------
+        loader :
+
+        node :
+
+
+        Returns
+        -------
+
+        """
         loader.flatten_mapping(node)
         return odict(loader.construct_pairs(node))
 
@@ -229,12 +337,38 @@ def yamlToData(stream='',fName=None):
 
 
 def dataToYaml(data):
-    """Convert data structure to yaml"""
+    """
+    Convert data structure to yaml
+
+    Parameters
+    ----------
+    data :
+
+
+    Returns
+    -------
+
+    """
 
     class PyrogueDumper(yaml.Dumper):
+        """ """
         pass
 
     def _var_representer(dumper, data):
+        """
+
+
+        Parameters
+        ----------
+        dumper :
+
+        data :
+
+
+        Returns
+        -------
+
+        """
         if type(data.value) == bool:
             enc = 'tag:yaml.org,2002:bool'
         elif data.enum is not None:
@@ -252,6 +386,20 @@ def dataToYaml(data):
             return dumper.represent_scalar(enc, data.valueDisp)
 
     def _dict_representer(dumper, data):
+        """
+
+
+        Parameters
+        ----------
+        dumper :
+
+        data :
+
+
+        Returns
+        -------
+
+        """
         return dumper.represent_mapping(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, data.items())
 
     PyrogueDumper.add_representer(pr.VariableValue, _var_representer)
@@ -261,6 +409,22 @@ def dataToYaml(data):
 
 
 def keyValueUpdate(old, key, value):
+    """
+
+
+    Parameters
+    ----------
+    old :
+
+    key :
+
+    value :
+
+
+    Returns
+    -------
+
+    """
     d = old
     parts = key.split('.')
     for part in parts[:-1]:
@@ -271,6 +435,20 @@ def keyValueUpdate(old, key, value):
 
 
 def dictUpdate(old, new):
+    """
+
+
+    Parameters
+    ----------
+    old :
+
+    new :
+
+
+    Returns
+    -------
+
+    """
     for k,v in new.items():
         if '.' in k:
             keyValueUpdate(old, k, v)
@@ -281,14 +459,56 @@ def dictUpdate(old, new):
 
 
 def yamlUpdate(old, new):
+    """
+
+
+    Parameters
+    ----------
+    old :
+
+    new :
+
+
+    Returns
+    -------
+
+    """
     dictUpdate(old, pr.yamlToData(new))
 
 
 def recreate_OrderedDict(name, values):
+    """
+
+
+    Parameters
+    ----------
+    name :
+
+    values :
+
+
+    Returns
+    -------
+
+    """
     return odict(values['items'])
 
 # Creation function wrapper for methods with variable args
 def functionWrapper(function, callArgs):
+    """
+
+
+    Parameters
+    ----------
+    function :
+
+    callArgs :
+
+
+    Returns
+    -------
+
+    """
 
     if function is None:
         return eval("lambda " + ", ".join(['function'] + callArgs) + ": None")
@@ -309,3 +529,94 @@ def functionWrapper(function, callArgs):
     ls = "lambda " + ", ".join(['function'] + callArgs) + ": function(" + ", ".join(args) + ")"
     #print("Creating Function: " + ls)
     return eval(ls)
+
+
+def genDocTableHeader(fields, indent, width):
+    """
+
+
+    Parameters
+    ----------
+    fields :
+
+    indent :
+
+    width :
+
+
+    Returns
+    -------
+
+    """
+    r = ' ' * indent + '+'
+
+    for _ in range(len(fields)):
+        r += '-' * width + '+'
+
+    r += '\n' + ' ' * indent + '|'
+
+    for f in fields:
+        r += f + ' '
+        r += ' ' * (width-len(f)-1) + '|'
+
+    r += '\n' + ' ' * indent + '+'
+
+    for _ in range(len(fields)):
+        r += '=' * width + '+'
+
+    return r
+
+def genDocTableRow(fields, indent, width):
+    """
+
+
+    Parameters
+    ----------
+    fields :
+
+    indent :
+
+    width :
+
+
+    Returns
+    -------
+
+    """
+    r = ' ' * indent + '|'
+
+    for f in fields:
+        r += f + ' '
+        r += ' ' * (width-len(f)-1) + '|'
+
+    r += '\n' + ' ' * indent + '+'
+
+    for _ in range(len(fields)):
+        r += '-' * width + '+'
+
+    return r
+
+def genDocDesc(desc, indent):
+    """
+
+
+    Parameters
+    ----------
+    desc :
+
+    indent :
+
+
+    Returns
+    -------
+
+    """
+    r = ''
+
+    for f in desc.split('.'):
+        f = f.strip()
+        if len(f) > 0:
+            r += ' ' * indent
+            r += '| ' + f + '.\n'
+
+    return r

--- a/python/pyrogue/_Memory.py
+++ b/python/pyrogue/_Memory.py
@@ -15,6 +15,8 @@ import threading
 
 
 class MemoryDevice(pr.Device):
+    """
+    """
     def __init__(self, *,
                  name=None,
                  description='',
@@ -29,6 +31,54 @@ class MemoryDevice(pr.Device):
                  wordBitSize=32,
                  stride=4,
                  verify=True):
+        """
+        Assigns numerical and categorical values to the MemoryDevice class object
+
+        Parameters
+        ----------
+        name : str
+             (Default value = None)
+
+        description : str
+             (Default value = '')
+
+        memBase :
+             (Default value = None)
+
+        offset : int
+             (Default value = 0)
+
+        size : int
+             (Default value = 0)
+
+        hidden : bool
+             (Default value = False)
+
+        groups : str
+             (Default value = None)
+
+        expand : bool
+             (Default value = True)
+
+        enabled : bool
+             (Default value = True)
+
+        base :
+
+
+        wordBitSize :
+
+
+        stride :
+
+
+        verify : int
+             (Default value = True)
+
+        returns
+        -------
+
+        """
 
         super().__init__(
             name=name,
@@ -61,10 +111,27 @@ class MemoryDevice(pr.Device):
 
 
     def _buildBlocks(self):
+        """
+        passes the buildBlocks function
+        """
         pass
 
     @pr.expose
     def set(self, offset, values, write=False):
+        """
+        Parameters
+        ----------
+        offset :
+
+        values :
+
+        write : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         with self._txnLock:
             self._setValues[offset] = values
             if write:
@@ -74,6 +141,20 @@ class MemoryDevice(pr.Device):
 
     @pr.expose
     def get(self, offset, numWords):
+        """
+        gets offset and numWords parameters
+
+        Parameters
+        ----------
+        offset :
+
+        numWords :
+
+
+        Returns
+        -------
+
+        """
         with self._txnLock:
             #print(f'get() self._wordBitSize={self._wordBitSize}')
             data = self._txnChunker(offset=offset, data=None,
@@ -87,15 +168,71 @@ class MemoryDevice(pr.Device):
 
 
     def _setDict(self, d, writeEach, modes,incGroups,excGroups,keys):
+        """
+
+
+        Parameters
+        ----------
+        d :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+        keys :
+
+
+        Returns
+        -------
+
+        """
         # Parse comma separated values at each offset (key) in d
         with self._txnLock:
             for offset, values in d.items():
                 self._setValues[offset] = [self._base.fromString(s) for s in values.split(',')]
 
     def _getDict(self,modes,incGroups,excGroups,properties):
+        """
+
+
+        Parameters
+        ----------
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
         return None
 
     def writeBlocks(self, force=False, recurse=True, variable=None, checkEach=False):
+        """
+
+
+        Parameters
+        ----------
+        force : bool
+             (Default value = False)
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         if self.enable.get() is not True:
             return
 
@@ -109,6 +246,22 @@ class MemoryDevice(pr.Device):
 
 
     def verifyBlocks(self, recurse=True, variable=None, checkEach=False):
+        """
+        If fall listed functions
+
+        Parameters
+        ----------
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         if (not self._verify) or (self.enable.get() is not True):
             return
 
@@ -118,6 +271,21 @@ class MemoryDevice(pr.Device):
                 self._verValues[offset] = self._txnChunker(offset, None, self._base, self._stride, self._wordBitSize, txnType=rim.Verify, numWords=len(ba))
 
     def checkBlocks(self, recurse=True, variable=None):
+        """
+        Converts the read verify data back into the native type, compares data and verifies it if necessary, then destroys txn maps when finished.
+
+        Parameters
+        ----------
+        recurse : bool
+             (Default value = True)
+
+        variable : str
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         with self._txnLock:
             # Wait for all txns to complete
             self._waitTransaction(0)
@@ -149,14 +317,55 @@ class MemoryDevice(pr.Device):
 
 
     def readBlocks(self, recurse=True, variable=None, checkEach=False):
+        """
+
+
+        Parameters
+        ----------
+        recurse : bool
+             (Default value = True)
+        variable : str
+             (Default value = None)
+        checkEach : bool
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
         pass
 
     @pr.expose
     @property
     def size(self):
+        """ """
         return self._rawSize
 
     def _txnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):
+        """
+
+
+        Parameters
+        ----------
+        offset :
+
+        data :
+
+        base :
+             (Default value = pr.UInt)
+        stride : int
+             (Default value = 4)
+        wordBitSize : int
+             (Default value = 32)
+        txnType :
+             (Default value = rim.Write)
+        numWords : int
+             (Default value = 1)
+
+        Returns
+        -------
+
+        """
 
         if not isinstance(base, pr.Model):
             base = base(wordBitSize)

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -14,6 +14,20 @@ import rogue.interfaces.memory as rim
 import numpy as np
 
 def wordCount(bits, wordSize):
+    """
+
+
+    Parameters
+    ----------
+    bits :
+
+    wordSize :
+
+
+    Returns
+    -------
+
+    """
     ret = bits // wordSize
     if (bits % wordSize != 0 or bits == 0):
         ret += 1
@@ -21,10 +35,36 @@ def wordCount(bits, wordSize):
 
 
 def byteCount(bits):
+    """
+
+
+    Parameters
+    ----------
+    bits :
+
+
+    Returns
+    -------
+
+    """
     return wordCount(bits, 8)
 
 
 def reverseBits(value, bitSize):
+    """
+
+
+    Parameters
+    ----------
+    value :
+
+    bitSize :
+
+
+    Returns
+    -------
+
+    """
     result = 0
     for i in range(bitSize):
         result <<= 1
@@ -34,13 +74,27 @@ def reverseBits(value, bitSize):
 
 
 def twosComplement(value, bitSize):
-    """compute the 2's complement of int value"""
+    """
+    compute the 2's complement of int value
+
+    Parameters
+    ----------
+    value :
+
+    bitSize :
+
+
+    Returns
+    -------
+
+    """
     if (value & (1 << (bitSize - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
         value = value - (1 << bitSize)      # compute negative value
     return value                            # return positive value as is
 
 
 class ModelMeta(type):
+    """ """
     def __init__(cls, *args, **kwargs):
         super().__init__(*args, **kwargs)
         cls.subclasses = {}
@@ -64,9 +118,11 @@ class Model(object, metaclass=ModelMeta):
     ----------
     bitSize : int
         Number of bits being represented
-
     binPoint : int
         Huh?
+
+    Returns
+    -------
 
     Attributes
     ----------
@@ -102,7 +158,6 @@ class Model(object, metaclass=ModelMeta):
 
     ndType: np.dtype
         numpy type value (bool, int32, int64, uint32, uin64, float32, float64)
-
     """
 
     fstring     = None
@@ -122,6 +177,7 @@ class Model(object, metaclass=ModelMeta):
 
     @property
     def isBigEndian(self):
+        """ """
         return self.endianness == 'big'
 
     def toBytes(self, value):
@@ -130,12 +186,13 @@ class Model(object, metaclass=ModelMeta):
 
         Parameters
         ----------
-        value: obj
+        value : obj
             Python value to convert
 
         Returns
         -------
-        bytearray : Byte array representation of value
+
+
         """
         return None
 
@@ -146,12 +203,13 @@ class Model(object, metaclass=ModelMeta):
 
         Parameters
         ----------
-        ba: bytearray
+        ba : bytearray
             Byte array to extract value from
 
         Returns
         -------
-        obj : Converted python value
+
+
         """
         return None
 
@@ -161,45 +219,27 @@ class Model(object, metaclass=ModelMeta):
 
         Parameters
         ----------
-        string: str
+        string : str
             String representation of the value
 
         Returns
         -------
-        obj : Converted python value
+
+
         """
         return None
 
     def minValue(self):
-        """
-        Return the minimum value for the Model type
-
-        Returns
-        -------
-        obj: Minimum value
-        """
+        """Return the minimum value for the Model type"""
         return None
 
     def maxValue(self):
-        """
-        Return the maximum value for the Model type
-
-        Returns
-        -------
-        obj: Maximum value
-        """
+        """Return the maximum value for the Model type"""
         return None
 
 
 class UInt(Model):
-    """
-    Model class for unsigned integers
-
-    Parameters
-    ----------
-    bitSize : int
-        Number of bits being represented
-    """
+    """Model class for unsigned integers"""
 
     pytype      = int
     defaultdisp = '{:#x}'
@@ -212,26 +252,62 @@ class UInt(Model):
 
     # Called by raw read/write and when bitsize > 64
     def toBytes(self, value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         return value.to_bytes(byteCount(self.bitSize), self.endianness, signed=self.signed)
 
     # Called by raw read/write and when bitsize > 64
     def fromBytes(self, ba):
+        """
+
+
+        Parameters
+        ----------
+        ba :
+
+
+        Returns
+        -------
+
+        """
         return int.from_bytes(ba, self.endianness, signed=self.signed)
 
     def fromString(self, string):
+        """
+
+
+        Parameters
+        ----------
+        string :
+
+
+        Returns
+        -------
+
+        """
         return int(string, 0)
 
     def minValue(self):
+        """ """
         return 0
 
     def maxValue(self):
+        """ """
         return (2**self.bitSize)-1
 
 
 class UIntReversed(UInt):
-    """
-    Model class for unsigned integers, stored in reverse bit order
-    """
+    """Model class for unsigned integers, stored in reverse bit order"""
 
     modelId    = rim.PyFunc # Not yet supported
     bitReverse = True
@@ -241,18 +317,40 @@ class UIntReversed(UInt):
         self.ndType = None
 
     def toBytes(self, value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         valueReverse = reverseBits(value, self.bitSize)
         return valueReverse.to_bytes(byteCount(self.bitSize), self.endianness, signed=self.signed)
 
     def fromBytes(self, ba):
+        """
+
+
+        Parameters
+        ----------
+        ba :
+
+
+        Returns
+        -------
+
+        """
         valueReverse = int.from_bytes(ba, self.endianness, signed=self.signed)
         return reverseBits(valueReverse, self.bitSize)
 
 
 class Int(UInt):
-    """
-    Model class for integers
-    """
+    """Model class for integers"""
 
     # Override these and inherit everything else from UInt
     defaultdisp = '{:d}'
@@ -265,6 +363,18 @@ class Int(UInt):
 
     # Called by raw read/write and when bitsize > 64
     def toBytes(self, value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         if (value < 0) and (self.bitSize < (byteCount(self.bitSize) * 8)):
             newValue = value & (2**(self.bitSize)-1) # Strip upper bits
             ba = newValue.to_bytes(byteCount(self.bitSize), self.endianness, signed=False)
@@ -275,6 +385,18 @@ class Int(UInt):
 
     # Called by raw read/write and when bitsize > 64
     def fromBytes(self,ba):
+        """
+
+
+        Parameters
+        ----------
+        ba :
+
+
+        Returns
+        -------
+
+        """
         if (self.bitSize < (byteCount(self.bitSize)*8)):
             value = int.from_bytes(ba, self.endianness, signed=False)
 
@@ -287,6 +409,18 @@ class Int(UInt):
         return
 
     def fromString(self, string):
+        """
+
+
+        Parameters
+        ----------
+        string :
+
+
+        Returns
+        -------
+
+        """
         i = int(string, 0)
         # perform twos complement if necessary
         if i>0 and ((i >> self.bitSize) & 0x1 == 1):
@@ -294,37 +428,28 @@ class Int(UInt):
         return i
 
     def minValue(self):
+        """ """
         return -1 * ((2**(self.bitSize-1))-1)
 
     def maxValue(self):
+        """ """
         return (2**(self.bitSize-1))-1
 
 
 class UIntBE(UInt):
-    """
-    Model class for big endian unsigned integers
-    """
+    """Model class for big endian unsigned integers"""
 
     endianness = 'big'
 
 
 class IntBE(Int):
-    """
-    Model class for big endian integers
-    """
+    """Model class for big endian integers"""
 
     endianness = 'big'
 
 
 class Bool(Model):
-    """
-    Model class for booleans
-
-    Parameters
-    ----------
-    bitSize : int
-        Number of bits being represented
-    """
+    """Model class for booleans"""
 
     pytype      = bool
     defaultdisp = {False: 'False', True: 'True'}
@@ -336,24 +461,31 @@ class Bool(Model):
         self.ndType = np.dtype(bool)
 
     def fromString(self, string):
+        """
+
+
+        Parameters
+        ----------
+        string :
+
+
+        Returns
+        -------
+
+        """
         return str.lower(string) == "true"
 
     def minValue(self):
+        """ """
         return 0
 
     def maxValue(self):
+        """ """
         return 1
 
 
 class String(Model):
-    """
-    Model class for strings
-
-    Parameters
-    ----------
-    bitSize : int
-        Number of bits being represented
-    """
+    """Model class for strings"""
 
     encoding    = 'utf-8'
     defaultdisp = '{}'
@@ -365,18 +497,23 @@ class String(Model):
         self.name = f'{self.__class__.__name__}({self.bitSize//8})'
 
     def fromString(self, string):
+        """
+
+
+        Parameters
+        ----------
+        string :
+
+
+        Returns
+        -------
+
+        """
         return string
 
 
 class Float(Model):
-    """
-    Model class for 32-bit floats
-
-    Parameters
-    ----------
-    bitSize : int
-        Number of bits being represented, must be 32
-    """
+    """Model class for 32-bit floats"""
 
     defaultdisp = '{:f}'
     pytype      = float
@@ -390,24 +527,31 @@ class Float(Model):
         self.ndType = np.dtype(np.float32)
 
     def fromString(self, string):
+        """
+
+
+        Parameters
+        ----------
+        string :
+
+
+        Returns
+        -------
+
+        """
         return float(string)
 
     def minValue(self):
+        """ """
         return -3.4e38
 
     def maxValue(self):
+        """ """
         return 3.4e38
 
 
 class Double(Float):
-    """
-    Model class for 64-bit floats
-
-    Parameters
-    ----------
-    bitSize : int
-        Number of bits being represented, must be 64
-    """
+    """Model class for 64-bit floats"""
 
     fstring = 'd'
     modelId = rim.Double
@@ -419,25 +563,23 @@ class Double(Float):
         self.ndType = np.dtype(np.float64)
 
     def minValue(self):
+        """ """
         return -1.80e308
 
     def maxValue(self):
+        """ """
         return 1.80e308
 
 
 class FloatBE(Float):
-    """
-    Model class for 32-bit floats stored as big endian
-    """
+    """Model class for 32-bit floats stored as big endian"""
 
     endianness = 'big'
     fstring = '!f'
 
 
 class DoubleBE(Double):
-    """
-    Model class for 64-bit floats stored as big endian
-    """
+    """Model class for 64-bit floats stored as big endian"""
 
     endianness = 'big'
     fstring = '!d'

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -19,6 +19,20 @@ import collections
 
 
 def logException(log,e):
+    """
+    logs instances of memory error, else, will log the exception.
+
+    Parameters
+    ----------
+    log :
+        calls command to log instance of memory error or exception
+    e :
+        stores values of memory errors or exceptions
+
+    Returns
+    -------
+    none
+    """
     if isinstance(e,pr.MemoryError):
         log.error(e)
     else:
@@ -26,12 +40,28 @@ def logException(log,e):
 
 
 def logInit(cls=None,name=None,path=None):
+    """
+    logs base classes in order of highest ranking class. Checks values of  cls, name, and path, if their value is not  =None, will do something
+
+    Parameters
+    ----------
+    cls :
+         (Default value = None)
+    name :
+         (Default value = None)
+    path :
+         (Default value = None)
+
+    Returns
+    -------
+    returns logger
+    """
 
     # Support base class in order of precedence
     baseClasses = odict({pr.BaseCommand : 'Command', pr.BaseVariable : 'Variable',
                          pr.Root : 'Root', pr.Device : 'Device'})
 
-    """Init a logging pbject. Set global options."""
+    """Init a logging object. Set global options."""
     logging.basicConfig(
         #level=logging.NOTSET,
         format="%(levelname)s:%(name)s:%(message)s",
@@ -62,6 +92,18 @@ def logInit(cls=None,name=None,path=None):
 
 
 def expose(item):
+    """
+    Allows user to interface with function under item parameter
+
+    Parameters
+    ----------
+    item :
+
+
+    Returns
+    -------
+    returns item
+    """
 
     # Property
     if inspect.isdatadescriptor(item):
@@ -74,7 +116,7 @@ def expose(item):
 
 
 class NodeError(Exception):
-    """ Exception for node manipulation errors."""
+    """ """
     pass
 
 
@@ -92,10 +134,55 @@ class Node(object):
     Each node is associated with a parent and has a link to the top node of a tree.
     A node has a list of sub-nodes as well as each sub-node being attached as an
     attribute. This allows tree browsing using: node1.node2.node3
+
+    Parameters
+    ----------
+    name :
+        global name of object
+
+    description :
+        Description of object
+
+    path :
+        full path to the node (ie. node1.node2.node3)
+
+    expand :
+
+    guiGroup :
+        arbitrary groups for gui and graphical aesthetic purposes
+    Returns
+    -------
+
     """
 
     def __init__(self, *, name, description="", expand=True, hidden=False, groups=None, guiGroup=None):
-        """Init the node with passed attributes"""
+        """
+        Init the node with passed attributes
+
+        Parameters
+        ----------
+        name : str
+            name of variable
+
+        description : str
+            description of variable
+
+        expand : bool
+
+
+        hidden : bool
+            Default value = False, variable is not part of hidden group
+
+        groups :
+
+
+        guiGroup :
+
+
+        Returns
+        -------
+
+        """
 
         # Public attributes
         self._name        = name
@@ -128,20 +215,36 @@ class Node(object):
 
     @property
     def name(self):
+        """
+        assigns and returns name attribute to class variable
+        """
         return self._name
 
     @property
     def description(self):
+        """
+        assigns and returns description attribute to class variable
+        """
         return self._description
 
     @property
     def groups(self):
-        """ Return list of groups this node is a part of """
+        """
+        assigns and returns groups attribute to class variable
+        """
         return self._groups
 
     def inGroup(self, group):
         """
-        Return true if this node is part of the passed group or one of the groups in a list
+
+
+        Parameters
+        ----------
+        group :
+
+
+        Returns
+        -------
         """
         if isinstance(group,list):
             return len(set(group) & set(self._groups)) > 0
@@ -149,12 +252,36 @@ class Node(object):
             return group in self._groups
 
     def filterByGroup(self, incGroups, excGroups):
-        """" Filter by the passed list of inclusion and exclusion groups """
+        """
+        Filter by the passed list of inclusion and exclusion groups
+
+        Parameters
+        ----------
+        incGroups :
+            list of passed inclusion groups
+        excGroups :
+            list of passed exclusion groups
+
+        Returns
+        -------
+
+        """
         return ((incGroups is None) or (len(incGroups) == 0) or (self.inGroup(incGroups))) and \
                ((excGroups is None) or (len(excGroups) == 0) or (not self.inGroup(excGroups)))
 
     def addToGroup(self,group):
-        """ Add this node to the passed group, recursive to children """
+        """
+        Add this node to the passed group, recursive to children
+
+        Parameters
+        ----------
+        group :
+            variable denoting a node that has not been passed
+
+        Returns
+        -------
+
+        """
         if group not in self._groups:
             self._groups.append(group)
 
@@ -162,18 +289,42 @@ class Node(object):
             v.addToGroup(group)
 
     def removeFromGroup(self,group):
-        """ Remove this node from the passed group, not recursive """
+        """
+        Remove this node from the passed group, not recursive
+
+        Parameters
+        ----------
+        group :
+            variable denoting a node that is in the passed group
+
+        Returns
+        -------
+        if in group, remove from group
+        """
         if group in self._groups:
             self._groups.remove(group)
 
     @property
     def hidden(self):
-        """ Return true if this node is a member of the Hidden group """
+        """
+        assigns and returns hidden attribute to class variable
+        """
         return self.inGroup('Hidden')
 
     @hidden.setter
     def hidden(self, value):
-        """ Add or remove node from the Hidden group """
+        """
+        Add or remove node from the Hidden group
+
+        Parameters
+        ----------
+        value : bool
+            Boolean value assigned to the Hidden group
+
+        Returns
+        -------
+        if value = true, add to group, else remove from group
+        """
         if value is True:
             self.addToGroup('Hidden')
         else:
@@ -181,21 +332,34 @@ class Node(object):
 
     @property
     def path(self):
+        """ """
         return self._path
 
     @property
     def expand(self):
+        """ """
         return self._expand
 
     @property
     def guiGroup(self):
+        """ """
         return self._guiGroup
 
     def __getattr__(self, name):
-        """Allow child Nodes with the 'name[key]' naming convention to be accessed as if they belong to a
+        """
+        Allow child Nodes with the 'name[key]' naming convention to be accessed as if they belong to a
         dictionary of Nodes with that 'name'.
-        This override builds an OrderedDict of all child nodes named as 'name[key]' and returns it.
-        Raises AttributeError if no such named Nodes are found. """
+        Raises AttributeError if no such named Nodes are found.
+
+        Parameters
+        ----------
+
+        name : str
+            builds an OrderedDict of all child nodes named as 'name[key]' and returns it.
+        Returns
+        -------
+
+        """
 
         # Node matches name in node list
         if name in self._nodes:
@@ -244,7 +408,18 @@ class Node(object):
         return item in self.nodes.values()
 
     def add(self,node):
-        """Add node as sub-node"""
+        """
+        Add node as sub-node
+
+        Parameters
+        ----------
+        node :
+
+
+        Returns
+        -------
+
+        """
 
         # Special case if list (or iterable of nodes) is passed
         if isinstance(node, collections.abc.Iterable) and all(isinstance(n, Node) for n in node):
@@ -279,6 +454,18 @@ class Node(object):
         self._nodes[node.name] = node
 
     def _addArrayNode(self, node):
+        """
+
+
+        Parameters
+        ----------
+        node :
+
+
+        Returns
+        -------
+
+        """
 
         # Generic test array method
         fields = re.split('\\]\\[|\\[|\\]',node.name)
@@ -328,9 +515,41 @@ class Node(object):
 
 
     def addNode(self, nodeClass, **kwargs):
+        """
+
+
+        Parameters
+        ----------
+        nodeClass :
+
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         self.add(nodeClass(**kwargs))
 
     def addNodes(self, nodeClass, number, stride, **kwargs):
+        """
+
+
+        Parameters
+        ----------
+        nodeClass :
+
+        number :
+
+        stride :
+
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         name = kwargs.pop('name')
         offset = kwargs.pop('offset')
         for i in range(number):
@@ -351,36 +570,57 @@ class Node(object):
         exc is a class type to exclude,
         incGroups is an optional group or list of groups that this node must be part of
         excGroups is an optional group or list of groups that this node must not be part of
+
+        Parameters
+        ----------
+        typ :
+
+        excTyp :
+             (Default value = None)
+        incGroups :
+             (Default value = None)
+        excGroups :
+             (Default value = None)
+
+        Returns
+        -------
+        ordered dictionary of nodes
         """
         return odict([(k,n) for k,n in self.nodes.items()
                       if (n.isinstance(typ) and ((excTyp is None) or (not n.isinstance(excTyp))) and n.filterByGroup(incGroups,excGroups))])
 
     @property
     def nodes(self):
-        """
-        Get a ordered dictionary of all nodes.
-        """
+        """Get a ordered dictionary of all nodes."""
         return self._nodes
 
     @property
     def variables(self):
-        """
-        Return an OrderedDict of the variables but not commands (which are a subclass of Variable
-        """
+        """ """
         return self.getNodes(typ=pr.BaseVariable,excTyp=pr.BaseCommand)
 
     def variablesByGroup(self,incGroups=None,excGroups=None):
         """
-        Return an OrderedDict of the variables but not commands (which are a subclass of Variable
-        Pass list of include and / or exclude groups
+
+
+        Parameters
+        ----------
+        incGroups :
+             (Default value = None)
+        excGroups :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            Pass list of include and / or exclude groups
+
         """
         return self.getNodes(typ=pr.BaseVariable,excTyp=pr.BaseCommand,incGroups=incGroups,excGroups=excGroups)
 
     @property
     def variableList(self):
-        """
-        Get a recursive list of variables and commands.
-        """
+        """Get a recursive list of variables and commands."""
         lst = []
         for key,value in self.nodes.items():
             if value.isinstance(pr.BaseVariable):
@@ -391,37 +631,55 @@ class Node(object):
 
     @property
     def commands(self):
-        """
-        Return an OrderedDict of the Commands that are children of this Node
-        """
+        """ """
         return self.getNodes(typ=pr.BaseCommand)
 
     def commandsByGroup(self,incGroups=None,excGroups=None):
         """
-        Return an OrderedDict of the variables but not commands (which are a subclass of Variable
-        Pass list of include and / or exclude groups
+
+
+        Parameters
+        ----------
+        incGroups :
+             (Default value = None)
+        excGroups :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            Pass list of include and / or exclude groups
+
         """
         return self.getNodes(typ=pr.BaseCommand,incGroups=incGroups,excGroups=excGroups)
 
     @property
     def devices(self):
-        """
-        Return an OrderedDict of the Devices that are children of this Node
-        """
+        """ """
         return self.getNodes(pr.Device)
 
     def devicesByGroup(self,incGroups=None,excGroups=None):
         """
-        Return an OrderedDict of the Devices that are children of this Node
-        Pass list of include and / or exclude groups
+
+
+        Parameters
+        ----------
+        incGroups :
+             (Default value = None)
+        excGroups :
+             (Default value = None)
+
+        Returns
+        -------
+        type
+            Pass list of include and / or exclude groups
+
         """
         return self.getNodes(pr.Device,incGroups=incGroups,excGroups=excGroups)
 
     @property
     def deviceList(self):
-        """
-        Get a recursive list of devices
-        """
+        """Get a recursive list of devices"""
         lst = []
         for key,value in self.nodes.items():
             if value.isinstance(pr.Device):
@@ -431,19 +689,27 @@ class Node(object):
 
     @property
     def parent(self):
-        """
-        Return parent node or NULL if no parent exists.
-        """
+        """ """
         return self._parent
 
     @property
     def root(self):
-        """
-        Return root node of tree.
-        """
+        """ """
         return self._root
 
     def node(self, name):
+        """
+
+
+        Parameters
+        ----------
+        name :
+
+
+        Returns
+        -------
+
+        """
         if name in self._nodes:
             return self._nodes[name]
         else:
@@ -451,14 +717,17 @@ class Node(object):
 
     @property
     def isDevice(self):
+        """ """
         return self.isinstance(pr.Device)
 
     @property
     def isVariable(self):
+        """ """
         return (self.isinstance(pr.BaseVariable) and (not self.isinstance(pr.BaseCommand)))
 
     @property
     def isCommand(self):
+        """ """
         return self.isinstance(pr.BaseCommand)
 
     def find(self, *, recurse=True, typ=None, **kwargs):
@@ -466,6 +735,21 @@ class Node(object):
         Find all child nodes that are a base class of 'typ'
         and whose properties match all of the kwargs.
         For string properties, accepts regexes.
+
+        Parameters
+        ----------
+        * :
+
+        recurse :
+             (Default value = True)
+        typ :
+             (Default value = None)
+        **kwargs :
+
+
+        Returns
+        -------
+
         """
 
         if typ is None:
@@ -494,6 +778,22 @@ class Node(object):
         return found
 
     def callRecursive(self, func, nodeTypes=None, **kwargs):
+        """
+
+
+        Parameters
+        ----------
+        func :
+
+        nodeTypes :
+             (Default value = None)
+        **kwargs :
+
+
+        Returns
+        -------
+
+        """
         # Call the function
         getattr(self, func)(**kwargs)
 
@@ -507,15 +807,66 @@ class Node(object):
 
     # this might be useful
     def makeRecursive(self, func, nodeTypes=None):
+        """
+
+
+        Parameters
+        ----------
+        func :
+
+        nodeTypes :
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         def closure(**kwargs):
+            """
+
+
+            Parameters
+            ----------
+            **kwargs :
+
+
+            Returns
+            -------
+
+            """
             self.callRecursive(func, nodeTypes, **kwargs)
         return closure
 
     def isinstance(self,typ):
+        """
+
+
+        Parameters
+        ----------
+        typ :
+
+
+        Returns
+        -------
+
+        """
         return isinstance(self,typ)
 
     def _rootAttached(self,parent,root):
-        """Called once the root node is attached."""
+        """
+        Called once the root node is attached.
+
+        Parameters
+        ----------
+        parent :
+
+        root :
+
+
+        Returns
+        -------
+
+        """
         self._parent = parent
         self._root   = root
         self._path   = parent.path + '.' + self.name
@@ -545,6 +896,19 @@ class Node(object):
         Get variable values in a dictionary starting from this level.
         Attributes that are Nodes are recursed.
         modes is a list of variable modes to include.
+
+        Parameters
+        ----------
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
         """
         data = odict()
         for key,value in self.variablesByGroup(incGroups, excGroups).items():
@@ -564,6 +928,28 @@ class Node(object):
             return data
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
+        """
+
+
+        Parameters
+        ----------
+        d :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+        keys :
+
+
+        Returns
+        -------
+
+        """
 
         # If keys is not none, someone tried to access this node with array
         # attributes incorrectly. This should only happen in the variable class.
@@ -581,22 +967,44 @@ class Node(object):
                             n._setDict(value,writeEach,modes,incGroups,excGroups,keys)
 
     def _setTimeout(self,timeout):
+        """
+
+
+        Parameters
+        ----------
+        timeout :
+
+
+        Returns
+        -------
+
+        """
         pass
 
     def nodeMatch(self,name):
         """
-        Return a list of nodes which match the given name. The name can either
-        be a single value or a list accessor:
+
+
+        Parameters
+        ----------
+        name :
+
+
+        Returns
+        -------
+        type
+            be a single value or a list accessor:
             value
             value[9]
             value[0:1]
             value[*]
             value[:]
-        Variables will only match if their depth matches the passed lookup and wildcard:
+            Variables will only match if their depth matches the passed lookup and wildcard:
             value[*] will match a variable named value[1] but not a variable named value[2][3]
             value[*][*] will match a variable named value[2][3].
-        The second return field will contain the array information if the base name
-        matches an item in the non list array.
+            The second return field will contain the array information if the base name
+            matches an item in the non list array.
+
         """
         # Node matches name in node list
         if name in self.nodes:
@@ -624,6 +1032,20 @@ class Node(object):
 
 
 def _iterateDict(d, keys):
+    """
+
+
+    Parameters
+    ----------
+    d :
+
+    keys :
+
+
+    Returns
+    -------
+
+    """
     retList = []
 
     # Wildcard, full list
@@ -664,6 +1086,7 @@ def _iterateDict(d, keys):
 
 
 def genBaseList(cls):
+    """ """
     ret = [str(cls)]
 
     for x in cls.__bases__:

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -19,6 +19,7 @@ import pyrogue as pr
 
 
 class PollQueueEntry(object):
+    """ """
     def __init__(self, readTime, count, interval, block):
         self.readTime = readTime
         self.count    = count
@@ -33,6 +34,7 @@ class PollQueueEntry(object):
 
 
 class PollQueue(object):
+    """ """
 
     def __init__(self,*, root):
         self._pq = [] # The heap queue
@@ -49,10 +51,25 @@ class PollQueue(object):
         self._log = pr.logInit(cls=self)
 
     def _start(self):
+        """ """
         self._pollThread.start()
         self._log.info("PollQueue Started")
 
     def _addEntry(self, block, interval):
+        """
+
+
+        Parameters
+        ----------
+        block :
+
+        interval :
+
+
+        Returns
+        -------
+
+        """
         with self._condLock:
             timedelta = datetime.timedelta(seconds=interval)
             # new entries are always polled first immediately
@@ -66,16 +83,30 @@ class PollQueue(object):
             self._condLock.notify()
 
     def _blockIncrement(self):
+        """ """
         with self._condLock:
             self.blockCount += 1
             self._condLock.notify()
 
     def _blockDecrement(self):
+        """ """
         with self._condLock:
             self.blockCount -= 1
             self._condLock.notify()
 
     def updatePollInterval(self, var):
+        """
+
+
+        Parameters
+        ----------
+        var :
+
+
+        Returns
+        -------
+
+        """
         with self._condLock:
             self._log.debug(f'updatePollInterval {var} - {var._pollInterval}')
             # Special case: Variable has no block and just depends on other variables
@@ -172,9 +203,19 @@ class PollQueue(object):
 
 
     def _expiredEntries(self, time=None):
-        """An iterator of all entries that expire by a given time.
+        """
+        An iterator of all entries that expire by a given time.
         Use datetime.now() if no time provided. Each entry is popped from the queue before being
         yielded by the iterator
+
+        Parameters
+        ----------
+        time :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
         with self._condLock:
             if time is None:
@@ -186,6 +227,7 @@ class PollQueue(object):
 
 
     def peek(self):
+        """ """
         with self._condLock:
             if self.empty() is False:
                 return self._pq[0]
@@ -193,15 +235,29 @@ class PollQueue(object):
                 return None
 
     def empty(self):
+        """ """
         with self._condLock:
             return len(self._pq)==0
 
     def _stop(self):
+        """ """
         with self._condLock:
             self._run = False
             self._condLock.notify()
 
     def pause(self, value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         if value is True:
             with self._condLock:
                 self._pause = True
@@ -212,5 +268,6 @@ class PollQueue(object):
 
 
     def paused(self):
+        """ """
         with self._condLock:
             return self._pause

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -32,19 +32,19 @@ class Process(pr.Device):
         self.add(pr.LocalCommand(
             name='Start',
             function=self._startProcess,
-            description='Start process.'))
+            description='Start process. No Args.'))
 
         self.add(pr.LocalCommand(
             name='Stop',
             function=self._stopProcess,
-            description='Stop process.'))
+            description='Stop process. No Args.'))
 
         self.add(pr.LocalVariable(
             name='Running',
             mode='RO',
             value=False,
             pollInterval=1.0,
-            description='Operation is running.'))
+            description='Status values indicating if operation is running.'))
 
         self.add(pr.LocalVariable(
             name='Progress',
@@ -55,14 +55,14 @@ class Process(pr.Device):
             minimum=0.0,
             maximum=1.0,
             pollInterval=1.0,
-            description='Percent complete: 0.0 - 1.0.'))
+            description='Percent complete: 0 - 100 %.'))
 
         self.add(pr.LocalVariable(
             name='Message',
             mode='RO',
             value='',
             pollInterval=1.0,
-            description='Process status message. Prefix with Error: if an error occurred.'))
+            description="Process status message. Prefixed with 'Error:' if an error occurred."))
 
         # Add arg variable if not already added
         if self._argVar is not None and self._argVar not in self:
@@ -74,6 +74,7 @@ class Process(pr.Device):
 
 
     def _startProcess(self):
+        """ """
         with self._lock:
             if self.Running.value() is False:
                 self._runEn  = True
@@ -83,10 +84,12 @@ class Process(pr.Device):
                 self._log.warning("Process already running!")
 
     def _stopProcess(self):
+        """ """
         with self._lock:
             self._runEn  = False
 
     def _stop(self):
+        """ """
         self._stopProcess()
         pr.Device._stop(self)
 
@@ -105,6 +108,7 @@ class Process(pr.Device):
         return None
 
     def _run(self):
+        """ """
         self.Running.set(True)
 
         try:
@@ -116,6 +120,7 @@ class Process(pr.Device):
         self.Running.set(False)
 
     def _process(self):
+        """ """
 
         # User has provided a function Update status at start and end and call their function
         if self._function is not None:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -31,6 +31,8 @@ from contextlib import contextmanager
 SystemLogInit = '[]'
 
 class UpdateTracker(object):
+    """
+    """
     def __init__(self,q):
         self._count = 0
         self._list = {}
@@ -39,6 +41,17 @@ class UpdateTracker(object):
         self._q = q
 
     def increment(self, period):
+        """
+
+        Parameters
+        ----------
+        period : int
+            default value period = 0
+
+        Returns
+        -------
+        """
+
         if self._count == 0 or self._period < period:
             self._period = period
         self._count +=1
@@ -57,16 +70,40 @@ class UpdateTracker(object):
             self._list = {}
 
     def update(self,var):
+        """
+
+
+        Parameters
+        ----------
+        var :
+
+
+        Returns
+        -------
+
+        """
         self._list[var.path] = var
         self._check()
 
 class RootLogHandler(logging.Handler):
-    """ Class to listen to log entries and add them to syslog variable"""
+    """Class to listen to log entries and add them to syslog variable"""
     def __init__(self,*, root):
         logging.Handler.__init__(self)
         self._root = root
 
     def emit(self,record):
+        """
+
+
+        Parameters
+        ----------
+        record :
+
+
+        Returns
+        -------
+
+        """
 
         if not self._root.running:
             return
@@ -117,6 +154,17 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     The root is a stream master which generates frames containing tree
     configuration and status values. This allows configuration and status
     to be stored in data files.
+
+    Attributes
+    ----------
+    rogue.interfaces.stream.Master :
+
+
+    pr.Device :
+
+    Returns
+    -------
+
     """
 
     def __enter__(self):
@@ -235,7 +283,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                                                     autoPrefix='state',
                                                                     autoCompress=True),
                                  hidden=True,
-                                 description='Save state to passed filename in YAML format'))
+                                 description='Save state to file. Data is saved in YAML format. Passed arg is full path to file to sore data to.'))
 
         self.add(pr.LocalCommand(name='SaveConfig', value='',
                                  function=lambda arg: self.saveYaml(name=arg,
@@ -246,7 +294,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                                                     autoPrefix='config',
                                                                     autoCompress=False),
                                  hidden=True,
-                                 description='Save configuration to passed filename in YAML format'))
+                                 description='Save configuration to file. Data is saved in YAML format. Passed arg is full path to file to sore data to.'))
 
         self.add(pr.LocalCommand(name='LoadConfig', value='',
                                  function=lambda arg: self.loadYaml(name=arg,
@@ -255,7 +303,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                                                     incGroups=None,
                                                                     excGroups='NoConfig'),
                                  hidden=True,
-                                 description='Read configuration from passed filename in YAML format'))
+                                 description='Read configuration from file. Data is read in YAML format. Passed arg is full path to file to read data from.'))
 
         self.add(pr.LocalCommand(name='RemoteVariableDump', value='',
                                  function=lambda arg: self.remoteVariableDump(name=arg,
@@ -291,7 +339,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                                                    incGroups=None,
                                                                    excGroups='NoConfig'),
                                  hidden=True,
-                                 description='Set configuration from passed YAML string'))
+                                 description='Set configuration from YAML string. Passed arg is configuration string in YAML format.'))
 
         self.add(pr.LocalCommand(name='GetYamlConfig', value=True, retValue='',
                                  function=lambda arg: self.getYaml(readFirst=arg,
@@ -300,7 +348,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
                                                                    excGroups='NoConfig',
                                                                    recurse=True),
                                  hidden=True,
-                                 description='Get current configuration as YAML string. Pass read first arg.'))
+                                 description='Get configuration in YAML string. '
+                                             'Passed arg is a boolean indicating if a full system read should be generated. '
+                                             'Return data is configuration as a YAML string.'))
 
         self.add(pr.LocalCommand(name='GetYamlState', value=True, retValue='',
                                  function=lambda arg: self.getYaml(readFirst=arg,
@@ -437,58 +487,173 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @property
     def serverPort(self):
+        """
+"""
         return self._serverPort
 
     @pr.expose
     @property
     def running(self):
+        """
+"""
         return self._running
 
     def addVarListener(self,func):
         """
         Add a variable update listener function.
         The variable and value structure will be passed as args: func(path,varValue)
+
+        Parameters
+        ----------
+        func :
+
+        Returns
+        -------
         """
+
+
         with self._varListenLock:
             self._varListeners.append(func)
 
     @pr.expose
     def get(self,path):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.get()
 
     @pr.expose
     def getDisp(self,path):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.getDisp()
 
     @pr.expose
     def value(self,path):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.value()
 
     @pr.expose
     def valueDisp(self,path):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.valueDisp()
 
     @pr.expose
     def set(self,path,value):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+        value :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.set(value)
 
     @pr.expose
     def setDisp(self,path,value):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+        value :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj.setDisp(value)
 
     @pr.expose
     def exec(self,path,arg):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+        arg :
+
+
+        Returns
+        -------
+
+        """
         obj = self.getNode(path)
         return obj(arg)
 
     @contextmanager
     def updateGroup(self, period=0):
+        """
+
+
+        Parameters
+        ----------
+        period :
+             (Default value = 0)
+
+        Returns
+        -------
+
+        """
         tid = threading.get_ident()
 
         # At with call
@@ -508,6 +673,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @contextmanager
     def pollBlock(self):
+        """
+"""
 
         # At with call
         self._pollQueue._blockIncrement()
@@ -522,9 +689,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @pr.expose
     def waitOnUpdate(self):
-        """
-        Wait until all update queue items have been processed.
-        """
+        """Wait until all update queue items have been processed."""
         self._updateQueue.join()
 
     def hardReset(self):
@@ -537,6 +702,18 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @ft.lru_cache(maxsize=None)
     def getNode(self,path):
+        """
+
+
+        Parameters
+        ----------
+        path :
+
+
+        Returns
+        -------
+
+        """
         obj = self
 
         if '.' in path:
@@ -557,6 +734,20 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @pr.expose
     def saveAddressMap(self,fname,headerEn=False):
+        """
+
+
+        Parameters
+        ----------
+        fname :
+
+        headerEn :
+             (Default value = False)
+
+        Returns
+        -------
+
+        """
 
         # First form header
         # Changing these names here requires changing the createVariable() method in LibraryBase.cpp
@@ -644,6 +835,22 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @pr.expose
     def saveVariableList(self,fname,polledOnly=False,incGroups=None):
+        """
+
+
+        Parameters
+        ----------
+        fname :
+
+        polledOnly : bool
+             (Default value = False)
+        incGroups :
+             (Default value = None)
+
+        Returns
+        -------
+
+        """
         with open(fname,'w') as f:
             f.write("Path\t")
             f.write("TypeStr\t")
@@ -665,6 +872,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
 
     def _hbeatWorker(self):
+        """
+"""
         while self._running:
             time.sleep(1)
 
@@ -681,6 +890,8 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     #    os.execl(py, py, *sys.argv)
 
     def _rootAttached(self):
+        """
+"""
         self._parent = self
         self._root   = self
         self._path   = self.name
@@ -697,6 +908,15 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
     def _sendYamlFrame(self,yml):
         """
         Generate a frame containing the passed string.
+
+        Parameters
+        ----------
+        yml :
+
+
+        Returns
+        -------
+
         """
         b = bytearray(yml,'utf-8')
         frame = self._reqFrame(len(b),True)
@@ -714,6 +934,23 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         incGroups are None, the default set of stream include and
         exclude groups will be used as specified when the Root class was created.
         By default all variables are included, except for members of the NoStream group.
+
+        Parameters
+        ----------
+        modes :
+             (Default value = ['RW')
+        'RO' :
+
+        'WO'] :
+
+        incGroups :
+             (Default value = None)
+        excGroups :
+             (Default value = None)
+
+        Returns
+        -------
+
         """
 
         # Don't send if there are not any Slaves connected
@@ -758,7 +995,30 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     @pr.expose
     def saveYaml(self,name,readFirst,modes,incGroups,excGroups,autoPrefix,autoCompress):
-        """Save YAML configuration/status to a file. Called from command"""
+        """
+        Save YAML configuration/status to a file. Called from command
+
+        Parameters
+        ----------
+        name :
+
+        readFirst :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+        autoPrefix :
+
+        autoCompress :
+
+
+        Returns
+        -------
+
+        """
 
         # Auto generate name if no arg
         if name is None or name == '':
@@ -781,7 +1041,26 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
 
     def loadYaml(self,name,writeEach,modes,incGroups,excGroups):
-        """Load YAML configuration from a file. Called from command"""
+        """
+        Load YAML configuration from a file. Called from command
+
+        Parameters
+        ----------
+        name :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
 
         # Pass arg is a python list
         if isinstance(name,list):
@@ -870,6 +1149,23 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         false a bulk write will be performed after all of the variable updates
         are completed. Bulk writes provide better performance when updating a large
         quantity of variables.
+
+        Parameters
+        ----------
+        yml :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
         """
         d = pr.yamlToData(yml)
 
@@ -883,7 +1179,22 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             self.initialize()
 
     def remoteVariableDump(self,name,modes,readFirst):
-        """Dump remote variable values to a file."""
+        """
+        Dump remote variable values to a file.
+
+        Parameters
+        ----------
+        name :
+
+        modes :
+
+        readFirst :
+
+
+        Returns
+        -------
+
+        """
 
         # Auto generate name if no arg
         if name is None or name == '':
@@ -901,6 +1212,26 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
 
     def _setDictRoot(self,d,writeEach,modes,incGroups,excGroups):
+        """
+
+
+        Parameters
+        ----------
+        d :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
         for key, value in d.items():
 
             # Attempt to get node
@@ -918,6 +1249,18 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         self.SystemLog.set(SystemLogInit)
 
     def _queueUpdates(self,var):
+        """
+
+
+        Parameters
+        ----------
+        var :
+
+
+        Returns
+        -------
+
+        """
         tid = threading.get_ident()
 
         with self._updateLock:
@@ -927,6 +1270,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     # Worker thread
     def _updateWorker(self):
+        """ """
         self._log.info("Starting update thread")
         strm = {}
         zmq  = {}

--- a/python/pyrogue/_RunControl.py
+++ b/python/pyrogue/_RunControl.py
@@ -15,10 +15,36 @@ import time
 
 
 class RunControl(pr.Device):
-    """Special base class to control runs. """
+    """
+    Special base class to control runs.
+
+    Attributes
+    ----------
+    attr1 :
+        pr.Device
+    """
 
     def __init__(self, *, hidden=True, rates=None, states=None, cmd=None, **kwargs):
-        """Initialize device class"""
+        """
+        Initialize device class - test
+
+        Parameters
+        ----------
+        param1 : *
+
+        param2 : hidden=True
+
+        param3 : rates=None
+
+        param4 : states=None
+
+        param5 : cmd=None
+
+        param6 : **kwargs
+
+        returns: none
+        ----------
+        """
 
         if rates is None:
             rates={1:'1 Hz', 10:'10 Hz'}
@@ -65,6 +91,16 @@ class RunControl(pr.Device):
         Set run state. Re-implement in sub-class.
         Enum of run states can also be overridden.
         Underlying run control must update runCount variable.
+
+        Parameters
+        ----------
+        param1: self
+        param2: value
+        param3: changed
+
+        returns:
+        -------
+
         """
         if changed:
             if self.runState.valueDisp() == 'Running':
@@ -79,10 +115,25 @@ class RunControl(pr.Device):
     def _setRunRate(self,value):
         """
         Set run rate. Re-implement in sub-class if necessary.
+
+        Parameters
+        ----------
+        param1: self
+        param2: value
+
+        returns:
+        -------
+
         """
         pass
 
     def _run(self):
+        """
+        Parameters
+        ----------
+        param1: self
+        ----------
+        """
         #print("Thread start")
         self.runCount.set(0)
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -426,9 +426,11 @@ class BaseVariable(pr.Node):
         try:
 
             if isinstance(value,np.ndarray):
-                with np.printoptions(formatter={'all':self.disp.format},threshold=sys.maxsize):
-                    ret = np.array2string(value, separator=', ')
-                return ret
+                return np.array2string(value,
+                                       separator=', ',
+                                       formatter={'all':self.disp.format},
+                                       threshold=sys.maxsize,
+                                       max_line_width=1000)
 
             elif self.disp == 'enum':
                 if value in self.enum:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 
 
 class VariableError(Exception):
-    """ Exception for variable access errors."""
+    """ """
     pass
 
 
@@ -36,10 +36,29 @@ def VariableWait(varList, testFunction, timeout=0):
     i.e. w = VariableWait([root.device.var1,root.device.var2],
                           lambda varValues: varValues['root.device.var1'].value >= 10 and \
                                             varValues['root.device.var1'].value >= 20)
+
+    Parameters
+    ----------
+    varList :
+
+    testFunction :
+
+    timeout : int
+         (Default value = 0)
+
+    Returns
+    -------
+
     """
 
     # Container class
     class varStates(object):
+        """
+
+
+
+
+        """
 
         def __init__(self):
             self.vlist  = odict()
@@ -47,6 +66,21 @@ def VariableWait(varList, testFunction, timeout=0):
 
         # Method to handle variable updates callback
         def varUpdate(self,path,varValue):
+            """
+
+
+            Parameters
+            ----------
+            path :
+
+            varValue :
+
+
+            Returns
+            -------
+            ret
+
+            """
             with self.cv:
                 if path in self.vlist:
                     self.vlist[path] = varValue
@@ -87,6 +121,7 @@ def VariableWait(varList, testFunction, timeout=0):
 
 
 class VariableValue(object):
+    """ """
     def __init__(self, var, read=False):
         self.value     = var.get(read=read)
         self.valueDisp = var.genDisp(self.value)
@@ -100,6 +135,7 @@ class VariableValue(object):
 
 
 class VariableListData(object):
+    """ """
     def __init__(self, numValues, valueBits, valueStride):
         self.numValues   = numValues
         self.valueBits   = valueBits
@@ -111,6 +147,12 @@ class VariableListData(object):
 
 
 class BaseVariable(pr.Node):
+    """
+    Documentation string for __init__ goes here
+    (under the 'class' definition)
+
+    Fill in the paremeters.
+    """
 
     PROPS = ['name', 'path', 'mode', 'typeStr', 'enum',
              'disp', 'precision', 'units', 'minimum', 'maximum',
@@ -208,16 +250,19 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def enum(self):
+        """ """
         return self._enum
 
     @pr.expose
     @property
     def revEnum(self):
+        """ """
         return self._revEnum
 
     @pr.expose
     @property
     def typeStr(self):
+        """ """
         if self._typeStr == 'Unknown':
             v = self.value()
             if self.nativeType is np.ndarray:
@@ -229,11 +274,13 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def disp(self):
+        """ """
         return self._disp
 
     @pr.expose
     @property
     def precision(self):
+        """ """
         if self.nativeType is float or self.nativeType is np.ndarray:
             res = re.search(r':([0-9])\.([0-9]*)f',self._disp)
             try:
@@ -246,58 +293,69 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def mode(self):
+        """ """
         return self._mode
 
     @pr.expose
     @property
     def units(self):
+        """ """
         return self._units
 
     @pr.expose
     @property
     def minimum(self):
+        """ """
         return self._minimum
 
     @pr.expose
     @property
     def maximum(self):
+        """ """
         return self._maximum
 
 
     @pr.expose
     @property
     def hasAlarm(self):
+        """ """
         return (self._lowWarning is not None or self._lowAlarm is not None or self._highWarning is not None or self._highAlarm is not None)
 
     @pr.expose
     @property
     def lowWarning(self):
+        """ """
         return self._lowWarning
 
     @pr.expose
     @property
     def lowAlarm(self):
+        """ """
         return self._lowAlarm
 
     @pr.expose
     @property
     def highWarning(self):
+        """ """
         return self._highWarning
 
     @pr.expose
     @property
     def highAlarm(self):
+        """ """
         return self._highAlarm
 
     @pr.expose
     @property
     def alarmStatus(self):
+        """ """
         stat,sevr = self._alarmState(self.value())
         return stat
 
     @pr.expose
     @property
     def alarmSeverity(self):
+        """ """
         stat,sevr = self._alarmState(self.value())
         return sevr
 
@@ -312,6 +370,18 @@ class BaseVariable(pr.Node):
         return d
 
     def addDependency(self, dep):
+        """
+
+
+        Parameters
+        ----------
+        dep :
+
+
+        Returns
+        -------
+
+        """
         if dep not in self.__dependencies:
             self.__dependencies.append(dep)
             dep.addListener(self)
@@ -319,6 +389,7 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def pollInterval(self):
+        """ """
         return self._pollInterval
 
     @pollInterval.setter
@@ -341,6 +412,7 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def lock(self):
+        """ """
         if self._block is not None:
             return self._block._lock
         else:
@@ -349,10 +421,12 @@ class BaseVariable(pr.Node):
     @pr.expose
     @property
     def updateNotify(self):
+        """ """
         return self._updateNotify
 
     @property
     def dependencies(self):
+        """ """
         return self.__dependencies
 
     def addListener(self, listener):
@@ -360,6 +434,15 @@ class BaseVariable(pr.Node):
         Add a listener Variable or function to call when variable changes.
         This is useful when chaining variables together. (ADC conversions, etc)
         The variable and value class are passed as an arg: func(path,varValue)
+
+        Parameters
+        ----------
+        listener :
+
+
+        Returns
+        -------
+
         """
         if isinstance(listener, BaseVariable):
             if listener not in self._listeners:
@@ -371,6 +454,15 @@ class BaseVariable(pr.Node):
     def delListener(self, listener):
         """
         Remove a listener Variable or function
+
+        Parameters
+        ----------
+        listener :
+
+
+        Returns
+        -------
+
         """
         if listener in self.__functions:
             self.__functions.remove(listener)
@@ -380,6 +472,25 @@ class BaseVariable(pr.Node):
         """
         Set the value and write to hardware if applicable
         Writes to hardware are blocking. An error will result in a logged exception.
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        index : int
+             (Default value = -1)
+        write : bool
+             (Default value = True)
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         pass
 
@@ -389,6 +500,19 @@ class BaseVariable(pr.Node):
         Set the value and write to hardware if applicable using a posted write.
         This method does not call through parent.writeBlocks(), but rather
         calls on self._block directly.
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
         """
         pass
 
@@ -398,6 +522,21 @@ class BaseVariable(pr.Node):
         Return the value after performing a read from hardware if applicable.
         Hardware read is blocking. An error will result in a logged exception.
         Listeners will be informed of the update.
+
+        Parameters
+        ----------
+        * :
+
+        index : int
+             (Default value = -1)
+        read : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         return None
 
@@ -405,6 +544,19 @@ class BaseVariable(pr.Node):
     def write(self, *, verify=True, check=True):
         """
         Force a write of the variable.
+
+        Parameters
+        ----------
+        * :
+
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         pass
 
@@ -414,15 +566,40 @@ class BaseVariable(pr.Node):
         Return the value after performing a read from hardware if applicable.
         Hardware read is blocking. An error will result in a logged exception.
         Listeners will be informed of the update.
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = True)
+
+        Returns
+        -------
+        type
+            Hardware read is blocking. An error will result in a logged exception.
+            Listeners will be informed of the update.
+
         """
         return VariableValue(self,read=read)
 
     @pr.expose
     def value(self, index=-1):
+        """ """
         return self.get(read=False, index=index)
 
     @pr.expose
     def genDisp(self, value):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+
+        """
         try:
 
             if isinstance(value,np.ndarray):
@@ -448,14 +625,54 @@ class BaseVariable(pr.Node):
 
     @pr.expose
     def getDisp(self, read=True, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         return self.genDisp(self.get(read=read,index=index))
 
     @pr.expose
     def valueDisp(self, index=-1): #, read=True, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         return self.getDisp(read=False, index=index)
 
     @pr.expose
     def parseDisp(self, sValue):
+        """
+
+
+        Parameters
+        ----------
+        sValue :
+
+
+        Returns
+        -------
+
+        """
         try:
             if not isinstance(sValue,str):
                 return sValue
@@ -475,10 +692,27 @@ class BaseVariable(pr.Node):
 
     @pr.expose
     def setDisp(self, sValue, write=True, index=-1):
+        """
+
+
+        Parameters
+        ----------
+        sValue :
+
+        write : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
+        """
         self.set(self.parseDisp(sValue), write=write, index=index)
 
     @property
     def nativeType(self):
+        """ """
         if self._nativeType is None:
             v = self.value()
             self._nativeType = type(v)
@@ -490,28 +724,55 @@ class BaseVariable(pr.Node):
 
     @property
     def ndType(self):
+        """ """
         if self._ndType is None:
             _ = self.nativeType
         return self._ndType
 
     @property
     def ndTypeStr(self):
+        """ """
         return str(self.ndType)
 
     def _setDefault(self):
+        """ """
         if self._default is not None:
             self.setDisp(self._default, write=False)
 
     def _updatePollInterval(self):
+        """ """
         if self.root is not None and self.root._pollQueue is not None:
             self.root._pollQueue.updatePollInterval(self)
 
     def _finishInit(self):
+        """ """
         # Set the default value but dont write
         self._setDefault()
         self._updatePollInterval()
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
+        """
+
+
+        Parameters
+        ----------
+        d :
+
+        writeEach :
+
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+        keys :
+
+
+        Returns
+        -------
+
+        """
 
         # If keys is not none, it should only contain one entry
         # and the variable should be a list variable
@@ -547,8 +808,23 @@ class BaseVariable(pr.Node):
         elif self._mode in modes:
             self.setDisp(d,writeEach)
 
-
     def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
+        """
+
+
+        Parameters
+        ----------
+        modes :
+
+        incGroups :
+
+        excGroups :
+
+
+        Returns
+        -------
+
+        """
         if self._mode in modes:
             if properties is False:
                 return VariableValue(self)
@@ -559,12 +835,14 @@ class BaseVariable(pr.Node):
 
 
     def _queueUpdate(self):
+        """ """
         self._root._queueUpdates(self)
 
         for var in self._listeners:
             var._queueUpdate()
 
     def _doUpdate(self):
+        """ """
         val = VariableValue(self)
 
         for func in self.__functions:
@@ -573,7 +851,20 @@ class BaseVariable(pr.Node):
         return val
 
     def _alarmState(self,value):
-        """ Return status, severity """
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+
+        Returns
+        -------
+        type
+
+
+        """
 
         if isinstance(value,list) or isinstance(value,dict):
             return 'None','None'
@@ -596,9 +887,39 @@ class BaseVariable(pr.Node):
         else:
             return 'Good','Good'
 
+    def _genDocs(self,file):
+        """
+
+        Parameters
+        ----------
+        file :
+
+
+        Returns
+        -------
+
+        """
+        print(f".. topic:: {self.path}",file=file)
+
+        print('',file=file)
+        print(pr.genDocDesc(self.description,4),file=file)
+        print('',file=file)
+
+        print(pr.genDocTableHeader(['Field','Value'],4,100),file=file)
+
+        for a in ['name', 'path', 'enum',
+                 'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum',
+                 'maximum', 'lowWarning', 'lowAlarm', 'highWarning',
+                 'highAlarm', 'alarmStatus', 'alarmSeverity']:
+
+            astr = str(getattr(self,a))
+
+            if astr != 'None':
+                print(pr.genDocTableRow([a,astr],4,100),file=file)
 
 
 class RemoteVariable(BaseVariable,rim.Variable):
+    """ """
 
     PROPS = BaseVariable.PROPS + [
         'address', 'overlapEn', 'offset', 'bitOffset', 'bitSize',
@@ -718,6 +1039,11 @@ class RemoteVariable(BaseVariable,rim.Variable):
     ##############################
 
 
+    @pr.expose
+    @property
+    def address(self):
+        return self._block.address
+
     @property
     def numValues(self):
         return self._numValues()
@@ -737,31 +1063,37 @@ class RemoteVariable(BaseVariable,rim.Variable):
     @pr.expose
     @property
     def varBytes(self):
+        """ """
         return self._varBytes()
 
     @pr.expose
     @property
     def offset(self):
+        """ """
         return self._offset()
 
     @pr.expose
     @property
     def overlapEn(self):
+        """ """
         return self._overlapEn()
 
     @pr.expose
     @property
     def bitSize(self):
+        """ """
         return self._bitSize()
 
     @pr.expose
     @property
     def bitOffset(self):
+        """ """
         return self._bitOffset()
 
     @pr.expose
     @property
     def verifyEn(self):
+        """ """
         return self._verifyEn()
 
 
@@ -772,17 +1104,14 @@ class RemoteVariable(BaseVariable,rim.Variable):
 
     @pr.expose
     @property
-    def address(self):
-        return self._block.address
-
-    @pr.expose
-    @property
     def base(self):
+        """ """
         return self._base
 
     @pr.expose
     @property
     def bulkEn(self):
+        """ """
         return self._bulkOpEn
 
     @pr.expose
@@ -793,6 +1122,25 @@ class RemoteVariable(BaseVariable,rim.Variable):
         A verify will be performed according to self.verifyEn if verify=True
         A verify will not be performed if verify=False
         An error will result in a logged exception.
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        index : int
+             (Default value = -1)
+        write : bool
+             (Default value = True)
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         try:
 
@@ -817,6 +1165,19 @@ class RemoteVariable(BaseVariable,rim.Variable):
         Set the value and write to hardware if applicable using a posted write.
         This method does not call through parent.writeBlocks(), but rather
         calls on self._block directly.
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
         """
         try:
 
@@ -833,10 +1194,26 @@ class RemoteVariable(BaseVariable,rim.Variable):
     @pr.expose
     def get(self, *, index=-1, read=True, check=True):
         """
-        Return the value after performing a read from hardware if applicable.
-        Hardware read is blocking if check=True, otherwise non-blocking.
-        An error will result in a logged exception.
-        Listeners will be informed of the update.
+
+
+        Parameters
+        ----------
+            * :
+
+        index : int
+             (Default value = -1)
+        read : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+        type
+            Hardware read is blocking if check=True, otherwise non-blocking.
+            An error will result in a logged exception.
+            Listeners will be informed of the update.
+
         """
         try:
             if read:
@@ -859,6 +1236,19 @@ class RemoteVariable(BaseVariable,rim.Variable):
         A verify will be performed according to self.verifyEn if verify=True
         A verify will not be performed if verify=False
         An error will result in a logged exception
+
+        Parameters
+        ----------
+             * :
+
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         try:
             self._parent.writeBlocks(force=True, recurse=False, variable=self)
@@ -872,13 +1262,46 @@ class RemoteVariable(BaseVariable,rim.Variable):
             raise e
 
     def _parseDispValue(self, sValue):
+        """
+
+
+        Parameters
+        ----------
+        sValue :
+
+
+        Returns
+        -------
+
+        """
         if self.disp == 'enum':
             return self.revEnum[sValue]
         else:
             return self._base.fromString(sValue)
 
+    def _genDocs(self,file):
+        """
+
+        Parameters
+        ----------
+        file :
+
+
+        Returns
+        -------
+
+        """
+        BaseVariable._genDocs(self,file)
+
+        for a in ['offset', 'numValues', 'bitSize', 'bitOffset', 'verify', 'varBytes']:
+            astr = str(getattr(self,a))
+
+            if astr != 'None':
+                print(pr.genDocTableRow([a,astr],4,100),file=file)
+
 
 class LocalVariable(BaseVariable):
+    """ """
 
     def __init__(self, *,
                  name,
@@ -923,6 +1346,25 @@ class LocalVariable(BaseVariable):
         """
         Set the value and write to hardware if applicable
         Writes to hardware are blocking. An error will result in a logged exception.
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        index : int
+             (Default value = -1)
+        write : bool
+             (Default value = True)
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
         """
         self._log.debug("{}.set({})".format(self, value))
 
@@ -947,6 +1389,19 @@ class LocalVariable(BaseVariable):
         Set the value and write to hardware if applicable using a posted write.
         This method does not call through parent.writeBlocks(), but rather
         calls on self._block directly.
+
+        Parameters
+        ----------
+        value :
+
+        * :
+
+        index : int
+             (Default value = -1)
+
+        Returns
+        -------
+
         """
         self._log.debug("{}.post({})".format(self, value))
 
@@ -963,9 +1418,25 @@ class LocalVariable(BaseVariable):
     @pr.expose
     def get(self, *, index=-1, read=True, check=True):
         """
-        Return the value after performing a read from hardware if applicable.
-        Hardware read is blocking. An error will result in a logged exception.
-        Listeners will be informed of the update.
+
+
+        Parameters
+        ----------
+            * :
+
+        index : int
+             (Default value = -1)
+        read : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+        type
+            Hardware read is blocking. An error will result in a logged exception.
+            Listeners will be informed of the update.
+
         """
         try:
             if read:
@@ -1036,6 +1507,7 @@ class LocalVariable(BaseVariable):
         return self
 
 class LinkVariable(BaseVariable):
+    """ """
 
     def __init__(self, *,
                  name,
@@ -1091,6 +1563,28 @@ class LinkVariable(BaseVariable):
 
     @pr.expose
     def set(self, value, *, write=True, index=-1, verify=True, check=True):
+        """
+
+
+        Parameters
+        ----------
+        value :
+
+            * :
+
+        write : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+        verify : bool
+             (Default value = True)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
+        """
         try:
             self._linkedSetWrap(function=self._linkedSet, dev=self.parent, var=self, value=value, write=write, index=index, verify=verify, check=check)
         except Exception as e:
@@ -1100,6 +1594,22 @@ class LinkVariable(BaseVariable):
 
     @pr.expose
     def get(self, read=True, index=-1, check=True):
+        """
+
+
+        Parameters
+        ----------
+        read : bool
+             (Default value = True)
+        index : int
+             (Default value = -1)
+        check : bool
+             (Default value = True)
+
+        Returns
+        -------
+
+        """
         try:
             return self._linkedGetWrap(function=self._linkedGet, dev=self.parent, var=self, read=read, index=index, check=check)
         except Exception as e:

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -22,7 +22,6 @@ from pydm import utilities
 import pyrogue
 from pyrogue.interfaces import VirtualClient
 from matplotlib.pyplot import Figure
-import numpy as np
 import pickle
 
 

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -12,7 +12,7 @@
 import pyrogue
 import pyrogue.pydm.widgets
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from pyrogue.pydm.widgets import PyRogueLabel, PyRogueLineEdit
+from pyrogue.pydm.widgets import PyRogueLineEdit
 
 from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
@@ -177,9 +177,6 @@ def makeVariableViewWidget(parent):
         w.showStepExponent      = False
         w.writeOnPress          = True
         w.installEventFilter(parent._top)
-
-    elif parent._var.mode == 'RO' and not parent._var.isCommand:
-        w = PyRogueLabel(parent=None, init_channel=parent._path + '/disp')
 
     else:
         w = PyRogueLineEdit(parent=None, init_channel=parent._path + '/disp')

--- a/python/pyrogue/pydm/widgets/label.py
+++ b/python/pyrogue/pydm/widgets/label.py
@@ -1,6 +1,6 @@
 from pydm.widgets import PyDMLabel
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QGridLayout
+from qtpy.QtWidgets import QHBoxLayout
 from pydm.widgets.base import str_types
 from pydm.widgets.display_format import parse_value_for_display
 
@@ -11,16 +11,15 @@ class PyRogueLabel(PyDMLabel):
         self._show_units = show_units
 
         self._unitWidget = PyDMLabel(parent)
-        self._unitWidget.setStyleSheet("QLabel { color : DimGrey; }")
+        self._unitWidget.setStyleSheet("QLabel { background-color: white; color : DimGrey; }")
         self._unitWidget.setAlignment(Qt.AlignRight)
         self._unitWidget.setText("")
 
-        grid = QGridLayout()
-        grid.addWidget(self._unitWidget, 0, 0)
-        grid.setVerticalSpacing(0)
-        grid.setHorizontalSpacing(0)
-        grid.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(grid)
+        hbox = QHBoxLayout()
+        hbox.addStretch(1)
+        hbox.addWidget(self._unitWidget)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(hbox)
 
     def unit_changed(self, new_unit):
         if self._show_units:

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -38,6 +38,84 @@ namespace ris = rogue::interfaces::stream;
 namespace bp  = boost::python;
 #endif
 
+std::map<std::string, std::shared_ptr<rha::AxiStreamDmaShared> > rha::AxiStreamDma::sharedBuffers_;
+
+rha::AxiStreamDmaShared::AxiStreamDmaShared(std::string path) {
+   this->fd = -1;
+   this->path = path;
+   this->openCount = 1;
+   this->rawBuff = NULL;
+   this->bCount = 0;
+   this->bSize = 0;
+}
+
+//! Open shared buffer space
+rha::AxiStreamDmaSharedPtr rha::AxiStreamDma::openShared (std::string path, rogue::LoggingPtr log) {
+   std::map<std::string, rha::AxiStreamDmaSharedPtr>::iterator it;
+
+   // Entry already exists
+   if ( (it = sharedBuffers_.find(path)) != sharedBuffers_.end() ) {
+      it->second->openCount++;
+      log->debug("Shared file descriptor already opened");
+      return it->second;
+   }
+
+   // Create new record
+   rha::AxiStreamDmaSharedPtr ret = std::make_shared<rha::AxiStreamDmaShared>(path);
+   log->debug("Opening new shared file descriptor");
+
+   // We need to open device and create shared buffers
+   if ( (ret->fd = ::open(path.c_str(), O_RDWR)) < 0 )
+      throw(rogue::GeneralError::create("AxiStreamDma::openShared", "Failed to open device file: %s",path.c_str()));
+
+   if ( dmaCheckVersion(ret->fd) < 0 ) {
+      ::close(ret->fd);
+      throw(rogue::GeneralError("AxiStreamDma::openShared","Bad kernel driver version detected. Please re-compile kernel driver.\n \
+      Note that aes-stream-driver (v5.15.2 or earlier) and rogue (v5.11.1 or earlier) are compatible with the 32-bit address API. \
+      To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
+      \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
+   }
+
+   // Result may be that rawBuff = NULL
+   // Should this just be a warning?
+   ret->rawBuff = dmaMapDma(ret->fd,&(ret->bCount),&(ret->bSize));
+   if ( ret->rawBuff == NULL ) {
+
+      ret->bCount = ioctl(ret->fd,DMA_Get_Buff_Count,0);
+
+      // New map limit should be 8K more than the total number of buffers we require
+      uint32_t mapSize = ret->bCount + 8192;
+
+      ::close(ret->fd);
+      throw(rogue::GeneralError::create("AxiStreamDma::openShared","Failed to map dma buffers. Increase vm map limit to : sudo sysctl -w vm.max_map_count=%i",mapSize));
+   }
+   log->debug("Mapped buffers. bCount = %i, bSize=%i", ret->bCount, ret->bSize);
+
+   // Add entry to map and return
+   sharedBuffers_.insert(std::pair<std::string, rha::AxiStreamDmaSharedPtr>(path,ret));
+   return ret;
+}
+
+//! Close shared buffer space
+void rha::AxiStreamDma::closeShared(rha::AxiStreamDmaSharedPtr desc) {
+   desc->openCount--;
+
+   if ( desc->openCount == 0 ) {
+
+      if ( desc->rawBuff != NULL ) {
+         dmaUnMapDma(desc->fd, desc->rawBuff);
+      }
+
+      ::close(desc->fd);
+      desc->fd = -1;
+      desc->bCount = 0;
+      desc->bSize = 0;
+      desc->rawBuff = NULL;
+
+      sharedBuffers_.erase(desc->path);
+   }
+}
+
 //! Class creation
 rha::AxiStreamDmaPtr rha::AxiStreamDma::create (std::string path, uint32_t dest, bool ssiEnable) {
    rha::AxiStreamDmaPtr r = std::make_shared<rha::AxiStreamDma>(path,dest,ssiEnable);
@@ -62,32 +140,28 @@ rha::AxiStreamDma::AxiStreamDma ( std::string path, uint32_t dest, bool ssiEnabl
 
    rogue::GilRelease noGil;
 
-   if ( (fd_ = ::open(path.c_str(), O_RDWR)) < 0 )
-      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", "Failed to open device file: %s",path.c_str()));
+   // Attempt to open shared structure
+   desc_ = openShared(path, log_);
 
-   if ( dmaCheckVersion(fd_) < 0 )
-      throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Bad kernel driver version detected. Please re-compile kernel driver.\n \
-      Note that aes-stream-driver (v5.15.2 or earlier) and rogue (v5.11.1 or earlier) are compatible with the 32-bit address API. \
-      To use later versions (64-bit address API),, you will need to upgrade both rogue and aes-stream-driver at the same time to:\n \
-      \t\taes-stream-driver = v5.16.0 (or later)\n\t\trogue = v5.13.0 (or later)"));
+   //if ( desc_->bCount_ >= 1000 ) retThold_ = 50;
+   if ( desc_->bCount >= 1000 ) retThold_ = 80;
+
+   // Open non shared file descriptor
+   if ( (fd_ = ::open(path.c_str(), O_RDWR)) < 0 ) {
+      closeShared(desc_);
+      throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma", "Failed to open device file: %s",path.c_str()));
+   }
 
    dmaInitMaskBytes(mask);
    dmaAddMaskBytes(mask,dest_);
 
    if  ( dmaSetMaskBytes(fd_,mask) < 0 ) {
+      closeShared(desc_);
       ::close(fd_);
       throw(rogue::GeneralError::create("AxiStreamDma::AxiStreamDma",
             "Failed to open device file %s with dest 0x%" PRIx32 "! Another process may already have it open!", path.c_str(), dest));
 
    }
-
-   // Result may be that rawBuff_ = NULL
-   rawBuff_ = dmaMapDma(fd_,&bCount_,&bSize_);
-   if ( rawBuff_ == NULL ) {
-      throw(rogue::GeneralError("AxiStreamDma::AxiStreamDma","Failed to map dma buffers. Increase vm map limit: sysctl -w vm.max_map_count=262144"));
-   }
-   //else if ( bCount_ >= 1000 ) retThold_ = 50;
-   else if ( bCount_ >= 1000 ) retThold_ = 80;
 
    // Start read thread
    threadEn_ = true;
@@ -112,10 +186,9 @@ void rha::AxiStreamDma::stop() {
     threadEn_ = false;
     thread_->join();
 
-    if ( rawBuff_ != NULL ) {
-      dmaUnMapDma(fd_, rawBuff_);
-    }
+    closeShared(desc_);
     ::close(fd_);
+    fd_ = -1;
   }
 }
 
@@ -154,11 +227,11 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
    uint32_t         buffSize;
 
    //! Adjust allocation size
-   if ( size > bSize_) buffSize = bSize_;
+   if ( size > desc_->bSize) buffSize = desc_->bSize;
    else buffSize = size;
 
    // Zero copy is disabled. Allocate from memory.
-   if ( zeroCopyEn_ == false || zeroCopyEn == false || rawBuff_ == NULL ) {
+   if ( zeroCopyEn_ == false || zeroCopyEn == false || desc_->rawBuff == NULL ) {
       frame = ris::Pool::acceptReq(size,false);
    }
 
@@ -197,7 +270,7 @@ ris::FramePtr rha::AxiStreamDma::acceptReq ( uint32_t size, bool zeroCopyEn) {
          while (res < 0);
 
          // Mark zero copy meta with bit 31 set, lower bits are index
-         buff = createBuffer(rawBuff_[res],0x80000000 | res,buffSize,bSize_);
+         buff = createBuffer(desc_->rawBuff[res],0x80000000 | res,buffSize,desc_->bSize);
          frame->appendBuffer(buff);
          alloc += buffSize;
       }
@@ -394,10 +467,10 @@ void rha::AxiStreamDma::runThread(std::weak_ptr<int> lockPtr) {
       if ( select(fd_+1,&fds,NULL,NULL,&tout) > 0 ) {
 
          // Zero copy buffers were not allocated
-         if ( zeroCopyEn_ == false || rawBuff_ == NULL ) {
+         if ( zeroCopyEn_ == false || desc_->rawBuff == NULL ) {
 
             // Allocate a buffer
-            buff[0] = allocBuffer(bSize_,NULL);
+            buff[0] = allocBuffer(desc_->bSize,NULL);
 
             // Attempt read, dest is not needed since only one lane/vc is open
             rxSize[0] = dmaRead(fd_, buff[0]->begin(), buff[0]->getAvailable(), rxFlags, rxError, NULL);
@@ -413,7 +486,7 @@ void rha::AxiStreamDma::runThread(std::weak_ptr<int> lockPtr) {
 
             // Allocate a buffer, Mark zero copy meta with bit 31 set, lower bits are index
             for (x=0; x < rxCount; x++)
-               buff[x] = createBuffer(rawBuff_[meta[x]],0x80000000 | meta[x],bSize_,bSize_);
+               buff[x] = createBuffer(desc_->rawBuff[meta[x]],0x80000000 | meta[x],desc_->bSize,desc_->bSize);
          }
 
          // Return of -1 is bad

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -14,6 +14,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/ZmqClient.h>
 #include <rogue/GeneralError.h>
 #include <memory>
@@ -255,6 +258,10 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
    if ( seconds != 0 ) log_->error("Finally got response from server after %f seconds!", seconds);
 
    PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("ZmqClient::send","Failed to generate bytearray"));
+
    zmq_msg_close(&rxMsg);
 
    bp::handle<> handle(val);

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -14,6 +14,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/ZmqServer.h>
 #include <rogue/GeneralError.h>
 #include <memory>
@@ -268,6 +271,10 @@ void rogue::interfaces::ZmqServer::runThread() {
          Py_buffer valueBuf;
          rogue::ScopedGil gil;
          PyObject *val = Py_BuildValue("y#",zmq_msg_data(&rxMsg),zmq_msg_size(&rxMsg));
+
+         if ( val == NULL )
+            throw(rogue::GeneralError::create("ZmqServer::runThread","Failed to generate bytearray"));
+
          bp::handle<> handle(val);
 
          bp::object ret = this->doRequest(bp::object(handle));

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -16,6 +16,9 @@
  * contained in the LICENSE.txt file.
  * ----------------------------------------------------------------------------
 **/
+
+#define PY_SSIZE_T_CLEAN
+
 #include <rogue/interfaces/memory/Block.h>
 #include <rogue/interfaces/memory/Slave.h>
 #include <rogue/interfaces/memory/Variable.h>
@@ -529,7 +532,7 @@ bp::object rim::Block::variablesPy() {
 void rim::Block::reverseBytes ( uint8_t *data, uint32_t byteSize ) {
    uint32_t x;
    uint8_t tmp;
-   
+
    for (x=0; x < byteSize/2; x++) {
       tmp = data[x];
       data[x] = data[byteSize-x-1];
@@ -718,6 +721,9 @@ bp::object rim::Block::getPyFunc ( rim::Variable *var, int32_t index ) {
       getBytes(getBuffer, var, index);
       PyObject *val = Py_BuildValue("y#",getBuffer,var->valueBytes_);
 
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getPyFunc","Failed to generate bytearray"));
+
       bp::handle<> handle(val);
       bp::object pass = bp::object(handle);
 
@@ -760,6 +766,9 @@ bp::object rim::Block::getByteArrayPy ( rim::Variable *var, int32_t index ) {
 
    getBytes(getBuffer, var,index);
    PyObject *val = Py_BuildValue("y#",getBuffer,var->valueBytes_);
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("Block::setByteArrayPy","Failed to generate bytearray"));
 
    bp::handle<> handle(val);
    return bp::object(handle);
@@ -890,6 +899,10 @@ bp::object rim::Block::getUIntPy (rim::Variable *var, int32_t index ) {
    }
    else {
       PyObject *val = Py_BuildValue("K",getUInt(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getUIntPy","Failed to generate UInt"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1031,6 +1044,10 @@ bp::object rim::Block::getIntPy ( rim::Variable *var, int32_t index ) {
    }
    else {
       PyObject *val = Py_BuildValue("L",getInt(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getIntPy","Failed to generate Int"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1216,6 +1233,10 @@ bp::object rim::Block::getStringPy ( rim::Variable *var, int32_t index ) {
 
    getString(var,strVal,index);
    PyObject *val = Py_BuildValue("s",strVal.c_str());
+
+   if ( val == NULL )
+      throw(rogue::GeneralError::create("Block::getStringPy","Failed to generate String"));
+
    bp::handle<> handle(val);
    return bp::object(handle);
 }
@@ -1346,6 +1367,10 @@ bp::object rim::Block::getFloatPy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("f",getFloat(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getFloatPy","Failed to generate Float"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1470,6 +1495,10 @@ bp::object rim::Block::getDoublePy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("d",getDouble(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getDoublePy","Failed to generate Double"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }
@@ -1593,6 +1622,10 @@ bp::object rim::Block::getFixedPy ( rim::Variable *var, int32_t index ) {
 
    else {
       PyObject *val = Py_BuildValue("d",getFixed(var,index));
+
+      if ( val == NULL )
+         throw(rogue::GeneralError::create("Block::getFixedPy","Failed to generate Fixed"));
+
       bp::handle<> handle(val);
       ret = bp::object(handle);
    }


### PR DESCRIPTION
# Pull Requests Since v5.15.3
### Bug
 1. #900 - Apply Fix For PyBuildValue errors when converting byte arrays In Python 10
 2. #903 - Reorg the .flake8 structure to address error in flake8 v6.0.0
### Enhancement
 1. #901 - Update AxiStreamDma to use a single virtual memory mapping across multiple instances
 1. #899 - PyDM GUI Enhancements
### Unlabeled
 1. #891 - Merges documentation changes from Cullen into pre-release branch
# Pull Request Details
### Merges documentation changes from Cullen into pre-release branch
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Mon Nov 28 10:52:45 2022 -0800|
|**Pull:**|#891 (3529 additions, 198 deletions, 16 files changed)|
|**Branch:**|slaclab/documentation|
|**Issues:**|#891|
|**Labels:**|documentation|

**Notes:**
> This PR merges in the documentation changes made between December and June. 
> 
> This also adds the auto documentation feature which can be used to generated project specific documentation pages. 

-------


### PyDM GUI Enhancements
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Nov 15 14:08:59 2022 -0800|
|**Pull:**|#899 (33 additions, 28 deletions, 4 files changed)|
|**Branch:**|slaclab/line-edit-fix|
|**Labels:**|enhancement|

**Notes:**
> <!--- Provide a one sentence summary of your changes in the Title above -->
> 
> ### Description
> <!--- Describe your changes in detail. This could include code examples, etc. -->
> <!--- If you leave this blank your PR will not be accepted. -->
> <!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
> Adds several enhancements to Rogue's PyDM GUI widgets.
> 
>  - `debug_tree` now displays read-only variables with PyRogueLineEdit rather than PyRogueLabel
>    - Allows for consistent borders around values and a cleaner look
>    - Override `check_enable_state()` from `PyDMWritableWidget` so that entire widget is not disabled
>      - Simply `setReadOnly()` instead, and adjust the styleSheet for grey background color
>  - Use `QHBoxLayout` to position units overlay
>    - `QGridLayout` was not rendering correctly in some environments
>    - This is the more correct way to do it anyway
>  - Prevent line breaks in array disp strings
>    - Line breaks cause value to be truncated when displayed in `debug_tree`.
> 
> <img width="1155" alt="image" src="https://user-images.githubusercontent.com/15825552/197260021-a6e23d98-f410-4bf6-8359-56a233b98429.png">

-------


### Apply Fix For PyBuildValue errors when converting byte arrays In Python 10
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Thu Nov 10 15:01:16 2022 -0800|
|**Pull:**|#900 (48 additions, 1 deletions, 3 files changed)|
|**Branch:**|slaclab/ESROGUE-602|
|**Issues:**|#900|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-602|
|**Labels:**|bug|

**Notes:**
> This resolves JIRA ESROGUE-602 which was seeing exceptions when running the gui with python 10.
> 
> It turns out this was generated by PyBuildValue returning a NULL value which was undetected. First I added checks for NULL returns on all instances of PyBuildValue.
> 
> Next I added an include at the start of each file which uses PyBuildValue per this note:
> 
> https://docs.python.org/3/c-api/arg.html
> 
> "Note For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python 3.9 and older, the type of the length argument is [Py_ssize_t](https://docs.python.org/3/c-api/intro.html#c.Py_ssize_t) if the PY_SSIZE_T_CLEAN macro is defined, or int otherwise."

-------


### Update AxiStreamDma to use a single virtual memory mapping across multiple instances
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Mon Nov 28 10:49:46 2022 -0800|
|**Pull:**|#901 (145 additions, 39 deletions, 3 files changed)|
|**Branch:**|slaclab/ESROGUE-607|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-607|
|**Labels:**|enhancement|

**Notes:**
> This PR allows multiple instances of AxiStreamDma to use a common virtual memory mapping of the DMA buffers in order to reduce the virtual memory footprint.
> 
> This PR also changes the error message to recommend a virtual memory map size based upon the number of buffers needed instead of the previous value which came from a online suggestion.
> 
> This addresses ESROGUE-607

-------
