### PR TITLE
Add ability to pull a list value out in a pydm widget

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -27,3 +27,4 @@ dependencies:
   - matplotlib
   - pytest
   - pytest-cov
+  - pyqt=5.12

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -127,8 +127,8 @@ def VariableWait(varList, testFunction, timeout=0):
 
 class VariableValue(object):
     """ """
-    def __init__(self, var, read=False):
-        self.value     = var.get(read=read)
+    def __init__(self, var, read=False, index=-1):
+        self.value     = var.get(read=read,index=index)
         self.valueDisp = var.genDisp(self.value)
         self.disp      = var.disp
         self.enum      = var.enum
@@ -572,7 +572,7 @@ class BaseVariable(pr.Node):
         pass
 
     @pr.expose
-    def getVariableValue(self,read=True):
+    def getVariableValue(self,read=True,index=-1):
         """
         Return the value after performing a read from hardware if applicable.
         Hardware read is blocking. An error will result in a logged exception.
@@ -582,6 +582,8 @@ class BaseVariable(pr.Node):
         ----------
         read : bool
              (Default value = True)
+        index : int
+             (Default value = -1)
 
         Returns
         -------
@@ -590,7 +592,7 @@ class BaseVariable(pr.Node):
             Listeners will be informed of the update.
 
         """
-        return VariableValue(self,read=read)
+        return VariableValue(self,read=read,index=index)
 
     @pr.expose
     def value(self, index=-1):

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -33,10 +33,10 @@ AlarmToInt = {'None':0, 'Good':0, 'AlarmMinor':1, 'AlarmMajor':2}
 
 
 def parseAddress(address):
-    # "rogue://index/<path>/<mode>"
+    # "rogue://index/<path>/<mode>/<index>"
     # or
-    # "rogue://host:port/<path>/<mode>"
-    # Mode: 'Value', 'Disp', 'Name' or 'Path'
+    # "rogue://host:port/<path>/<mode>/<index>"
+    # Mode: 'value', 'disp', 'name' or 'path'
     envList = os.getenv('ROGUE_SERVERS')
 
     if envList is None:
@@ -58,12 +58,13 @@ def parseAddress(address):
     port = int(data_server[1])
     path = data[1]
     mode = 'value' if (len(data) < 3) else data[2]
+    index = -1 if (len(data) < 4) else int(data[3])
 
-    return (host,port,path,mode)
+    return (host,port,path,mode,index)
 
 
 def nodeFromAddress(address):
-    host, port, path, mode = parseAddress(address)
+    host, port, path, mode, index = parseAddress(address)
     client = VirtualClient(host, port)
     return client.root.getNode(path)
 
@@ -75,7 +76,7 @@ class RogueConnection(PyDMConnection):
 
         self.app = QApplication.instance()
 
-        self._host, self._port, self._path, self._mode = parseAddress(channel.address)
+        self._host, self._port, self._path, self._mode, self._index = parseAddress(channel.address)
 
         self._cmd    = False
         self._int    = False
@@ -204,7 +205,7 @@ class RogueConnection(PyDMConnection):
                 self.new_value_signal[str].emit(self._node.path)
             else:
                 self.write_access_signal.emit(self._cmd or self._node.mode!='RO')
-                self._updateVariable(self._node.path,self._node.getVariableValue(read=False))
+                self._updateVariable(self._node.path,self._node.getVariableValue(read=False, index=self._index))
 
         else:
             self.new_value_signal[str].emit(self._node.name)

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -115,6 +115,10 @@ class RogueConnection(PyDMConnection):
 
 
     def _updateVariable(self,path,varValue):
+
+        if self._index != -1:
+            varValue = self._node.getVariableValue(read=False, index=self._index)
+
         if self._mode == 'name':
             self.new_value_signal[str].emit(self._node.name)
         elif self._mode == 'path':

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -154,7 +154,7 @@ class RogueConnection(PyDMConnection):
         if self._cmd:
             self._node.__call__(val)
         else:
-            self._node.setDisp(val)
+            self._node.setDisp(val,index=self._index)
 
 
     def add_listener(self, channel):

