### PR TITLE
Hot Fix: CMake and add memory emulate debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,9 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 # Boost + Python
 #####################################
 if ( NOT NO_PYTHON )
+
    # Find newest python interpreter first
-   set(Python3_FIND_STRATEGY "VERSION")
+   set(Python3_FIND_STRATEGY "LOCATION")
    find_package(Python3 QUIET REQUIRED COMPONENTS Interpreter Development)
 
    # Find Numpy
@@ -68,10 +69,6 @@ if ( NOT NO_PYTHON )
    # Hint for boost on anaconda
    if (DEFINED ENV{CONDA_PREFIX})
       set(Boost_ROOT $ENV{CONDA_PREFIX})
-
-   # SLAC AFS custom path
-   elseif (DEFINED ENV{BOOST_PATH})
-      set(Boost_ROOT $ENV{BOOST_PATH})
    endif()
 
    # libboost_python3.7 style libraries

--- a/include/rogue/interfaces/memory/Emulate.h
+++ b/include/rogue/interfaces/memory/Emulate.h
@@ -44,11 +44,19 @@ namespace memory {
  * and write transactions.
  */
 class Emulate : public Slave {
+
     // Map to store 4K address space chunks
     MAP_TYPE memMap_;
 
     // Lock
     std::mutex mtx_;
+
+    // Total allocated memory
+    uint32_t totAlloc_;
+    uint32_t totSize_;
+
+    //! Log
+    std::shared_ptr<rogue::Logging> log_;
 
   public:
     //! Class factory which returns a pointer to a Emulate (EmulatePtr)

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -90,7 +90,6 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
                memMap_.insert(std::make_pair(addr4k, (uint8_t*)malloc(0x1000)));
                totSize_ += 0x1000;
                totAlloc_ ++;
-               printf("Got Here\n");
                log_->debug("Allocating block at 0x%x. Total Blocks %i, Total Size = %i", addr4k, totAlloc_, totSize_);
             }
 

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -46,7 +46,11 @@ rim::EmulatePtr rim::Emulate::create(uint32_t min, uint32_t max) {
 }
 
 //! Create an block
-rim::Emulate::Emulate(uint32_t min, uint32_t max) : Slave(min, max) {}
+rim::Emulate::Emulate(uint32_t min, uint32_t max) : Slave(min, max) {
+   totAlloc_ = 0;
+   totSize_ = 0;
+   log_ = rogue::Logging::create("memory.Emulate");
+}
 
 //! Destroy a block
 rim::Emulate::~Emulate() {
@@ -82,7 +86,13 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
             size -= size4k;
             addr += size4k;
 
-            if (memMap_.find(addr4k) == memMap_.end()) memMap_.insert(std::make_pair(addr4k, (uint8_t*)malloc(0x1000)));
+            if (memMap_.find(addr4k) == memMap_.end()) {
+               memMap_.insert(std::make_pair(addr4k, (uint8_t*)malloc(0x1000)));
+               totSize_ += 0x1000;
+               totAlloc_ ++;
+               printf("Got Here\n");
+               log_->debug("Allocating block at 0x%x. Total Blocks %i, Total Size = %i", addr4k, totAlloc_, totSize_);
+            }
 
             // Write or post
             if (tran->type() == rogue::interfaces::memory::Write || tran->type() == rogue::interfaces::memory::Post) {


### PR DESCRIPTION
The existing Cmake script was broken in an anaconda environment. 

This also adds additional debug for the memory emulator. 