### PR TITLE
Update migration guide

### DIFF
--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -13,7 +13,7 @@ This biggest impacting change in Rogue V6 is to remove the ZmqServer feature fro
 
 Similiarly the previous feature which allowed the user to pass the root class to pydm to figure out the server port no longer works. Below is an example of including the ZmqServer in your root class and then using it with pydm.
 
-.. code::
+.. code-block:: python
 
    class ExampleRoot(pyrogue.Root):
 
@@ -39,7 +39,7 @@ SqlLogger
 
 Similiar to the zmqServer, the sql logger is now removed to be an external interface. See below for example usage of the sql logger:
 
-.. code::
+.. code-block:: python
 
    class ExampleRoot(pyrogue.Root):
 
@@ -61,7 +61,7 @@ Root Configuration Streaming
 
 In previous versions of rogue the Root class automatically supported the ability to stream configuration changes. This allowed the Root class to be added as a stream source to the StreamWriter class allow for configuration changes and status updates to be logged alongside the event data. In RogueV6 this feature is removed from the Root class with a new Variable streaming class which provides the same functionality. See below for an example of using this new class to stream configuration changes to the StreamWriter. This new method continues to support dumping the current status to the file immediatly after opening and right before closing:.
 
-.. code::
+.. code-block:: python
 
    class ExampleRoot(pyrogue.Root):
 
@@ -84,7 +84,7 @@ EPICS Version 3 Channel Access Server
 
 Epics version 3 channel access server is removed from Rogue V6. Please use the epics 4 pv access server (P4P) instead:
 
-.. code::
+.. code-block:: python
 
    class ExampleRoot(pyrogue.Root):
 
@@ -107,7 +107,7 @@ The ``_rawWrite(address, wrValue)`` and ``rdValue = _rawRead(address)`` can be r
 
 For a single write/read:
 
-.. code::
+.. code-block:: python
 
     # Declare register
     self.add(
@@ -130,7 +130,7 @@ For a single write/read:
 
 For a block write:
 
-.. code::
+.. code-block:: python
 
     # Declare ram register
     ## bitSize: ram size in bits (e.g.: 1024 words of 32b)
@@ -170,13 +170,13 @@ Setting pollInterval
 There API for setting a Variable's pollInterval has
 changed. Previously, it could be set directly:
 
-.. code::
+.. code-block:: python
 
    someVar.pollInterval = 5   # Poll someVar every 5 seconds
 
 This has been deprecated in favor of:
 
-.. code::
+.. code-block:: python
 
    someVar.setPollInterval(5)  # Poll someVar every 5 seconds
 
@@ -191,7 +191,7 @@ Previously Deprecated Legacy GUI has Been Removed
 The legacy GUI has been removed. You can no longer use the following
 code to launch a generic tree GUI.
 
-.. code::
+.. code-block:: python
    
    import pyrogue.gui
 
@@ -204,7 +204,7 @@ code to launch a generic tree GUI.
 
 Instead, use the new PyDM GUI
 
-.. code::
+.. code-block:: python
    
    import pyrogue.pydm
 

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -103,6 +103,63 @@ RawWrite and RawRead
 
 The deprecated rawWrite and rawRead calls are removed from Rogue V6. The new array variables added in Rogue V5 make these calls no longer needed. The user should no longer pass a 'size' arg to the Device class and then use rawWrite and rawRead to access memory space. Instead a array Variable should be used with the appropriate similiar size. The large Variables can then be configured to be excluded from the bulk read and write transactions and can also have other smaller Variables mapped to specific locations in the overall register space. See below for an example of how a Device can be upgraded to use list Variables instead of the rawWrite and rawRead calls:
 
+The ``_rawWrite(address, wrValue)`` and ``rdValue = _rawRead(address)`` can be replaced as following.
+
+For a single write/read:
+
+.. code::
+    # Declare register
+    self.add(
+        pr.RemoteVariable(
+            name='egReg',
+            description='Example',
+            offset=address,
+            bitSize=32,
+            bitOffset=0,
+            base=pr.UInt,
+            mode='RW',
+       )
+    )
+
+    # Write
+    self.egReg.set(wrValue)
+
+    # Read
+    rdValue = self.egReg.get()
+
+For a block write:
+
+.. code::
+    # Declare ram register
+    ## bitSize: ram size in bits (e.g.: 1024 words of 32b)
+    ## numValues: number of words (e.g.: 1024 words)
+    ## valueBits: word size (e.g.: 32bits)
+    ## valueStride: word size (e.g.: 32bits)
+
+    self.add(pr.RemoteVariable(
+        name         = 'ramReg',
+        description  = 'Example',
+        offset       = address,
+        bitSize      = 32*1024,
+        bitOffset    = 0,
+        numValues    = 1024,
+        valueBits    = 32,
+        valueStride  = 32,
+        bulkOpEn     = False, # FALSE for large variables
+        base         = pr.Int,
+        mode         = "RW",
+    ))
+
+    # For the example, a random array of 1024 words is generated
+    values = np.random.rand(1024)
+
+    # Loop through the values
+    for idx in range(len(values)):
+        self.ramReg.set(value=values[idx], index=idx, write=False)
+
+    # Send the write command
+    self.ramReg.write()
+
 
 
 Setting pollInterval

--- a/docs/src/migration/rogue_v6.rst
+++ b/docs/src/migration/rogue_v6.rst
@@ -108,6 +108,7 @@ The ``_rawWrite(address, wrValue)`` and ``rdValue = _rawRead(address)`` can be r
 For a single write/read:
 
 .. code::
+
     # Declare register
     self.add(
         pr.RemoteVariable(
@@ -130,6 +131,7 @@ For a single write/read:
 For a block write:
 
 .. code::
+
     # Declare ram register
     ## bitSize: ram size in bits (e.g.: 1024 words of 32b)
     ## numValues: number of words (e.g.: 1024 words)


### PR DESCRIPTION
### Description
Add `_rawWrite` and `_rawRead` examples in `migration to v.6` guide.
