### PR TITLE
Post-build step to remove egg files

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -7,6 +7,13 @@ source:
 
 build:
    number: {{ environ.get('GIT_DESCRIBE_NUMBER',0) }}
+   script: |
+     # Existing build steps
+     python setup.py install
+
+     # Post-build step to remove egg files
+     find $SP_DIR -name "*.egg-info" -exec rm -rf {} +
+     find $SP_DIR -name "*.eggs" -exec rm -rf {} +
 
 requirements:
    build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -8,12 +8,12 @@ source:
 build:
    number: {{ environ.get('GIT_DESCRIBE_NUMBER',0) }}
    script: |
-     # Existing build steps
-     python setup.py install
-
-     # Post-build step to remove egg files
+     # Pre-build step to remove egg files
      find $SP_DIR -name "*.egg-info" -exec rm -rf {} +
      find $SP_DIR -name "*.eggs" -exec rm -rf {} +
+
+     # Existing build steps
+     python setup.py install
 
 requirements:
    build:


### PR DESCRIPTION
### Description
- Egg files from PIP install can mess up python environments.
- Make clean should remove the egg files.