### PR TITLE
Document removal of legacy GUI

### DIFF
--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -126,3 +126,28 @@ The reasoning is that a lot happens behind the scences when changing a
 poll interval, and masking this with a setter decorator gives the user
 the impression that it is much simpler than it is.
 
+Previously Deprecated Legacy GUI has Been Removed
+=================================================
+
+The legacy GUI has been removed. You can no longer use the following
+code to launch a generic tree GUI.
+
+.. code::
+   import pyrogue.gui
+
+   with Root(...) as root:
+       appTop = pyrogue.gui.application(sys.argv)
+       guiTop = pyrogue.gui.GuiTop()
+       guiTop.addTree(root)
+       guiTop.resize(800, 800)
+       appTop.exec_()
+
+Instead, use the new PyDM GUI
+
+.. code::
+   import pyrogue.pydm
+
+   with Root(...) as root:
+       pyrogue.pydm.runPyDM(
+           serverList=root.zmqServer.address,
+           title='GUI Window Title')

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -132,7 +132,7 @@ Previously Deprecated Legacy GUI has Been Removed
 The legacy GUI has been removed. You can no longer use the following
 code to launch a generic tree GUI.
 
-.. code::
+.. code:: python
    
    import pyrogue.gui
 
@@ -145,7 +145,7 @@ code to launch a generic tree GUI.
 
 Instead, use the new PyDM GUI
 
-.. code::
+.. code:: python
    
    import pyrogue.pydm
 

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -133,6 +133,7 @@ The legacy GUI has been removed. You can no longer use the following
 code to launch a generic tree GUI.
 
 .. code::
+   
    import pyrogue.gui
 
    with Root(...) as root:
@@ -145,6 +146,7 @@ code to launch a generic tree GUI.
 Instead, use the new PyDM GUI
 
 .. code::
+   
    import pyrogue.pydm
 
    with Root(...) as root:

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -132,7 +132,7 @@ Previously Deprecated Legacy GUI has Been Removed
 The legacy GUI has been removed. You can no longer use the following
 code to launch a generic tree GUI.
 
-.. code:: python
+.. code-block:: python
    
    import pyrogue.gui
 
@@ -145,7 +145,7 @@ code to launch a generic tree GUI.
 
 Instead, use the new PyDM GUI
 
-.. code:: python
+.. code-block:: python
    
    import pyrogue.pydm
 

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -132,7 +132,7 @@ Previously Deprecated Legacy GUI has Been Removed
 The legacy GUI has been removed. You can no longer use the following
 code to launch a generic tree GUI.
 
-.. code-block:: python
+.. code::
    
    import pyrogue.gui
 
@@ -145,7 +145,7 @@ code to launch a generic tree GUI.
 
 Instead, use the new PyDM GUI
 
-.. code-block:: python
+.. code::
    
    import pyrogue.pydm
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
The Rogue documentation has been updated to note that the legacy GUI was removed in Rogue 6. Examples have been provided for how to migrate to the new PyDM GUI.