### PR TITLE
ESROGUE-684 - Frame.getNumpy now allows user defined data type

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -50,9 +50,9 @@ jobs:
           flake8 --count ./tests/
 
       # C++ Linter
-#       - name: C++ Linter
-#         run: |
-#           find . -name '*.h' -o -name '*.cpp' | xargs cpplint
+      - name: C++ Linter
+        run: |
+          find . -name '*.h' -o -name '*.cpp' | xargs cpplint
 
       # Rogue
       - name: Build Rogue

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -50,9 +50,9 @@ jobs:
           flake8 --count ./tests/
 
       # C++ Linter
-      - name: C++ Linter
-        run: |
-          find . -name '*.h' -o -name '*.cpp' | xargs cpplint
+#       - name: C++ Linter
+#         run: |
+#           find . -name '*.h' -o -name '*.cpp' | xargs cpplint
 
       # Rogue
       - name: Build Rogue

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -328,7 +328,6 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
 
 #ifndef NO_PYTHON
 
-
     //! Python Frame data read function
     /** Read data from Frame into passed Python byte array.
      *
@@ -353,7 +352,6 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      * Exposed as getMemoryview() to Python
      */
     boost::python::object getMemoryviewPy();
-
 
     //! Python Frame data write function
     /** Write data into from Frame from passed Python byte array.

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -343,8 +343,9 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      *
      * Exposed as getBa() to Python
      * @param offset First location of Frame data to copy to byte array
+     * @param count Number of bytes to read
      */
-    boost::python::object getBytearrayPy(uint32_t offset);
+    boost::python::object getBytearrayPy(uint32_t offset, uint32_t count);
 
     //! Python Frame data read function
     /** Read data from Frame into a python bytearray which is allocated and returned as a memoryview

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -28,6 +28,8 @@
 #include "rogue/EnableSharedFromThis.h"
 
 #ifndef NO_PYTHON
+    #include <numpy/ndarrayobject.h>
+
     #include <boost/python.hpp>
 #endif
 
@@ -354,7 +356,7 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      *  @param[in]   size The number of bytes to write
      *
      */
-    boost::python::object getNumpy(uint32_t offset, uint32_t size);
+    boost::python::object getNumpy(uint32_t offset = 0, uint32_t size = 0, int dtype = NPY_UINT8);
 
     //! Python Frame data write using a numpy array as the source
     /*

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -341,10 +341,17 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
     //! Python Frame data read function
     /** Read data from Frame into a python bytearray which is allocated and returned
      *
-     * Exposed as readBa() to Python
+     * Exposed as getBa() to Python
      * @param offset First location of Frame data to copy to byte array
      */
-    boost::python::object readBytearrayPy(uint32_t offset);
+    boost::python::object getBytearrayPy(uint32_t offset);
+
+    //! Python Frame data read function
+    /** Read data from Frame into a python bytearray which is allocated and returned as a memoryview
+     *
+     * Exposed as getMemoryview() to Python
+     */
+    boost::python::object getMemoryviewPy();
     
 
     //! Python Frame data write function

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -353,10 +353,10 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      *  @return The read data as a 1-D numpy byte array
      *
      *  @param[in] offset The byte offset into the frame to write to
-     *  @param[in]   size The number of bytes to write
+     *  @param[in]  count The number of bytes to write
      *
      */
-    boost::python::object getNumpy(uint32_t offset = 0, uint32_t count = 0, int dtype = NPY_UINT8);
+    boost::python::object getNumpy(uint32_t offset, uint32_t count, boost::python::object dtype);
 
     //! Python Frame data write using a numpy array as the source
     /*

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -356,7 +356,7 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      *  @param[in]   size The number of bytes to write
      *
      */
-    boost::python::object getNumpy(uint32_t offset = 0, uint32_t size = 0, int dtype = NPY_UINT8);
+    boost::python::object getNumpy(uint32_t offset = 0, uint32_t count = 0, int dtype = NPY_UINT8);
 
     //! Python Frame data write using a numpy array as the source
     /*

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -327,7 +327,7 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
     rogue::interfaces::stream::FrameIterator endWrite();
 
 #ifndef NO_PYTHON
-    
+
 
     //! Python Frame data read function
     /** Read data from Frame into passed Python byte array.
@@ -353,7 +353,7 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      * Exposed as getMemoryview() to Python
      */
     boost::python::object getMemoryviewPy();
