### PR TITLE
Fix bugs which did not allow array variables to share memory

### DIFF
--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -67,19 +67,19 @@ class Variable {
     // Bit reverse flag
     bool bitReverse_;
 
-    // Total number of bits for this value
+    // Total number of used bits for this value, used for standard non list variables
     uint32_t bitTotal_;
 
     // Fast copy base array
     uint32_t* fastByte_;
 
-    // Total bytes (rounded up) for this value
+    // Total bytes (rounded up) for this value, based upon bitTotal_
     uint32_t byteSize_;
 
-    // Variable coverage bytes
+    // Variable coverage bytes, regardless of if bits are used
     uint32_t varBytes_;
 
-    // Variable offset
+    // Variable offset, in bytes
     uint64_t offset_;
 
     // Array of bit offsets
@@ -110,16 +110,10 @@ class Variable {
     bool verifyEn_;
 
     // Low byte value
-    uint32_t lowTranByte_;
+    uint32_t* lowTranByte_;
 
     // High byte value
-    uint32_t highTranByte_;
-
-    // Low byte value for list variables
-    uint32_t* listLowTranByte_;
-
-    // High byte value for list variables
-    uint32_t* listHighTranByte_;
+    uint32_t* highTranByte_;
 
     // Poiner to custom data
     void* customData_;

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -715,6 +715,7 @@ class Device(pr.Node,rim.Hub):
 
         # Sort var list by offset, size
         remVars.sort(key=lambda x: (x.offset, x.varBytes))
+        print(remVars)
         blocks = []
         blk = None
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -709,13 +709,15 @@ class Device(pr.Node,rim.Hub):
 
             # Align to min access, create list of remote variables
             elif isinstance(n,pr.RemoteVariable) and n.offset is not None:
+                self._log.info(f"Before Shift variable {n.name} offset={n.offset} bitSize={n.bitSize} bytes={n.varBytes}")
                 n._updatePath(n.path)
                 n._shiftOffsetDown(n.offset % blkSize, blkSize)
                 remVars += [n]
 
+                self._log.info(f"Creating variable {n.name} offset={n.offset} bitSize={n.bitSize} bytes={n.varBytes}")
+
         # Sort var list by offset, size
         remVars.sort(key=lambda x: (x.offset, x.varBytes))
-        print(remVars)
         blocks = []
         blk = None
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1037,7 +1037,9 @@ class RemoteVariable(BaseVariable,rim.Variable):
                 raise VariableError(f'ValueBits {valueBits} is greater than valueStrude {valueStride}')
 
             # Override the bitSize
-            bitSize[0] = numValues * valueStride
+            bitSize[0] = numValues * valueBits
+
+            print(f"List var: numValues={numValues}, valueStride={valueStride}, bitSize={bitSize[0]}")
 
             if self._ndType is None:
                 raise VariableError(f'Invalid base type {self._base} with numValues = {numValues}')

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1039,8 +1039,6 @@ class RemoteVariable(BaseVariable,rim.Variable):
             # Override the bitSize
             bitSize[0] = numValues * valueBits
 
-            print(f"List var: numValues={numValues}, valueStride={valueStride}, bitSize={bitSize[0]}")
-
             if self._ndType is None:
                 raise VariableError(f'Invalid base type {self._base} with numValues = {numValues}')
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -167,64 +167,59 @@ rim::Variable::Variable(std::string name,
     valueStride_  = valueStride;
     retryCount_   = retryCount;
 
-    // Compute bit total
-    bitTotal_ = bitSize_[0];
-    for (x = 1; x < bitSize_.size(); x++) bitTotal_ += bitSize_[x];
-
-    // Compute rounded up byte size
-    byteSize_ = (int)std::ceil((float)bitTotal_ / 8.0);
-
-    // Compute total bit range of accessed bits
-    varBytes_ = (int)std::ceil((float)(bitOffset_[bitOffset_.size() - 1] + bitSize_[bitSize_.size() - 1]) / 8.0);
-
-    // Compute the lowest byte
-    lowTranByte_ = (int)std::floor((float)bitOffset_[0] / 8.0);
-
-    // Compute the highest byte
-    highTranByte_ = varBytes_ - 1;
-
-    // Init stale
-    stale_         = false;
-    staleLowByte_  = lowTranByte_;
-    staleHighByte_ = highTranByte_;
-
-    // Variable can use fast copies
-    fastByte_ = NULL;
-
+    // Not a list variable
     if (numValues_ == 0) {
-        valueBits_        = bitTotal_;
-        valueStride_      = bitTotal_;
-        valueBytes_       = byteSize_;
-        listLowTranByte_  = NULL;
-        listHighTranByte_ = NULL;
-    } else {
-        valueBytes_       = (uint32_t)std::ceil((float)(valueBits_) / 8.0);
-        listLowTranByte_  = (uint32_t*)malloc(numValues_ * sizeof(uint32_t));
-        listHighTranByte_ = (uint32_t*)malloc(numValues_ * sizeof(uint32_t));
 
-        for (x = 0; x < numValues_; x++) {
-            listLowTranByte_[x] = (uint32_t)std::floor(((float)bitOffset_[0] + (float)x * (float)valueStride_) / 8.0);
-            listHighTranByte_[x] =
-                (uint32_t)std::ceil(((float)bitOffset_[0] + (float)(x + 1) * (float)valueStride_) / 8.0) - 1;
-        }
+        // Compute bit total
+        bitTotal_ = bitSize_[0];
+        for (x = 1; x < bitSize_.size(); x++) bitTotal_ += bitSize_[x];
+
+        // Compute rounded up byte size
+        byteSize_ = (int)std::ceil((float)bitTotal_ / 8.0);
+
+        lowTranByte_ = (uint32_t*)malloc(sizeof(uint32_t));
+        highTranByte_ = (uint32_t*)malloc(sizeof(uint32_t));
+
+        // Init remaining fields
+        valueBytes_ = 0;
     }
 
-    // Bit offset vector must have one entry, the offset must be byte aligned and the total number of bits must be byte
-    // aligned
+    // List variables
+    else {
+
+        // Compute bit total
+        bitTotal_ = bitSize_[0];
+
+        // Compute rounded up byte size
+        byteSize_ = (int)std::ceil((float)bitTotal_ / 8.0);
+
+        // Compute total bit range of accessed bits
+        valueBytes_ = (uint32_t)std::ceil((float)(valueBits_) / 8.0);
+
+        // High and low byte tracking
+        lowTranByte_ = (uint32_t*)malloc(numValues_ * sizeof(uint32_t));
+        highTranByte_ = (uint32_t*)malloc(numValues_ * sizeof(uint32_t));
+    }
+
+    // Byte array for fast copies
+    fastByte_ = NULL;
+
+    // Determine if fast byte copies can be utilized
+    // Bit offset vector must have one entry, the offset must be byte aligned and the total number of bits must be byte aligned
     if ((bitOffset_.size() == 1) && (bitOffset_[0] % 8 == 0) && (bitSize_[0] % 8 == 0)) {
+
         // Standard variable
-        if (numValues_ == 0) {
-            fastByte_    = (uint32_t*)malloc(sizeof(uint32_t));
-            fastByte_[0] = bitOffset_[0] / 8;
-        }
+        if (numValues_ == 0) fastByte_ = (uint32_t*)malloc(sizeof(uint32_t));
 
         // List variable
         else if ((valueBits_ % 8) == 0 && (valueStride_ % 8) == 0) {
             fastByte_ = (uint32_t*)malloc(numValues_ * sizeof(uint32_t));
-
-            for (x = 0; x < numValues_; x++) fastByte_[x] = (bitOffset_[0] + (valueStride_ * x)) / 8;
         }
     }
+    stale_ = false;
+
+    // Call aligning function to init values
+    shiftOffsetDown(0, 1);
 
     // Custom data is NULL for now
     customData_ = NULL;
@@ -446,8 +441,8 @@ rim::Variable::Variable(std::string name,
 
 // Destroy the variable
 rim::Variable::~Variable() {
-    if (listLowTranByte_ != NULL) free(listLowTranByte_);
-    if (listHighTranByte_ != NULL) free(listHighTranByte_);
+    if (lowTranByte_ != NULL) free(lowTranByte_);
+    if (highTranByte_ != NULL) free(highTranByte_);
     if (fastByte_ != NULL) free(fastByte_);
 }
 
@@ -460,26 +455,31 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
         for (x = 0; x < bitOffset_.size(); x++) bitOffset_[x] += shift * 8;
     }
 
-    // Compute total bit range of accessed bits, aligned to min size
-    varBytes_ = (int)std::ceil((float)(bitOffset_[bitOffset_.size() - 1] + bitSize_[bitSize_.size() - 1]) /
-                               ((float)minSize * 8.0)) *
-                minSize;
+    // Standard variable
+    if ( numValues_ == 0 ) {
 
-    // Compute the lowest byte, aligned to min access
-    lowTranByte_ = (int)std::floor((float)bitOffset_[0] / ((float)minSize * 8.0)) * minSize;
+        // Compute total bit range of accessed bytes
+        varBytes_ = (int)std::ceil((float)(bitOffset_[bitOffset_.size() - 1] + bitSize_[bitSize_.size() - 1]) / ((float)minSize * 8.0)) * minSize;
 
-    // Compute the highest byte, aligned to min access
-    highTranByte_ = varBytes_ - 1;
+        // Compute the lowest byte, aligned to min access
+        lowTranByte_[0] = (int)std::floor((float)bitOffset_[0] / ((float)minSize * 8.0)) * minSize;
+
+        // Compute the highest byte, aligned to min access
+        highTranByte_[0] = varBytes_ - 1;
+        staleHighByte_ = highTranByte_[0];
+    }
 
     // List variable
-    for (x = 0; x < numValues_; x++) {
-        listLowTranByte_[x] =
-            (uint32_t)std::floor(((float)bitOffset_[0] + (float)x * (float)valueStride_) / ((float)minSize * 8.0)) *
-            minSize;
-        listHighTranByte_[x] = (uint32_t)std::ceil(((float)bitOffset_[0] + (float)(x + 1) * (float)valueStride_) /
-                                                   ((float)minSize * 8.0)) *
-                                   minSize -
-                               1;
+    else {
+
+        for (x = 0; x < numValues_; x++) {
+            lowTranByte_[x] = (uint32_t)std::floor(((float)bitOffset_[0] + (float)x * (float)valueStride_) / ((float)minSize * 8.0)) * minSize;
+            highTranByte_[x] = (uint32_t)std::ceil(((float)bitOffset_[0] + (float)x * (float)valueStride_ + valueBits_) / ((float)minSize * 8.0)) * minSize - 1;
+        }
+
+        // Compute total bit range of accessed bytes
+        varBytes_ = highTranByte_[numValues_-1] - lowTranByte_[0] + 1;
+        staleHighByte_ = highTranByte_[numValues_-1];
     }
 
     // Adjust fast copy locations
@@ -491,6 +491,8 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
             for (x = 0; x < numValues_; x++) fastByte_[x] = (bitOffset_[0] + (valueStride_ * x)) / 8;
         }
     }
+
+    staleLowByte_  = lowTranByte_[0];
 }
 
 void rim::Variable::updatePath(std::string path) {

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -181,7 +181,9 @@ rim::Variable::Variable(std::string name,
         highTranByte_ = (uint32_t*)malloc(sizeof(uint32_t));
 
         // Init remaining fields
-        valueBytes_ = 0;
+        valueBytes_ = byteSize_;
+        valueBits_ = bitTotal_;
+        valueStride_ = bitTotal_;
     }
 
     // List variables

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -11,7 +11,7 @@
 import pyrogue as pr
 import rogue
 
-rogue.Logging.setLevel(rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Debug)
 
 class SimpleVarDevice(pr.Device):
     def __init__(self, **kwargs):

--- a/tests/test_block_overlap.py
+++ b/tests/test_block_overlap.py
@@ -11,7 +11,7 @@
 import pyrogue as pr
 import rogue
 
-#rogue.Logging.setLevel(rogue.Logging.Debug)
+rogue.Logging.setLevel(rogue.Logging.Debug)
 
 class SimpleVarDevice(pr.Device):
     def __init__(self, **kwargs):
@@ -41,7 +41,6 @@ class BlockDevice(pr.Device):
             name         = "DataBlock",
             description  = "Large Data Block",
             offset       = 0,
-            bitSize      = 32 * numRegs,
             bitOffset    = 0,
             numValues    = numRegs,
             valueBits    = 32,
@@ -70,7 +69,6 @@ class BlockDevice(pr.Device):
             name         = "ListVar",
             description  = "List Variable",
             offset       = (numRegs//2)*4,
-            bitSize      = 32 * numRegs//2,
             bitOffset    = 0,
             numValues    = numRegs//2,
             valueBits    = 32,

--- a/tests/test_list_memory.py
+++ b/tests/test_list_memory.py
@@ -42,7 +42,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'UInt32List',
             offset       = 0x0000,
-            bitSize      = 32 * 32,
             bitOffset    = 0x0000,
             base         = pr.UInt,
             mode         = 'RW',
@@ -55,7 +54,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'Int32List',
             offset       = 0x1000,
-            bitSize      = 32 * 32,
             bitOffset    = 0x0000,
             base         = pr.Int,
             mode         = 'RW',
@@ -68,7 +66,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'UInt48List',
             offset       = 0x2000,
-            bitSize      = 48 * 32,
             bitOffset    = 0x0000,
             base         = pr.UInt,
             mode         = 'RW',
@@ -81,7 +78,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'FloatList',
             offset       = 0x3000,
-            bitSize      = 32 * 32,
             bitOffset    = 0x0000,
             base         = pr.Float,
             mode         = 'RW',
@@ -94,7 +90,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'DoubleList',
             offset       = 0x4000,
-            bitSize      = 64 * 32,
             bitOffset    = 0x0000,
             base         = pr.Double,
             mode         = 'RW',
@@ -107,7 +102,6 @@ class ListDevice(pr.Device):
         self.add(pr.RemoteVariable(
             name         = 'UInt16List',
             offset       = 0x5000,
-            bitSize      = 16 * 32,
             bitOffset    = 0x0000,
             base         = pr.UInt,
             mode         = 'RW',
@@ -118,9 +112,32 @@ class ListDevice(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = 'UInt21List',
+            name         = 'UInt16Pack0',
             offset       = 0x6000,
-            bitSize      = 32 * 32,
+            bitOffset    = 0x0000,
+            base         = pr.UInt,
+            mode         = 'RW',
+            disp         = '{}',
+            numValues    = 32,
+            valueBits    = 16,
+            valueStride  = 32
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'UInt16Pack1',
+            offset       = 0x6000,
+            bitOffset    = 16,
+            base         = pr.UInt,
+            mode         = 'RW',
+            disp         = '{}',
+            numValues    = 32,
+            valueBits    = 16,
+            valueStride  = 32
+        ))
+
+        self.add(pr.RemoteVariable(
+            name         = 'UInt21List',
+            offset       = 0x7000,
             bitOffset    = 0x0000,
             base         = pr.UInt,
             mode         = 'RW',
@@ -132,8 +149,7 @@ class ListDevice(pr.Device):
 
         self.add(pr.RemoteVariable(
             name         = 'BoolList',
-            offset       = 0x7000,
-            bitSize      = 32,
+            offset       = 0x8000,
             bitOffset    = 0x0000,
             base         = pr.Bool,
             mode         = 'RW',
@@ -163,32 +179,38 @@ class DummyTree(pr.Root):
 
 def test_memory():
 
-    UInt32ListARaw = [int(random.random()*1000) for i in range(32)]
-    Int32ListARaw  = [int(random.random()*1000) for i in range(32)]
-    UInt48ListARaw = [int(random.random()*1000) for i in range(32)]
-    FloatListARaw  = [random.random()*1000 for i in range(32)]
-    DoubleListARaw = [random.random()*1000 for i in range(32)]
-    UInt16ListARaw = [int(random.random()*1000) for i in range(32)]
-    UInt21ListARaw = [int(random.random()*1000) for i in range(32)]
-    BoolListARaw   = [int(random.random()*1000)%2==0 for i in range(32)]
+    UInt32ListARaw  = [int(random.random()*1000) for i in range(32)]
+    Int32ListARaw   = [int(random.random()*1000) for i in range(32)]
+    UInt48ListARaw  = [int(random.random()*1000) for i in range(32)]
+    FloatListARaw   = [random.random()*1000 for i in range(32)]
+    DoubleListARaw  = [random.random()*1000 for i in range(32)]
+    UInt16ListARaw  = [int(random.random()*1000) for i in range(32)]
+    UInt16Pack0ARaw = [int(random.random()*1000) for i in range(32)]
+    UInt16Pack1ARaw = [int(random.random()*1000) for i in range(32)]
+    UInt21ListARaw  = [int(random.random()*1000) for i in range(32)]
+    BoolListARaw    = [int(random.random()*1000)%2==0 for i in range(32)]
 
-    UInt32ListA = np.array(UInt32ListARaw,np.uint32)
-    Int32ListA  = np.array(Int32ListARaw,np.int32)
-    UInt48ListA = np.array(UInt48ListARaw,np.uint64)
-    FloatListA  = np.array(FloatListARaw,np.float32)
-    DoubleListA = np.array(DoubleListARaw,np.float64)
-    UInt16ListA = np.array(UInt16ListARaw,np.uint32)
-    UInt21ListA = np.array(UInt21ListARaw,np.uint32)
-    BoolListA   = np.array(BoolListARaw,bool)
+    UInt32ListA  = np.array(UInt32ListARaw,np.uint32)
+    Int32ListA   = np.array(Int32ListARaw,np.int32)
+    UInt48ListA  = np.array(UInt48ListARaw,np.uint64)
+    FloatListA   = np.array(FloatListARaw,np.float32)
+    DoubleListA  = np.array(DoubleListARaw,np.float64)
+    UInt16ListA  = np.array(UInt16ListARaw,np.uint32)
+    UInt16Pack0A = np.array(UInt16Pack0ARaw,np.uint32)
+    UInt16Pack1A = np.array(UInt16Pack1ARaw,np.uint32)
+    UInt21ListA  = np.array(UInt21ListARaw,np.uint32)
+    BoolListA    = np.array(BoolListARaw,bool)
 
-    UInt32ListB = [int(random.random()*1000) for i in range(32)]
-    Int32ListB  = [int(random.random()*1000) for i in range(32)]
-    UInt48ListB = [int(random.random()*1000) for i in range(32)]
-    FloatListB  = [random.random()*1000 for i in range(32)]
-    DoubleListB = [random.random()*1000 for i in range(32)]
-    UInt16ListB = [int(random.random()*1000) for i in range(32)]
-    UInt21ListB = [int(random.random()*1000) for i in range(32)]
-    BoolListB   = [int(random.random()*1000)%2==0 for i in range(32)]
+    UInt32ListB  = [int(random.random()*1000) for i in range(32)]
+    Int32ListB   = [int(random.random()*1000) for i in range(32)]
+    UInt48ListB  = [int(random.random()*1000) for i in range(32)]
+    FloatListB   = [random.random()*1000 for i in range(32)]
+    DoubleListB  = [random.random()*1000 for i in range(32)]
+    UInt16ListB  = [int(random.random()*1000) for i in range(32)]
+    UInt16Pack0B = [int(random.random()*1000) for i in range(32)]
+    UInt16Pack1B = [int(random.random()*1000) for i in range(32)]
+    UInt21ListB  = [int(random.random()*1000) for i in range(32)]
+    BoolListB    = [int(random.random()*1000)%2==0 for i in range(32)]
 
     with DummyTree() as root:
 
@@ -199,36 +221,44 @@ def test_memory():
             root.ListDevice.FloatList.set(FloatListARaw)
             root.ListDevice.DoubleList.set(DoubleListARaw)
             root.ListDevice.UInt16List.set(UInt16ListARaw)
+            root.ListDevice.UInt16Pack0.set(UInt16Pack0ARaw)
+            root.ListDevice.UInt16Pack1.set(UInt16Pack1ARaw)
             root.ListDevice.UInt21List.set(UInt21ListARaw)
             root.ListDevice.BoolList.set(BoolListARaw)
 
-            UInt32ListAA = root.ListDevice.UInt32List.get()
-            Int32ListAA  = root.ListDevice.Int32List.get()
-            UInt48ListAA = root.ListDevice.UInt48List.get()
-            FloatListAA  = root.ListDevice.FloatList.get()
-            DoubleListAA = root.ListDevice.DoubleList.get()
-            UInt16ListAA = root.ListDevice.UInt16List.get()
-            UInt21ListAA = root.ListDevice.UInt21List.get()
-            BoolListAA   = root.ListDevice.BoolList.get()
+            UInt32ListAA  = root.ListDevice.UInt32List.get()
+            Int32ListAA   = root.ListDevice.Int32List.get()
+            UInt48ListAA  = root.ListDevice.UInt48List.get()
+            FloatListAA   = root.ListDevice.FloatList.get()
+            DoubleListAA  = root.ListDevice.DoubleList.get()
+            UInt16ListAA  = root.ListDevice.UInt16List.get()
+            UInt16Pack0AA = root.ListDevice.UInt16Pack0.get()
+            UInt16Pack1AA = root.ListDevice.UInt16Pack1.get()
+            UInt21ListAA  = root.ListDevice.UInt21List.get()
+            BoolListAA    = root.ListDevice.BoolList.get()
 
-            UInt32ListAB = np.array([0] * 32,np.uint32)
-            Int32ListAB  = np.array([0] * 32,np.int32)
-            UInt48ListAB = np.array([0] * 32,np.uint64)
-            FloatListAB  = np.array([0] * 32,np.float32)
-            DoubleListAB = np.array([0] * 32,np.float64)
-            UInt16ListAB = np.array([0] * 32,np.uint32)
-            UInt21ListAB = np.array([0] * 32,np.uint32)
-            BoolListAB   = np.array([0] * 32,bool)
+            UInt32ListAB  = np.array([0] * 32,np.uint32)
+            Int32ListAB   = np.array([0] * 32,np.int32)
+            UInt48ListAB  = np.array([0] * 32,np.uint64)
+            FloatListAB   = np.array([0] * 32,np.float32)
+            DoubleListAB  = np.array([0] * 32,np.float64)
+            UInt16ListAB  = np.array([0] * 32,np.uint32)
+            UInt16Pack0AB = np.array([0] * 32,np.uint32)
+            UInt16Pack1AB = np.array([0] * 32,np.uint32)
+            UInt21ListAB  = np.array([0] * 32,np.uint32)
+            BoolListAB    = np.array([0] * 32,bool)
 
             for i in range(32):
-                UInt32ListAB[i] = root.ListDevice.UInt32List.get(index=i)
-                Int32ListAB[i]  = root.ListDevice.Int32List.get(index=i)
-                UInt48ListAB[i] = root.ListDevice.UInt48List.get(index=i)
-                FloatListAB[i]  = root.ListDevice.FloatList.get(index=i)
-                DoubleListAB[i] = root.ListDevice.DoubleList.get(index=i)
-                UInt16ListAB[i] = root.ListDevice.UInt16List.get(index=i)
-                UInt21ListAB[i] = root.ListDevice.UInt21List.get(index=i)
-                BoolListAB[i]   = root.ListDevice.BoolList.get(index=i)
+                UInt32ListAB[i]  = root.ListDevice.UInt32List.get(index=i)
+                Int32ListAB[i]   = root.ListDevice.Int32List.get(index=i)
+                UInt48ListAB[i]  = root.ListDevice.UInt48List.get(index=i)
+                FloatListAB[i]   = root.ListDevice.FloatList.get(index=i)
+                DoubleListAB[i]  = root.ListDevice.DoubleList.get(index=i)
+                UInt16ListAB[i]  = root.ListDevice.UInt16List.get(index=i)
+                UInt16Pack0AB[i] = root.ListDevice.UInt16Pack0.get(index=i)
+                UInt16Pack1AB[i] = root.ListDevice.UInt16Pack1.get(index=i)
+                UInt21ListAB[i]  = root.ListDevice.UInt21List.get(index=i)
+                BoolListAB[i]    = root.ListDevice.BoolList.get(index=i)
 
             for i in range(32):
                 if UInt32ListAA[i] != UInt32ListA[i]:
@@ -248,6 +278,12 @@ def test_memory():
 
                 if UInt16ListAA[i] != UInt16ListA[i]:
                     raise AssertionError(f'Verification Failure for UInt16ListAA at position {i}')
+
+                if UInt16Pack0AA[i] != UInt16Pack0A[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack0AA at position {i}')
+
+                if UInt16Pack1AA[i] != UInt16Pack1A[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack1AA at position {i}')
 
                 if UInt21ListAA[i] != UInt21ListA[i]:
                     raise AssertionError(f'Verification Failure for UInt21ListAA at position {i}')
@@ -270,6 +306,12 @@ def test_memory():
                 if UInt16ListAB[i] != UInt16ListA[i]:
                     raise AssertionError(f'Verification Failure for UInt16ListAB at position {i}')
 
+                if UInt16Pack0AB[i] != UInt16Pack0A[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack0AB at position {i}')
+
+                if UInt16Pack1AB[i] != UInt16Pack1A[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack1AB at position {i}')
+
                 if UInt21ListAB[i] != UInt21ListA[i]:
                     raise AssertionError(f'Verification Failure for UInt21ListAB at position {i}')
 
@@ -283,36 +325,44 @@ def test_memory():
                 root.ListDevice.FloatList.set(FloatListB[i],index=i)
                 root.ListDevice.DoubleList.set(DoubleListB[i],index=i)
                 root.ListDevice.UInt16List.set(UInt16ListB[i],index=i)
+                root.ListDevice.UInt16Pack0.set(UInt16Pack0B[i],index=i)
+                root.ListDevice.UInt16Pack1.set(UInt16Pack1B[i],index=i)
                 root.ListDevice.UInt21List.set(UInt21ListB[i],index=i)
                 root.ListDevice.BoolList.set(BoolListB[i],index=i)
 
-            UInt32ListBA = root.ListDevice.UInt32List.get()
-            Int32ListBA  = root.ListDevice.Int32List.get()
-            UInt48ListBA = root.ListDevice.UInt48List.get()
-            FloatListBA  = root.ListDevice.FloatList.get()
-            DoubleListBA = root.ListDevice.DoubleList.get()
-            UInt16ListBA = root.ListDevice.UInt16List.get()
-            UInt21ListBA = root.ListDevice.UInt21List.get()
-            BoolListBA   = root.ListDevice.BoolList.get()
+            UInt32ListBA  = root.ListDevice.UInt32List.get()
+            Int32ListBA   = root.ListDevice.Int32List.get()
+            UInt48ListBA  = root.ListDevice.UInt48List.get()
+            FloatListBA   = root.ListDevice.FloatList.get()
+            DoubleListBA  = root.ListDevice.DoubleList.get()
+            UInt16ListBA  = root.ListDevice.UInt16List.get()
+            UInt16Pack0BA = root.ListDevice.UInt16Pack0.get()
+            UInt16Pack1BA = root.ListDevice.UInt16Pack1.get()
+            UInt21ListBA  = root.ListDevice.UInt21List.get()
+            BoolListBA    = root.ListDevice.BoolList.get()
 
-            UInt32ListBB = np.array([0] * 32,np.uint32)
-            Int32ListBB  = np.array([0] * 32,np.int32)
-            UInt48ListBB = np.array([0] * 32,np.uint64)
-            FloatListBB  = np.array([0] * 32,np.float32)
-            DoubleListBB = np.array([0] * 32,np.float64)
-            UInt16ListBB = np.array([0] * 32,np.uint32)
-            UInt21ListBB = np.array([0] * 32,np.uint32)
-            BoolListBB   = np.array([0] * 32,bool)
+            UInt32ListBB  = np.array([0] * 32,np.uint32)
+            Int32ListBB   = np.array([0] * 32,np.int32)
+            UInt48ListBB  = np.array([0] * 32,np.uint64)
+            FloatListBB   = np.array([0] * 32,np.float32)
+            DoubleListBB  = np.array([0] * 32,np.float64)
+            UInt16ListBB  = np.array([0] * 32,np.uint32)
+            UInt16Pack0BB = np.array([0] * 32,np.uint32)
+            UInt16Pack1BB = np.array([0] * 32,np.uint32)
+            UInt21ListBB  = np.array([0] * 32,np.uint32)
+            BoolListBB    = np.array([0] * 32,bool)
 
             for i in range(32):
-                UInt32ListBB[i] = root.ListDevice.UInt32List.get(index=i)
-                Int32ListBB[i]  = root.ListDevice.Int32List.get(index=i)
-                UInt48ListBB[i] = root.ListDevice.UInt48List.get(index=i)
-                FloatListBB[i]  = root.ListDevice.FloatList.get(index=i)
-                DoubleListBB[i] = root.ListDevice.DoubleList.get(index=i)
-                UInt16ListBB[i] = root.ListDevice.UInt16List.get(index=i)
-                UInt21ListBB[i] = root.ListDevice.UInt21List.get(index=i)
-                BoolListBB[i]   = root.ListDevice.BoolList.get(index=i)
+                UInt32ListBB[i]  = root.ListDevice.UInt32List.get(index=i)
+                Int32ListBB[i]   = root.ListDevice.Int32List.get(index=i)
+                UInt48ListBB[i]  = root.ListDevice.UInt48List.get(index=i)
+                FloatListBB[i]   = root.ListDevice.FloatList.get(index=i)
+                DoubleListBB[i]  = root.ListDevice.DoubleList.get(index=i)
+                UInt16ListBB[i]  = root.ListDevice.UInt16List.get(index=i)
+                UInt16Pack0BB[i] = root.ListDevice.UInt16Pack0.get(index=i)
+                UInt16Pack1BB[i] = root.ListDevice.UInt16Pack1.get(index=i)
+                UInt21ListBB[i]  = root.ListDevice.UInt21List.get(index=i)
+                BoolListBB[i]    = root.ListDevice.BoolList.get(index=i)
 
             for i in range(32):
                 if UInt32ListBA[i] != UInt32ListB[i]:
@@ -333,6 +383,12 @@ def test_memory():
                 if UInt16ListBA[i] != UInt16ListB[i]:
                     raise AssertionError(f'Verification Failure for UInt16ListBA at position {i}')
 
+                if UInt16Pack0BA[i] != UInt16Pack0B[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack0BA at position {i}')
+
+                if UInt16Pack1BA[i] != UInt16Pack1B[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack1BA at position {i}')
+
                 if UInt21ListBA[i] != UInt21ListB[i]:
                     raise AssertionError(f'Verification Failure for UInt21ListBA at position {i}')
 
@@ -350,6 +406,12 @@ def test_memory():
 
                 if UInt16ListBB[i] != UInt16ListB[i]:
                     raise AssertionError(f'Verification Failure for UInt16ListBB at position {i}')
+
+                if UInt16Pack0BB[i] != UInt16Pack0B[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack0BB at position {i}')
+
+                if UInt16Pack1BB[i] != UInt16Pack1B[i]:
+                    raise AssertionError(f'Verification Failure for UInt16Pack1BB at position {i}')
 
                 if UInt21ListBB[i] != UInt21ListB[i]:
                     raise AssertionError(f'Verification Failure for UInt21ListBB at position {i}')


### PR DESCRIPTION
Existing code had a bug where you could not create list variables which shared memory space. For example a list of 32 - 16 bit values in the lower 16-bits of each 32-bit memory location, co-located with a list of 32 - 16 bit values in the upper 16-bit of each 32-bit memory location.

This PR fixes this error and also cleans up some of the code related to mapping bytes.