### PR TITLE
Rogue v5.16.1 Release Candidate

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -216,7 +216,6 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
         src:
           - conda-recipe
           - conda-recipe-e3
@@ -237,37 +236,15 @@ jobs:
           OS_NAME: ${{ matrix.os }}
         run: |
           cd ${HOME}
-          if [ $OS_NAME == "macos-10.15" ]
-          then
-            wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-          else
-            wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          fi
+          wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
           bash miniconda.sh -b -p ${HOME}/miniconda
           export PATH="${HOME}/miniconda/bin:$PATH"
           source ${HOME}/miniconda/etc/profile.d/conda.sh
           conda config --set always_yes yes
           conda update -n base -c conda-forge conda
           conda install conda-build anaconda-client conda-verify
-          if [ $OS_NAME == "macos-10.15" ]
-          then
-            conda install libiconv libarchive -c conda-forge
-          fi
           conda update -q conda conda-build
           conda update --all
-
-      - name: Setup MacOS
-        if: matrix.os == 'macos-10.15'
-        run: |
-          cd ${HOME}
-          wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.15.sdk.tar.xz
-          tar xzf MacOSX10.15.sdk.tar.xz
-          sudo mkdir -p /opt/
-          sudo mv MacOSX10.15.sdk /opt/
-          CONDA_BUILD_SYSROOT=/opt/MacOSX10.15.sdk
-          CONDA_BUILD=1
-          echo "CONDA_BUILD_SYSROOT=$CONDA_BUILD_SYSROOT" >> $GITHUB_ENV
-          echo "CONDA_BUILD=$CONDA_BUILD" >> $GITHUB_ENV
 
       - name: Get Image Information
         id: get_image_info
@@ -282,12 +259,7 @@ jobs:
           else
               echo ::set-output name=token::$CONDA_UPLOAD_TOKEN_TAG
           fi
-          if [ ${OS_NAME} == "macos-10.15" ]
-          then
-              echo ::set-output name=os::osx-64
-          else
-              echo ::set-output name=os::linux-64
-          fi
+          echo ::set-output name=os::linux-64
 
       - name: Build
         env:

--- a/conda-recipe-e3/meta.yaml
+++ b/conda-recipe-e3/meta.yaml
@@ -47,7 +47,7 @@ requirements:
      - click
      - pyqt
      - sqlalchemy
-     - pydm
+     - pydm>=1.18.0
      - pyserial
      - matplotlib
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
      - click
      - pyqt
      - sqlalchemy
-     - pydm
+     - pydm>=1.18.0
      - pyserial
      - matplotlib
 

--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -55,7 +55,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_v5.16.0 -c tidair-packages -c conda-forge -c tidair-tag rogue=v5.16.0
+   $ conda create -n rogue_v5.16.1 -c tidair-packages -c conda-forge -c tidair-tag rogue=v5.16.1
 
 Using Rogue In Anaconda
 =======================

--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -55,7 +55,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_5.8.0 -c tidair-packages -c conda-forge -c pydm-tag -c tidair-tag rogue=v5.8.0
+   $ conda create -n rogue_v5.16.0 -c tidair-packages -c conda-forge -c tidair-tag rogue=v5.16.0
 
 Using Rogue In Anaconda
 =======================

--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -19,6 +19,7 @@
 #ifndef __ROGUE_INTERFACES_MEMORY_VARIABLE_H__
 #define __ROGUE_INTERFACES_MEMORY_VARIABLE_H__
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <vector>
 #include <rogue/EnableSharedFromThis.h>

--- a/include/rogue/interfaces/stream/FrameAccessor.h
+++ b/include/rogue/interfaces/stream/FrameAccessor.h
@@ -20,6 +20,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <memory>
 #include <rogue/GeneralError.h>

