### PR TITLE
Add default values to data writer

### DIFF
--- a/python/pyrogue/_DataWriter.py
+++ b/python/pyrogue/_DataWriter.py
@@ -16,7 +16,7 @@ import pyrogue as pr
 class DataWriter(pr.Device):
     """Special base class to control data files. TODO: Update comments"""
 
-    def __init__(self, *, hidden=True, **kwargs):
+    def __init__(self, *, hidden=True, bufferSize=0, maxFileSize=0, **kwargs):
         """
         Initialize device class
         Parameters
@@ -64,7 +64,7 @@ class DataWriter(pr.Device):
         self.add(pr.LocalVariable(
             name='BufferSize',
             mode='RW',
-            value=0,
+            value=bufferSize,
             typeStr='UInt32',
             localSet=self._setBufferSize,
             description='File buffering size. Enables caching of data before call to file system.'))
@@ -72,7 +72,7 @@ class DataWriter(pr.Device):
         self.add(pr.LocalVariable(
             name='MaxFileSize',
             mode='RW',
-            value=0,
+            value=maxFileSize,
             typeStr='UInt64',
             localSet=self._setMaxFileSize,
             description='Maximum size for an individual file. Setting to a non zero splits the run data into multiple files.'))

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -87,14 +87,6 @@ class DataWriter(PyDMFrame):
         fl.setLabelAlignment(Qt.AlignRight)
         vbl.addLayout(fl)
 
-        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.BufferSize')
-        w.alarmSensitiveContent = False
-        w.alarmSensitiveBorder  = True
-        w.check_enable_state = lambda: None
-        w.setReadOnly(True)
-        if w.text().isnumeric() and w.text() != '0':
-            fl.addRow('Buffer Size:',w)
-
         w = PyDMLabel(parent=None, init_channel=self._path + '.IsOpen/disp')
         w.alarmSensitiveContent = False
         w.alarmSensitiveBorder  = True
@@ -113,14 +105,6 @@ class DataWriter(PyDMFrame):
         fl.setFormAlignment(Qt.AlignHCenter | Qt.AlignTop)
         fl.setLabelAlignment(Qt.AlignRight)
         vbr.addLayout(fl)
-
-        w = PyRogueLineEdit(parent=None, init_channel=self._path + '.MaxFileSize')
-        w.alarmSensitiveContent = False
-        w.alarmSensitiveBorder  = True
-        w.check_enable_state = lambda: None
-        w.setReadOnly(True)
-        if w.text().isnumeric() and w.text() != '0':
-            fl.addRow('Max Size:',w)
 
         w = PyDMLabel(parent=None, init_channel=self._path + '.FrameCount')
         w.alarmSensitiveContent = False


### PR DESCRIPTION
This adds the ability to provide default values for bufferSize and maxFileSize to the DataWriter class.

This also removes the fields from the pydm widget as the previous method to conditionally include the fields was not working. 