### PR TITLE
Update petalinux.rst

### DIFF
--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -18,29 +18,54 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
 
 .. code::
 
-   ROGUE_VERSION = "5.14.0"
-   ROGUE_MD5SUM  = "ba8146e03f60e463a2aa3d978c1dc46e"
+   ROGUE_VERSION = "5.18.2"
+   ROGUE_MD5SUM  = "38bf1bc4108eb08fc56ee9017be40c50"
 
-   SUMMARY = "Rogue Application"
-   SECTION = "PETALINUX/apps"
+   SUMMARY = "Recipe to build Rogue"
+   HOMEPAGE ="https://github.com/slaclab/rogue"
    LICENSE = "MIT"
    LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
    SRC_URI = "https://github.com/slaclab/rogue/archive/v${ROGUE_VERSION}.tar.gz"
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
+
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
-
-   DEPENDS += "python3 python3-numpy python3-native python3-numpy-native python3-pyzmq"
-   DEPENDS += "python3-parse python3-pyyaml python3-click python3-sqlalchemy python3-pyserial"
-   DEPENDS += "cmake boost zeromq bzip2 python3-jupyter"
-
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
 
-   inherit cmake python3native distutils3 xilinx-pynq setuptools3
+   inherit cmake python3native distutils3
 
-   FILES_${PN}-dev += "/usr/include/rogue/*"
-   FILES_${PN} += "/usr/lib/*"
+   DEPENDS += " \
+      python3 \
+      python3-native \
+      python3-numpy \
+      python3-numpy-native \
+      python3-pyzmq \
+      python3-parse \
+      python3-pyyaml \
+      python3-click \
+      python3-sqlalchemy \
+      python3-pyserial \
+      bzip2 \
+      zeromq \
+      boost \
+      cmake \
+   "
+
+   RDEPENDS:${PN} += " \
+      python3-numpy \
+      python3-pyzmq \
+      python3-parse \
+      python3-pyyaml \
+      python3-click \
+      python3-sqlalchemy \
+      python3-pyserial \
+      python3-json \
+      python3-logging \
+   "
+
+   FILES:${PN}-dev += "/usr/include/rogue/*"
+   FILES:${PN} += "/usr/lib/*"
 
    do_configure() {
       cmake_do_configure
@@ -51,6 +76,8 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       cmake_do_install
       distutils3_do_install
    }
+
+
 
 Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
 


### PR DESCRIPTION
### Description
- Updating to receipe example for rogue v5.18.2
- Adding the missing `RDEPENDS`
