### PR TITLE
Handle commands without arg in process widget

### DIFF
--- a/python/pyrogue/pydm/widgets/process.py
+++ b/python/pyrogue/pydm/widgets/process.py
@@ -114,6 +114,11 @@ class Process(PyDMFrame):
                     w.showStepExponent      = False
                     w.writeOnPress          = True
 
+                elif v.isCommand and not v.arg:
+                    w = PyDMPushButton(label='Exec',
+                                       pressValue=1,
+                                       init_channel=self._path + '.{}/disp'.format(v.name))
+
                 else:
                     w = PyRogueLineEdit(parent=None, init_channel=self._path + '.{}/disp'.format(v.name))
                     w.showUnits             = True


### PR DESCRIPTION
Handle commands without arg in process widget.

This ensures a button is present for process commands that do not take an arg.