### PR TITLE
Remove block to block overlap support

### DIFF
--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -130,9 +130,6 @@ namespace rogue {
                // Block logging
                std::shared_ptr<rogue::Logging> bLog_;
 
-               // Overlap Enable
-               bool overlapEn_;
-
                // Variable list
                std::vector< std::shared_ptr<rogue::interfaces::memory::Variable> > variables_;
 
@@ -215,14 +212,6 @@ namespace rogue {
                 * @return bulk enable flag
                 */
                bool bulkOpEn();
-
-               //! Return overlap enable flag
-               /** Return the overlap enable flag
-                *
-                * Exposed as overlapEn property to Python
-                * @return overlap enable flag
-                */
-               bool overlapEn();
 
                //! Set enable state
                /** Set the enable state

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -399,29 +399,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
             if (tmpList[i].size != 0) and (tmpList[i]._reqSlaveId() == tmpList[i-1]._reqSlaveId()) and \
                (tmpList[i].address < (tmpList[i-1].address + tmpList[i-1].size)):
 
-                # Allow overlaps between Devices and Blocks if the Device is an ancestor of the Block and the block allows overlap.
-                # Check for instances when device comes before block and when block comes before device
-                # This will be removed in the future and an error will always be raised
-                if (not (isinstance(tmpList[i-1],pr.Device) and isinstance(tmpList[i],rim.Block) and (tmpList[i].path.find(tmpList[i-1].path) == 0 and tmpList[i].overlapEn))) and \
-                        (not (isinstance(tmpList[i],pr.Device) and isinstance(tmpList[i-1],rim.Block) and (tmpList[i-1].path.find(tmpList[i].path) == 0 and tmpList[i-1].overlapEn))):
-
-                    raise pr.NodeError("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
-                                       tmpList[i].path,tmpList[i].address,
-                                       tmpList[i-1].path,tmpList[i-1].address,tmpList[i-1].size))
-
-                # Deprecation Error
-                print("")
-                print("========== Deprecation Warning ===============================")
-                print(" Detected overlap between the following Devices/Blocks        ")
-                print("    {} at address={:#x} wht size {}".format(tmpList[i].path,tmpList[i].address,tmpList[i].size))
-                print("    {} at address={:#x} wht size {}".format(tmpList[i-1].path,tmpList[i-1].address,tmpList[i-1].size))
-                print(" Creating these types of overlaps can generate inconsistencies")
-                print(" in the variable state and can cause errors. Please consider  ")
-                print(" using a listDevice and or a MemoryDevice class instead.      ")
-                print(" Link variables can be used to map multiple variables to the  ")
-                print(" underlying address space. Future releases of Rogue will treat")
-                print(" these overlaps as errors.")
-                print("==============================================================")
+                raise pr.NodeError("{} at address={:#x} overlaps {} at address={:#x} with size={}".format(
+                                   tmpList[i].path,tmpList[i].address,
+                                   tmpList[i-1].path,tmpList[i-1].address,tmpList[i-1].size))
 
         # Set timeout if not default
         if self._timeout != 1.0:

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -58,7 +58,6 @@ void rim::Block::setup_python() {
        .add_property("path",      &rim::Block::path)
        .add_property("mode",      &rim::Block::mode)
        .add_property("bulkOpEn",  &rim::Block::bulkOpEn)
-       .add_property("overlapEn", &rim::Block::overlapEn)
        .add_property("offset",    &rim::Block::offset)
        .add_property("address",   &rim::Block::address)
        .add_property("size",      &rim::Block::size)
@@ -128,11 +127,6 @@ std::string rim::Block::mode() {
 // Return bulk enable flag
 bool rim::Block::bulkOpEn() {
    return bulkOpEn_;
-}
-
-// Return overlap enable flag
-bool rim::Block::overlapEn() {
-   return overlapEn_;
 }
 
 // Set enable state
@@ -483,17 +477,12 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
       bLog_->debug("Adding variable %s to block %s at offset 0x%.8" PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_);
    }
 
-   // Init overlap enable before check, block level overlap enable flag will be removed in the future
-   overlapEn_ = true;
-
    // Check for overlaps by anding exclusive and overlap bit vectors
    for (x=0; x < size_; x++) {
       if ( oleMask[x] & excMask[x] )
          throw(rogue::GeneralError::create("Block::addVariables",
                "Variable bit overlap detected for block %s with address 0x%.8x",
                path_.c_str(), address()));
-
-      if ( excMask[x] != 0 ) overlapEn_ = false;
    }
 
    // Execute custom init


### PR DESCRIPTION
This PR removes block to block overlap support. Having two blocks own the same memory space is dangerous and can create unpredictable behavior.

The overlapEn flag is still supported on variables allowing two variables to overlap the same space in a single block. The current block implementation allows to this be supported safely with proper update notification when the underlying memory space changes. 

This is a rogueV6 change. 