### PR TITLE
Fix the way nativeType and ndType are setup

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -991,11 +991,6 @@ class Device(pr.Node,rim.Hub):
                 for var in nodes:
                     var._default = defValue
 
-        # Some variable initialization can run until the blocks are built
-        for v in self.variables.values():
-            v._finishInit()
-
-
     def _setTimeout(self,timeout):
         """
         Set timeout value on all devices & blocks

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -876,6 +876,10 @@ class Node(object):
         for grp in parent.groups:
             self.addToGroup(grp)
 
+    def _finishInit(self):
+        for key,value in self._nodes.items():
+            value._finishInit()
+
     @expose
     def getYaml(self, readFirst=False, modes=['RW','RO','WO'], incGroups=None, excGroups=['Hidden'], recurse=True):
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -904,12 +904,6 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         self._buildBlocks()
 
-    def _finishInit(self):
-        """
-        """
-        for key,value in self._nodes.items():
-            value._finishInit()
-
     def _sendYamlFrame(self,yml):
         """
         Generate a frame containing the passed string.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -377,6 +377,9 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
         # Call special root level rootAttached
         self._rootAttached()
 
+        # Finish Initialization
+        self._finishInit()
+
         # Get full list of Devices and Blocks
         tmpList = []
         for d in self.deviceList:
@@ -891,7 +894,7 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
     def _rootAttached(self):
         """
-"""
+        """
         self._parent = self
         self._root   = self
         self._path   = self.name
@@ -901,9 +904,11 @@ class Root(rogue.interfaces.stream.Master,pr.Device):
 
         self._buildBlocks()
 
-        # Some variable initialization can run until the blocks are built
-        for v in self.variables.values():
-            v._finishInit()
+    def _finishInit(self):
+        """
+        """
+        for key,value in self._nodes.items():
+            value._finishInit()
 
     def _sendYamlFrame(self,yml):
         """

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -34,7 +34,7 @@ def VariableWait(varList, testFunction, timeout=0):
     The test function is passed a dictionary containing the current
     variableValue state index by variable path
     i.e. w = VariableWait([root.device.var1,root.device.var2],
-                          lambda varValues: varValues['root.device.var1'].value >= 10 and \
+                          lambda varValues: varValues['ooot.device.var1'].value >= 10 and \
                                             varValues['root.device.var1'].value >= 20)
 
     Parameters
@@ -716,20 +716,11 @@ class BaseVariable(pr.Node):
     @property
     def nativeType(self):
         """ """
-        if self._nativeType is None:
-            v = self.value()
-            self._nativeType = type(v)
-
-            if self._nativeType is np.ndarray:
-                self._ndType = v.dtype
-
         return self._nativeType
 
     @property
     def ndType(self):
         """ """
-        if self._ndType is None:
-            _ = self.nativeType
         return self._ndType
 
     @property
@@ -752,6 +743,14 @@ class BaseVariable(pr.Node):
         # Set the default value but dont write
         self._setDefault()
         self._updatePollInterval()
+
+        # Setup native type
+        if self._nativeType is None:
+            v = self.value()
+            self._nativeType = type(v)
+
+            if self._nativeType is np.ndarray:
+                self._ndType = v.dtype
 
     def _setDict(self,d,writeEach,modes,incGroups,excGroups,keys):
         """

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -34,7 +34,7 @@ def VariableWait(varList, testFunction, timeout=0):
     The test function is passed a dictionary containing the current
     variableValue state index by variable path
     i.e. w = VariableWait([root.device.var1,root.device.var2],
-                          lambda varValues: varValues['ooot.device.var1'].value >= 10 and \
+                          lambda varValues: varValues['root.device.var1'].value >= 10 and \
                                             varValues['root.device.var1'].value >= 20)
 
     Parameters


### PR DESCRIPTION
In the previous code nativeType and ndType were setup the first time the nativeType() property was accessed.

This caused inefficiency as well as a potential lockup situation.

This updated code sets up nativeType and ndType in the _finishInit() routine.

This PR also changes the order to finishInit() is not called entire the entire tree is finished building.