### PR TITLE
Fix doc gen typo

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1323,7 +1323,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         """
         BaseVariable._genDocs(self,file)
 
-        for a in ['offset', 'numValues', 'bitSize', 'bitOffset', 'verify', 'varBytes']:
+        for a in ['offset', 'numValues', 'bitSize', 'bitOffset', 'verifyEn', 'varBytes']:
             astr = str(getattr(self,a))
 
             if astr != 'None':


### PR DESCRIPTION
Fixes a typo that was breaking document generation. 

This also updates the Process pydm window to generate a "Exec" button instead of an input field when a command does not take a arg.