### PR TITLE
Fix suggested default address. Fix broken address/port lookup

### DIFF
--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -24,7 +24,7 @@ Similiarly the previous feature which allowed the user to pass the root class to
 				 pollEn=True)
 
 	   # Add zmq server, keep it as an attribute so we can access it later
-	   self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', port=0)
+	   self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='127.0.0.1', port=0)
 	   self.addInterface(self.zmqServer)
 
    with ExampleRoot() as root:

--- a/python/pyrogue/examples/_ExampleRoot.py
+++ b/python/pyrogue/examples/_ExampleRoot.py
@@ -73,7 +73,7 @@ class ExampleRoot(pyrogue.Root):
         self.add(pyrogue.RunControl())
 
         # Add zmq server
-        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='*', port=0)
+        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='127.0.0.1', port=0)
         self.addInterface(self.zmqServer)
 
         # Add sql logger

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -20,12 +20,16 @@ class ZmqServer(rogue.interfaces.ZmqServer):
     def __init__(self,*,root,addr,port,incGroups=None, excGroups=['NoServe']):
         rogue.interfaces.ZmqServer.__init__(self,addr,port)
         self._root = root
+        self._addr = addr
         self._root.addVarListener(func=self._varUpdate, done=self._varDone, incGroups=incGroups, excGroups=excGroups)
         self._updateList = {}
 
     @property
     def address(self):
-        return f"localhost:{self.port()}"
+        if self._addr == "*":
+            return f"127.0.0.1:{self.port()}"
+        else:
+            return f"{self._addr}:{self.port()}"
 
     def _doOperation(self,d):
         path    = d['path']   if 'path'   in d else None


### PR DESCRIPTION
This updates the documentation to suggest using 127.0.0.1 for the zmqServer listen address. This will avoid getting annoying messages from cyber security port scanners.

We still need to properly document ZmqServer to explain the various addr arg options.

I also fixed a bug where the address lookup always returns localhost, which will break the gui when users define options other than * or 127.0.0.1

