### PR TITLE
Improve variable update performance

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -65,11 +65,12 @@ class UpdateTracker(object):
         self._check()
 
     def _check(self):
-        if len(self._list) != 0 and (self._count == 0 or (self._period != 0 and (time.time() - self._last) > self._period)):
-            #print(f"Update fired {time.time()}")
-            self._last = time.time()
-            self._q.put(self._list)
-            self._list = {}
+        if self._count == 0 or (self._period != 0 and (time.time() - self._last) > self._period):
+            if len(self._list) != 0:
+                #print(f"Update fired {time.time()}")
+                self._last = time.time()
+                self._q.put(self._list)
+                self._list = {}
 
     def update(self,var):
         """
@@ -85,8 +86,7 @@ class UpdateTracker(object):
 
         """
         self._list[var.path] = var
-        if self._period != 0:
-            self._check()
+        self._check()
 
 class RootLogHandler(logging.Handler):
     """Class to listen to log entries and add them to syslog variable"""

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -1059,22 +1059,7 @@ class Root(pr.Device):
             elif len(uvars) > 0:
                 self._log.debug(F'Process update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}')
                 for p,v in uvars.items():
-                    val = v._doUpdate()
-
-                    # Call listener functions,
-                    with self._varListenLock:
-                        for func,doneFunc,incGroups,excGroups in self._varListeners:
-                            if v.filterByGroup(incGroups, excGroups):
-                                try:
-                                    func(p,val)
-
-                                except Exception as e:
-                                    if v == self.SystemLog or v == self.SystemLogLast:
-                                        print("------- Error Executing Syslog Listeners -------")
-                                        print("Error: {}".format(e))
-                                        print("------------------------------------------------")
-                                    else:
-                                        pr.logException(self._log,e)
+                    self._updateVarWithRecurse(v)
 
                 # Finalize listeners
                 with self._varListenLock:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -1002,14 +1002,14 @@ class Root(pr.Device):
         tid = threading.get_ident()
 
         try:
-           self._updateTrack[tid].update(var)
+            self._updateTrack[tid].update(var)
         except Exception:
             with self._updateLock:
-               self._updateTrack[tid] = UpdateTracker(self._updateQueue)
-               self._updateTrack[tid].update(var)
+                self._updateTrack[tid] = UpdateTracker(self._updateQueue)
+                self._updateTrack[tid].update(var)
 
     # Perform update on each variable and recurse the listeners list
-    def _updateVarWithRecurse(self, v):
+    def _updateVarWithRecurse(self, p, v):
 
         val = v._doUpdate()
 
@@ -1029,8 +1029,8 @@ class Root(pr.Device):
                             pr.logException(self._log,e)
 
         # Process listeners
-        for l in v._listeners:
-            self._updateVarWithRecurse(l)
+        for vl in v._listeners:
+            self._updateVarWithRecurse(vl.path, vl)
 
     # Worker thread
     def _updateWorker(self):
@@ -1050,7 +1050,7 @@ class Root(pr.Device):
             elif len(uvars) > 0:
                 self._log.debug(F'Process update group. Length={len(uvars)}. Entry={list(uvars.keys())[0]}')
                 for p,v in uvars.items():
-                    self._updateVarWithRecurse(v)
+                    self._updateVarWithRecurse(p,v)
 
                 # Finalize listeners
                 with self._varListenLock:

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -1008,6 +1008,13 @@ class Root(pr.Device):
                 self._updateTrack[tid] = UpdateTracker(self._updateQueue)
                 self._updateTrack[tid].update(var)
 
+    # Recursively add listeners to update list
+    def _recurseAddListeners(self, nvars, var):
+        for vl in var._listeners:
+            nvars[vl.path] = vl
+
+            self._recurseAddListeners(nvars, vl)
+
     # Worker thread
     def _updateWorker(self):
         """ """
@@ -1029,8 +1036,7 @@ class Root(pr.Device):
                 # Copy list and add listeners
                 nvars = uvars.copy()
                 for p,v in uvars.items():
-                    for vl in v._listeners:
-                        nvars[vl.path] = vl
+                    self._recurseAddListeners(nvars, v)
 
                 # Process the new list
                 for p,v in nvars.items():

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -484,16 +484,11 @@ class Root(pr.Device):
 
         # At with call
         try:
