### PR TITLE
Fix var bytes calculation to support list variables which span transaction size

### DIFF
--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -518,9 +518,8 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                 if ((*vit)->overlapEn_) {
                     setBits(oleMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
 
-                    // Otherwise add to exclusive mask and check for existing mapping
+                // Otherwise add to exclusive mask and check for existing mapping
                 } else {
-
                     if (anyBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
                         throw(rogue::GeneralError::create(
                             "Block::addVariables",

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -511,7 +511,7 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                     (*vit)->verifyEn_);
             }
 
-            // List variables
+        // List variables
         } else {
             for (x = 0; x < (*vit)->numValues_; x++) {
                 // Variable allows overlaps, add to overlap enable mask
@@ -520,6 +520,9 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
 
                     // Otherwise add to exclusive mask and check for existing mapping
                 } else {
+
+                    printf("Overlap Check size = %i, index = %i, base = %i, bits = %i\n", size_, x, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
+
                     if (anyBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
                         throw(rogue::GeneralError::create(
                             "Block::addVariables",

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -521,8 +521,6 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                     // Otherwise add to exclusive mask and check for existing mapping
                 } else {
 
-                    printf("Overlap Check size = %i, index = %i, base = %i, bits = %i\n", size_, x, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
-
                     if (anyBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
                         throw(rogue::GeneralError::create(
                             "Block::addVariables",

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -487,7 +487,7 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
         }
 
         // Compute total bit range of accessed bytes
-        varBytes_      = highTranByte_[numValues_ - 1];
+        varBytes_      = highTranByte_[numValues_ - 1] + 1;
         staleHighByte_ = highTranByte_[numValues_ - 1];
     }
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -484,7 +484,6 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
                                              (static_cast<float>(minSize) * 8.0))) *
                                    minSize -
                                1;
-            printf("Idx = %i, low = %i, high = %i\n", x, lowTranByte_[x], highTranByte_[x]);
         }
 
         // Compute total bit range of accessed bytes

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -470,7 +470,7 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
         highTranByte_[0] = varBytes_ - 1;
         staleHighByte_   = highTranByte_[0];
 
-        // List variable
+    // List variable
     } else {
         for (x = 0; x < numValues_; x++) {
             lowTranByte_[x] =
@@ -484,10 +484,11 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
                                              (static_cast<float>(minSize) * 8.0))) *
                                    minSize -
                                1;
+            printf("Idx = %i, low = %i, high = %i\n", x, lowTranByte_[x], highTranByte_[x]);
         }
 
         // Compute total bit range of accessed bytes
-        varBytes_      = highTranByte_[numValues_ - 1] - lowTranByte_[0] + 1;
+        varBytes_      = highTranByte_[numValues_ - 1];
         staleHighByte_ = highTranByte_[numValues_ - 1];
     }
 

--- a/tests/test_list_memory.py
+++ b/tests/test_list_memory.py
@@ -16,7 +16,7 @@ import rogue.interfaces.memory
 import numpy as np
 import random
 
-rogue.Logging.setLevel(rogue.Logging.Debug)
+#rogue.Logging.setLevel(rogue.Logging.Debug)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)

--- a/tests/test_list_memory.py
+++ b/tests/test_list_memory.py
@@ -16,7 +16,7 @@ import rogue.interfaces.memory
 import numpy as np
 import random
 
-#rogue.Logging.setLevel(rogue.Logging.Warning)
+rogue.Logging.setLevel(rogue.Logging.Debug)
 #import logging
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This fixes how varBytes is calculated for list varibles. This change is neccessary to support list variables where the first entry of a list is beyond the min transaction size.

This does require that all entries added to a listVariable (block of memory) use the same offset value and use the bitOffset to define the location of each value in the block of memory.

