### PR TITLE
Update Docker base and apply fixes to docker build

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -11,7 +11,6 @@
 # ----------------------------------------------------------------------------
 # The following environment variables are required for this process:
 # secrets.GH_TOKEN
-# secrets.CONDA_UPLOAD_TOKEN_DEV
 # secrets.CONDA_UPLOAD_TOKEN_TAG
 # secrets.DOCKERHUB_TOKEN
 
@@ -24,8 +23,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      EPICS_BASE: /home/runner/packages/epics/base-7.0.3
-      EPICS_PCAS_ROOT: /home/runner/packages/pcas/pcas-4.13.2
+      EPICS_BASE: /home/runner/packages/epics/base-7.0.7
+      EPICS_PCAS_ROOT: /home/runner/packages/pcas/pcas-4.13.3
 
     steps:
 
@@ -78,8 +77,8 @@ jobs:
           mkdir -p ${EPICS_BASE}
           cd ${EPICS_BASE}
           pwd
-          wget -O base-7.0.3.tar.gz  https://github.com/epics-base/epics-base/archive/R7.0.3.tar.gz
-          tar xzf base-7.0.3.tar.gz --strip 1
+          wget -O base-7.0.7.tar.gz  https://github.com/epics-base/epics-base/archive/R7.0.7.tar.gz
+          tar xzf base-7.0.7.tar.gz --strip 1
           make clean && make && make install
 
       - if: ${{ steps.epics-cache.outputs.cache-hit != 'true' }}
@@ -87,8 +86,8 @@ jobs:
         run: |
           mkdir -p ${EPICS_PCAS_ROOT}
           cd ${EPICS_PCAS_ROOT}
-          wget -O pcas-4.13.2.tar.gz https://github.com/epics-modules/pcas/archive/v4.13.2.tar.gz
-          tar xzf pcas-4.13.2.tar.gz --strip 1
+          wget -O pcas-4.13.3.tar.gz https://github.com/epics-modules/pcas/archive/v4.13.3.tar.gz
+          tar xzf pcas-4.13.3.tar.gz --strip 1
           echo "EPICS_BASE=$EPICS_BASE" >> configure/RELEASE.local
           make clean && make && make install
 
@@ -211,7 +210,7 @@ jobs:
   conda_build:
     name: Anaconda Build
     needs: [full_build_test, small_build_test]
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/pre-release'
+    if: startsWith(github.ref, 'refs/tags/')
     strategy:
       matrix:
         os:
@@ -250,16 +249,10 @@ jobs:
       - name: Get Image Information
         id: get_image_info
         env:
-          CONDA_UPLOAD_TOKEN_DEV: ${{ secrets.CONDA_UPLOAD_TOKEN_DEV }}
           CONDA_UPLOAD_TOKEN_TAG: ${{ secrets.CONDA_UPLOAD_TOKEN_TAG }}
           OS_NAME: ${{ matrix.os }}
         run: |
-          if [ ${GITHUB_REF} == "refs/heads/pre-release" ]
-          then
-              echo ::set-output name=token::$CONDA_UPLOAD_TOKEN_DEV
-          else
-              echo ::set-output name=token::$CONDA_UPLOAD_TOKEN_TAG
-          fi
+          echo ::set-output name=token::$CONDA_UPLOAD_TOKEN_TAG
           echo ::set-output name=os::linux-64
 
       - name: Build
@@ -280,7 +273,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-20.04
     needs: [full_build_test, small_build_test]
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/pre-release'
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
 
       # This step checks out a copy of your repository.
@@ -293,12 +286,7 @@ jobs:
         run: |
           echo ::set-output name=tag::`git describe --tags`
           echo ::set-output name=branch::`echo ${GITHUB_REF} | awk 'BEGIN { FS = "/" } ; { print $3 }'`
-          if [ ${GITHUB_REF} == "refs/heads/pre-release" ]
-          then
-              echo ::set-output name=name::"rogue-dev"
-          else
-              echo ::set-output name=name::"rogue"
-          fi
+          echo ::set-output name=name::"rogue"
 
       # Setup docker build environment
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/rogue-base:v3.0.1
+FROM tidair/rogue-base:v3.0.2
 
 # Install Rogue
 ARG branch
@@ -10,4 +10,7 @@ WORKDIR build
 RUN cmake .. -DROGUE_INSTALL=system -DDO_EPICS=1
 RUN make -j4 install
 RUN ldconfig
+ENV PYQTDESIGNERPATH /usr/local/lib/python3.10/dist-packages/pyrogue/pydm
+ENV PYDM_DATA_PLUGINS_PATH /usr/local/lib/python3.10/dist-packages/pyrogue/pydm/data_plugins
+ENV PYDM_TOOLS_PATH /usr/local/lib/python3.10/dist-packages/pyrogue/pydm/tools
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/rogue-base:v2.0.1
+FROM tidair/rogue-base:v3.0.0
 
 # Install Rogue
 ARG branch
@@ -9,3 +9,5 @@ RUN mkdir build
 WORKDIR build
 RUN cmake .. -DROGUE_INSTALL=system -DDO_EPICS=1
 RUN make -j4 install
+RUN ldconfig
+WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/rogue-base:v3.0.0
+FROM tidair/rogue-base:v3.0.1
 
 # Install Rogue
 ARG branch

--- a/docs/src/installing/docker.rst
+++ b/docs/src/installing/docker.rst
@@ -54,6 +54,13 @@ where:
 
 If your application uses a graphical interface, then you need to pass additional arguments in order to properly forward X:
 
+As an example use can test the docker install and X11 with the following command:
+
+.. code::
+
+   $ setfacl -m user:0:r ${HOME}/.Xauthority
+   $ docker run -ti --net=host -e DISPLAY -v ${HOME}/.Xauthority:/root/.Xauthority tidair/rogue python3 -m pyrogue.examples --gui
+
 GUI On A Linux OS
 =================
 


### PR DESCRIPTION
This updates the docker base image to ubuntu 22.10 through rogue-base-docker 3.0.2.

This also fixes missing ldconfig setting and other environment settings required for rogue.

This also updates the CI run to use the latest epics and pcas versions. 

Additionally pushes of pre-release to anaconda and docker are removed. 

