### PR TITLE
Misc. Documentation Updates

### DIFF
--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -58,7 +58,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_v6.0.0 -c conda-forge -c tidair-tag rogue=v6.0.0
+   $ conda create -n rogue_v6.1.3 -c conda-forge -c tidair-tag rogue=v6.1.3
 
 Using Rogue In Anaconda
 =======================
@@ -71,7 +71,7 @@ To activate:
 
    $ conda activate rogue_tag
 
-Replace rogue_tag with the name you used when creating your environment (e.g. rogue_v6.0.0).
+Replace rogue_tag with the name you used when creating your environment (e.g. rogue_v6.1.3).
 
 
 To deactivate:

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -18,24 +18,24 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
 
 .. code::
 
-   ROGUE_VERSION = "6.0.0"
-   ROGUE_MD5SUM  = "42d6ffe9894c10a5d0e4c43834878e73"
+   ROGUE_VERSION = "6.1.3"
+   ROGUE_MD5SUM  = "1df912b8525c01930bb869c3a2b2e7e3"
    
    SUMMARY = "Recipe to build Rogue"
    HOMEPAGE ="https://github.com/slaclab/rogue"
    LICENSE = "MIT"
    LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-   
+
    SRC_URI = "https://github.com/slaclab/rogue/archive/v${ROGUE_VERSION}.tar.gz"
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
-   
+
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
 
-   # Note: distutils3 is depreciated in petalinux 2023.1 and need to switch to setuptools3
+   # Note: distutils3 is depreciated (not removed) in petalinux 2023.2 and need to switch to setuptools3 in petalinux 2024 release
    inherit cmake python3native distutils3
-   
+
    DEPENDS += " \
       python3 \
       python3-native \
@@ -52,7 +52,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       boost \
       cmake \
    "
-   
+
    RDEPENDS:${PN} += " \
       python3-numpy \
       python3-pyzmq \
@@ -64,21 +64,22 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       python3-json \
       python3-logging \
    "
-   
+
    FILES:${PN}-dev += "/usr/include/rogue/*"
    FILES:${PN} += "/usr/lib/*"
-   
+
    do_configure:prepend() {
       cmake_do_configure
       bbplain $(cp -vH ${WORKDIR}/build/setup.py ${S}/.)
       bbplain $(sed -i "s/..\/python/python/" ${S}/setup.py)
    }
-   
+
    do_install:prepend() {
       cmake_do_install
    }
 
-Update the ROGUE_VERSION line for an updated version when appropriate (min version is 5.6.1). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
+
+Update the ROGUE_VERSION line for an updated version when appropriate (min version is 6.1.3). You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
 
 .. code::
 
@@ -99,8 +100,8 @@ In order to install the rogue headers you will need to enable the rogue-dev pack
 
 .. code::
 
-   CONFIG_rogue=y
-   CONFIG_rogue-dev=y
+   echo CONFIG_rogue=y >> project-spec/configs/rootfs_config
+   echo CONFIG_rogue-dev=y >> project-spec/configs/rootfs_config
 
 You can then build the rogue package with the following command:
 

--- a/docs/src/interfaces/stream/usingTcp.rst
+++ b/docs/src/interfaces/stream/usingTcp.rst
@@ -28,9 +28,9 @@ on the client. The Python server is able to interface with either a Python or C+
    # Local receiver
    dst = MyCustomSlave()
 
-   # Start a TCP Bridge Server, Listen on ports 8000 & 8001 on all interfaces
+   # Start a TCP Bridge Server, Listen on ports 8000 & 8001 on localhost
    # Pass an address of 192.168.1.1 to listen on only that specific interface
-   tcp = rogue.interfaces.stream.TcpServer("*",8000)
+   tcp = rogue.interfaces.stream.TcpServer("127.0.0.1",8000)
 
    # Connect the transmitter and the receiver
    src >> tcp >> dst
@@ -77,9 +77,9 @@ on the client.  The C++ server is able to interface with either a Python or C++ 
    // Local receiver
    MyCustomSlavePtr dst = MyCustomSlave::create()
 
-   // Start a TCP Bridge Server, Listen on all interfaces, ports 8000 & 8001.
+   // Start a TCP Bridge Server, Listen on localhost, ports 8000 & 8001.
    // Pass an address of 192.168.1.1 to listen on only that specific interface
-   rogue::interfaces::stream::TcpServerPtr tcp = rogue::interfaces::stream::TcpServer::create("*",8000)
+   rogue::interfaces::stream::TcpServerPtr tcp = rogue::interfaces::stream::TcpServer::create("127.0.0.1",8000)
 
    // Connect the transmitter
    *( *src >> tcp ) >> dst;


### PR DESCRIPTION
### Description
- [This updates the documentation to suggest using 127.0.0.1 for the tcpServer. This will avoid getting annoying messages from cyber security port scanners](https://github.com/slaclab/rogue/commit/6c3524f07f990ca4531385921977f0058ecdeaa8)
  - Related to https://github.com/slaclab/rogue/pull/985
- [Update anaconda.rst to use latest tag release](https://github.com/slaclab/rogue/pull/990/commits/16a501df296404df82f71239e8b1519bbf7b04ed)
- [Update petalinux.rst for rogue v6.1.3 and petlinux 2023.2](https://github.com/slaclab/rogue/pull/990/commits/525730ed1cce722d0e27ff6e1b0c688c7ce776bf)
