### PR TITLE
Fix minimum value for Int

### DIFF
--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -430,7 +430,7 @@ class Int(UInt):
 
     def minValue(self):
         """ """
-        return -1 * ((2**(self.bitSize-1))-1)
+        return -1 * (2**(self.bitSize-1))
 
     def maxValue(self):
         """ """


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
pyrogue's integer type had it's minimum value set to `-(2**(width-1)-1)`. In two's complement it's actually `-2**(width-1)`
