### PR TITLE
Update variable wait to allow for triggering on any update

### DIFF
--- a/docs/src/interfaces/clients/virtual.rst
+++ b/docs/src/interfaces/clients/virtual.rst
@@ -77,7 +77,7 @@ The VariableWait helper function can also be used.
 .. code-block:: python
 
    # Wait for the uptime to be greater than 1000 seconds
-   VariableWait(root.AxiVersion.UpTime, lambda varValues: varValues['root.UpTime'].value > 1000)
+   VariableWait([root.AxiVersion.UpTime], lambda varValues: varValues[0].value > 1000)
 
 The VirtualClient maintains a connection to the Rogue core. The status of this connection
 can be directly accessed through the linked attribute. Additionally a callback function

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -77,10 +77,6 @@ class Process(pr.Device):
             value = 1,
             description = "Total number of loops steps for the process"))
 
-        @self.command(hidden=True)
-        def Advance(arg):
-            self._incrementSteps(1)
-
         # Add arg variable if not already added
         if self._argVar is not None and self._argVar not in self:
             self.add(self._argVar)

--- a/python/pyrogue/_Process.py
+++ b/python/pyrogue/_Process.py
@@ -169,10 +169,11 @@ class Process(pr.Device):
         # No function run example process
         else:
             self.Message.setDisp("Started")
+            self.TotalSteps.set(100)
             for i in range(101):
                 if self._runEn is False:
                     break
                 time.sleep(1)
-                self.Progress.set(i/100)
+                self._setSteps(i+1)
                 self.Message.setDisp(f"Running for {i} seconds.")
             self.Message.setDisp("Done")


### PR DESCRIPTION
This adds an update flag to the local VariableValue class used in the variable wait lambda function. This allows VariableWait to stall on an update of a variable without caring about a particular value. This is useful for variables which are updated on data reception.

This also updates the incorrect documentation and code comments.

The Advance function is removed from the Process class and the default example loop updates are fixed. 