### PR TITLE
Initial capture of the pyrogue tree documentation

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -15,6 +15,7 @@ branch of Rogue. New documentation is being added incrementally over time.
    :caption: Contents:
 
    installing/index
+   pyrogue_tree/index
    interfaces/index
    utilities/index
    hardware/index

--- a/docs/src/pyrogue_tree/index.rst
+++ b/docs/src/pyrogue_tree/index.rst
@@ -1,0 +1,14 @@
+.. _pyrogue_tree:
+
+================
+PyRogue Tree
+================
+
+The PyRogue Tree implements a tree structure for the hierarchical organization of devices ...
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Using Nodes In The PyRogue Tree:
+
+   node/index
+

--- a/docs/src/pyrogue_tree/node/command/index.rst
+++ b/docs/src/pyrogue_tree/node/command/index.rst
@@ -1,0 +1,49 @@
+.. _pyrogue_tree_node_command:
+
+=======
+Command 
+=======
+
+The Command class ...
+
+In this example ... 
+
+Python Command Example
+======================
+
+Below is an example of creating a Command which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a command 
+    class MyCommand(...):
+
+C++ Command Example
+===================
+
+Below is an example of creating a Command device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a command 
+   class MyCommand : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Types Of Commands In The PyRogue Tree:
+
+   local_command/index
+   remote_command/index
+

--- a/docs/src/pyrogue_tree/node/command/local_command/index.rst
+++ b/docs/src/pyrogue_tree/node/command/local_command/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_command_local_command:
+
+============
+LocalCommand
+============
+
+The LocalCommand class ...
+
+In this example ... 
+
+Python LocalCommand Example
+===========================
+
+Below is an example of creating a LocalCommand which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a LocalCommand 
+    class MyLocalCommand(...):
+
+C++ LocalCommand Example
+========================
+
+Below is an example of creating a LocalCommand device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a LocalCommand 
+   class MyLocalCommand : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/command/remote_command/index.rst
+++ b/docs/src/pyrogue_tree/node/command/remote_command/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_command_remote_command:
+
+=============
+RemoteCommand
+=============
+
+The RemoteCommand class ...
+
+In this example ... 
+
+Python RemoteCommand Example
+============================
+
+Below is an example of creating a RemoteCommand which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a RemoteCommand 
+    class MyRemoteCommand(...):
+
+C++ RemoteCommand Example
+=========================
+
+Below is an example of creating a RemoteCommand device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a RemoteCommand 
+   class MyRemoteCommand : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/device/index.rst
+++ b/docs/src/pyrogue_tree/node/device/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_device:
+
+======
+Device 
+======
+
+The Device class ...
+
+In this example ... 
+
+Python Device Example
+=====================
+
+Below is an example of creating a Device which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a Device 
+    class MyDevice(...):
+
+C++ Device Example
+==================
+
+Below is an example of creating a Device class in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a Device 
+   class MyDevice : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/index.rst
+++ b/docs/src/pyrogue_tree/node/index.rst
@@ -1,0 +1,17 @@
+.. _pyrogue_tree_node:
+
+====
+Node 
+====
+
+The Node class is the base class of all devices ...
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Types Of Nodes In The PyRogue Tree:
+
+   root/index
+   device/index
+   command/index
+   variable/index
+

--- a/docs/src/pyrogue_tree/node/root/index.rst
+++ b/docs/src/pyrogue_tree/node/root/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_root:
+
+====
+Root
+====
+
+The Root class ...
+
+In this example ... 
+
+Python Root Example
+===================
+
+Below is an example of creating a root which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a root 
+    class MyRoot(...):
+
+C++ Root Example
+================
+
+Below is an example of creating a root device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a root 
+   class MyRoot : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/variable/index.rst
+++ b/docs/src/pyrogue_tree/node/variable/index.rst
@@ -1,0 +1,49 @@
+.. _pyrogue_tree_node_variable:
+
+========
+Variable
+========
+
+The Variable class ...
+
+In this example ... 
+
+Python Variable Example
+=======================
+
+Below is an example of creating a Variable which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a Variable 
+    class MyVariable(...):
+
+C++ Variable Example
+====================
+
+Below is an example of creating a Variable device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a Variable 
+   class MyVariable : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Types Of Variables In The PyRogue Tree:
+
+   link_variable/index
+   local_variable/index
+   remote_variable/index