-    
+
 
     //! Python Frame data write function
     /** Write data into from Frame from passed Python byte array.

--- a/include/rogue/interfaces/stream/Frame.h
+++ b/include/rogue/interfaces/stream/Frame.h
@@ -327,6 +327,7 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
     rogue::interfaces::stream::FrameIterator endWrite();
 
 #ifndef NO_PYTHON
+    
 
     //! Python Frame data read function
     /** Read data from Frame into passed Python byte array.
@@ -336,6 +337,15 @@ class Frame : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Fram
      * @param offset First location of Frame data to copy to byte array
      */
     void readPy(boost::python::object p, uint32_t offset);
+
+    //! Python Frame data read function
+    /** Read data from Frame into a python bytearray which is allocated and returned
+     *
+     * Exposed as readBa() to Python
+     * @param offset First location of Frame data to copy to byte array
+     */
+    boost::python::object readBytearrayPy(uint32_t offset);
+    
 
     //! Python Frame data write function
     /** Write data into from Frame from passed Python byte array.

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -375,11 +375,11 @@ void ris::Frame::readPy(boost::python::object p, uint32_t offset) {
 bp::object ris::Frame::getBytearrayPy(uint32_t offset, uint32_t count) {
     // Get the size of the frame
     uint32_t size = getPayload();
-    
+
     if (count == 0) {
         count = size - offset;
     }
-    
+
 
     // Create a Python bytearray to hold the data
     bp::object byteArray(bp::handle<>(PyByteArray_FromStringAndSize(nullptr, count)));
@@ -408,7 +408,7 @@ bp::object ris::Frame::getMemoryviewPy() {
     }
 
     // Return the memoryview as a Python object
-    return bp::object(bp::handle<>(memoryView));    
+    return bp::object(bp::handle<>(memoryView));
 
 }
 

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -344,7 +344,8 @@ ris::FrameIterator ris::Frame::endWrite() {
 
 #ifndef NO_PYTHON
 
-//! Read up to count bytes from frame, starting from offset. Python version.
+
+//! Read bytes from frame into a passed bytearray, starting from offset. Python version.
 void ris::Frame::readPy(boost::python::object p, uint32_t offset) {
     Py_buffer pyBuf;
 
@@ -368,6 +369,20 @@ void ris::Frame::readPy(boost::python::object p, uint32_t offset) {
     ris::fromFrame(beg, count, reinterpret_cast<uint8_t*>(pyBuf.buf));
     PyBuffer_Release(&pyBuf);
 }
+
+//! Allocate a bytearray and read bytes from frame into it, starting at offset
+bp::object ris::Frame::readBytearrayPy(uint32_t offset) {
+    // Get the size of the frame
+    uint32_t size = getPayload();
+
+    // Create a Python bytearray to hold the data
+    boost::python::object byteArray = boost::python::eval("bytearray")(size - offset);
+
+    this->readPy(byteArray, offset);
+
+    return byteArray;
+}
+
 
 //! Write python buffer to frame, starting at offset. Python Version
 void ris::Frame::writePy(boost::python::object p, uint32_t offset) {
@@ -513,6 +528,8 @@ void ris::Frame::setup_python() {
         .def("getAvailable", &ris::Frame::getAvailable)
         .def("getPayload", &ris::Frame::getPayload)
         .def("read", &ris::Frame::readPy, (
+            bp::arg("offset")=0))
+        .def("readBa", &ris::Frame::readBytearrayPy, (
             bp::arg("offset")=0))
         .def("write", &ris::Frame::writePy, (
             bp::arg("offset")=0))

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -512,8 +512,10 @@ void ris::Frame::setup_python() {
         .def("getSize", &ris::Frame::getSize)
         .def("getAvailable", &ris::Frame::getAvailable)
         .def("getPayload", &ris::Frame::getPayload)
-        .def("read", &ris::Frame::readPy)
-        .def("write", &ris::Frame::writePy)
+        .def("read", &ris::Frame::readPy, (
+            bp::arg("offset")=0))
+        .def("write", &ris::Frame::writePy, (
+            bp::arg("offset")=0))
         .def("setError", &ris::Frame::setError)
         .def("getError", &ris::Frame::getError)
         .def("setFlags", &ris::Frame::setFlags)
@@ -528,7 +530,8 @@ void ris::Frame::setup_python() {
             bp::arg("offset")=0,
             bp::arg("count")=0,
             bp::arg("dtype")=bp::object(bp::handle<>(bp::borrowed(dtype_uint8)))))
-        .def("putNumpy", &ris::Frame::putNumpy)
+        .def("putNumpy", &ris::Frame::putNumpy, (
+            bp::arg("offset")=0))
         .def("_debug", &ris::Frame::debug);
 #endif
 }

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -345,7 +345,6 @@ ris::FrameIterator ris::Frame::endWrite() {
 
 #ifndef NO_PYTHON
 
-
 //! Read bytes from frame into a passed bytearray, starting from offset. Python version.
 void ris::Frame::readPy(boost::python::object p, uint32_t offset) {
     Py_buffer pyBuf;
@@ -380,7 +379,6 @@ bp::object ris::Frame::getBytearrayPy(uint32_t offset, uint32_t count) {
         count = size - offset;
     }
 
-
     // Create a Python bytearray to hold the data
     bp::object byteArray(bp::handle<>(PyByteArray_FromStringAndSize(nullptr, count)));
 
@@ -403,16 +401,12 @@ bp::object ris::Frame::getMemoryviewPy() {
     // Create a memoryview from the bytearray
     PyObject* memoryView = PyMemoryView_FromObject(byteArray.ptr());
     if (!memoryView) {
-        throw(rogue::GeneralError::create("Frame::getMemoryviewPy",
-                                          "Failed to create memoryview."));
+        throw(rogue::GeneralError::create("Frame::getMemoryviewPy", "Failed to create memoryview."));
     }
 
     // Return the memoryview as a Python object
     return bp::object(bp::handle<>(memoryView));
-
 }
-
-
 
 //! Write python buffer to frame, starting at offset. Python Version
 void ris::Frame::writePy(boost::python::object p, uint32_t offset) {
@@ -459,15 +453,13 @@ boost::python::object ris::Frame::getNumpy(uint32_t offset, uint32_t count, bp::
                                           size));
     }
 
-
     // Convert Python dtype object to NumPy type
     int numpy_type;
     PyObject* dtype_pyobj = dtype.ptr();  // Get the raw PyObject from the Boost.Python object
     if (PyArray_DescrCheck(dtype_pyobj)) {
         numpy_type = (reinterpret_case<PyArray_Descr*>(dtype_pyobj))->type_num;
     } else {
-        throw(rogue::GeneralError::create("Frame::getNumpy",
-                                          "Invalid dtype argument. Must be a NumPy dtype object."));
+        throw(rogue::GeneralError::create("Frame::getNumpy", "Invalid dtype argument. Must be a NumPy dtype object."));
     }
 
     // Create a numpy array to receive it and locate the destination data buffer
@@ -547,24 +539,19 @@ void ris::Frame::setup_python() {
     // Create a NumPy dtype object from the NPY_UINT8 constant
     PyObject* dtype_uint8 = reinterpret_cast<PyObject*>(PyArray_DescrFromType(NPY_UINT8));
     if (!dtype_uint8) {
-        throw(rogue::GeneralError::create("Frame::setup_python",
-                                          "Failed to create default dtype object for NPY_UINT8."));
+        throw(
+            rogue::GeneralError::create("Frame::setup_python", "Failed to create default dtype object for NPY_UINT8."));
     }
-
 
     bp::class_<ris::Frame, ris::FramePtr, boost::noncopyable>("Frame", bp::no_init)
         .def("lock", &ris::Frame::lock)
         .def("getSize", &ris::Frame::getSize)
         .def("getAvailable", &ris::Frame::getAvailable)
         .def("getPayload", &ris::Frame::getPayload)
-        .def("read", &ris::Frame::readPy, (
-            bp::arg("offset")=0))
-        .def("getBa", &ris::Frame::getBytearrayPy, (
-            bp::arg("offset")=0,
-            bp::arg("count")=0))
+        .def("read", &ris::Frame::readPy, (bp::arg("offset") = 0))
+        .def("getBa", &ris::Frame::getBytearrayPy, (bp::arg("offset") = 0, bp::arg("count") = 0))
         .def("getMemoryview", &ris::Frame::getMemoryviewPy)
-        .def("write", &ris::Frame::writePy, (
-            bp::arg("offset")=0))
+        .def("write", &ris::Frame::writePy, (bp::arg("offset") = 0))
         .def("setError", &ris::Frame::setError)
         .def("getError", &ris::Frame::getError)
         .def("setFlags", &ris::Frame::setFlags)
@@ -575,12 +562,12 @@ void ris::Frame::setup_python() {
         .def("getLastUser", &ris::Frame::getLastUser)
         .def("setChannel", &ris::Frame::setChannel)
         .def("getChannel", &ris::Frame::getChannel)
-        .def("getNumpy", &ris::Frame::getNumpy, (
-            bp::arg("offset")=0,
-            bp::arg("count")=0,
-            bp::arg("dtype")=bp::object(bp::handle<>(bp::borrowed(dtype_uint8)))))
-        .def("putNumpy", &ris::Frame::putNumpy, (
-            bp::arg("offset")=0))
+        .def("getNumpy",
+             &ris::Frame::getNumpy,
+             (bp::arg("offset") = 0,
+              bp::arg("count")  = 0,
+              bp::arg("dtype")  = bp::object(bp::handle<>(bp::borrowed(dtype_uint8)))))
+        .def("putNumpy", &ris::Frame::putNumpy, (bp::arg("offset") = 0))
         .def("_debug", &ris::Frame::debug);
 #endif
 }

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -424,7 +424,7 @@ boost::python::object ris::Frame::getNumpy(uint32_t offset, uint32_t count, bp::
         throw(rogue::GeneralError::create("Frame::getNumpy",
                                           "Invalid dtype argument. Must be a NumPy dtype object."));
     }
-    
+
     // Create a numpy array to receive it and locate the destination data buffer
     npy_intp dims[1]   = {count};
     PyObject* obj      = PyArray_SimpleNew(1, dims, numpy_type);
@@ -505,7 +505,7 @@ void ris::Frame::setup_python() {
         throw(rogue::GeneralError::create("Frame::setup_python",
                                           "Failed to create default dtype object for NPY_UINT8."));
     }
-    
+
 
     bp::class_<ris::Frame, ris::FramePtr, boost::noncopyable>("Frame", bp::no_init)
         .def("lock", &ris::Frame::lock)

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -376,7 +376,8 @@ bp::object ris::Frame::readBytearrayPy(uint32_t offset) {
     uint32_t size = getPayload();
 
     // Create a Python bytearray to hold the data
-    boost::python::object byteArray = boost::python::eval("bytearray")(size - offset);
+    bp::object byteArray(bp::handle<>(PyByteArray_FromStringAndSize(nullptr, size - offset)));
+
 
     this->readPy(byteArray, offset);
 

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -371,14 +371,19 @@ void ris::Frame::readPy(boost::python::object p, uint32_t offset) {
 }
 
 //! Allocate a bytearray and read bytes from frame into it starting at offset, return array
-bp::object ris::Frame::getBytearrayPy(uint32_t offset) {
+bp::object ris::Frame::getBytearrayPy(uint32_t offset, uint32_t count) {
     // Get the size of the frame
     uint32_t size = getPayload();
+    
+    if (count == 0) {
+        count = size - offset;
+    }
+    
 
     // Create a Python bytearray to hold the data
-    bp::object byteArray(bp::handle<>(PyByteArray_FromStringAndSize(nullptr, size - offset)));
+    bp::object byteArray(bp::handle<>(PyByteArray_FromStringAndSize(nullptr, count)));
 
-
+    // readPy will check bounds
     this->readPy(byteArray, offset);
 
     return byteArray;
@@ -554,7 +559,8 @@ void ris::Frame::setup_python() {
         .def("read", &ris::Frame::readPy, (
             bp::arg("offset")=0))
         .def("getBa", &ris::Frame::getBytearrayPy, (
-            bp::arg("offset")=0))
+            bp::arg("offset")=0,
+            bp::arg("count")=0))
         .def("getMemoryview", &ris::Frame::getMemoryviewPy)
         .def("write", &ris::Frame::writePy, (
             bp::arg("offset")=0))

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -464,7 +464,7 @@ boost::python::object ris::Frame::getNumpy(uint32_t offset, uint32_t count, bp::
     int numpy_type;
     PyObject* dtype_pyobj = dtype.ptr();  // Get the raw PyObject from the Boost.Python object
     if (PyArray_DescrCheck(dtype_pyobj)) {
-        numpy_type = ((PyArray_Descr*)dtype_pyobj)->type_num;
+        numpy_type = (reinterpret_case<PyArray_Descr*>(dtype_pyobj))->type_num;
     } else {
         throw(rogue::GeneralError::create("Frame::getNumpy",
                                           "Invalid dtype argument. Must be a NumPy dtype object."));

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -457,7 +457,7 @@ boost::python::object ris::Frame::getNumpy(uint32_t offset, uint32_t count, bp::
     int numpy_type;
     PyObject* dtype_pyobj = dtype.ptr();  // Get the raw PyObject from the Boost.Python object
     if (PyArray_DescrCheck(dtype_pyobj)) {
-        numpy_type = (reinterpret_case<PyArray_Descr*>(dtype_pyobj))->type_num;
+        numpy_type = (reinterpret_cast<PyArray_Descr*>(dtype_pyobj))->type_num;
     } else {
         throw(rogue::GeneralError::create("Frame::getNumpy", "Invalid dtype argument. Must be a NumPy dtype object."));
     }


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

#### Changes to `Frame.getNumpy()`

The `Frame.getNumpy()` method now takes an additional `dtype` argument, which allows a numpy type to be specified for the returned array.

```python
array = frame.getNumpy(0, frame.getPayload(), np.uint32)
```

Additionally, the `getNumpy()` method now has default arguments for all parameters

```
offset = 0
count = 0, 
dtype = np.uint8
```

Allowing for calls such as
```python
# Read the entire frame into a np.uint8 array
array = frame.getNumpy()

# Read the entire frame into a np.uint32 array
array = frame.getNumpy(dtype=np.uint32)
```

The `count` argument defaults to 0, which functionally will return the entire array starting at `offset`.

The `offset` and `count` parameters are still specified in bytes, not in the dtype size.

#### Other changes

The `offset` argument of `Frame.readPy()` and `Frame.writePy()` has also been given a default of 0 when called from python.

A new `Frame.getBa()` method has been added that will allocate the bytearray internally and return it. This makes things a bit more concise in python when reading from a Frame.

```python
# New
ba = frame.getBa() # Create a bytearray, fill it, and return it

#Old
ba = bytearray(frame.getPayload())
frame.read(ba)
```

The `getBa()` method takes an `offset` and `count` which function the same as in `getNumpy()` with the same defaults.

Also, a new `Frame.getMemoryview()` method has been added that allocates a bytearray but returns it as a `memoryview`. This allows for efficient slicing of the frame data without any copying. In most cases where copyless slicing is needed, a `getNumpy()` would be preferred, but `getMemoryview()` is useful for efficiently parsing complex header structures.

```python
memory_view = frame.getMemoryview()

# Parse the header (4 bytes), length (2 bytes), and checksum (2 bytes)
header, length, checksum = struct.unpack_from('IHH', memory_view, 0)
```