### PR TITLE
Add warning when loading a configuration and variable mode is not enabled

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -54,6 +54,8 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
+                                  disp='',
+                                  groups=['NoState'],
                                   value=value,
                                   hidden=hideData,
                                   description='Data Frame Container'))

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -55,7 +55,7 @@ class DataReceiver(pr.Device,ris.Slave):
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
                                   disp='',
-                                  groups=['NoState'],
+                                  groups=['NoState','NoStream'],
                                   value=value,
                                   hidden=hideData,
                                   description='Data Frame Container'))

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -54,7 +54,6 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
-                                  disp='',
                                   value=value,
                                   hidden=hideData,
                                   description='Data Frame Container'))

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -814,10 +814,14 @@ class BaseVariable(pr.Node):
 
                         for val,i in zip(s,idxSlice):
                             self.setDisp(val.strip(), write=writeEach, index=i)
+            else:
+                self._log.warning(f"Skipping set for Entry {self.name} with mode {self._mode}. Enabled Modes={modes}.")
 
         # Standard set
         elif self._mode in modes:
             self.setDisp(d,writeEach)
+        else:
+            self._log.warning(f"Skipping set for Entry {self.name} with mode {self._mode}. Enabled Modes={modes}.")
 
     def _getDict(self, modes=['RW', 'RO', 'WO'], incGroups=None, excGroups=None, properties=False):
         """


### PR DESCRIPTION
By default loading a configuration does not apply to WO variables. Instead of failing silently this PR will generate a warning message when an entry exists in the configuration file, but will not be used because the variable has a mode which is not enabled for the configuration load.

This also fixes a bug found in the display value for the DataReceiver.
