### PR TITLE
Fix RSSI sgement size calculation

### DIFF
--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -28,10 +28,10 @@ class UdpRssiPack(pr.Device):
 
         if server:
             self._udp  = rogue.protocols.udp.Server(port,jumbo)
-            self._rssi = rogue.protocols.rssi.Server(self._udp.maxPayload())
+            self._rssi = rogue.protocols.rssi.Server(self._udp.maxPayload()-8)
         else:
             self._udp  = rogue.protocols.udp.Client(host,port,jumbo)
-            self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
+            self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload()-8)
 
         if packVer == 2:
             self._pack = rogue.protocols.packetizer.CoreV2(False,True,enSsi) # ibCRC = False, obCRC = True

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -202,7 +202,7 @@ void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
         if (res > 0) {
             // Message was too big
             if (res > avail) {
-                udpLog_->warning("Receive data was too large. Rx=%i, avail=%i Dropping.",res,avail);
+                udpLog_->warning("Receive data was too large. Rx=%i, avail=%i Dropping.", res, avail);
             } else {
                 buff->setPayload(res);
                 sendFrame(frame);

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -202,7 +202,7 @@ void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
         if (res > 0) {
             // Message was too big
             if (res > avail) {
-                udpLog_->warning("Receive data was too large. Dropping.");
+                udpLog_->warning("Receive data was too large. Rx=%i, avail=%i Dropping.",res,avail);
             } else {
                 buff->setPayload(res);
                 sendFrame(frame);


### PR DESCRIPTION
The current segment size calculation does not include enough space for the RSSI header. This resulted in dropped packets when running with a 1500 byte MTU.

