### PR TITLE
Use isinstance to check types in variable representation

### DIFF
--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -349,13 +349,13 @@ def dataToYaml(data):
         -------
 
         """
-        if type(data.value) == bool:
+        if isinstance(type(data.value), bool):
             enc = 'tag:yaml.org,2002:bool'
         elif data.enum is not None:
             enc = 'tag:yaml.org,2002:str'
-        elif type(data.value) == int:
+        elif isinstance(type(data.value), int):
             enc = 'tag:yaml.org,2002:int'
-        elif type(data.value) == float:
+        elif isinstance(type(data.value), float):
             enc = 'tag:yaml.org,2002:float'
         else:
             enc = 'tag:yaml.org,2002:str'

--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -349,13 +349,13 @@ def dataToYaml(data):
         -------
 
         """
-        if isinstance(type(data.value), bool):
+        if isinstance(data.value, bool):
             enc = 'tag:yaml.org,2002:bool'
         elif data.enum is not None:
             enc = 'tag:yaml.org,2002:str'
-        elif isinstance(type(data.value), int):
+        elif isinstance(data.value, int):
             enc = 'tag:yaml.org,2002:int'
-        elif isinstance(type(data.value), float):
+        elif isinstance(data.value, float):
             enc = 'tag:yaml.org,2002:float'
         else:
             enc = 'tag:yaml.org,2002:str'

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -214,7 +214,7 @@ class BaseVariable(pr.Node):
             self._enum = disp
         elif isinstance(disp, list):
             self._enum = {k:str(k) for k in disp}
-        elif type(value) == bool and enum is None:
+        elif isinstance(type(value), bool) and enum is None:
             self._enum = {False: 'False', True: 'True'}
 
         if self._enum is not None:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -214,7 +214,7 @@ class BaseVariable(pr.Node):
             self._enum = disp
         elif isinstance(disp, list):
             self._enum = {k:str(k) for k in disp}
-        elif isinstance(type(value), bool) and enum is None:
+        elif isinstance(value, bool) and enum is None:
             self._enum = {False: 'False', True: 'True'}
 
         if self._enum is not None:


### PR DESCRIPTION
This change uses isinstance(value) instead of type(value) == type calls. 