--- a/docs/src/pyrogue_tree/node/variable/link_variable/index.rst
+++ b/docs/src/pyrogue_tree/node/variable/link_variable/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_variable_link_variable:
+
+============
+LinkVariable
+============
+
+The LinkVariable class ...
+
+In this example ... 
+
+Python LinkVariable Example
+===========================
+
+Below is an example of creating a LinkVariable which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a LinkVariable 
+    class MyLinkVariable(...):
+
+C++ LinkVariable Example
+========================
+
+Below is an example of creating a LinkVariable device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a LinkVariable 
+   class MyLinkVariable : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/variable/local_variable/index.rst
+++ b/docs/src/pyrogue_tree/node/variable/local_variable/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_variable_local_variable:
+
+=============
+LocalVariable
+=============
+
+The LocalVariable class ...
+
+In this example ... 
+
+Python LocalVariable Example
+============================
+
+Below is an example of creating a LocalVariable which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a LocalVariable 
+    class MyLocalVariable(...):
+
+C++ LocalVariable Example
+=========================
+
+Below is an example of creating a LocalVariable device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a LocalVariable 
+   class MyLocalVariable : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+

--- a/docs/src/pyrogue_tree/node/variable/remote_variable/index.rst
+++ b/docs/src/pyrogue_tree/node/variable/remote_variable/index.rst
@@ -1,0 +1,42 @@
+.. _pyrogue_tree_node_variable_remote_variable:
+
+==============
+RemoteVariable
+==============
+
+The RemoteVariable class ...
+
+In this example ... 
+
+Python RemoteVariable Example
+=============================
+
+Below is an example of creating a RemoteVariable which ...
+
+.. code-block:: python
+
+    import pyrogue
+
+    # Create a subclass of a RemoteVariable 
+    class MyRemoteVariable(...):
+
+C++ RemoteVariable Example
+==========================
+
+Below is an example of creating a RemoteVariable device in C++.
+
+.. code-block:: c
+
+   #include <rogue/interfaces/memory/Constants.h>
+   #include <boost/thread.hpp>
+
+   // Create a subclass of a RemoteVariable 
+   class MyRemoteVariable : public rogue:: ... {
+      public:
+
+      protected:
+
+   };
+
+A few notes on the above examples ...
+


### PR DESCRIPTION
Initial capture of placeholder pages for documenting the pyrogue tree classes.

### Description
Added documentation directories and index.rst files to capture the essential pyrogue tree classes: node, root, command, device and variable. Note that these are placeholder pages and not populated pages.

### Details
Added the following directories and files:
```
docs/src/pyrogue_tree/index.rst
docs/src/pyrogue_tree/node/command/index.rst
docs/src/pyrogue_tree/node/command/local_command/index.rst
docs/src/pyrogue_tree/node/command/remote_command/index.rst
docs/src/pyrogue_tree/node/device/index.rst
docs/src/pyrogue_tree/node/index.rst
docs/src/pyrogue_tree/node/root/index.rst
docs/src/pyrogue_tree/node/variable/index.rst
docs/src/pyrogue_tree/node/variable/link_variable/index.rst
docs/src/pyrogue_tree/node/variable/local_variable/index.rst
docs/src/pyrogue_tree/node/variable/remote_variable/index.rst
docs/src/index.rst
```

Removed the following file:
`docs/src/pyrogue_tree/_Node.py `

### JIRA
N/A

### Related
N/A