--- a/python/pyrogue/pydm/examples/rogue_plugin_test.ui
+++ b/python/pyrogue/pydm/examples/rogue_plugin_test.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>4</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="tab_6">
         <property name="sizePolicy">
@@ -34,6 +34,16 @@
         <layout class="QVBoxLayout" name="verticalLayout_12">
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_11">
+           <item>
+            <widget class="PyDMLineEdit" name="PyDMLineEdit">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="channel" stdset="0">
+              <string>rogue://0/root.AxiVersion.TestListA/disp/3</string>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="DebugTree" name="DebugTree_2">
              <property name="sizePolicy">
@@ -105,7 +115,7 @@
            </property>
            <property name="yAxes">
             <stringlist>
-             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Scatter&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Scatter&quot;, &quot;minRange&quot;: -1.04, &quot;maxRange&quot;: 1.04, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
             </stringlist>
            </property>
            <property name="curves">
@@ -125,7 +135,7 @@
            </property>
            <property name="yAxes">
             <stringlist>
-             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Time&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: null}</string>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Plot Time&quot;, &quot;minRange&quot;: -1.04, &quot;maxRange&quot;: 1.04, &quot;autoRange&quot;: true, &quot;logMode&quot;: null}</string>
             </stringlist>
            </property>
            <property name="curves">
@@ -151,7 +161,7 @@
            </property>
            <property name="yAxes">
             <stringlist>
-             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Array Waveform&quot;, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+             <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: &quot;Test Array Waveform&quot;, &quot;minRange&quot;: -1.04, &quot;maxRange&quot;: 1.04, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
             </stringlist>
            </property>
            <property name="curves">
@@ -297,6 +307,11 @@
    <extends>QFrame</extends>
    <header>pydm.widgets.frame</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/python/pyrogue/pydm/examples/rogue_plugin_test.ui
+++ b/python/pyrogue/pydm/examples/rogue_plugin_test.ui
@@ -35,16 +35,6 @@
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_11">
            <item>
-            <widget class="PyDMLineEdit" name="PyDMLineEdit">
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="channel" stdset="0">
-              <string>rogue://0/root.AxiVersion.TestListA/disp/3</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="DebugTree" name="DebugTree_2">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -307,11 +297,6 @@
    <extends>QFrame</extends>
    <header>pydm.widgets.frame</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>PyDMLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/python/pyrogue/pydm/tools/generic_file_tool.py
+++ b/python/pyrogue/pydm/tools/generic_file_tool.py
@@ -41,7 +41,7 @@ class OpenFileBrowse(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 

--- a/python/pyrogue/pydm/tools/node_info_tool.py
+++ b/python/pyrogue/pydm/tools/node_info_tool.py
@@ -36,7 +36,7 @@ class NodeInformation(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 

--- a/python/pyrogue/pydm/tools/read_node_tool.py
+++ b/python/pyrogue/pydm/tools/read_node_tool.py
@@ -34,7 +34,7 @@ class ReadNode(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 

--- a/python/pyrogue/pydm/tools/read_recursive_tool.py
+++ b/python/pyrogue/pydm/tools/read_recursive_tool.py
@@ -34,7 +34,7 @@ class ReadRecursive(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 

--- a/python/pyrogue/pydm/tools/write_node_tool.py
+++ b/python/pyrogue/pydm/tools/write_node_tool.py
@@ -34,7 +34,7 @@ class WriteVariable(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 

--- a/python/pyrogue/pydm/tools/write_recursive_tool.py
+++ b/python/pyrogue/pydm/tools/write_recursive_tool.py
@@ -33,7 +33,7 @@ class WriteVariable(ExternalTool):
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
-        addr, port, path, mode = parseAddress(channels[0].address)
+        addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
 


### PR DESCRIPTION
This add the ability to display a single list value in a pydm widget. Example channel value to achieve this is:

rogue://0/root.AxiVersion.TestListA/disp/3

There the last value is the index value.

There is a performance hit with this as the value has to be retrieved again to pull out the sliced value from the server:

    def _updateVariable(self,path,varValue):

        if self._index != -1:
            varValue = self._node.getVariableValue(read=False, index=self._index)

