### PR TITLE
Update meta.yaml

### DIFF
--- a/conda-recipe-e3/meta.yaml
+++ b/conda-recipe-e3/meta.yaml
@@ -47,7 +47,7 @@ requirements:
      - click
      - pyqt
      - sqlalchemy
-     - pydm
+     - pydm>=1.18.0
      - pyserial
      - matplotlib
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
      - click
      - pyqt
      - sqlalchemy
-     - pydm
+     - pydm>=1.18.0
      - pyserial
      - matplotlib
 


### PR DESCRIPTION
### Description
- Updating conda to use `pydm>=1.18.0` due to an incompatibility with older pydm and newer rogue