### PR TITLE
Remove deprecated features

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -22,6 +22,7 @@ branch of Rogue. New documentation is being added incrementally over time.
    logging/index
    custom_module/index
    pydm/index
+   migration/index
 
 Please email rherbst@slac.stanford.edu if you see any errors or have any
 questions about anything in the current documentation. We are still adding

--- a/docs/src/migration/index.rst
+++ b/docs/src/migration/index.rst
@@ -1,0 +1,13 @@
+.. _migration:
+
+===============
+Migration Notes
+===============
+
+This section includes nots for migrating between versions of Rogue.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Migration:
+
+   rogue_v6

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -1,0 +1,108 @@
+.. _migrating_rogue_v6:
+
+=====================
+Migrating To Rogue V6
+=====================
+
+The following instructions covers features that are no longer support in Rogue V6 and how to upgrade your classes to follow the new Rogue V6 styles.
+
+ZmqServer
+=========
+
+This biggest impacting change in Rogue V6 is to remove the ZmqServer feature from the Root class. It is now treated as an interface to be consistent with the Rogue interface model. In the past the ZmqServer feature was controlled by setting the serverPort arg when instantiating the root class. By default this arg was '0' which resulted in the server port being automatically allocated. Instead you will need to add the zmqServer manually to the root class.
+
+Similiarly the previous feature which allowed the user to pass the root class to pydm to figure out the server port no longer works. Below is an example of including the ZmqServer in your root class and then using it with pydm.
+
+.. code::
+
+   class ExampleRoot(pyrogue.Root):
+
+       def __init__(self):
+           pyrogue.Root.__init__(self,
+                                 description="Example Root",
+                                 timeout=2.0,
+                                 pollEn=True)
+
+           # Add zmq server, keep it as an attribute so we can access it later
+           self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', port=0)
+           self.addInterface(self.zmqServer)
+
+   with ExampleRoot() as root:
+        pyrogue.pydm.runPyDM(serverList=root.zmqServer.address,title='Test UI',sizeX=1000,sizeY=500)
+
+
+More information can be found int he ZmqServer class documenation (TBD).
+
+
+SqlLogger
+=========
+
+Similiar to the zmqServer, the sql logger is now removed to be an external interface. See below for example usage of the sql logger:
+
+.. code::
+
+   class ExampleRoot(pyrogue.Root):
+
+       def __init__(self):
+           pyrogue.Root.__init__(self,
+                                 description="Example Root",
+                                 timeout=2.0,
+                                 pollEn=True)
+
+           # Add sql logger
+           self.addInterface(pyrogue.interfaces.SqlLogger(root=self, url='sqlite:///test.db'))
+
+
+More information can be found int he SqlLogger class documenation (TBD).
+
+
+Root Configuration Streaming
+============================
+
+In previous versions of rogue the Root class automatically supported the ability to stream configuration changes. This allowed the Root class to be added as a stream source to the StreamWriter class allow for configuration changes and status updates to be logged alongside the event data. In RogueV6 this feature is removed from the Root class with a new Variable streaming class which provides the same functionality. See below for an example of using this new class to stream configuration changes to the StreamWriter. This new method continues to support dumping the current status to the file immediatly after opening and right before closing:.
+
+.. code::
+
+   class ExampleRoot(pyrogue.Root):
+
+       def __init__(self):
+           pyrogue.Root.__init__(self,
+                                 description="Example Root",
+                                 timeout=2.0,
+                                 pollEn=True)
+
+           # Create configuration stream
+           stream = pyrogue.interfaces.stream.Variable(root=self)
+
+           # Create StreamWriter with the configuration stream included as channel 1
+           sw = pyrogue.utilities.fileio.StreamWriter(configStream={1: stream})
+           self.add(sw)
+
+
+EPICS Version 3 Channel Access Server
+=====================================
+
+Epics version 3 channel access server is removed from Rogue V6. Please use the epics 4 pv access server (P4P) instead:
+
+.. code::
+
+   class ExampleRoot(pyrogue.Root):
+
+       def __init__(self):
+           pyrogue.Root.__init__(self,
+                                 description="Example Root",
+                                 timeout=2.0,
+                                 pollEn=True)
+
+           pvserv = pyrogue.protocols.epicsV4.EpicsPvServer(base="test", root=self,incGroups=None,excGroups=None)
+           self.addProtocol(pvserv)
+
+
+RawWrite and RawRead
+====================
+
+The deprecated rawWrite and rawRead calls are removed from Rogue V6. The new array variables added in Rogue V5 make these calls no longer needed. The user should no longer pass a 'size' arg to the Device class and then use rawWrite and rawRead to access memory space. Instead a array Variable should be used with the appropriate similiar size. The large Variables can then be configured to be excluded from the bulk read and write transactions and can also have other smaller Variables mapped to specific locations in the overall register space. See below for an example of how a Device can be upgraded to use list Variables instead of the rawWrite and rawRead calls:
+
+
+
+

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -60,11 +60,7 @@ class BaseCommand(pr.BaseVariable):
 
         self._thread = None
         self._lock = threading.Lock()
