### PR TITLE
PRIu32 bug fix for newer kernel

### DIFF
--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -19,6 +19,7 @@
 #ifndef __ROGUE_INTERFACES_MEMORY_VARIABLE_H__
 #define __ROGUE_INTERFACES_MEMORY_VARIABLE_H__
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <vector>
 #include <rogue/EnableSharedFromThis.h>

--- a/include/rogue/interfaces/stream/FrameAccessor.h
+++ b/include/rogue/interfaces/stream/FrameAccessor.h
@@ -20,6 +20,7 @@
 #ifndef __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #define __ROGUE_INTERFACES_STREAM_FRAME_ACCESSOR_H__
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <memory>
 #include <rogue/GeneralError.h>

--- a/include/rogue/protocols/xilinx/JtagDriver.h
+++ b/include/rogue/protocols/xilinx/JtagDriver.h
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <vector>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 using std::vector;

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #if defined(__linux__)

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <string>
 #include <sstream>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef NO_PYTHON

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rh  = rogue::hardware;

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rha = rogue::hardware::axi;

--- a/src/rogue/hardware/pgp/PgpCard.cpp
+++ b/src/rogue/hardware/pgp/PgpCard.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rhp = rogue::hardware::pgp;

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GeneralError.h>
 #include <string>
 #include <zmq.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef NO_PYTHON

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <string>
 #include <zmq.h>

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <cmath>
 #include <exception>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <cmath>
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <stdlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <memory>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -29,6 +29,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/ScopedGil.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rim = rogue::interfaces::memory;

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -26,6 +26,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Filter.cpp
+++ b/src/rogue/interfaces/stream/Filter.cpp
@@ -25,6 +25,7 @@
 #include <rogue/interfaces/stream/Frame.h>
 #include <rogue/interfaces/stream/Filter.h>
 #include <rogue/Logging.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -24,6 +24,7 @@
 #include <rogue/interfaces/stream/Buffer.h>
 #include <rogue/GeneralError.h>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris  = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -27,6 +27,7 @@
 #include <rogue/GeneralError.h>
 #include <memory>
 #include <rogue/GilRelease.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -33,6 +33,7 @@
 #include <rogue/ScopedGil.h>
 #include <rogue/Logging.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/Logging.h>
 #include <zmq.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -51,6 +51,7 @@
 #include <rogue/protocols/batcher/Data.h>
 #include <rogue/GeneralError.h>
 #include <math.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpb = rogue::protocols::batcher;

--- a/src/rogue/protocols/epicsV3/Server.cpp
+++ b/src/rogue/protocols/epicsV3/Server.cpp
@@ -25,6 +25,7 @@
 #include <rogue/GilRelease.h>
 #include <rogue/GeneralError.h>
 #include <fdManager.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpe = rogue::protocols::epicsV3;

--- a/src/rogue/protocols/epicsV3/Value.cpp
+++ b/src/rogue/protocols/epicsV3/Value.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <memory>
 #include <aitTypes.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifdef __MACH__

--- a/src/rogue/protocols/epicsV3/Variable.cpp
+++ b/src/rogue/protocols/epicsV3/Variable.cpp
@@ -26,6 +26,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <memory>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifdef __MACH__

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <rogue/GilRelease.h>
 #include <math.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpp = rogue::protocols::packetizer;

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpr = rogue::protocols::rssi;

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <string.h>
 #include <sys/time.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpr = rogue::protocols::rssi;

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -35,6 +35,7 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rps = rogue::protocols::srp;

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -35,6 +35,7 @@
 #include <rogue/Logging.h>
 #include <rogue/GilRelease.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rps = rogue::protocols::srp;

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Core.cpp
+++ b/src/rogue/protocols/udp/Core.cpp
@@ -22,6 +22,7 @@
 #include <rogue/GeneralError.h>
 #include <rogue/Helpers.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace rpu = rogue::protocols::udp;

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -35,6 +35,7 @@
 #include <rogue/GeneralError.h>
 #include <sys/time.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/StreamUnZip.cpp
+++ b/src/rogue/utilities/StreamUnZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/StreamZip.cpp
+++ b/src/rogue/utilities/StreamZip.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GilRelease.h>
 #include <memory>
 #include <bzlib.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <stdio.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamWriter.cpp
@@ -44,6 +44,7 @@
 #include <fcntl.h>
 #include <rogue/GilRelease.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <fcntl.h>
 #include <unistd.h>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -47,6 +47,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <cstring>
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 namespace ris = rogue::interfaces::stream;


### PR DESCRIPTION
### Description
Defining `__STDC_FORMAT_MACROS` before `inttypes.h` is required for `PRIu32` + newer kernel
