### PR TITLE
Updating petalinux.rst and anaconda.rst

### DIFF
--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -53,12 +53,6 @@ If you already have an anaconda environment that you would like to install Rogue
 
    $ conda install -c tidair-tag -c conda-forge rogue
 
-The above commands will install the latest version of Rogue from the `main` branch. If you want to install the `pre-release` version of Rogue, run the following:
-
-.. code::
-
-   $ conda create -n rogue_dev -c tidair-dev -c conda-forge rogue
-
 Alternatively you can install a specific released version of Rogue:
 
 .. code::
@@ -76,7 +70,7 @@ To activate:
 
    $ conda activate rogue_tag
 
-Replace rogue_tag with the name you used when creating your environment (rogue_dev or rogue_v6.0.0).
+Replace rogue_tag with the name you used when creating your environment (e.g. rogue_v6.0.0).
 
 
 To deactivate:
@@ -99,8 +93,6 @@ If you want to update Rogue, run the following command after activating the Rogu
 .. code::
 
    $ conda update rogue -c tidair-tag
-
-Replace tidair-tag with tidair-dev for pre-release
 
 Deleting Anaconda Environment
 =============================

--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -63,7 +63,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_v5.18.4 -c conda-forge -c tidair-tag rogue=v5.18.4
+   $ conda create -n rogue_v6.0.0 -c conda-forge -c tidair-tag rogue=v6.0.0
 
 Using Rogue In Anaconda
 =======================
@@ -76,7 +76,7 @@ To activate:
 
    $ conda activate rogue_tag
 
-Replace rogue_tag with the name you used when creating your environment (rogue_dev or rogue_5.8.0).
+Replace rogue_tag with the name you used when creating your environment (rogue_dev or rogue_v6.0.0).
 
 
 To deactivate:

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -76,7 +76,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
    
    do_install() {
       cmake_do_install
-      distutils3_do_install
+      setuptools3_do_install
    }
 
 Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -18,25 +18,26 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
 
 .. code::
 
-   ROGUE_VERSION = "5.18.2"
-   ROGUE_MD5SUM  = "38bf1bc4108eb08fc56ee9017be40c50"
-
+   ROGUE_VERSION = "6.0.0"
+   ROGUE_MD5SUM  = "42d6ffe9894c10a5d0e4c43834878e73"
+   
    SUMMARY = "Recipe to build Rogue"
    HOMEPAGE ="https://github.com/slaclab/rogue"
    LICENSE = "MIT"
    LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-
+   
    SRC_URI = "https://github.com/slaclab/rogue/archive/v${ROGUE_VERSION}.tar.gz"
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
-
+   
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
-
-   inherit cmake python3native distutils3
-
+   
+   inherit cmake python3native setuptools3
+   
    DEPENDS += " \
       python3 \
+      python3-setuptools \
       python3-native \
       python3-numpy \
       python3-numpy-native \
@@ -51,7 +52,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       boost \
       cmake \
    "
-
+   
    RDEPENDS:${PN} += " \
       python3-numpy \
       python3-pyzmq \
@@ -63,21 +64,20 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       python3-json \
       python3-logging \
    "
-
+   
    FILES:${PN}-dev += "/usr/include/rogue/*"
    FILES:${PN} += "/usr/lib/*"
-
+   
    do_configure() {
       cmake_do_configure
       bbplain $(cp -vH ${WORKDIR}/build/setup.py ${S}/.)
+      bbplain $(sed -i "s/..\/python/python/" ${S}/setup.py)
    }
-
+   
    do_install() {
       cmake_do_install
       distutils3_do_install
    }
-
-
 
 Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
 

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -32,12 +32,12 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
-   
-   inherit cmake python3native setuptools3
+
+   # Note: distutils3 is depreciated in petalinux 2023.1 and need to switch to setuptools3
+   inherit cmake python3native distutils3
    
    DEPENDS += " \
       python3 \
-      python3-setuptools \
       python3-native \
       python3-numpy \
       python3-numpy-native \
@@ -68,15 +68,14 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
    FILES:${PN}-dev += "/usr/include/rogue/*"
    FILES:${PN} += "/usr/lib/*"
    
-   do_configure() {
+   do_configure:prepend() {
       cmake_do_configure
       bbplain $(cp -vH ${WORKDIR}/build/setup.py ${S}/.)
       bbplain $(sed -i "s/..\/python/python/" ${S}/setup.py)
    }
    
-   do_install() {
+   do_install:prepend() {
       cmake_do_install
-      setuptools3_do_install
    }
 
 Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:


### PR DESCRIPTION
### Description
- Updating for rogue v6 for petalinux
- Removed tidair-dev from the anaconda install instructions
