### PR TITLE
Fix confusing lock scoping

### DIFF
--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -69,7 +69,7 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
 
     // printf("Got transaction address=0x%" PRIx64 ", size=%" PRIu32 ", type = %" PRIu32 "\n", addr, size, type);
 
-    rogue::interfaces::memory::TransactionLockPtr lock = tran->lock();
+    rogue::interfaces::memory::TransactionLockPtr tlock = tran->lock();
     {
         std::lock_guard<std::mutex> lock(mtx_);
 


### PR DESCRIPTION
This lock scoping is confusing due to duplicate names. It is technically correct but reads badyly.