### PR TITLE
PyDM Interface Cleanup And Show Example GUI

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -14,7 +14,6 @@ dependencies:
   - parse
   - click
   - numpy
-  - pyqt
   - boost
   - bzip2
   - zeromq
@@ -24,7 +23,7 @@ dependencies:
   - pyserial
   - p4p
   - sqlalchemy
-  - pydm
+  - pydm>=1.18.0
   - matplotlib
   - pytest
   - pytest-cov

--- a/python/pyrogue/examples/_ExampleRoot.py
+++ b/python/pyrogue/examples/_ExampleRoot.py
@@ -39,6 +39,7 @@ class ExampleRoot(pyrogue.Root):
         self._sdata = np.zeros(100,dtype=np.float64)
 
         self._fig = None
+        self._ax = None
         pyrogue.Root.__init__(self,
                               description="Example Root",
                               timeout=2.0,
@@ -135,8 +136,10 @@ class ExampleRoot(pyrogue.Root):
 
         if self._fig is not None:
             plt.close(self._fig)
+            self._fig.clf()
+            del self._ax, self._fig
 
         self._fig = plt.Figure()
-        ax = self._fig.add_subplot(111)
-        ax.plot(self.TestArray.get(read=read))
+        self._ax = self._fig.add_subplot(111)
+        self._ax.plot(self.TestArray.get(read=read))
         return self._fig

--- a/python/pyrogue/examples/__main__.py
+++ b/python/pyrogue/examples/__main__.py
@@ -40,6 +40,14 @@ parser.add_argument(
     help     = "Enable EPICS 4",
 )
 
+parser.add_argument(
+    "--map",
+    action   = 'store_true',
+    required = False,
+    default  = False,
+    help     = "Store address map",
+)
+
 # Get the arguments
 args = parser.parse_args()
 
@@ -51,12 +59,16 @@ args = parser.parse_args()
 #logger.setLevel(logging.DEBUG)
 
 with pyrogue.examples.ExampleRoot(epics3En=args.epics3, epics4En=args.epics4) as root:
-    root.saveAddressMap('addr_map.csv')
-    root.saveAddressMap('addr_map.h',headerEn=True)
+    if args.map:
+        root.saveAddressMap('addr_map.csv')
+        root.saveAddressMap('addr_map.h',headerEn=True)
+
+
 
     if args.gui:
         import pyrogue.pydm
-        pyrogue.pydm.runPyDM(root=root,title='test123',sizeX=1000,sizeY=500)
+        ui = pyrogue.pydm.__path__[0] + '/examples/rogue_plugin_test.ui'
+        pyrogue.pydm.runPyDM(root=root,ui=ui,title='Test UI',sizeX=1000,sizeY=500)
 
     else:
         pyrogue.waitCntrlC()

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -22,7 +22,6 @@ from pydm import utilities
 import pyrogue
 from pyrogue.interfaces import VirtualClient
 from matplotlib.pyplot import Figure
-import pickle
 
 
 logger = logging.getLogger(__name__)
@@ -122,7 +121,7 @@ class RogueConnection(PyDMConnection):
             if isinstance(varValue.value, list):
                 self.new_value_signal[str].emit(varValue.valueDisp)
             elif isinstance(varValue.value, Figure):
-                self.new_value_signal[str].emit(pickle.dumps(varValue.value).hex())
+                self.new_value_signal[object].emit(varValue.value)
             else:
                 self.new_value_signal[type(varValue.value)].emit(varValue.value)
 

--- a/python/pyrogue/pydm/examples/rogue_plugin_test.ui
+++ b/python/pyrogue/pydm/examples/rogue_plugin_test.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1809</width>
-    <height>917</height>
+    <width>1540</width>
+    <height>1068</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,139 +15,224 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="DebugTree" name="DebugTree">
-       <property name="toolTip">
-        <string/>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>3</number>
        </property>
-       <property name="channel" stdset="0">
-        <string>rogue://0/root</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+       <widget class="QWidget" name="tab_6">
+        <attribute name="title">
+         <string>Debug Tree</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_12">
          <item>
-          <widget class="PyDMCheckbox" name="PyDMCheckbox">
+          <layout class="QVBoxLayout" name="verticalLayout_11">
+           <item>
+            <widget class="DebugTree" name="DebugTree_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/root</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_7">
+        <attribute name="title">
+         <string>System Window</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_8">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <item>
+            <widget class="SystemWindow" name="SystemWindow_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/root</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_8">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <attribute name="title">
+         <string>PyDM Plots</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_13">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_9"/>
+         </item>
+         <item>
+          <widget class="PyDMScatterPlot" name="PyDMScatterPlot_2">
            <property name="toolTip">
             <string/>
            </property>
-           <property name="channel" stdset="0">
-            <string>rogue://0/ExampleRoot.AxiVersion.TestBool</string>
+           <property name="yAxes">
+            <stringlist>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Scatter&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+            </stringlist>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;rogue://0/ExampleRoot.TestPlot&quot;, &quot;x_channel&quot;: &quot;rogue://0/ExampleRoot.TestXAxis&quot;, &quot;name&quot;: &quot;Test2&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;redraw_mode&quot;: 2, &quot;buffer_size&quot;: 1200, &quot;bufferSizeChannelAddress&quot;: null}</string>
+            </stringlist>
+           </property>
+           <property name="autoRangeX">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="PyDMEnumButton" name="PyDMEnumButton">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_2">
            <property name="toolTip">
             <string/>
            </property>
-           <property name="channel" stdset="0">
-            <string>rogue://0/ExampleRoot.AxiVersion.TestBool</string>
+           <property name="yAxes">
+            <stringlist>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Time&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: null}</string>
+            </stringlist>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;rogue://0/ExampleRoot.TestPlot&quot;, &quot;plot_style&quot;: null, &quot;name&quot;: &quot;TestPlot&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="updatesAsynchronously">
+            <bool>false</bool>
+           </property>
+           <property name="timeSpan">
+            <double>200.000000000000000</double>
+           </property>
+           <property name="autoRangeY">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="yAxes">
+            <stringlist>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Array Waveform&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+            </stringlist>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;rogue://0/ExampleRoot.TestArray&quot;, &quot;x_channel&quot;: null, &quot;plot_style&quot;: null, &quot;name&quot;: &quot;Test&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;redraw_mode&quot;: 2}</string>
+            </stringlist>
            </property>
           </widget>
          </item>
         </layout>
