### PR TITLE
Disable disp generation for some variables

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -54,6 +54,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
+                                  disp='',
                                   value=value,
                                   hidden=hideData,
                                   description='Data Frame Container'))

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -602,7 +602,7 @@ class BaseVariable(pr.Node):
         """
         try:
 
-            if useDisp == '':
+            if self.disp == '':
                 return ''
 
             if isinstance(value,np.ndarray):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -602,6 +602,9 @@ class BaseVariable(pr.Node):
         """
         try:
 
+            if useDisp == '':
+                return ''
+
             if isinstance(value,np.ndarray):
                 return np.array2string(value,
                                        separator=', ',


### PR DESCRIPTION
Disables genDisp routine when disp=''. This will help processing large numpy arrays at large rates.