### PR TITLE
Fix bug in ArrayDevice

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -1010,7 +1010,7 @@ class ArrayDevice(Device):
         if arrayArgs is None:
             arrayArgs = [{} for x in range(number)]
         elif isinstance(arrayArgs, dict):
-            arrayArgs = [arrayArgs for x in range(number)]
+            arrayArgs = [arrayArgs.copy() for x in range(number)]
 
         for i in range(number):
             args = arrayArgs[i]


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

When passing a single `arrayArgs` `dict` to `ArrayDevice`, need to copy the dict for each instantiated array member. Otherwise it is passed by reference and a later per-instance `pop()` call affects all instances.