-        self._background = background
         self._retDisp = "{}"
-
-        if self._background:
-            self._log.error('Background commands are deprecated. Please use a Process device instead.')
 
         if retValue is None:
             self._retTypeStr = None
@@ -94,18 +90,7 @@ class BaseCommand(pr.BaseVariable):
         return self._retTypeStr
 
     def __call__(self,arg=None):
-        if self._background:
-            with self._lock:
-                if self._thread is not None and self._thread.isAlive():
-                    self._log.warning('Command execution is already in progress!')
-                    return None
-                else:
-                    self._thread = threading.Thread(target=self._doFunc, args=(arg,))
-                    self._thread.start()
-
-            return None
-        else:
-            return self._doFunc(arg)
+        return self._doFunc(arg)
 
     def _doFunc(self,arg):
         """

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -177,7 +177,7 @@ class Device(pr.Node,rim.Hub):
                  guiGroup=None):
 
         if size != 0:
-            raise pr.NodeError("Size attribute in Device is not supported!)
+            raise pr.NodeError("Size attribute in Device is not supported!")
 
         """Initialize device class"""
         if name is None:

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -176,6 +176,8 @@ class Device(pr.Node,rim.Hub):
                  hubMax=0,
                  guiGroup=None):
 
+        if size != 0:
+            raise pr.NodeError("Size attribute in Device is not supported!)
 
         """Initialize device class"""
         if name is None:
@@ -189,18 +191,7 @@ class Device(pr.Node,rim.Hub):
         self._custBlocks = []
         self._memBase    = memBase
         self._memLock    = threading.RLock()
-        self._size       = size
         self._defaults   = defaults if defaults is not None else {}
-
-        if size != 0:
-            print("")
-            print("============ Deprecation Warning =========================")
-            print(f" Detected non zero size for Device {name}")
-            print(" Creating devices with a non zero size to enable rawWrite ")
-            print(" and rawRead is now deprecated.                           ")
-            print(" The Device size attribute will be removed in a future    ")
-            print(" Rogue release                                            ")
-            print("==========================================================")
 
         self._ifAndProto = []
 
@@ -240,12 +231,6 @@ class Device(pr.Node,rim.Hub):
     def offset(self):
         """ """
         return self._getOffset()
-
-    @pr.expose
-    @property
-    def size(self):
-        """ """
-        return self._size
 
     def addCustomBlock(self, block):
         """
@@ -711,161 +696,6 @@ class Device(pr.Node,rim.Hub):
 
         for key,value in self.devices.items():
             value._updateBlockEnable()