--- a/include/rogue/protocols/xilinx/JtagDriver.h
+++ b/include/rogue/protocols/xilinx/JtagDriver.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <vector>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 using std::vector;

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #if defined(__linux__)

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <string>
 #include <sstream>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef NO_PYTHON

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rh  = rogue::hardware;

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rhp = rogue::hardware::pgp;

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GeneralError.h>
 #include <string>
 #include <zmq.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef NO_PYTHON

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <string>
 #include <zmq.h>

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <cmath>
 #include <exception>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <cmath>
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -29,6 +29,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -26,6 +26,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Filter.cpp
+++ b/src/rogue/interfaces/stream/Filter.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/Filter.h>
 #include <rogue/Logging.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris  = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -27,6 +27,7 @@
 #include <rogue/GeneralError.h>
 #include <memory>
 #include <rogue/GilRelease.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -33,6 +33,7 @@
 #include <rogue/ScopedGil.h>
 #include <rogue/Logging.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
 #include <zmq.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -51,6 +51,7 @@
 #include <rogue/protocols/batcher/Data.h>
 #include <rogue/GeneralError.h>
 #include <math.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpb = rogue::protocols::batcher;

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/GeneralError.h>
 #include <fdManager.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpe = rogue::protocols::epicsV3;

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <memory>
 #include <aitTypes.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifdef __MACH__

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -26,6 +26,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifdef __MACH__

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <math.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpr = rogue::protocols::rssi;

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <string.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpr = rogue::protocols::rssi;

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -35,6 +35,7 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rps = rogue::protocols::srp;

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -35,6 +35,7 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rps = rogue::protocols::srp;

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -22,6 +22,7 @@
 #include <rogue/GeneralError.h>
 #include <rogue/Helpers.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -35,6 +35,7 @@
 #include <rogue/GeneralError.h>
 #include <sys/time.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
@@ -44,6 +44,7 @@
 #include <fcntl.h>
 #include <rogue/GilRelease.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <fcntl.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -47,6 +47,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <cstring>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;


### PR DESCRIPTION
# Pull Requests Since v5.16.0
### Bug
 1. #909 - PRIu32 bug fix for newer kernel
 1. #905 - Update meta.yaml
### Enhancement
 1. #906 - Update rogue_ci.yml
### Documentation
 1. #907 - Update anaconda.rst
 1. #904 - Update anaconda.rst
# Pull Request Details
### Update anaconda.rst
|||
|---:|:---|
|**Author:**|Larry Ruckman <ruckman@slac.stanford.edu>|
|**Date:**|Thu Jan 19 19:34:45 2023 -0800|
|**Pull:**|#904 (1 additions, 1 deletions, 1 files changed)|
|**Branch:**|slaclab/anaconda-rst-patch|
|**Issues:**|#904|
|**Labels:**|documentation|

**Notes:**
> ### Description
> - Removed `-c pydm-tag` because pydm is now in conda forge
> - Updated example from rogue v5.8.0 to v5.16.0 (more current release version)

-------


### Update meta.yaml
|||
|---:|:---|
|**Author:**|Larry Ruckman <ruckman@slac.stanford.edu>|
|**Date:**|Tue Jan 24 13:13:05 2023 -0800|
|**Pull:**|#905 (2 additions, 2 deletions, 2 files changed)|
|**Branch:**|slaclab/meta-yaml-update|
|**Issues:**|#905|
|**Labels:**|bug|

**Notes:**
> ### Description
> - Updating conda to use `pydm>=1.18.0` due to an incompatibility with older pydm and newer rogue

-------


### Update rogue_ci.yml
|||
|---:|:---|
|**Author:**|Larry Ruckman <ruckman@slac.stanford.edu>|
|**Date:**|Mon Jan 30 09:55:10 2023 -0800|
|**Pull:**|#906 (2 additions, 30 deletions, 1 files changed)|
|**Branch:**|slaclab/macos-removal|
|**Labels:**|enhancement|

**Notes:**
> ### Description
> - Removing anaconda macos build

-------


### Update anaconda.rst
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 7 13:04:40 2023 -0800|
|**Pull:**|#907 (1 additions, 1 deletions, 1 files changed)|
|**Branch:**|slaclab/anaconda-update|
|**Labels:**|documentation|

**Notes:**
> ### Description
> - Update for v5.16.1 release

-------


### PRIu32 bug fix for newer kernel
|||
|---:|:---|
|**Author:**|Benjamin Reese <bengineerd@users.noreply.github.com>|
|**Date:**|Tue Feb 7 13:05:36 2023 -0800|
|**Pull:**|#909 (45 additions, 0 deletions, 45 files changed)|
|**Branch:**|slaclab/ESROGUE-614|
|**Jira:**|https://jira.slac.stanford.edu/issues/ESROGUE-614|
|**Labels:**|bug|

**Notes:**
> ### Description
> Defining `__STDC_FORMAT_MACROS` before `inttypes.h` is required for `PRIu32` + newer kernel

-------

