### PR TITLE
Update anaconda.rst

### DIFF
--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -55,7 +55,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_5.8.0 -c tidair-packages -c conda-forge -c pydm-tag -c tidair-tag rogue=v5.8.0
+   $ conda create -n rogue_v5.16.0 -c tidair-packages -c conda-forge -c tidair-tag rogue=v5.16.0
 
 Using Rogue In Anaconda
 =======================


### PR DESCRIPTION
### Description
- Removed `-c pydm-tag` because pydm is now in conda forge
- Updated example from rogue v5.8.0 to v5.16.0 (more current release version)