-       </item>
-       <item>
-        <widget class="PyDMScatterPlot" name="PyDMScatterPlot">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="curves">
-          <stringlist>
-           <string>{&quot;y_channel&quot;: &quot;rogue://0/ExampleRoot.TestPlot&quot;, &quot;x_channel&quot;: &quot;rogue://0/ExampleRoot.TestXAxis&quot;, &quot;name&quot;: &quot;Test2&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;redraw_mode&quot;: 2, &quot;buffer_size&quot;: 1200}</string>
-          </stringlist>
-         </property>
-         <property name="autoRangeX">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="curves">
-          <stringlist>
-           <string>{&quot;y_channel&quot;: &quot;rogue://0/ExampleRoot.TestArray&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Test&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;redraw_mode&quot;: 2}</string>
-          </stringlist>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PyDMTimePlot" name="PyDMTimePlot">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="yAxes">
-          <stringlist>
-           <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true}</string>
-          </stringlist>
-         </property>
-         <property name="curves">
-          <stringlist>
-           <string>{&quot;channel&quot;: &quot;rogue://0/ExampleRoot.TestPlot&quot;, &quot;name&quot;: &quot;TestPlot&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;Axis 1&quot;}</string>
-          </stringlist>
-         </property>
-         <property name="updatesAsynchronously">
-          <bool>false</bool>
-         </property>
-         <property name="timeSpan">
-          <double>200.000000000000000</double>
-         </property>
-         <property name="autoRangeY">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="RootControl" name="RootControl">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string>rogue://0/root</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Plotter" name="Plotter">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string>rogue://0/ExampleRoot.TestPlotFigure</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Process" name="Process">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="channel" stdset="0">
-          <string>rogue://0/root.Process</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="DebugTree" name="DebugTree_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="channel" stdset="0">
-        <string>rogue://0/root.AxiVersion</string>
-       </property>
-       <property name="excGroups" stdset="0">
-        <string>Hidden,NoConfig</string>
-       </property>
+       </widget>
+       <widget class="QWidget" name="tab_9">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <attribute name="title">
+         <string>Rogue Widgets</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_14">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_10">
+           <item>
+            <widget class="Plotter" name="Plotter_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/ExampleRoot.TestPlotFigure</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Process" name="Process_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/root.Process</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_10">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <attribute name="title">
+         <string>Rogue Time Plotter</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_16">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_15">
+           <item>
+            <widget class="TimePlotter" name="TimePlotter_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/root</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -161,14 +246,19 @@
    <header>pyrogue.pydm.widgets.debug_tree</header>
   </customwidget>
   <customwidget>
-   <class>RootControl</class>
+   <class>SystemWindow</class>
    <extends>PyDMFrame</extends>
-   <header>pyrogue.pydm.widgets.root_control</header>
+   <header>pyrogue.pydm.widgets.system_window</header>
   </customwidget>
   <customwidget>
    <class>Plotter</class>
    <extends>PyDMFrame</extends>
    <header>pyrogue.pydm.widgets.plot</header>
+  </customwidget>
+  <customwidget>
+   <class>TimePlotter</class>
+   <extends>PyDMFrame</extends>
+   <header>pyrogue.pydm.widgets.time_plotter</header>
   </customwidget>
   <customwidget>
    <class>Process</class>
@@ -189,16 +279,6 @@
    <class>PyDMScatterPlot</class>
    <extends>QGraphicsView</extends>
    <header>pydm.widgets.scatterplot</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMCheckbox</class>
-   <extends>QCheckBox</extends>
-   <header>pydm.widgets.checkbox</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMEnumButton</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.enum_button</header>
   </customwidget>
   <customwidget>
    <class>PyDMFrame</class>

--- a/python/pyrogue/pydm/examples/rogue_plugin_test.ui
+++ b/python/pyrogue/pydm/examples/rogue_plugin_test.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1540</width>
-    <height>1068</height>
+    <width>1544</width>
+    <height>1073</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,9 +19,15 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>3</number>
+        <number>4</number>
        </property>
        <widget class="QWidget" name="tab_6">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <attribute name="title">
          <string>Debug Tree</string>
         </attribute>
@@ -46,6 +52,12 @@
         </layout>
        </widget>
        <widget class="QWidget" name="tab_7">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <attribute name="title">
          <string>System Window</string>
         </attribute>

--- a/python/pyrogue/pydm/widgets/plot.py
+++ b/python/pyrogue/pydm/widgets/plot.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import QVBoxLayout
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt
-import pickle
+import gc
 
 class Plotter(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):
@@ -43,9 +43,10 @@ class Plotter(PyDMFrame):
         if self._canvas is not None:
             self._vb.removeWidget(self._canvas)
             self._vb.removeWidget(self._nav)
-            plt.close(self._fig)
+            self._canvas.setParent(None)
+            self._nav.setParent(None)
 
-        self._fig = pickle.loads(bytes.fromhex(new_val))
+        self._fig = new_val
         self._canvas = FigureCanvas(self._fig)
         self._nav = NavigationToolbar(self._canvas, self)
         self._vb.addWidget(self._nav)

--- a/python/pyrogue/pydm/widgets/plot.py
+++ b/python/pyrogue/pydm/widgets/plot.py
@@ -45,6 +45,7 @@ class Plotter(PyDMFrame):
             self._vb.removeWidget(self._nav)
             self._canvas.setParent(None)
             self._nav.setParent(None)
+            del self._canvas, self._nav, self._fig
 
         self._fig = new_val
         self._canvas = FigureCanvas(self._fig)

--- a/python/pyrogue/pydm/widgets/plot.py
+++ b/python/pyrogue/pydm/widgets/plot.py
@@ -16,7 +16,6 @@ from qtpy.QtWidgets import QVBoxLayout
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 import matplotlib.pyplot as plt
-import gc
 
 class Plotter(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):

--- a/python/pyrogue/pydm/widgets/plot.py
+++ b/python/pyrogue/pydm/widgets/plot.py
@@ -15,7 +15,6 @@ from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtWidgets import QVBoxLayout
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-import matplotlib.pyplot as plt
 
 class Plotter(PyDMFrame):
     def __init__(self, parent=None, init_channel=None):

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -509,7 +509,7 @@ class TimePlotter(PyDMFrame):
         self.plots.plotItem.enableAutoRange(ViewBox.YAxis, enable=True)
 
     def minimumSizeHint(self):
-        return QtCore.QSize(1500, 1000)
+        return QtCore.QSize(1500, 900)
 
     def ui_filepath(self):
         return None

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -255,8 +255,6 @@ class SelectionTree(PyDMFrame):
 
         self._colWidths = [250,50,150,50,50]
 
-        print("Selection tree created")
-
     def connection_changed(self, connected):
 
         build = (self._node is None) and (self._connected != connected and connected is True)
@@ -390,8 +388,6 @@ class TimePlotter(PyDMFrame):
         if not build:
             return
 
-        print("Calling setup UI")
-
         self._node = nodeFromAddress(self.channel)
         self.setup_ui()
 
@@ -508,7 +504,6 @@ class TimePlotter(PyDMFrame):
             pass
 
     def do_autoheight(self):
-        print('setting')
         # self.plots.setAutoRangeY(True)
         # self.plots.autoRangeY = True
         self.plots.plotItem.enableAutoRange(ViewBox.YAxis, enable=True)

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -381,7 +381,6 @@ class TimePlotter(PyDMFrame):
 
         self._addColor = '#dddddd'
         self._colorSelector = ColorSelector()
-        self.setup_ui()
 
     def connection_changed(self, connected):
 

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -88,7 +88,7 @@ class DebugDev(QTreeWidgetItem):
 
             if val.guiGroup is not None:
                 if val.guiGroup not in self._groups:
-                    self._groups[val.guiGroup] = DebugGroup(path=self._path, top=self._top, parent=self, name=val.guiGroup)
+                    self._groups[val.guiGroup] = DebugGroup(path=self._path, main=self._main, top=self._top, parent=self, name=val.guiGroup)
 
                 self._groups[val.guiGroup].addNode(val)
 
@@ -100,7 +100,7 @@ class DebugDev(QTreeWidgetItem):
 
             if val.guiGroup is not None:
                 if val.guiGroup not in self._groups:
-                    self._groups[val.guiGroup] = DebugGroup(path=self._path, top=self._top, parent=self, name=val.guiGroup)
+                    self._groups[val.guiGroup] = DebugGroup(path=self._path, main=self._main, top=self._top, parent=self, name=val.guiGroup)
 
                 self._groups[val.guiGroup].addNode(val)
 
@@ -242,7 +242,7 @@ class DebugHolder(QTreeWidgetItem):
 
 
 class SelectionTree(PyDMFrame):
-    def __init__(self,main, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+    def __init__(self, main, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._main = main
@@ -255,7 +255,10 @@ class SelectionTree(PyDMFrame):
 
         self._colWidths = [250,50,150,50,50]
 
+        print("Selection tree created")
+
     def connection_changed(self, connected):
+
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(SelectionTree, self).connection_changed(connected)
 
@@ -273,7 +276,6 @@ class SelectionTree(PyDMFrame):
 
         self._tree.setColumnCount(4)
         self._tree.setHeaderLabels(['Node','Value','Plot','Poll Interval'])
-
 
         self._tree.itemExpanded.connect(self._expandCb)
 
@@ -379,10 +381,20 @@ class TimePlotter(PyDMFrame):
 
         self._addColor = '#dddddd'
         self._colorSelector = ColorSelector()
-
-
         self.setup_ui()
 
+    def connection_changed(self, connected):
+
+        build = (self._node is None) and (self._connected != connected and connected is True)
+        super(TimePlotter, self).connection_changed(connected)
+
+        if not build:
+            return
+
+        print("Calling setup UI")
+
+        self._node = nodeFromAddress(self.channel)
+        self.setup_ui()
 
     def setup_ui(self):
 
@@ -413,7 +425,6 @@ class TimePlotter(PyDMFrame):
         # Create a Frame to host the items in the legend
         self.frm_legend = QFrame(parent=self)
         self.frm_legend.setLayout(self.legend_layout)
-
 
         # Create a ScrollArea
         self.scroll_area = QScrollArea(parent=self)
@@ -480,7 +491,6 @@ class TimePlotter(PyDMFrame):
         disp.setMaximumHeight(50)
         self.legend_layout.addWidget(disp)
 
-
     def do_remove(self,path):
         curve = self.plots.findCurve(path)
         self.plots.removeYChannel(curve)
@@ -528,7 +538,6 @@ class LegendRow(Display):
         main_layout = QHBoxLayout()
         main_box = QGroupBox(parent=self)
         main_box.setLayout(main_layout)
-
 
         #Add widgets to layout
         main_layout.addWidget(QLabel(self._path))

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -15,11 +15,11 @@
 # contained in the LICENSE.txt file.
 # ----------------------------------------------------------------------------
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 rawVersion = '${ROGUE_VERSION}'
 
-fields = rawVersion.split('-')
+fields = rawVersion[1:].split('-')
 
 if len(fields) == 1:
     pyVersion = fields[0]
@@ -29,18 +29,8 @@ else:
 setup (
     name='rogue',
     version=pyVersion,
-    packages=['pyrogue',
-              'pyrogue.gui',
-              'pyrogue.utilities',
-              'pyrogue.utilities.fileio',
-              'pyrogue.utilities.hls',
-              'pyrogue.interfaces',
-              'pyrogue.protocols',
-              'pyrogue.examples',
-              'pyrogue.pydm',
-              'pyrogue.pydm.widgets',
-              'pyrogue.pydm.tools',
-              'pyrogue.pydm.data_plugins' ],
-    package_dir={'':'${PROJECT_SOURCE_DIR}/python'},
-    package_data={'':['../rogue.so']},
+    packages=find_packages(where="../python"),
+    package_dir={'':'../python'},
+    package_data={'':['../rogue.so'], 'pyrogue.pydm':['examples/*.ui']},
+    include_package_data=True,
 )


### PR DESCRIPTION
This PR cleans up the PYDM interface and displays the example .ui GUI which includes demonstrations of Rogue specific pydm widgets when running the following command:

python -m pyrogue.examples --gui

The setup.py file was cleaned up to auto find packages in the tree as well as include the .ui file in the distribution. 

The pydm interface now passes a figure object directly instead of pickling it through the interface.

Fixes were made to TimePlot to deal with guiGroups.

The local conda.yml file now limits the pydm version correctly. 

This PR also seems to have addresses the memory leak when displaying rogue generated figures in pydm.

