### PR TITLE
Fix stale tracking for offset variables

### DIFF
--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -211,6 +211,7 @@ void rim::Block::intStartTransaction(uint32_t type, bool forceWr, bool check, ri
 
              lowByte = var->staleLowByte_;
              highByte = var->staleHighByte_;
+
              // Catch case where fewer stale bytes than min access or non-aligned
              if (lowByte % minAccess != 0) lowByte -= lowByte % minAccess;
              if ((highByte+1) % minAccess != 0) highByte += minAccess - ((highByte+1) % minAccess);
@@ -585,6 +586,8 @@ void rim::Block::setBytes ( const uint8_t *data, rim::Variable *var, uint32_t in
 
    // Standard variable
    else {
+      var->staleLowByte_ = var->lowTranByte_;
+      var->staleHighByte_ = var->highTranByte_;
 
       // Fast copy
       if ( var->fastByte_ != NULL ) memcpy(blockData_+var->fastByte_[0],buff,var->valueBytes_);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -28,6 +28,7 @@
 #include <rogue/GeneralError.h>
 #include <sys/time.h>
 #include <string.h>
+#include <iomanip>
 #include <memory>
 #include <cmath>
 #include <exception>
@@ -479,9 +480,9 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
             verifyEn_ = true;
             setBits(verifyMask_,(*vit)->bitOffset_[x],(*vit)->bitSize_[x]);
          }
-      }
 
-      bLog_->debug("Adding variable %s to block %s at offset 0x%.8" PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_);
+         bLog_->debug("Adding variable %s to block %s at offset 0x%.8x,  bitOffset %i, bitSize %i, mode %s, verifyEn %d " PRIx64, (*vit)->name_.c_str(), path_.c_str(), offset_, (*vit)->bitOffset_[x], (*vit)->bitSize_[x], (*vit)->mode_.c_str(), (*vit)->verifyEn_);
+      }
    }
 
    // Init overlap enable before check, block level overlap enable flag will be removed in the future
@@ -499,6 +500,24 @@ void rim::Block::addVariables (std::vector<rim::VariablePtr> variables) {
 
    // Execute custom init
    customInit();
+
+   // Debug the results of the build
+   std::stringstream ss;
+   uint32_t rem = size_;
+   uint32_t idx;
+   idx = 0;
+   x = 0;
+
+   while (rem > 0) {
+      ss << "0x" << std::setfill('0') << std::hex << std::setw(2) << (uint32_t)(verifyMask_[x]) << " ";
+      x++;
+      rem--;
+      if ( rem == 0 || x % 10 == 0) {
+         bLog_->debug("Done adding variables. Verify Mask %.3i - %.3i: %s", idx, x-1, ss.str().c_str());
+         ss.str("");
+         idx = x;
+      }
+   }
 }
 
 #ifndef NO_PYTHON

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -29,6 +29,7 @@
 #include <sys/time.h>
 #include <string.h>
 #include <iomanip>
+#include <sstream>
 #include <memory>
 #include <cmath>
 #include <exception>

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -1,9 +1,9 @@
 #-----------------------------------------------------------------------------
-# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# This file is part of the rogue_example software. It is subject to
 # the license terms in the LICENSE.txt file found in the top-level directory
 # of this distribution and at:
 #    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
-# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# No part of the rogue_example software, including this file, may be
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
@@ -28,9 +28,9 @@ class BlockDevice(pr.Device):
             numValues    = numRegs,
             valueBits    = 32,
             valueStride  = 32,
-            bulkOpEn     = False, # FALSE for large variables
+            bulkOpEn     = False,
             overlapEn    = True,
-            verify       = False, # FALSE due to a mix of RO/WO/RW variables
+            verify       = False,
             hidden       = True,
             base         = pr.UInt,
             mode         = "RW",

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -1,0 +1,124 @@
+#-----------------------------------------------------------------------------
+# This file is part of the 'SLAC Firmware Standard Library'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'SLAC Firmware Standard Library', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+import rogue
+
+#rogue.Logging.setLevel(rogue.Logging.Debug)
+
+class BlockDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        numRegs = 16
+
+        self.add(pr.RemoteVariable(
+            name         = "DataBlock",
+            description  = "Large Data Block",
+            offset       = 0,
+            bitSize      = 32 * numRegs,
+            bitOffset    = 0,
+            numValues    = numRegs,
+            valueBits    = 32,
+            valueStride  = 32,
+            bulkOpEn     = False, # FALSE for large variables
+            overlapEn    = True,
+            verify       = False, # FALSE due to a mix of RO/WO/RW variables
+            hidden       = True,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        for i in range(numRegs//2):
+            self.add(pr.RemoteVariable(
+                name        = f'DataVar[{i}]',
+                description = f'Data Value {i}',
+                offset      = i * 4,
+                bitOffset   = 0,
+                bitSize     = 32,
+                disp        = '0x{:x}',
+                mode        = 'RW',
+                overlapEn   = True,
+            ))
+
+        self.add(pr.RemoteVariable(
+            name         = "ListVar",
+            description  = "List Variable",
+            offset       = (numRegs//2)*4,
+            bitSize      = 32 * numRegs//2,
+            bitOffset    = 0,
+            numValues    = numRegs//2,
+            valueBits    = 32,
+            valueStride  = 32,
+            overlapEn    = True,
+            disp         = '0x{:x}',
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+        @self.command(description='Load the Config')
+        def LoadConfig(arg):
+
+            for i in range(numRegs):
+                self.DataBlock.set(value=i, index=i, write=False)
+
+            self.writeAndVerifyBlocks()
+
+class BlockRoot(pr.Root):
+
+    def __init__(self):
+        pr.Root.__init__(self,
+                         name='BlockRoot',
+                         description="Dummy tree for example",
+                         timeout=2.0,
+                         pollEn=False,
+                         serverPort=None)
+
+        # Use a memory space emulator
+        sim = rogue.interfaces.memory.Emulate(4,0x1000)
+        self.addInterface(sim)
+
+        self.add(BlockDevice(
+            offset     = 0,
+            memBase    = sim,
+        ))
+
+def test_block():
+
+    with BlockRoot() as root:
+
+        root.BlockDevice.LoadConfig()
+
+        setVal = 0x55555
+
+        root.BlockDevice.DataVar[4].set(setVal)
+        root.BlockDevice.ListVar.set(setVal,index=4)
+
+        if setVal != root.BlockDevice.DataVar[4].value():
+            raise AssertionError('Read error detected after value!')
+
+        if setVal != root.BlockDevice.DataVar[4].get():
+            raise AssertionError('Read error detected after get!')
+
+        if setVal != root.BlockDevice.ListVar.get(index=4):
+            raise AssertionError('Read error detected after index get!')
+
+        root.BlockDevice.readBlocks()
+
+        if setVal != root.BlockDevice.DataVar[4].get():
+            raise AssertionError('Read error detected after read then get!')
+
+        if setVal != root.BlockDevice.ListVar.get(index=4):
+            raise AssertionError('Read error detected after read then index get!')
+
+
+if __name__ == "__main__":
+    test_block()
+

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -121,4 +121,3 @@ def test_block():
 
 if __name__ == "__main__":
     test_block()
-


### PR DESCRIPTION
The stale tracking was incorrect for variables that were shifted away from a zero offset. This impacted variables that were mapped to a larger block.