-           self._updateTrack[tid].increment(period)
-        except:
+            self._updateTrack[tid].increment(period)
+        except Exception:
             with self._updateLock:
                 self._updateTrack[tid] = UpdateTracker(self._updateQueue)
                 self._updateTrack[tid].increment(period)
-
-            #if tid not in self._updateTrack:
-            #    self._updateTrack[tid] = UpdateTracker(self._updateQueue)
-
-            #self._updateTrack[tid].increment(period)
 
         try:
             yield
@@ -1008,14 +1003,10 @@ class Root(pr.Device):
 
         try:
            self._updateTrack[tid].update(var)
-        except:
+        except Exception:
             with self._updateLock:
                self._updateTrack[tid] = UpdateTracker(self._updateQueue)
                self._updateTrack[tid].update(var)
-
-            #if tid not in self._updateTrack:
-            #    self._updateTrack[tid] = UpdateTracker(self._updateQueue)
-            #self._updateTrack[tid].update(var)
 
     # Perform update on each variable and recurse the listeners list
     def _updateVarWithRecurse(self, v):

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -860,9 +860,6 @@ class BaseVariable(pr.Node):
         """ """
         self._root._queueUpdates(self)
 
-        for var in self._listeners:
-            var._queueUpdate()
-
     def _doUpdate(self):
         """ """
         val = VariableValue(self)

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -16,8 +16,8 @@ import rogue.interfaces.memory
 import time
 import hwcounter
 
-import cProfile, pstats, io
-from pstats import SortKey
+#import cProfile, pstats, io
+#from pstats import SortKey
 
 #rogue.Logging.setLevel(rogue.Logging.Debug)
 #import logging
@@ -108,8 +108,8 @@ class DummyTree(pr.Root):
 
 def test_rate():
 
-    pr = cProfile.Profile()
-    pr.enable()
+    #pr = cProfile.Profile()
+    #pr.enable()
 
     with DummyTree() as root:
         count = 100000
@@ -185,13 +185,13 @@ def test_rate():
             raise AssertionError('Rate check failed')
 
 
-    pr.disable()
+    #pr.disable()
 
-    s = io.StringIO()
-    sortby = SortKey.CUMULATIVE
-    ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
-    ps.print_stats()
-    print(s.getvalue())
+    #s = io.StringIO()
+    #sortby = SortKey.CUMULATIVE
+    #ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+    #ps.print_stats()
+    #print(s.getvalue())
 
 if __name__ == "__main__":
     test_rate()

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -16,6 +16,9 @@ import rogue.interfaces.memory
 import time
 import hwcounter
 
+import cProfile, pstats, io
+from pstats import SortKey
+
 #rogue.Logging.setLevel(rogue.Logging.Debug)
 #import logging
 #logger = logging.getLogger('pyrogue')
@@ -105,6 +108,9 @@ class DummyTree(pr.Root):
 
 def test_rate():
 
+    pr = cProfile.Profile()
+    pr.enable()
+
     with DummyTree() as root:
         count = 100000
         resultRate = {}
@@ -177,6 +183,15 @@ def test_rate():
 
         if passed is False:
             raise AssertionError('Rate check failed')
+
+
+    pr.disable()
+
+    s = io.StringIO()
+    sortby = SortKey.CUMULATIVE
+    ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+    ps.print_stats()
+    print(s.getvalue())
 
 if __name__ == "__main__":
     test_rate()


### PR DESCRIPTION

This PR improves the variable update performance by making the following changes:

- Do not always check for the existence of a thread specific UpdateTracker object in the tracking list.  This check requires an expensive dictionary lookup which previously occurred within a lock context. Instead the access is called as if the entry exists and if this is a new thread the resulting exception is caught and the object is then created inside the necessary lock. This change occurs in both the entry into the updateGroup context and more importantly in the _queueUpdates call.

- Take advantage of the fact that each UpdateTrack instance is per thread and remove any locking around the update of this object.

- In the check() call in the UpdateTrack first check the context counter and update period. This check is not expensive as compared to checking the variable list length, which now only occurs when the count and period tests pass.

- Change the variable listener processing to only occur when the update worker processes the list. In the previous version, every listener for a variable was added with each set or get call which was not necessary. In the new code the listeners are first added to the existing update list before the update calls are made. 