-
-    def _rawTxnChunker(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, txnType=rim.Write, numWords=1):
-        """
-
-
-        Parameters
-        ----------
-        offset :
-
-        data :
-
-        base : str
-             (Default value = pr.UInt)
-        stride : int
-             (Default value = 4)
-        wordBitSize : int
-             (Default value = 32)
-        txnType : str
-             (Default value = rim.Write)
-        numWords : int
-             (Default value = 1)
-
-        Returns
-        -------
-
-        """
-
-        if not isinstance(base, pr.Model):
-            base = base(wordBitSize)
-
-        if offset + (numWords * stride) > self._size:
-            raise pr.MemoryError(name=self.name, address=offset|self.address,
-                                 msg='Raw transaction outside of device size')
-
-        if base.bitSize > stride*8:
-            raise pr.MemoryError(name=self.name, address=offset|self.address,
-                                 msg='Called raw memory access with wordBitSize > stride')
-
-        if txnType == rim.Write or txnType == rim.Post:
-            if isinstance(data, bytearray):
-                ldata = data
-            elif isinstance(data, collections.abc.Iterable):
-                ldata = b''.join(base.toBytes(word).ljust(stride, b'\0') for word in data)
-            else:
-                ldata = base.toBytes(data)
-
-        else:
-            if data is not None:
-                ldata = data
-            else:
-                ldata = bytearray(numWords*stride)
-
-        with self._memLock:
-            for i in range(offset, offset+len(ldata), self._reqMaxAccess()):
-                sliceOffset = i | self.offset
-                txnSize = min(self._reqMaxAccess(), len(ldata)-(i-offset))
-                #print(f'sliceOffset: {sliceOffset:#x}, ldata: {ldata}, txnSize: {txnSize}, buffOffset: {i-offset}')
-                self._reqTransaction(sliceOffset, ldata, txnSize, i-offset, txnType)
-
-            return ldata
-
-    def _rawWrite(self, offset, data, base=pr.UInt, stride=4, wordBitSize=32, tryCount=1, posted=False):
-        """
-
-
-        Parameters
-        ----------
-        offset :
-
-        data :
-
-        base : str
-             (Default value = pr.UInt)
-        stride : int
-             (Default value = 4)
-        wordBitSize : int
-             (Default value = 32)
-        tryCount : int
-             (Default value = 1)
-        posted : bool
-             (Default value = False)
-
-        Returns
-        -------
-
-        """
-
-        if not isinstance(base, pr.Model):
-            base = base(wordBitSize)
-
-        with self._memLock:
-
-            if posted:
-                txn = rim.Post
-            else:
-                txn = rim.Write
-
-            for _ in range(tryCount):
-                self._clearError()
-                self._rawTxnChunker(offset, data, base, stride, wordBitSize, txn)
-                self._waitTransaction(0)
-
-                if self._getError() == "":
-                    return
-                elif posted:
-                    break
-                self._log.warning("Retrying raw write transaction")
-
-            # If we get here an error has occurred
-            raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
-
-    def _rawRead(self, offset, numWords=1, base=pr.UInt, stride=4, wordBitSize=32, data=None, tryCount=1):
-        """
-
-
-        Parameters
-        ----------
-        offset :
-
-        numWords : int
-             (Default value = 1)
-        base : str
-             (Default value = pr.UInt)
-        stride : int
-             (Default value = 4)
-        wordBitSize : int
-             (Default value = 32)
-        data : str
-             (Default value = None)
-        tryCount : int
-             (Default value = 1)
-
-        Returns
-        -------
-
-        """
-
-        if not isinstance(base, pr.Model):
-            base = base(wordBitSize)
-
-        with self._memLock:
-            for _ in range(tryCount):
-                self._clearError()
-                ldata = self._rawTxnChunker(offset, data, base, stride, wordBitSize, txnType=rim.Read, numWords=numWords)
-                self._waitTransaction(0)
-
-                if self._getError() == "":
-                    if numWords == 1:
-                        return base.fromBytes(ldata)
-                    else:
-                        return [base.fromBytes(ldata[i:i+stride]) for i in range(0, len(ldata), stride)]
-                self._log.warning("Retrying raw read transaction")
-
-            # If we get here an error has occurred
-            raise pr.MemoryError (name=self.name, address=offset|self.address, msg=self._getError())
 
     def _buildBlocks(self):
         """ """

--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -150,26 +150,6 @@ def streamConnect(source, dest):
 
     master._addSlave(slave)
 
