### PR TITLE
Make Rogue DataReceiver status Variables read-only

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -38,27 +38,31 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='FrameCount',
                                   value=0,
+                                  mode = 'RO',
                                   pollInterval=1,
                                   description='Frame Rx Counter'))
 
         self.add(pr.LocalVariable(name='ErrorCount',
                                   value=0,
+                                  mode = 'RO',
                                   pollInterval=1,
                                   description='Frame Error Counter'))
 
         self.add(pr.LocalVariable(name='ByteCount',
                                   value=0,
+                                  mode = 'RO',
                                   pollInterval=1,
                                   description='Byte Rx Counter'))
 
         self.add(pr.LocalVariable(name='Updated',
                                   value=False,
+                                  mode = 'RO',                                  
                                   description='Data has been updated flag'))
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
                                   disp='',
-                                  groups=['NoState','NoStream'],
+                                  groups=['NoState','NoStream', 'NoConfig'],
                                   value=value,
                                   hidden=hideData,
                                   description='Data Frame Container'))


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
`FrameCount`, `ErrorCount`, `ByteCount` and `Updated` are now read only. This prevents them from being written in the GUI and from being dumped when saving a YAML configuration.

The `Data` Variable has been added to the `'NoConfig'` group to prevent it from being dumped when saving a YAML configuration.
