### PR TITLE
updating typeStr for Fixed/UFixed to match AMD naming convention

### DIFF
--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -699,7 +699,7 @@ class Fixed(Model):
 
     def __init__(self, bitSize, binPoint):
         super().__init__(bitSize,binPoint)
-        self.name = f'Fixed_{self.bitSize-self.binPoint-1}_{self.binPoint}'
+        self.name = f'Fixed_{self.bitSize}_{self.binPoint}'
         self.ndType = np.dtype(np.float64)
 
 class UFixed(Model):
@@ -721,5 +721,5 @@ class UFixed(Model):
 
     def __init__(self, bitSize, binPoint):
         super().__init__(bitSize,binPoint)
-        self.name = f'UFixed_{self.bitSize-self.binPoint-1}_{self.binPoint}'
+        self.name = f'UFixed_{self.bitSize}_{self.binPoint}'
         self.ndType = np.dtype(np.float64)


### PR DESCRIPTION
### Description
- This changes the 1st number in the fixed/ufixed typeStr from {self.bitSize} instead {self.bitSize-self.binPoint-1} to match the AMD naming convention

![image](https://github.com/slaclab/rogue/assets/11821758/054f8711-e4e3-49c0-9441-1ec618518875)