-
-def streamTap(source, tap):
-    """
-    DEPRECATED!
-
-    Parameters
-    ----------
-    source :
-
-    tap :
-
-
-    Returns
-    -------
-
-    """
-    #print("******** Stream TAP is deprecated. Use streamConnect instead. ********")
-    streamConnect(source,tap)
-
-
 def streamConnectBiDir(deviceA, deviceB):
     """
     Attach the passed dest object to the source a stream.

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -182,9 +182,7 @@ class Root(pr.Device):
                  initRead=False,
                  initWrite=False,
                  pollEn=True,
-                 maxLog=1000,
-                 # Deprecated
-                 serverPort=None):
+                 maxLog=1000):
 
         """Init the node with passed attributes"""
         rogue.interfaces.stream.Master.__init__(self)
@@ -197,8 +195,6 @@ class Root(pr.Device):
         self._maxLog          = maxLog
         self._doHeartbeat     = True # Backdoor flag
 
-        # Deprecated
-        self._serverPort      = serverPort
         # Create log listener to add to SystemLog variable
         formatter = logging.Formatter("%(msg)s")
         handler = RootLogHandler(root=self)
@@ -399,17 +395,6 @@ class Root(pr.Device):
             for key,value in self._nodes.items():
                 value._setTimeout(self._timeout)
 
-        # Start ZMQ server if enabled
-        if self._serverPort is not None:
-            print("========== Deprecation Warning ===============================================")
-            print(" Setting up zmq server through the Root class creator is                      ")
-            print(" no longer supported. Instead create the ZmqServer seperately                 ")
-            print(" add add it as an interface:                                                  ")
-            print("                                                                              ")
-            print("    with Root() as r:                                                         ")
-            print("       r.addInterface(pyrogue.interfaces.ZmqServer(root=r, addr='*', port=0)) ")
-            print("==============================================================================")
-            self.addProtocol(pr.interfaces.ZmqServer(root=self, addr="*", port=self._serverPort))
         # Start update thread
         self._running = True
         self._updateThread = threading.Thread(target=self._updateWorker)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -368,7 +368,7 @@ class Root(pr.Device):
         tmpList = []
         for d in self.deviceList:
 
-            if hasattr(d,size):
+            if hasattr(d,"size"):
                 tmpList.append(d)
 
             for b in d._blocks:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -364,10 +364,9 @@ class Root(pr.Device):
         # Finish Initialization
         self._finishInit()
 
-        # Get full list of Devices and Blocks
+        # Get full list of Blocks
         tmpList = []
         for d in self.deviceList:
-            tmpList.append(d)
             for b in d._blocks:
                 if isinstance(b, rim.Block):
                     tmpList.append(b)

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -1066,4 +1066,3 @@ class Root(pr.Device):
 
             # Set done
             self._updateQueue.task_done()
-

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -184,12 +184,8 @@ class Root(pr.Device):
                  pollEn=True,
                  maxLog=1000,
                  # Deprecated
-                 serverPort=None,  # 9099 is the default, 0 for auto
-                 sqlUrl=None,
-                 streamIncGroups=None,
-                 streamExcGroups=['NoStream'],
-                 sqlIncGroups=None,
-                 sqlExcGroups=['NoSql']):
+                 serverPort=None):
+
         """Init the node with passed attributes"""
         rogue.interfaces.stream.Master.__init__(self)
 
@@ -203,13 +199,6 @@ class Root(pr.Device):
 
         # Deprecated
         self._serverPort      = serverPort
-        self._sqlUrl          = sqlUrl
-        self._sqlIncGroups    = sqlIncGroups
-        self._sqlExcGroups    = sqlExcGroups
-        self._streamIncGroups = streamIncGroups
-        self._streamExcGroups = streamExcGroups
-        self._streamMaster    = None
-
         # Create log listener to add to SystemLog variable
         formatter = logging.Formatter("%(msg)s")
         handler = RootLogHandler(root=self)
@@ -421,19 +410,6 @@ class Root(pr.Device):
             print("       r.addInterface(pyrogue.interfaces.ZmqServer(root=r, addr='*', port=0)) ")
             print("==============================================================================")
             self.addProtocol(pr.interfaces.ZmqServer(root=self, addr="*", port=self._serverPort))
-
-        # Start sql interface
-        if self._sqlUrl is not None:
-            print("========== Deprecation Warning =========================================")
-            print(" Setting up sql logger through the Root class creator is                ")
-            print(" no longer supported. Instead create the SqlLogger seperately           ")
-            print(" add add it as an interface:                                            ")
-            print("                                                                        ")
-            print("    with Root() as r:                                                   ")
-            print("       r.addInterface(pyrogue.interfaces.SqlLogger(root=r, url=sqlUrl)) ")
-            print("========================================================================")
-            self.addProtocol(pr.interfaces.SqlLogger(root=self, url=self._sqlUrl, incGroups=self._sqlIncGroups, excGroups=self._sqlExcGroups))
-
         # Start update thread
         self._running = True
         self._updateThread = threading.Thread(target=self._updateWorker)
@@ -1106,29 +1082,3 @@ class Root(pr.Device):
             # Set done
             self._updateQueue.task_done()
 
-    # Deprecated
-    def _getStreamMaster(self):
-        if self._streamMaster is None:
-            print("========== Deprecation Warning =============================== ")
-            print(" Setting up variable streaming directly through the root class ")
-            print(" is no longer supported. Instead create a VariableStram        ")
-            print(" object seperately and add it as an interface:                 ")
-            print("                                                               ")
-            print("    with Root() as r:                                          ")
-            print("       stream = pyrogue.interfaces.stream.Variable(root=r)     ")
-            print("       r.addInterface(stream)                                  ")
-            print("                                                               ")
-            print(" You can then connect stream slaves to the newly created       ")
-            print(" VariableStream instance:                                      ")
-            print("                                                               ")
-            print("    slave << stream                                            ")
-            print("===============================================================")
-            self._streamMaster = pr.interfaces.stream.Variable(root=self, incGroups=self._streamIncGroups, excGroups=self._streamExcGroups)
-            self.addInterface(self._streamMaster)
-
-        return self._streamMaster
-
-    # Deprecated support
-    def __rshift__(self,other):
-        pr.streamConnect(self,other)
-        return other

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -364,9 +364,13 @@ class Root(pr.Device):
         # Finish Initialization
         self._finishInit()
 
-        # Get full list of Blocks
+        # Get full list of Blocks and Devices with size
         tmpList = []
         for d in self.deviceList:
+
+            if hasattr(d,size):
+                tmpList.append(d)
+
             for b in d._blocks:
                 if isinstance(b, rim.Block):
                     tmpList.append(b)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -405,16 +405,6 @@ class BaseVariable(pr.Node):
         """ """
         return self._pollInterval
 
-    @pollInterval.setter
-    def pollInterval(self, interval):
-        print()
-        print('=========== Deprecation Warming ===============')
-        print(f'Called {self.path}.pollInterval = {interval}')
-        print('This way of setting the poll interval is deprecated')
-        print(f'Use {self.path}.setPollInterval({interval}) instead')
-        self._pollInterval = interval
-        self._updatePollInterval()
-
     @pr.expose
     def setPollInterval(self, interval):
         print(f'{self.path}.setPollInterval({interval})')

--- a/python/pyrogue/protocols/_uart.py
+++ b/python/pyrogue/protocols/_uart.py
@@ -30,10 +30,6 @@ class UartMemory(rogue.interfaces.memory.Slave):
         self._workerThread = threading.Thread(target=self._worker)
         self._workerThread.start()
 
-    # Deprecated
-    def close(self):
-        self.stop()
-
     def _stop(self):
         self._workerQueue.put(None)
         self._workerQueue.join()

--- a/python/pyrogue/protocols/epicsV4.py
+++ b/python/pyrogue/protocols/epicsV4.py
@@ -281,14 +281,6 @@ class EpicsPvServer(object):
 
         self._provider = p4p.server.StaticProvider(__name__)
 
-    def start(self):
-        # Add deprecration warning in the future
-        self._start()
-
-    def stop(self):
-        # Add deprecration warning in the future
-        self._stop()
-
     def _stop(self):
         if self._server is not None:
             self._server.stop()

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -15,15 +15,7 @@ import pydm
 import pyrogue
 import pyrogue.pydm.data_plugins.rogue_plugin
 
-def runPyDM(serverList='localhost:9090', root=None, ui=None, title=None, sizeX=800, sizeY=1000, maxListExpand=5, maxListSize=100):
-
-    if root is not None:
-        print("")
-        print("========== Deprecation Warning ===============================")
-        print(" Pass root to runPyDM is not longer supported. Please extract ")
-        print("    the port number from the ZMQ server and pass in the       ")
-        print("    serverList argument.                                      ")
-        print("==============================================================")
+def runPyDM(serverList='localhost:9090', ui=None, title=None, sizeX=800, sizeY=1000, maxListExpand=5, maxListSize=100):
 
     os.environ['ROGUE_SERVERS'] = serverList
 

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -78,8 +78,7 @@ class BlockRoot(pr.Root):
                          name='BlockRoot',
                          description="Dummy tree for example",
                          timeout=2.0,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         sim = rogue.interfaces.memory.Emulate(4,0x1000)

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -61,8 +61,7 @@ class DummyTree(pr.Root):
                          name='dummyTree',
                          description="Dummy tree for example",
                          timeout=2.0,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         #sim = pr.interfaces.simulation.MemEmulate()

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -32,7 +32,7 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root', serverPort=None)
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
         my_device=myDevice()
         self.add(my_device)
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -255,8 +255,7 @@ class DummyTree(pr.Root):
             name='dummyTree',
             description="Dummy tree for example",
             timeout=2.0,
-            pollEn=False,
-            serverPort=None)
+            pollEn=False)
 
         # Use a memory space emulator
         sim = TestEmulate()

--- a/tests/test_int.py
+++ b/tests/test_int.py
@@ -86,8 +86,7 @@ class DummyTree(pr.Root):
             name='dummyTree',
             description="Dummy tree for example",
             timeout=2.0,
-            pollEn=False,
-            serverPort=None)
+            pollEn=False)
 
         # Use a memory space emulator
         #sim = pr.interfaces.simulation.MemEmulate()

--- a/tests/test_list_memory.py
+++ b/tests/test_list_memory.py
@@ -151,7 +151,6 @@ class DummyTree(pr.Root):
             description="Dummy tree for example",
             timeout=2.0,
             pollEn=False)
-            #serverPort=None)
 
         # Use a memory space emulator
         sim = rogue.interfaces.memory.Emulate(4,0x1000)

--- a/tests/test_loadsave.py
+++ b/tests/test_loadsave.py
@@ -70,8 +70,7 @@ class DummyTree(pr.Root):
                          name='DummyTree',
                          description="Dummy tree for example",
                          timeout=2.0,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         #sim = pr.interfaces.simulation.MemEmulate()

--- a/tests/test_localcommand.py
+++ b/tests/test_localcommand.py
@@ -26,13 +26,6 @@ class myDevice(pyrogue.Device):
             description='Command running in the foreground',
             function=self._DelayFunction))
 
-        # This command calls _DelayFunction in the background
-        self.add(pyrogue.LocalCommand(
-            name='cmd_bg',
-            description='Command running in the background',
-            background=True,
-            function=self._DelayFunction))
-
     # Blocking function. The passed argument specify how many seconds
     # it will block.
     def _DelayFunction(self,arg):
@@ -57,15 +50,6 @@ def test_local_cmd():
         duration=end-start
         if duration < delay:
             raise AssertionError('Command running in foreground returned too soon: '
-                'delay was set to {} s, and the command took {} s.'.format(delay, duration))
-
-        # Test a local command running in the background
-        start=time()
-        root.myDevice.cmd_bg.call(2)
-        end=time()
-        duration=end-start
-        if duration > delay:
-            raise AssertionError('Command running in background returned too late: '
                 'delay was set to {} s, and the command took {} s.'.format(delay, duration))
 
 if __name__ == "__main__":

--- a/tests/test_localcommand.py
+++ b/tests/test_localcommand.py
@@ -40,7 +40,7 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root',serverPort=None)
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
         my_device=myDevice()
         self.add(my_device)
 

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -92,7 +92,7 @@ class myDevice(pyrogue.Device):
 
 class LocalRoot(pyrogue.Root):
     def __init__(self):
-        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root',serverPort=None)
+        pyrogue.Root.__init__(self, name='LocalRoot', description='Local root')
         my_device=myDevice()
         self.add(my_device)
 

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -163,7 +163,7 @@ def test_local_root():
             raise AssertionError('Value written was {}, but value read back was = {}'.format(test_value, test_result))
 
         # Check pollInterval set/readback methods
-        root.myDevice.var_with_properties.pollInterval=poll_set
+        root.myDevice.var_with_properties.setPollInterval(poll_set)
         poll_read=root.myDevice.var_with_properties.pollInterval
         if poll_read != poll_set:
             raise AssertionError('Poll Interval was set to {} was was read back as {}'. format(poll_set,poll_read))

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -118,8 +118,7 @@ class DummyTree(pr.Root):
                          name='dummyTree',
                          description="Dummy tree for example",
                          timeout=2.0,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         #sim = pr.interfaces.simulation.MemEmulate()

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -81,8 +81,7 @@ class DummyTree(pr.Root):
                          name='dummyTree',
                          description="Dummy tree for example",
                          timeout=2.0,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         sim = rogue.interfaces.memory.Emulate(4,0x1000)

--- a/tests/test_retry_memory.py
+++ b/tests/test_retry_memory.py
@@ -93,8 +93,7 @@ class DummyTree(pr.Root):
                          name='dummyTree',
                          description="Dummy tree for example",
                          timeout=.01,
-                         pollEn=False,
-                         serverPort=None)
+                         pollEn=False)
 
         # Use a memory space emulator
         sim = pr.interfaces.simulation.MemEmulate(dropCount=2)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -14,7 +14,7 @@ import pyrogue
 def test_root():
 
     # Test __enter__ and __exit_ methods
-    with pyrogue.Root(name='root',timeout=2.0, initRead=True, initWrite=True, serverPort=None) as root:
+    with pyrogue.Root(name='root',timeout=2.0, initRead=True, initWrite=True) as root:
         # Test:
         # - a non-default poll value
         # - set the initRead to true


### PR DESCRIPTION
This PR removes the last of the deprecated features in preparation for Rogue V6. 

Removed deprecated features include:

- RawRead / RawWrite
- Background commands
- ZmqServer in Root class
- SqlLogger in Root class
- Configuration streaming from Root class
