### PR TITLE
cpplint v2 - linter fix

### DIFF
--- a/include/rogue/hardware/drivers/DmaDriver.h
+++ b/include/rogue/hardware/drivers/DmaDriver.h
@@ -167,7 +167,7 @@ static inline ssize_t dmaWrite(int32_t fd, const void* buf, size_t size, uint32_
     w.flags = flags;
     w.size  = size;
     w.is32  = (sizeof(void*) == 4);
-    w.data  = (uint64_t)buf;
+    w.data  = (uint64_t)buf;//NOLINT
 
     return (write(fd, &w, sizeof(struct DmaWriteData)));
 }
@@ -237,7 +237,7 @@ static inline ssize_t dmaWriteVector(int32_t fd,
         w.flags = (x == 0) ? begFlags : ((x == (iovlen - 1)) ? endFlags : midFlags);
         w.size  = iov[x].iov_len;
         w.is32  = (sizeof(void*) == 4);
-        w.data  = (uint64_t)iov[x].iov_base;
+        w.data  = (uint64_t)iov[x].iov_base;//NOLINT
 
         do {
             res = write(fd, &w, sizeof(struct DmaWriteData));
@@ -288,7 +288,7 @@ static inline ssize_t dmaWriteIndexVector(int32_t fd,
         w.flags = (x == 0) ? begFlags : ((x == (iovlen - 1)) ? endFlags : midFlags);
         w.size  = iov[x].iov_len;
         w.is32  = (sizeof(void*) == 4);
-        w.index = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);
+        w.index = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);//NOLINT
 
         do {
             res = write(fd, &w, sizeof(struct DmaWriteData));
@@ -324,7 +324,7 @@ static inline ssize_t dmaRead(int32_t fd, void* buf, size_t maxSize, uint32_t* f
     memset(&r, 0, sizeof(struct DmaReadData));
     r.size = maxSize;
     r.is32 = (sizeof(void*) == 4);
-    r.data = (uint64_t)buf;
+    r.data = (uint64_t)buf;//NOLINT
 
     ret = read(fd, &r, sizeof(struct DmaReadData));
 

--- a/include/rogue/hardware/drivers/DmaDriver.h
+++ b/include/rogue/hardware/drivers/DmaDriver.h
@@ -133,16 +133,17 @@ struct DmaRegisterData {
 
 // Conditional inclusion for non-kernel environments
 #ifndef DMA_IN_KERNEL
-    #include <signal.h>
-    #include <stdio.h>
-    #include <stdlib.h>
-    #include <string.h>
     #include <sys/fcntl.h>
     #include <sys/ioctl.h>
     #include <sys/mman.h>
     #include <sys/signal.h>
     #include <sys/socket.h>
     #include <unistd.h>
+
+    #include <csignal>
+    #include <cstdio>
+    #include <cstdlib>
+    #include <cstring>
 
 /**
  * dmaWrite - Writes data to a DMA channel.
@@ -167,7 +168,7 @@ static inline ssize_t dmaWrite(int32_t fd, const void* buf, size_t size, uint32_
     w.flags = flags;
     w.size  = size;
     w.is32  = (sizeof(void*) == 4);
-    w.data  = (uint64_t)buf;//NOLINT
+    w.data  = (uint64_t)buf;  // NOLINT
 
     return (write(fd, &w, sizeof(struct DmaWriteData)));
 }
@@ -237,7 +238,7 @@ static inline ssize_t dmaWriteVector(int32_t fd,
         w.flags = (x == 0) ? begFlags : ((x == (iovlen - 1)) ? endFlags : midFlags);
         w.size  = iov[x].iov_len;
         w.is32  = (sizeof(void*) == 4);
-        w.data  = (uint64_t)iov[x].iov_base;//NOLINT
+        w.data  = (uint64_t)iov[x].iov_base;  // NOLINT
 
         do {
             res = write(fd, &w, sizeof(struct DmaWriteData));
@@ -288,7 +289,7 @@ static inline ssize_t dmaWriteIndexVector(int32_t fd,
         w.flags = (x == 0) ? begFlags : ((x == (iovlen - 1)) ? endFlags : midFlags);
         w.size  = iov[x].iov_len;
         w.is32  = (sizeof(void*) == 4);
-        w.index = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);//NOLINT
+        w.index = (uint32_t)(((uint64_t)iov[x].iov_base) & 0xFFFFFFFF);  // NOLINT
 
         do {
             res = write(fd, &w, sizeof(struct DmaWriteData));
@@ -324,7 +325,7 @@ static inline ssize_t dmaRead(int32_t fd, void* buf, size_t maxSize, uint32_t* f
     memset(&r, 0, sizeof(struct DmaReadData));
     r.size = maxSize;
     r.is32 = (sizeof(void*) == 4);
-    r.data = (uint64_t)buf;//NOLINT
+    r.data = (uint64_t)buf;  // NOLINT
 
     ret = read(fd, &r, sizeof(struct DmaReadData));
 
@@ -645,9 +646,7 @@ static inline ssize_t dmaGetBuffCount(int32_t fd) {
  */
 static inline std::string dmaGetGitVersion(int32_t fd) {
     char gitv[32] = {0};  // Initialize with zeros to ensure null-termination
-    if (ioctl(fd, DMA_Get_GITV, gitv) < 0) {
-        return "";
-    }
+    if (ioctl(fd, DMA_Get_GITV, gitv) < 0) { return ""; }
     gitv[32 - 1] = '\0';  // Ensure null-termination
     return std::string(gitv);
 }

--- a/include/rogue/hardware/drivers/DmaDriver.h
+++ b/include/rogue/hardware/drivers/DmaDriver.h
@@ -646,7 +646,9 @@ static inline ssize_t dmaGetBuffCount(int32_t fd) {
  */
 static inline std::string dmaGetGitVersion(int32_t fd) {
     char gitv[32] = {0};  // Initialize with zeros to ensure null-termination
-    if (ioctl(fd, DMA_Get_GITV, gitv) < 0) { return ""; }
+    if (ioctl(fd, DMA_Get_GITV, gitv) < 0) {
+        return "";
+    }
     gitv[32 - 1] = '\0';  // Ensure null-termination
     return std::string(gitv);
 }

--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -48,9 +48,7 @@ template <class T>
 inline boost::python::list std_vector_to_py_list(std::vector<T> vector) {
     typename std::vector<T>::iterator iter;
     boost::python::list list;
-    for (iter = vector.begin(); iter != vector.end(); ++iter) {
-        list.append(*iter);
-    }
+    for (iter = vector.begin(); iter != vector.end(); ++iter) { list.append(*iter); }
     return list;
 }
 

--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -48,7 +48,9 @@ template <class T>
 inline boost::python::list std_vector_to_py_list(std::vector<T> vector) {
     typename std::vector<T>::iterator iter;
     boost::python::list list;
-    for (iter = vector.begin(); iter != vector.end(); ++iter) { list.append(*iter); }
+    for (iter = vector.begin(); iter != vector.end(); ++iter) {
+        list.append(*iter);
+    }
     return list;
 }
 

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -19,8 +19,8 @@
 #include "rogue/Directives.h"
 
 #include <stdint.h>
-#include <stdio.h>
 
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/include/rogue/protocols/packetizer/CRC.h
+++ b/include/rogue/protocols/packetizer/CRC.h
@@ -273,11 +273,11 @@ class CRC {
 #endif
 
 #ifdef CRCPP_USE_CPP11
-    CRC()                 = delete;
-    CRC(const CRC& other) = delete;
+    CRC()                            = delete;
+    CRC(const CRC& other)            = delete;
     CRC& operator=(const CRC& other) = delete;
     CRC(CRC&& other)                 = delete;
-    CRC& operator=(CRC&& other) = delete;
+    CRC& operator=(CRC&& other)      = delete;
 #endif
 
   private:
@@ -553,7 +553,9 @@ inline CRCType CRC::Finalize(CRCType remainder, CRCType finalXOR, bool reflectOu
     static crcpp_constexpr CRCType BIT_MASK =
         (CRCType(1) << (CRCWidth - CRCType(1))) | ((CRCType(1) << (CRCWidth - CRCType(1))) - CRCType(1));
 
-    if (reflectOutput) { remainder = Reflect(remainder, CRCWidth); }
+    if (reflectOutput) {
+        remainder = Reflect(remainder, CRCWidth);
+    }
 
     return (remainder ^ finalXOR) & BIT_MASK;
 }
@@ -583,7 +585,9 @@ inline CRCType CRC::UndoFinalize(CRCType crc, CRCType finalXOR, bool reflectOutp
 
     crc = (crc & BIT_MASK) ^ finalXOR;
 
-    if (reflectOutput) { crc = Reflect(crc, CRCWidth); }
+    if (reflectOutput) {
+        crc = Reflect(crc, CRCWidth);
+    }
 
     return crc;
 }

--- a/include/rogue/protocols/packetizer/CRC.h
+++ b/include/rogue/protocols/packetizer/CRC.h
@@ -273,11 +273,11 @@ class CRC {
 #endif
 
 #ifdef CRCPP_USE_CPP11
-    CRC()                            = delete;
-    CRC(const CRC& other)            = delete;
+    CRC()                 = delete;
+    CRC(const CRC& other) = delete;
     CRC& operator=(const CRC& other) = delete;
     CRC(CRC&& other)                 = delete;
-    CRC& operator=(CRC&& other)      = delete;
+    CRC& operator=(CRC&& other) = delete;
 #endif
 
   private:
@@ -553,9 +553,7 @@ inline CRCType CRC::Finalize(CRCType remainder, CRCType finalXOR, bool reflectOu
     static crcpp_constexpr CRCType BIT_MASK =
         (CRCType(1) << (CRCWidth - CRCType(1))) | ((CRCType(1) << (CRCWidth - CRCType(1))) - CRCType(1));
 
-    if (reflectOutput) {
-        remainder = Reflect(remainder, CRCWidth);
-    }
+    if (reflectOutput) { remainder = Reflect(remainder, CRCWidth); }
 
     return (remainder ^ finalXOR) & BIT_MASK;
 }
@@ -585,9 +583,7 @@ inline CRCType CRC::UndoFinalize(CRCType crc, CRCType finalXOR, bool reflectOutp
 
     crc = (crc & BIT_MASK) ^ finalXOR;
 
-    if (reflectOutput) {
-        crc = Reflect(crc, CRCWidth);
-    }
+    if (reflectOutput) { crc = Reflect(crc, CRCWidth); }
 
     return crc;
 }

--- a/include/rogue/protocols/xilinx/JtagDriver.h
+++ b/include/rogue/protocols/xilinx/JtagDriver.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <stdexcept>
 #include <vector>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/Logging.h"

--- a/include/rogue/protocols/xilinx/JtagDriver.h
+++ b/include/rogue/protocols/xilinx/JtagDriver.h
@@ -20,18 +20,17 @@
 
 #include "rogue/Directives.h"
 
-#include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <exception>
 #include <memory>
 #include <stdexcept>
 #include <vector>
-#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/Logging.h"

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -17,9 +17,8 @@
 
 #include "rogue/Directives.h"
 
-#include <cstdio>
-
 #include <boost/python.hpp>
+#include <cstdio>
 
 #include "rogue/Version.h"
 #include "rogue/module.h"

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -17,6 +17,8 @@
 
 #include "rogue/Directives.h"
 
+#include <cstdio>
+
 #include <boost/python.hpp>
 
 #include "rogue/Version.h"

--- a/src/rogue/GeneralError.cpp
+++ b/src/rogue/GeneralError.cpp
@@ -20,6 +20,9 @@
 
 #include <stdarg.h>
 
+#include <cstdio>
+#include <string>
+
 #ifndef NO_PYTHON
     #include <boost/python.hpp>
 namespace bp = boost::python;

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -25,6 +25,9 @@
 #include <unistd.h>
 
 #include <memory>
+#include <vector>
+#include <string>
+#include <cstdio>
 
 #if defined(__linux__)
     #include <sys/syscall.h>

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -159,7 +159,7 @@ void rogue::Logging::logThreadId() {
 #elif defined(__APPLE__) && defined(__MACH__)
     uint64_t tid64;
     pthread_threadid_np(NULL, &tid64);
-    tid = (uint32_t)tid64;
+    tid = static_cast<uint32_t>(tid64);
 #else
     tid = 0;
 #endif

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -20,14 +20,14 @@
 
 #include <inttypes.h>
 #include <stdarg.h>
-#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
-#include <memory>
-#include <vector>
-#include <string>
 #include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
 
 #if defined(__linux__)
     #include <sys/syscall.h>

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -24,6 +24,7 @@
 
 #include <sstream>
 #include <string>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -22,9 +22,9 @@
 #include <inttypes.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <sstream>
 #include <string>
-#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/hardware/MemMap.cpp
+++ b/src/rogue/hardware/MemMap.cpp
@@ -20,12 +20,12 @@
 
 #include <fcntl.h>
 #include <inttypes.h>
-#include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <thread>

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <memory>
 #include <thread>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/hardware/axi/AxiMemMap.cpp
+++ b/src/rogue/hardware/axi/AxiMemMap.cpp
@@ -20,16 +20,16 @@
 
 #include <fcntl.h>
 #include <inttypes.h>
-#include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <cstring>
 #include <memory>
-#include <thread>
 #include <string>
+#include <thread>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -133,7 +133,9 @@ void rha::AxiStreamDma::closeShared(rha::AxiStreamDmaSharedPtr desc) {
     desc->openCount--;
 
     if (desc->openCount == 0) {
-        if (desc->rawBuff != NULL) { dmaUnMapDma(desc->fd, desc->rawBuff); }
+        if (desc->rawBuff != NULL) {
+            dmaUnMapDma(desc->fd, desc->rawBuff);
+        }
 
         ::close(desc->fd);
         desc->fd      = -1;

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -22,6 +22,9 @@
 #include <stdlib.h>
 
 #include <memory>
+#include <map>
+#include <cstdio>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/hardware/axi/AxiStreamDma.cpp
+++ b/src/rogue/hardware/axi/AxiStreamDma.cpp
@@ -19,11 +19,11 @@
 #include "rogue/hardware/axi/AxiStreamDma.h"
 
 #include <inttypes.h>
-#include <stdlib.h>
 
-#include <memory>
-#include <map>
 #include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <memory>
 #include <string>
 
 #include "rogue/GeneralError.h"
@@ -133,9 +133,7 @@ void rha::AxiStreamDma::closeShared(rha::AxiStreamDmaSharedPtr desc) {
     desc->openCount--;
 
     if (desc->openCount == 0) {
-        if (desc->rawBuff != NULL) {
-            dmaUnMapDma(desc->fd, desc->rawBuff);
-        }
+        if (desc->rawBuff != NULL) { dmaUnMapDma(desc->fd, desc->rawBuff); }
 
         ::close(desc->fd);
         desc->fd      = -1;

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -22,9 +22,9 @@
 #include <inttypes.h>
 #include <zmq.h>
 
+#include <cstdio>
 #include <memory>
 #include <string>
-#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -289,9 +289,7 @@ void rogue::interfaces::ZmqClientWrap::doUpdate(bp::object data) {
     if (bp::override f = this->get_override("_doUpdate")) {
         try {
             f(data);
-        } catch (...) {
-            PyErr_Print();
-        }
+        } catch (...) { PyErr_Print(); }
     }
     rogue::interfaces::ZmqClient::doUpdate(data);
 }

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -289,7 +289,9 @@ void rogue::interfaces::ZmqClientWrap::doUpdate(bp::object data) {
     if (bp::override f = this->get_override("_doUpdate")) {
         try {
             f(data);
-        } catch (...) { PyErr_Print(); }
+        } catch (...) {
+            PyErr_Print();
+        }
     }
     rogue::interfaces::ZmqClient::doUpdate(data);
 }

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -243,9 +243,7 @@ bp::object rogue::interfaces::ZmqServerWrap::doRequest(bp::object data) {
     if (bp::override f = this->get_override("_doRequest")) {
         try {
             return (f(data));
-        } catch (...) {
-            PyErr_Print();
-        }
+        } catch (...) { PyErr_Print(); }
     }
     return (rogue::interfaces::ZmqServer::doRequest(data));
 }
@@ -260,9 +258,7 @@ std::string rogue::interfaces::ZmqServerWrap::doString(std::string data) {
         if (bp::override f = this->get_override("_doString")) {
             try {
                 return (f(data));
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     return (rogue::interfaces::ZmqServer::doString(data));

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -243,7 +243,9 @@ bp::object rogue::interfaces::ZmqServerWrap::doRequest(bp::object data) {
     if (bp::override f = this->get_override("_doRequest")) {
         try {
             return (f(data));
-        } catch (...) { PyErr_Print(); }
+        } catch (...) {
+            PyErr_Print();
+        }
     }
     return (rogue::interfaces::ZmqServer::doRequest(data));
 }
@@ -258,7 +260,9 @@ std::string rogue::interfaces::ZmqServerWrap::doString(std::string data) {
         if (bp::override f = this->get_override("_doString")) {
             try {
                 return (f(data));
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     return (rogue::interfaces::ZmqServer::doString(data));

--- a/src/rogue/interfaces/api/Bsp.cpp
+++ b/src/rogue/interfaces/api/Bsp.cpp
@@ -17,7 +17,9 @@
 #include "rogue/interfaces/api/Bsp.h"
 
 #include <boost/make_shared.hpp>
+
 #include <string>
+#include <memory>
 
 #include "rogue/GeneralError.h"
 

--- a/src/rogue/interfaces/api/Bsp.cpp
+++ b/src/rogue/interfaces/api/Bsp.cpp
@@ -56,7 +56,9 @@ ria::Bsp::Bsp(std::string modName, std::string rootClass) {
 }
 
 ria::Bsp::~Bsp() {
-    if (this->_isRoot) { this->_obj.attr("stop")(); }
+    if (this->_isRoot) {
+        this->_obj.attr("stop")();
+    }
 }
 
 void ria::Bsp::addVarListener(void (*func)(std::string, std::string), void (*done)()) {
@@ -110,14 +112,18 @@ std::shared_ptr<rogue::interfaces::api::Bsp> ria::Bsp::getNode(std::string name)
 std::string ria::Bsp::operator()(std::string arg) {
     try {
         return (std::string(bp::extract<char*>(this->_obj.attr("callDisp")(arg))));
-    } catch (...) { throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str())); }
+    } catch (...) {
+        throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str()));
+    }
 }
 
 //! Execute command operator without arg
 std::string ria::Bsp::operator()() {
     try {
         return (std::string(bp::extract<char*>(this->_obj.attr("callDisp")())));
-    } catch (...) { throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str())); }
+    } catch (...) {
+        throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str()));
+    }
 }
 
 //! Execute command

--- a/src/rogue/interfaces/api/Bsp.cpp
+++ b/src/rogue/interfaces/api/Bsp.cpp
@@ -17,9 +17,8 @@
 #include "rogue/interfaces/api/Bsp.h"
 
 #include <boost/make_shared.hpp>
-
-#include <string>
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 
@@ -57,9 +56,7 @@ ria::Bsp::Bsp(std::string modName, std::string rootClass) {
 }
 
 ria::Bsp::~Bsp() {
-    if (this->_isRoot) {
-        this->_obj.attr("stop")();
-    }
+    if (this->_isRoot) { this->_obj.attr("stop")(); }
 }
 
 void ria::Bsp::addVarListener(void (*func)(std::string, std::string), void (*done)()) {
@@ -113,18 +110,14 @@ std::shared_ptr<rogue::interfaces::api::Bsp> ria::Bsp::getNode(std::string name)
 std::string ria::Bsp::operator()(std::string arg) {
     try {
         return (std::string(bp::extract<char*>(this->_obj.attr("callDisp")(arg))));
-    } catch (...) {
-        throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str()));
-    }
+    } catch (...) { throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str())); }
 }
 
 //! Execute command operator without arg
 std::string ria::Bsp::operator()() {
     try {
         return (std::string(bp::extract<char*>(this->_obj.attr("callDisp")())));
-    } catch (...) {
-        throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str()));
-    }
+    } catch (...) { throw(rogue::GeneralError::create("Bsp::()", "Error executing node %s", this->_name.c_str())); }
 }
 
 //! Execute command

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -575,7 +575,7 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
     x   = 0;
 
     while (rem > 0) {
-        ss << "0x" << std::setfill('0') << std::hex << std::setw(2) << (uint32_t)(verifyMask_[x]) << " ";
+        ss << "0x" << std::setfill('0') << std::hex << std::setw(2) << static_cast<uint32_t>(verifyMask_[x]) << " ";
         x++;
         rem--;
         if (rem == 0 || x % 10 == 0) {
@@ -1013,7 +1013,7 @@ bp::object rim::Block::getUIntPy(rim::Variable* var, int32_t index) {
             PyArrayObject* arr = reinterpret_cast<PyArrayObject*>(obj);
             uint32_t* dst      = reinterpret_cast<uint32_t*>(PyArray_DATA(arr));
 
-            for (x = 0; x < var->numValues_; x++) dst[x] = (uint32_t)getUInt(var, x);
+            for (x = 0; x < var->numValues_; x++) dst[x] = static_cast<uint32_t>(getUInt(var, x));
         }
         boost::python::handle<> handle(obj);
         ret = bp::object(handle);
@@ -1178,7 +1178,7 @@ bp::object rim::Block::getIntPy(rim::Variable* var, int32_t index) {
             PyArrayObject* arr = reinterpret_cast<PyArrayObject*>(obj);
             int32_t* dst       = reinterpret_cast<int32_t*>(PyArray_DATA(arr));
 
-            for (x = 0; x < var->numValues_; x++) dst[x] = (int32_t)getInt(var, x);
+            for (x = 0; x < var->numValues_; x++) dst[x] = static_cast<int32_t>(getInt(var, x));
         }
         boost::python::handle<> handle(obj);
         ret = bp::object(handle);
@@ -1217,7 +1217,9 @@ int64_t rim::Block::getInt(rim::Variable* var, int32_t index) {
     getBytes(reinterpret_cast<uint8_t*>(&tmp), var, index);
 
     if (var->valueBits_ != 64) {
-        if (tmp >= (uint64_t)pow(2, var->valueBits_ - 1)) tmp -= (uint64_t)pow(2, var->valueBits_);
+        if (tmp >= static_cast<uint64_t>(pow(2, var->valueBits_ - 1))) {
+            tmp -= static_cast<uint64_t>(pow(2, var->valueBits_));
+        }
     }
     return tmp;
 }
@@ -1870,7 +1872,7 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
                                           var->maxValue_));
 
     // Convert
-    int64_t fPoint = (int64_t)round(val * pow(2, var->binPoint_));
+    int64_t fPoint = static_cast<int64_t>(round(val * pow(2, var->binPoint_)));
     // Check for positive edge case
     uint64_t mask = 1 << (var->valueBits_ - 1);
     if (val > 0 && ((fPoint & mask) != 0)) {

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -20,17 +20,17 @@
 #include "rogue/interfaces/memory/Block.h"
 
 #include <inttypes.h>
-#include <string.h>
 #include <sys/time.h>
 
 #include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <exception>
 #include <iomanip>
 #include <memory>
 #include <sstream>
-#include <vector>
 #include <string>
-#include <cstdio>
+#include <vector>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -191,19 +191,17 @@ void rim::Block::intStartTransaction(uint32_t type, bool forceWr, bool check, ri
             highByte = size_ - 1;
             if (type == rim::Write || type == rim::Post) {
                 stale_ = false;
-                for (vit = variables_.begin(); vit != variables_.end(); ++vit) {
-                    (*vit)->stale_ = false;
-                }
+                for (vit = variables_.begin(); vit != variables_.end(); ++vit) { (*vit)->stale_ = false; }
             }
         } else {
             if (type == rim::Read || type == rim::Verify) {
                 if (index < 0 || index >= var->numValues_) {
-                    lowByte  = var->lowTranByte_[0];
+                    lowByte = var->lowTranByte_[0];
 
-                    if ( var->numValues_ == 0 ) {
+                    if (var->numValues_ == 0) {
                         highByte = var->highTranByte_[0];
                     } else {
-                        highByte = var->highTranByte_[var->numValues_-1];
+                        highByte = var->highTranByte_[var->numValues_ - 1];
                     }
                 } else {
                     lowByte  = var->lowTranByte_[index];
@@ -514,14 +512,14 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                     (*vit)->verifyEn_);
             }
 
-        // List variables
+            // List variables
         } else {
             for (x = 0; x < (*vit)->numValues_; x++) {
                 // Variable allows overlaps, add to overlap enable mask
                 if ((*vit)->overlapEn_) {
                     setBits(oleMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
 
-                // Otherwise add to exclusive mask and check for existing mapping
+                    // Otherwise add to exclusive mask and check for existing mapping
                 } else {
                     if (anyBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
                         throw(rogue::GeneralError::create(
@@ -735,9 +733,7 @@ void rim::Block::getBytes(uint8_t* data, rim::Variable* var, uint32_t index) {
     }
 
     // Change byte order
-    if (var->byteReverse_) {
-        reverseBytes(data, var->valueBytes_);
-    }
+    if (var->byteReverse_) { reverseBytes(data, var->valueBytes_); }
 }
 
 //////////////////////////////////////////
@@ -926,15 +922,11 @@ void rim::Block::setUIntPy(bp::object& value, rim::Variable* var, int32_t index)
         if (PyArray_TYPE(arr) == NPY_UINT64) {
             uint64_t* src   = reinterpret_cast<uint64_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(uint64_t);
-            for (x = 0; x < dims[0]; x++) {
-                setUInt(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setUInt(src[x * stride], var, index + x); }
         } else if (PyArray_TYPE(arr) == NPY_UINT32) {
             uint32_t* src   = reinterpret_cast<uint32_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(uint32_t);
-            for (x = 0; x < dims[0]; x++) {
-                setUInt(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setUInt(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setUIntPy",
                                               "Passed nparray is not of type (uint64 or uint32) for %s",
@@ -1089,17 +1081,13 @@ void rim::Block::setIntPy(bp::object& value, rim::Variable* var, int32_t index) 
                                               var->name_.c_str()));
 
         if (PyArray_TYPE(arr) == NPY_INT64) {
-            int64_t* src   = reinterpret_cast<int64_t*>(PyArray_DATA(arr));
+            int64_t* src    = reinterpret_cast<int64_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(int64_t);
-            for (x = 0; x < dims[0]; x++) {
-                setInt(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setInt(src[x * stride], var, index + x); }
         } else if (PyArray_TYPE(arr) == NPY_INT32) {
-            int32_t* src   = reinterpret_cast<int32_t*>(PyArray_DATA(arr));
+            int32_t* src    = reinterpret_cast<int32_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(int32_t);
-            for (x = 0; x < dims[0]; x++) {
-                setInt(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setInt(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setIntPy",
                                               "Passed nparray is not of type (int64 or int32) for %s",
@@ -1260,11 +1248,9 @@ void rim::Block::setBoolPy(bp::object& value, rim::Variable* var, int32_t index)
                                               var->name_.c_str()));
 
         if (PyArray_TYPE(arr) == NPY_BOOL) {
-            bool* src   = reinterpret_cast<bool*>(PyArray_DATA(arr));
+            bool* src       = reinterpret_cast<bool*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(bool);
-            for (x = 0; x < dims[0]; x++) {
-                setBool(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setBool(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setBoolPy",
                                               "Passed nparray is not of type (bool) for %s",
@@ -1472,11 +1458,9 @@ void rim::Block::setFloatPy(bp::object& value, rim::Variable* var, int32_t index
                                               var->name_.c_str()));
 
         if (PyArray_TYPE(arr) == NPY_FLOAT32) {
-            float* src   = reinterpret_cast<float*>(PyArray_DATA(arr));
+            float* src      = reinterpret_cast<float*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(float);
-            for (x = 0; x < dims[0]; x++) {
-                setFloat(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setFloat(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setFLoatPy",
                                               "Passed nparray is not of type (float32) for %s",
@@ -1621,11 +1605,9 @@ void rim::Block::setDoublePy(bp::object& value, rim::Variable* var, int32_t inde
                                               var->name_.c_str()));
 
         if (PyArray_TYPE(arr) == NPY_FLOAT64) {
-            double* src   = reinterpret_cast<double*>(PyArray_DATA(arr));
+            double* src     = reinterpret_cast<double*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(double);
-            for (x = 0; x < dims[0]; x++) {
-                setDouble(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setDouble(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setFLoatPy",
                                               "Passed nparray is not of type (double) for %s",
@@ -1770,11 +1752,9 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
                                               var->name_.c_str()));
 
         if (PyArray_TYPE(arr) == NPY_FLOAT64) {
-            double* src   = reinterpret_cast<double*>(PyArray_DATA(arr));
+            double* src     = reinterpret_cast<double*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(double);
-            for (x = 0; x < dims[0]; x++) {
-                setFixed(src[x * stride], var, index + x);
-            }
+            for (x = 0; x < dims[0]; x++) { setFixed(src[x * stride], var, index + x); }
         } else {
             throw(rogue::GeneralError::create("Block::setFixedPy",
                                               "Passed nparray is not of type (double) for %s",
@@ -1875,9 +1855,7 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
     int64_t fPoint = static_cast<int64_t>(round(val * pow(2, var->binPoint_)));
     // Check for positive edge case
     uint64_t mask = 1 << (var->valueBits_ - 1);
-    if (val > 0 && ((fPoint & mask) != 0)) {
-        fPoint -= 1;
-    }
+    if (val > 0 && ((fPoint & mask) != 0)) { fPoint -= 1; }
     setBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
 }
 
@@ -1888,9 +1866,7 @@ double rim::Block::getFixed(rim::Variable* var, int32_t index) {
 
     getBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
     // Do two-complement if negative
-    if ((fPoint & (1 << (var->valueBits_ - 1))) != 0) {
-        fPoint = fPoint - (1 << var->valueBits_);
-    }
+    if ((fPoint & (1 << (var->valueBits_ - 1))) != 0) { fPoint = fPoint - (1 << var->valueBits_); }
 
     // Convert to float
     tmp = static_cast<double>(fPoint);

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -28,6 +28,9 @@
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <vector>
+#include <string>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -191,7 +191,9 @@ void rim::Block::intStartTransaction(uint32_t type, bool forceWr, bool check, ri
             highByte = size_ - 1;
             if (type == rim::Write || type == rim::Post) {
                 stale_ = false;
-                for (vit = variables_.begin(); vit != variables_.end(); ++vit) { (*vit)->stale_ = false; }
+                for (vit = variables_.begin(); vit != variables_.end(); ++vit) {
+                    (*vit)->stale_ = false;
+                }
             }
         } else {
             if (type == rim::Read || type == rim::Verify) {
@@ -733,7 +735,9 @@ void rim::Block::getBytes(uint8_t* data, rim::Variable* var, uint32_t index) {
     }
 
     // Change byte order
-    if (var->byteReverse_) { reverseBytes(data, var->valueBytes_); }
+    if (var->byteReverse_) {
+        reverseBytes(data, var->valueBytes_);
+    }
 }
 
 //////////////////////////////////////////
@@ -922,11 +926,15 @@ void rim::Block::setUIntPy(bp::object& value, rim::Variable* var, int32_t index)
         if (PyArray_TYPE(arr) == NPY_UINT64) {
             uint64_t* src   = reinterpret_cast<uint64_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(uint64_t);
-            for (x = 0; x < dims[0]; x++) { setUInt(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setUInt(src[x * stride], var, index + x);
+            }
         } else if (PyArray_TYPE(arr) == NPY_UINT32) {
             uint32_t* src   = reinterpret_cast<uint32_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(uint32_t);
-            for (x = 0; x < dims[0]; x++) { setUInt(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setUInt(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setUIntPy",
                                               "Passed nparray is not of type (uint64 or uint32) for %s",
@@ -1083,11 +1091,15 @@ void rim::Block::setIntPy(bp::object& value, rim::Variable* var, int32_t index) 
         if (PyArray_TYPE(arr) == NPY_INT64) {
             int64_t* src    = reinterpret_cast<int64_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(int64_t);
-            for (x = 0; x < dims[0]; x++) { setInt(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setInt(src[x * stride], var, index + x);
+            }
         } else if (PyArray_TYPE(arr) == NPY_INT32) {
             int32_t* src    = reinterpret_cast<int32_t*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(int32_t);
-            for (x = 0; x < dims[0]; x++) { setInt(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setInt(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setIntPy",
                                               "Passed nparray is not of type (int64 or int32) for %s",
@@ -1250,7 +1262,9 @@ void rim::Block::setBoolPy(bp::object& value, rim::Variable* var, int32_t index)
         if (PyArray_TYPE(arr) == NPY_BOOL) {
             bool* src       = reinterpret_cast<bool*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(bool);
-            for (x = 0; x < dims[0]; x++) { setBool(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setBool(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setBoolPy",
                                               "Passed nparray is not of type (bool) for %s",
@@ -1460,7 +1474,9 @@ void rim::Block::setFloatPy(bp::object& value, rim::Variable* var, int32_t index
         if (PyArray_TYPE(arr) == NPY_FLOAT32) {
             float* src      = reinterpret_cast<float*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(float);
-            for (x = 0; x < dims[0]; x++) { setFloat(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setFloat(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setFLoatPy",
                                               "Passed nparray is not of type (float32) for %s",
@@ -1607,7 +1623,9 @@ void rim::Block::setDoublePy(bp::object& value, rim::Variable* var, int32_t inde
         if (PyArray_TYPE(arr) == NPY_FLOAT64) {
             double* src     = reinterpret_cast<double*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(double);
-            for (x = 0; x < dims[0]; x++) { setDouble(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setDouble(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setFLoatPy",
                                               "Passed nparray is not of type (double) for %s",
@@ -1754,7 +1772,9 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
         if (PyArray_TYPE(arr) == NPY_FLOAT64) {
             double* src     = reinterpret_cast<double*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(double);
-            for (x = 0; x < dims[0]; x++) { setFixed(src[x * stride], var, index + x); }
+            for (x = 0; x < dims[0]; x++) {
+                setFixed(src[x * stride], var, index + x);
+            }
         } else {
             throw(rogue::GeneralError::create("Block::setFixedPy",
                                               "Passed nparray is not of type (double) for %s",
@@ -1855,7 +1875,9 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
     int64_t fPoint = static_cast<int64_t>(round(val * pow(2, var->binPoint_)));
     // Check for positive edge case
     uint64_t mask = 1 << (var->valueBits_ - 1);
-    if (val > 0 && ((fPoint & mask) != 0)) { fPoint -= 1; }
+    if (val > 0 && ((fPoint & mask) != 0)) {
+        fPoint -= 1;
+    }
     setBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
 }
 
@@ -1866,7 +1888,9 @@ double rim::Block::getFixed(rim::Variable* var, int32_t index) {
 
     getBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
     // Do two-complement if negative
-    if ((fPoint & (1 << (var->valueBits_ - 1))) != 0) { fPoint = fPoint - (1 << var->valueBits_); }
+    if ((fPoint & (1 << (var->valueBits_ - 1))) != 0) {
+        fPoint = fPoint - (1 << var->valueBits_);
+    }
 
     // Convert to float
     tmp = static_cast<double>(fPoint);

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -24,6 +24,8 @@
 #include <string.h>
 
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "rogue/GilRelease.h"
 #include "rogue/interfaces/memory/Constants.h"

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -21,8 +21,8 @@
 #include "rogue/interfaces/memory/Emulate.h"
 
 #include <inttypes.h>
-#include <string.h>
 
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -181,7 +181,9 @@ void rim::HubWrap::doTransaction(rim::TransactionPtr transaction) {
             try {
                 pb(transaction);
                 return;
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     rim::Hub::doTransaction(transaction);

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -181,9 +181,7 @@ void rim::HubWrap::doTransaction(rim::TransactionPtr transaction) {
             try {
                 pb(transaction);
                 return;
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     rim::Hub::doTransaction(transaction);

--- a/src/rogue/interfaces/memory/Hub.cpp
+++ b/src/rogue/interfaces/memory/Hub.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <memory>
+#include <string>
 
 #include "rogue/GilRelease.h"
 #include "rogue/ScopedGil.h"

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -23,6 +23,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/Master.cpp
+++ b/src/rogue/interfaces/memory/Master.cpp
@@ -19,8 +19,8 @@
 #include "rogue/interfaces/memory/Master.h"
 
 #include <inttypes.h>
-#include <stdlib.h>
 
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <string>

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -100,7 +100,9 @@ rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
 
         // Clean up if we found an expired transaction, overtime this will clean up
         // the list, even if it deletes one expired transaction per call
-        if (exp != tranMap_.end()) { tranMap_.erase(exp); }
+        if (exp != tranMap_.end()) {
+            tranMap_.erase(exp);
+        }
     }
     return ret;
 }
@@ -188,7 +190,9 @@ uint32_t rim::SlaveWrap::doMinAccess() {
         if (boost::python::override pb = this->get_override("_doMinAccess")) {
             try {
                 return (pb());
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     return (rim::Slave::doMinAccess());
@@ -207,7 +211,9 @@ uint32_t rim::SlaveWrap::doMaxAccess() {
         if (boost::python::override pb = this->get_override("_doMaxAccess")) {
             try {
                 return (pb());
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     return (rim::Slave::doMaxAccess());
@@ -226,7 +232,9 @@ uint64_t rim::SlaveWrap::doAddress() {
         if (boost::python::override pb = this->get_override("_doAddress")) {
             try {
                 return (pb());
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     return (rim::Slave::doAddress());
@@ -246,7 +254,9 @@ void rim::SlaveWrap::doTransaction(rim::TransactionPtr transaction) {
             try {
                 pb(transaction);
                 return;
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     rim::Slave::doTransaction(transaction);

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -19,6 +19,7 @@
 #include "rogue/interfaces/memory/Slave.h"
 
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/Slave.cpp
+++ b/src/rogue/interfaces/memory/Slave.cpp
@@ -100,9 +100,7 @@ rim::TransactionPtr rim::Slave::getTransaction(uint32_t index) {
 
         // Clean up if we found an expired transaction, overtime this will clean up
         // the list, even if it deletes one expired transaction per call
-        if (exp != tranMap_.end()) {
-            tranMap_.erase(exp);
-        }
+        if (exp != tranMap_.end()) { tranMap_.erase(exp); }
     }
     return ret;
 }
@@ -190,9 +188,7 @@ uint32_t rim::SlaveWrap::doMinAccess() {
         if (boost::python::override pb = this->get_override("_doMinAccess")) {
             try {
                 return (pb());
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     return (rim::Slave::doMinAccess());
@@ -211,9 +207,7 @@ uint32_t rim::SlaveWrap::doMaxAccess() {
         if (boost::python::override pb = this->get_override("_doMaxAccess")) {
             try {
                 return (pb());
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     return (rim::Slave::doMaxAccess());
@@ -232,9 +226,7 @@ uint64_t rim::SlaveWrap::doAddress() {
         if (boost::python::override pb = this->get_override("_doAddress")) {
             try {
                 return (pb());
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     return (rim::Slave::doAddress());
@@ -254,9 +246,7 @@ void rim::SlaveWrap::doTransaction(rim::TransactionPtr transaction) {
             try {
                 pb(transaction);
                 return;
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     rim::Slave::doTransaction(transaction);

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -19,7 +19,6 @@
 #include "rogue/interfaces/memory/TcpClient.h"
 
 #include <inttypes.h>
-#include <string.h>
 #include <zmq.h>
 
 #include <cstring>

--- a/src/rogue/interfaces/memory/TcpClient.cpp
+++ b/src/rogue/interfaces/memory/TcpClient.cpp
@@ -24,6 +24,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -24,6 +24,7 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/TcpServer.cpp
+++ b/src/rogue/interfaces/memory/TcpServer.cpp
@@ -19,7 +19,6 @@
 #include "rogue/interfaces/memory/TcpServer.h"
 
 #include <inttypes.h>
-#include <string.h>
 #include <zmq.h>
 
 #include <cstring>

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -22,9 +22,9 @@
 #include <stdarg.h>
 #include <sys/time.h>
 
+#include <cstdio>
 #include <memory>
 #include <string>
-#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -109,9 +109,7 @@ rim::TransactionLockPtr rim::Transaction::lock() {
 //! Get expired state
 bool rim::Transaction::expired() {
     bool done = false;
-    if (isSubTransaction_) {
-        done = parentTransaction_.expired();
-    }
+    if (isSubTransaction_) { done = parentTransaction_.expired(); }
     return done || (iter_ == NULL || done_);
 }
 

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -23,6 +23,8 @@
 #include <sys/time.h>
 
 #include <memory>
+#include <string>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/Transaction.cpp
+++ b/src/rogue/interfaces/memory/Transaction.cpp
@@ -109,7 +109,9 @@ rim::TransactionLockPtr rim::Transaction::lock() {
 //! Get expired state
 bool rim::Transaction::expired() {
     bool done = false;
-    if (isSubTransaction_) { done = parentTransaction_.expired(); }
+    if (isSubTransaction_) {
+        done = parentTransaction_.expired();
+    }
     return done || (iter_ == NULL || done_);
 }
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -18,17 +18,17 @@
 
 #include "rogue/interfaces/memory/Variable.h"
 
-#include <string.h>
 #include <sys/time.h>
 
 #include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <memory>
 #include <sstream>
-#include <vector>
-#include <cstdio>
 #include <string>
+#include <vector>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -473,7 +473,7 @@ void rim::Variable::shiftOffsetDown(uint32_t shift, uint32_t minSize) {
         highTranByte_[0] = varBytes_ - 1;
         staleHighByte_   = highTranByte_[0];
 
-    // List variable
+        // List variable
     } else {
         for (x = 0; x < numValues_; x++) {
             lowTranByte_[x] =
@@ -623,9 +623,7 @@ void rim::VariableWrap::queueUpdate() {
         try {
             pb();
             return;
-        } catch (...) {
-            PyErr_Print();
-        }
+        } catch (...) { PyErr_Print(); }
     }
 }
 
@@ -654,9 +652,7 @@ void rim::Variable::rateTest() {
     uint32_t ret;
 
     gettimeofday(&stime, NULL);
-    for (x = 0; x < count; ++x) {
-        ret = getUInt();
-    }
+    for (x = 0; x < count; ++x) { ret = getUInt(); }
     gettimeofday(&etime, NULL);
 
     timersub(&etime, &stime, &dtime);
@@ -666,9 +662,7 @@ void rim::Variable::rateTest() {
     printf("\nVariable c++ get: Read %" PRIu64 " times in %f seconds. Rate = %f\n", count, durr, rate);
 
     gettimeofday(&stime, NULL);
-    for (x = 0; x < count; ++x) {
-        setUInt(x);
-    }
+    for (x = 0; x < count; ++x) { setUInt(x); }
     gettimeofday(&etime, NULL);
 
     timersub(&etime, &stime, &dtime);

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -26,6 +26,9 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <vector>
+#include <cstdio>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -623,7 +623,9 @@ void rim::VariableWrap::queueUpdate() {
         try {
             pb();
             return;
-        } catch (...) { PyErr_Print(); }
+        } catch (...) {
+            PyErr_Print();
+        }
     }
 }
 
@@ -652,7 +654,9 @@ void rim::Variable::rateTest() {
     uint32_t ret;
 
     gettimeofday(&stime, NULL);
-    for (x = 0; x < count; ++x) { ret = getUInt(); }
+    for (x = 0; x < count; ++x) {
+        ret = getUInt();
+    }
     gettimeofday(&etime, NULL);
 
     timersub(&etime, &stime, &dtime);
@@ -662,7 +666,9 @@ void rim::Variable::rateTest() {
     printf("\nVariable c++ get: Read %" PRIu64 " times in %f seconds. Rate = %f\n", count, durr, rate);
 
     gettimeofday(&stime, NULL);
-    for (x = 0; x < count; ++x) { setUInt(x); }
+    for (x = 0; x < count; ++x) {
+        setUInt(x);
+    }
     gettimeofday(&etime, NULL);
 
     timersub(&etime, &stime, &dtime);

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -705,7 +705,7 @@ std::string rim::Variable::getDumpValue(bool read) {
     else
         index = 0;
 
-    while (index < (int32_t)numValues_) {
+    while (index < static_cast<int32_t>(numValues_)) {
         ret << " ";
 
         switch (modelId_) {
@@ -713,7 +713,7 @@ std::string rim::Variable::getDumpValue(bool read) {
                 (block_->*getByteArray_)(byteData, this, index);
                 ret << "0x";
                 for (x = 0; x < valueBytes_; x++)
-                    ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
+                    ret << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint32_t>(byteData[x]);
                 break;
 
             case rim::UInt:
@@ -721,7 +721,7 @@ std::string rim::Variable::getDumpValue(bool read) {
                     (block_->*getByteArray_)(byteData, this, index);
                     ret << "0x";
                     for (x = 0; x < valueBytes_; x++)
-                        ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
+                        ret << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint32_t>(byteData[x]);
                 } else {
                     ret << (block_->*getUInt_)(this, index);
                 }
@@ -732,7 +732,7 @@ std::string rim::Variable::getDumpValue(bool read) {
                     (block_->*getByteArray_)(byteData, this, index);
                     ret << "0x";
                     for (x = 0; x < valueBytes_; x++)
-                        ret << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)byteData[x];
+                        ret << std::setfill('0') << std::setw(2) << std::hex << static_cast<uint32_t>(byteData[x]);
                 } else {
                     ret << (block_->*getInt_)(this, index);
                 }

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -19,8 +19,8 @@
 
 #include <inttypes.h>
 
-#include <memory>
 #include <cstdio>
+#include <memory>
 
 #include "rogue/GeneralError.h"
 #include "rogue/interfaces/stream/Frame.h"

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 
 #include <memory>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/interfaces/stream/Frame.h"

--- a/src/rogue/interfaces/stream/Buffer.cpp
+++ b/src/rogue/interfaces/stream/Buffer.cpp
@@ -78,14 +78,14 @@ void ris::Buffer::setMeta(uint32_t meta) {
 //! Adjust header by passed value
 void ris::Buffer::adjustHeader(int32_t value) {
     // Decreasing header size
-    if (value < 0 && (uint32_t)abs(value) > headRoom_)
+    if (value < 0 && static_cast<uint32_t>(abs(value)) > headRoom_)
         throw(rogue::GeneralError::create("Buffer::adjustHeader",
                                           "Attempt to reduce header with size %" PRIu32 " by %" PRIi32,
                                           headRoom_,
                                           value));
 
     // Increasing header size
-    if (value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)))
+    if (value > 0 && static_cast<uint32_t>(value) > (rawSize_ - (headRoom_ + tailRoom_)))
         throw(rogue::GeneralError::create("Buffer::adjustHeader",
                                           "Attempt to increase header by %" PRIi32 " in buffer with size %" PRIu32,
                                           value,
@@ -112,14 +112,14 @@ void ris::Buffer::zeroHeader() {
 //! Adjust tail by passed value
 void ris::Buffer::adjustTail(int32_t value) {
     // Decreasing tail size
-    if (value < 0 && (uint32_t)abs(value) > tailRoom_)
+    if (value < 0 && static_cast<uint32_t>(abs(value)) > tailRoom_)
         throw(rogue::GeneralError::create("Buffer::adjustTail",
                                           "Attempt to reduce tail with size %" PRIu32 " by %" PRIi32,
                                           tailRoom_,
                                           value));
 
     // Increasing tail size
-    if (value > 0 && (uint32_t)value > (rawSize_ - (headRoom_ + tailRoom_)))
+    if (value > 0 && static_cast<uint32_t>(value) > (rawSize_ - (headRoom_ + tailRoom_)))
         throw(rogue::GeneralError::create("Buffer::adjustTail",
                                           "Attempt to increase header by %" PRIi32 " in buffer with size %" PRIu32,
                                           value,
@@ -227,7 +227,7 @@ void ris::Buffer::minPayload(uint32_t size) {
 
 //! Adjust payload size
 void ris::Buffer::adjustPayload(int32_t value) {
-    if (value < 0 && (uint32_t)abs(value) > getPayload())
+    if (value < 0 && static_cast<uint32_t>(abs(value)) > getPayload())
         throw(rogue::GeneralError::create("Buffer::adjustPayload",
                                           "Attempt to decrease payload by %" PRIi32 " in buffer with size %" PRIu32,
                                           value,

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -21,6 +21,7 @@
 #include <inttypes.h>
 
 #include <memory>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/interfaces/stream/Buffer.h"

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -220,7 +220,7 @@ void ris::Frame::minPayload(uint32_t size) {
 void ris::Frame::adjustPayload(int32_t value) {
     uint32_t size = getPayload();
 
-    if (value < 0 && (uint32_t)abs(value) > size)
+    if (value < 0 && static_cast<uint32_t>(abs(value)) > size)
         throw(rogue::GeneralError::create("Frame::adjustPayload",
                                           "Attempt to reduce payload by %" PRIi32 " in frame with size %" PRIu32,
                                           value,

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -434,7 +434,9 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     PyObject* obj = p.ptr();
 
     // Check that this is a PyArrayObject
-    if (!PyArray_Check(obj)) { throw(rogue::GeneralError("Frame::putNumpy", "Object is not a numpy array")); }
+    if (!PyArray_Check(obj)) {
+        throw(rogue::GeneralError("Frame::putNumpy", "Object is not a numpy array"));
+    }
 
     // Cast to an array object and check that the numpy array
     // data buffer is write-able and contiguous
@@ -442,7 +444,9 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     PyArrayObject* arr = reinterpret_cast<decltype(arr)>(obj);
     int flags          = PyArray_FLAGS(arr);
     bool ctg           = flags & (NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
-    if (!ctg) { arr = PyArray_GETCONTIGUOUS(arr); }
+    if (!ctg) {
+        arr = PyArray_GETCONTIGUOUS(arr);
+    }
 
     // Get the number of bytes in both the source and destination buffers
     uint32_t size  = getSize();
@@ -468,7 +472,9 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     ris::toFrame(beg, count, src);
 
     // If were forced to make a temporary copy, release it
-    if (!ctg) { Py_XDECREF(arr); }
+    if (!ctg) {
+        Py_XDECREF(arr);
+    }
 
     return;
 }

--- a/src/rogue/interfaces/stream/Frame.cpp
+++ b/src/rogue/interfaces/stream/Frame.cpp
@@ -20,8 +20,8 @@
 
 #include <inttypes.h>
 
-#include <memory>
 #include <cstdio>
+#include <memory>
 
 #include "rogue/GeneralError.h"
 #include "rogue/interfaces/stream/Buffer.h"
@@ -434,9 +434,7 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     PyObject* obj = p.ptr();
 
     // Check that this is a PyArrayObject
-    if (!PyArray_Check(obj)) {
-        throw(rogue::GeneralError("Frame::putNumpy", "Object is not a numpy array"));
-    }
+    if (!PyArray_Check(obj)) { throw(rogue::GeneralError("Frame::putNumpy", "Object is not a numpy array")); }
 
     // Cast to an array object and check that the numpy array
     // data buffer is write-able and contiguous
@@ -444,9 +442,7 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     PyArrayObject* arr = reinterpret_cast<decltype(arr)>(obj);
     int flags          = PyArray_FLAGS(arr);
     bool ctg           = flags & (NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
-    if (!ctg) {
-        arr = PyArray_GETCONTIGUOUS(arr);
-    }
+    if (!ctg) { arr = PyArray_GETCONTIGUOUS(arr); }
 
     // Get the number of bytes in both the source and destination buffers
     uint32_t size  = getSize();
@@ -472,9 +468,7 @@ void ris::Frame::putNumpy(boost::python::object p, uint32_t offset) {
     ris::toFrame(beg, count, src);
 
     // If were forced to make a temporary copy, release it
-    if (!ctg) {
-        Py_XDECREF(arr);
-    }
+    if (!ctg) { Py_XDECREF(arr); }
 
     return;
 }

--- a/src/rogue/interfaces/stream/FrameIterator.cpp
+++ b/src/rogue/interfaces/stream/FrameIterator.cpp
@@ -156,7 +156,7 @@ uint8_t* ris::FrameIterator::ptr() const {
 //! De-reference by index
 uint8_t ris::FrameIterator::operator[](const uint32_t offset) const {
     ris::FrameIterator ret(*this);
-    ret.increment((int32_t)offset);
+    ret.increment(static_cast<int32_t>(offset));
     return *ret;
 }
 

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include <memory>
+#include <vector>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -156,7 +156,9 @@ void ris::Master::equalsPy(boost::python::object p) {
         boost::python::extract<ris::MasterPtr> get_master(p.attr("_getStreamMaster")());
 
         // Test extraction
-        if (get_master.check()) { rMst = get_master(); }
+        if (get_master.check()) {
+            rMst = get_master();
+        }
     }
 
     // Attempt to access object as a stream slave
@@ -172,7 +174,9 @@ void ris::Master::equalsPy(boost::python::object p) {
         boost::python::extract<ris::SlavePtr> get_slave(p.attr("_getStreamSlave")());
 
         // Test extraction
-        if (get_slave.check()) { rSlv = get_slave(); }
+        if (get_slave.check()) {
+            rSlv = get_slave();
+        }
     }
 
     if (rMst == NULL || rSlv == NULL || lSlv == NULL)
@@ -200,7 +204,9 @@ bp::object ris::Master::rshiftPy(bp::object p) {
         boost::python::extract<ris::SlavePtr> get_slave(p.attr("_getStreamSlave")());
 
         // Test extraction
-        if (get_slave.check()) { slv = get_slave(); }
+        if (get_slave.check()) {
+            slv = get_slave();
+        }
     }
 
     if (slv != NULL)

--- a/src/rogue/interfaces/stream/Master.cpp
+++ b/src/rogue/interfaces/stream/Master.cpp
@@ -156,9 +156,7 @@ void ris::Master::equalsPy(boost::python::object p) {
         boost::python::extract<ris::MasterPtr> get_master(p.attr("_getStreamMaster")());
 
         // Test extraction
-        if (get_master.check()) {
-            rMst = get_master();
-        }
+        if (get_master.check()) { rMst = get_master(); }
     }
 
     // Attempt to access object as a stream slave
@@ -174,9 +172,7 @@ void ris::Master::equalsPy(boost::python::object p) {
         boost::python::extract<ris::SlavePtr> get_slave(p.attr("_getStreamSlave")());
 
         // Test extraction
-        if (get_slave.check()) {
-            rSlv = get_slave();
-        }
+        if (get_slave.check()) { rSlv = get_slave(); }
     }
 
     if (rMst == NULL || rSlv == NULL || lSlv == NULL)
@@ -204,9 +200,7 @@ bp::object ris::Master::rshiftPy(bp::object p) {
         boost::python::extract<ris::SlavePtr> get_slave(p.attr("_getStreamSlave")());
 
         // Test extraction
-        if (get_slave.check()) {
-            slv = get_slave();
-        }
+        if (get_slave.check()) { slv = get_slave(); }
     }
 
     if (slv != NULL)

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -49,9 +49,7 @@ ris::Pool::Pool() {
 
 //! Destructor
 ris::Pool::~Pool() {
-    while (!dataQ_.empty()) {
-        free(dataQ_.front());
-    }
+    while (!dataQ_.empty()) { free(dataQ_.front()); }
 }
 
 //! Get allocated memory

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -49,7 +49,9 @@ ris::Pool::Pool() {
 
 //! Destructor
 ris::Pool::~Pool() {
-    while (!dataQ_.empty()) { free(dataQ_.front()); }
+    while (!dataQ_.empty()) {
+        free(dataQ_.front());
+    }
 }
 
 //! Get allocated memory

--- a/src/rogue/interfaces/stream/RateDrop.cpp
+++ b/src/rogue/interfaces/stream/RateDrop.cpp
@@ -21,8 +21,8 @@
 #include <stdint.h>
 #include <sys/time.h>
 
-#include <memory>
 #include <cstdio>
+#include <memory>
 
 #include "rogue/Logging.h"
 #include "rogue/interfaces/stream/Frame.h"

--- a/src/rogue/interfaces/stream/RateDrop.cpp
+++ b/src/rogue/interfaces/stream/RateDrop.cpp
@@ -22,6 +22,7 @@
 #include <sys/time.h>
 
 #include <memory>
+#include <cstdio>
 
 #include "rogue/Logging.h"
 #include "rogue/interfaces/stream/Frame.h"

--- a/src/rogue/interfaces/stream/RateDrop.cpp
+++ b/src/rogue/interfaces/stream/RateDrop.cpp
@@ -58,12 +58,12 @@ ris::RateDrop::RateDrop(bool period, double value) : ris::Master(), ris::Slave()
 
     if ((!period) || value == 0) {
         periodFlag_ = false;
-        dropCount_  = (uint32_t)value;
-        dropTarget_ = (uint32_t)value;
+        dropCount_  = static_cast<uint32_t>(value);
+        dropTarget_ = static_cast<uint32_t>(value);
     } else {
         periodFlag_ = true;
 
-        per = (uint32_t)(value * 1e6);
+        per = static_cast<uint32_t>(value * 1e6);
 
         div_t divResult     = div(per, 1000000);
         timePeriod_.tv_sec  = divResult.quot;

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -21,12 +21,12 @@
 #include "rogue/interfaces/stream/Slave.h"
 
 #include <inttypes.h>
-#include <string.h>
 #include <unistd.h>
 
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
-#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -115,9 +115,7 @@ void ris::SlaveWrap::acceptFrame(ris::FramePtr frame) {
             try {
                 pb(frame);
                 return;
-            } catch (...) {
-                PyErr_Print();
-            }
+            } catch (...) { PyErr_Print(); }
         }
     }
     ris::Slave::acceptFrame(frame);

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/stream/Slave.cpp
+++ b/src/rogue/interfaces/stream/Slave.cpp
@@ -115,7 +115,9 @@ void ris::SlaveWrap::acceptFrame(ris::FramePtr frame) {
             try {
                 pb(frame);
                 return;
-            } catch (...) { PyErr_Print(); }
+            } catch (...) {
+                PyErr_Print();
+            }
         }
     }
     ris::Slave::acceptFrame(frame);

--- a/src/rogue/interfaces/stream/TcpClient.cpp
+++ b/src/rogue/interfaces/stream/TcpClient.cpp
@@ -21,6 +21,7 @@
 #include <zmq.h>
 
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -19,9 +19,9 @@
 #include "rogue/interfaces/stream/TcpCore.h"
 
 #include <inttypes.h>
-#include <string.h>
 #include <zmq.h>
 
+#include <cstring>
 #include <memory>
 #include <string>
 

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -23,6 +23,7 @@
 #include <zmq.h>
 
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/interfaces/stream/TcpServer.cpp
+++ b/src/rogue/interfaces/stream/TcpServer.cpp
@@ -21,6 +21,7 @@
 #include <zmq.h>
 
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/batcher/CoreV1.cpp
+++ b/src/rogue/protocols/batcher/CoreV1.cpp
@@ -41,9 +41,9 @@
 #include "rogue/protocols/batcher/CoreV1.h"
 
 #include <inttypes.h>
-#include <math.h>
 #include <stdint.h>
 
+#include <cmath>
 #include <memory>
 #include <thread>
 

--- a/src/rogue/protocols/batcher/InverterV1.cpp
+++ b/src/rogue/protocols/batcher/InverterV1.cpp
@@ -18,9 +18,9 @@
 
 #include "rogue/protocols/batcher/InverterV1.h"
 
-#include <math.h>
 #include <stdint.h>
 
+#include <cmath>
 #include <memory>
 #include <thread>
 

--- a/src/rogue/protocols/batcher/SplitterV1.cpp
+++ b/src/rogue/protocols/batcher/SplitterV1.cpp
@@ -18,9 +18,9 @@
 
 #include "rogue/protocols/batcher/SplitterV1.h"
 
-#include <math.h>
 #include <stdint.h>
 
+#include <cmath>
 #include <memory>
 #include <thread>
 

--- a/src/rogue/protocols/packetizer/Controller.cpp
+++ b/src/rogue/protocols/packetizer/Controller.cpp
@@ -17,8 +17,8 @@
 #include "rogue/protocols/packetizer/Controller.h"
 
 #include <inttypes.h>
-#include <math.h>
 
+#include <cmath>
 #include <memory>
 
 #include "rogue/GeneralError.h"

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -17,11 +17,11 @@
 #include "rogue/protocols/packetizer/ControllerV1.h"
 
 #include <inttypes.h>
-#include <math.h>
-#include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <cmath>
+#include <cstdlib>
 #include <memory>
 
 #include "rogue/GeneralError.h"
@@ -165,9 +165,7 @@ void rpp::ControllerV1::transportRx(ris::FramePtr frame) {
     if (tmpEof) {
         tranFrame_[0]->setLastUser(tmpLuser);
         tranCount_[0] = 0;
-        if (app_[tranDest_]) {
-            app_[tranDest_]->pushFrame(tranFrame_[0]);
-        }
+        if (app_[tranDest_]) { app_[tranDest_]->pushFrame(tranFrame_[0]); }
         tranFrame_[0].reset();
 
         // Detect SSI error

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -87,12 +87,12 @@ void rpp::ControllerV1::transportRx(ris::FramePtr frame) {
         return;
     }
 
-    tmpIdx = uint32_t(data[0]) >> 4;
-    tmpIdx |= uint32_t(data[1]) << 4;
+    tmpIdx = static_cast<uint32_t>(data[0]) >> 4;
+    tmpIdx |= static_cast<uint32_t>(data[1]) << 4;
 
-    tmpCount = uint32_t(data[2]);
-    tmpCount |= uint32_t(data[3]) << 8;
-    tmpCount |= uint32_t(data[4]) << 16;
+    tmpCount = static_cast<uint32_t>(data[2]);
+    tmpCount |= static_cast<uint32_t>(data[3]) << 8;
+    tmpCount |= static_cast<uint32_t>(data[4]) << 16;
 
     tmpDest  = data[5];
     tmpId    = data[6];

--- a/src/rogue/protocols/packetizer/ControllerV1.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV1.cpp
@@ -165,7 +165,9 @@ void rpp::ControllerV1::transportRx(ris::FramePtr frame) {
     if (tmpEof) {
         tranFrame_[0]->setLastUser(tmpLuser);
         tranCount_[0] = 0;
-        if (app_[tranDest_]) { app_[tranDest_]->pushFrame(tranFrame_[0]); }
+        if (app_[tranDest_]) {
+            app_[tranDest_]->pushFrame(tranFrame_[0]);
+        }
         tranFrame_[0].reset();
 
         // Detect SSI error

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -118,21 +118,21 @@ void rpp::ControllerV2::transportRx(ris::FramePtr frame) {
     tmpId    = data[3];
 
     // Header word 1
-    tmpCount = uint32_t(data[4]) << 0;
-    tmpCount |= uint32_t(data[5]) << 8;
+    tmpCount = static_cast<uint32_t>(data[4]) << 0;
+    tmpCount |= static_cast<uint32_t>(data[5]) << 8;
     tmpSof = ((data[7] & 0x80) ? true : false);  // SOF (PACKETIZER2_HDR_SOF_BIT_C = 63)
 
     // Tail word 0
     tmpLuser = data[size - 8];
     tmpEof   = ((data[size - 7] & 0x1) ? true : false);
-    last     = uint32_t(data[size - 6]);
+    last     = static_cast<uint32_t>(data[size - 6]);
 
     if (enIbCrc_) {
         // Tail word 1
-        tmpCrc = uint32_t(data[size - 1]) << 0;
-        tmpCrc |= uint32_t(data[size - 2]) << 8;
-        tmpCrc |= uint32_t(data[size - 3]) << 16;
-        tmpCrc |= uint32_t(data[size - 4]) << 24;
+        tmpCrc = static_cast<uint32_t>(data[size - 1]) << 0;
+        tmpCrc |= static_cast<uint32_t>(data[size - 2]) << 8;
+        tmpCrc |= static_cast<uint32_t>(data[size - 3]) << 16;
+        tmpCrc |= static_cast<uint32_t>(data[size - 4]) << 24;
 
         // Compute CRC
         if (tmpSof)
@@ -179,7 +179,7 @@ void rpp::ControllerV2::transportRx(ris::FramePtr frame) {
 
     // Shorten message by removing tail and adjusting for last value
     // Do this before adjusting tail reservation
-    buff->adjustPayload(-8 + ((int32_t)last - 8));
+    buff->adjustPayload(-8 + (static_cast<int32_t>(last) - 8));
 
     // Add 8 bytes to headroom and tail reservation
     buff->adjustHeader(8);

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -233,7 +233,9 @@ void rpp::ControllerV2::transportRx(ris::FramePtr frame) {
         tranFrame_[tmpDest]->setLastUser(tmpLuser);
         transSof_[tmpDest]  = true;
         tranCount_[tmpDest] = 0;
-        if (app_[tmpDest]) { app_[tmpDest]->pushFrame(tranFrame_[tmpDest]); }
+        if (app_[tmpDest]) {
+            app_[tmpDest]->pushFrame(tranFrame_[tmpDest]);
+        }
         tranFrame_[tmpDest].reset();
 
         // Detect SSI error

--- a/src/rogue/protocols/packetizer/ControllerV2.cpp
+++ b/src/rogue/protocols/packetizer/ControllerV2.cpp
@@ -17,11 +17,11 @@
 #include "rogue/protocols/packetizer/ControllerV2.h"
 
 #include <inttypes.h>
-#include <math.h>
-#include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <cmath>
+#include <cstdlib>
 #include <memory>
 
 #include "rogue/GeneralError.h"
@@ -233,9 +233,7 @@ void rpp::ControllerV2::transportRx(ris::FramePtr frame) {
         tranFrame_[tmpDest]->setLastUser(tmpLuser);
         transSof_[tmpDest]  = true;
         tranCount_[tmpDest] = 0;
-        if (app_[tmpDest]) {
-            app_[tmpDest]->pushFrame(tranFrame_[tmpDest]);
-        }
+        if (app_[tmpDest]) { app_[tmpDest]->pushFrame(tranFrame_[tmpDest]); }
         tranFrame_[tmpDest].reset();
 
         // Detect SSI error

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -25,6 +25,8 @@
 
 #include <cmath>
 #include <memory>
+#include <map>
+#include <utility>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -17,15 +17,14 @@
 #include "rogue/protocols/rssi/Controller.h"
 
 #include <inttypes.h>
-#include <math.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
 #include <cmath>
-#include <memory>
+#include <cstdlib>
+#include <cstring>
 #include <map>
+#include <memory>
 #include <utility>
 
 #include "rogue/GeneralError.h"
@@ -237,9 +236,7 @@ void rpr::Controller::transportRx(ris::FramePtr frame) {
 
     // Reset
     if (head->rst) {
-        if (state_ == StOpen || state_ == StWaitSyn) {
-            stQueue_.push(head);
-        }
+        if (state_ == StOpen || state_ == StWaitSyn) { stQueue_.push(head); }
 
         // Syn frame goes to state machine if state = open
         // or we are waiting for ack replay
@@ -391,9 +388,7 @@ void rpr::Controller::applicationRx(ris::FramePtr frame) {
     flock->unlock();
 
     // Connection is closed
-    if (state_ != StOpen) {
-        return;
-    }
+    if (state_ != StOpen) { return; }
 
     // Wait while busy either by flow control or buffer starvation
     while (txListCount_ >= curMaxBuffers_) {

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -702,7 +702,7 @@ void rpr::Controller::convTime(struct timeval& tme, uint32_t rssiTime) {
     float units = std::pow(10, -TimeoutUnit);
     float value = units * static_cast<float>(rssiTime);
 
-    uint32_t usec = (uint32_t)(value / 1e-6);
+    uint32_t usec = static_cast<uint32_t>(value / 1e-6);
 
     div_t divResult = div(usec, 1000000);
     tme.tv_sec      = divResult.quot;

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -236,7 +236,9 @@ void rpr::Controller::transportRx(ris::FramePtr frame) {
 
     // Reset
     if (head->rst) {
-        if (state_ == StOpen || state_ == StWaitSyn) { stQueue_.push(head); }
+        if (state_ == StOpen || state_ == StWaitSyn) {
+            stQueue_.push(head);
+        }
 
         // Syn frame goes to state machine if state = open
         // or we are waiting for ack replay
@@ -388,7 +390,9 @@ void rpr::Controller::applicationRx(ris::FramePtr frame) {
     flock->unlock();
 
     // Connection is closed
-    if (state_ != StOpen) { return; }
+    if (state_ != StOpen) {
+        return;
+    }
 
     // Wait while busy either by flow control or buffer starvation
     while (txListCount_ >= curMaxBuffers_) {

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -19,9 +19,9 @@
 #include <arpa/inet.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include <string.h>
 #include <sys/time.h>
 
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/src/rogue/protocols/rssi/Header.cpp
+++ b/src/rogue/protocols/rssi/Header.cpp
@@ -233,7 +233,7 @@ std::string rpr::Header::dump() {
     ret << "   Raw Header : ";
 
     for (x = 0; x < data[1]; x++) {
-        ret << "0x" << std::hex << std::setw(2) << std::setfill('0') << (uint32_t)data[x] << " ";
+        ret << "0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<uint32_t>(data[x]) << " ";
         if ((x % 8) == 7 && (x + 1) != data[1]) ret << std::endl << "                ";
     }
     ret << std::endl;
@@ -243,22 +243,22 @@ std::string rpr::Header::dump() {
     ret << "          Rst : " << std::dec << rst << std::endl;
     ret << "          Nul : " << std::dec << nul << std::endl;
     ret << "         Busy : " << std::dec << busy << std::endl;
-    ret << "     Sequence : " << std::dec << (uint32_t)sequence << std::endl;
-    ret << "  Acknowledge : " << std::dec << (uint32_t)acknowledge << std::endl;
+    ret << "     Sequence : " << std::dec << static_cast<uint32_t>(sequence) << std::endl;
+    ret << "  Acknowledge : " << std::dec << static_cast<uint32_t>(acknowledge) << std::endl;
 
     if (!syn) return (ret.str());
 
-    ret << "      Version : " << std::dec << (uint32_t)version << std::endl;
+    ret << "      Version : " << std::dec << static_cast<uint32_t>(version) << std::endl;
     ret << "          Chk : " << std::dec << chk << std::endl;
-    ret << "  Max Out Seg : " << std::dec << (uint32_t)maxOutstandingSegments << std::endl;
-    ret << " Max Seg Size : " << std::dec << (uint32_t)maxSegmentSize << std::endl;
-    ret << "  Retran Tout : " << std::dec << (uint32_t)retransmissionTimeout << std::endl;
-    ret << " Cum Ack Tout : " << std::dec << (uint32_t)cumulativeAckTimeout << std::endl;
-    ret << "    Null Tout : " << std::dec << (uint32_t)nullTimeout << std::endl;
-    ret << "  Max Retrans : " << std::dec << (uint32_t)maxRetransmissions << std::endl;
-    ret << "  Max Cum Ack : " << std::dec << (uint32_t)maxCumulativeAck << std::endl;
-    ret << " Timeout Unit : " << std::dec << (uint32_t)timeoutUnit << std::endl;
-    ret << "      Conn Id : " << std::dec << (uint32_t)connectionId << std::endl;
+    ret << "  Max Out Seg : " << std::dec << static_cast<uint32_t>(maxOutstandingSegments) << std::endl;
+    ret << " Max Seg Size : " << std::dec << static_cast<uint32_t>(maxSegmentSize) << std::endl;
+    ret << "  Retran Tout : " << std::dec << static_cast<uint32_t>(retransmissionTimeout) << std::endl;
+    ret << " Cum Ack Tout : " << std::dec << static_cast<uint32_t>(cumulativeAckTimeout) << std::endl;
+    ret << "    Null Tout : " << std::dec << static_cast<uint32_t>(nullTimeout) << std::endl;
+    ret << "  Max Retrans : " << std::dec << static_cast<uint32_t>(maxRetransmissions) << std::endl;
+    ret << "  Max Cum Ack : " << std::dec << static_cast<uint32_t>(maxCumulativeAck) << std::endl;
+    ret << " Timeout Unit : " << std::dec << static_cast<uint32_t>(timeoutUnit) << std::endl;
+    ret << "      Conn Id : " << std::dec << static_cast<uint32_t>(connectionId) << std::endl;
 
     return (ret.str());
 }

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -20,8 +20,8 @@
 
 #include <inttypes.h>
 #include <stdint.h>
-#include <string.h>
 
+#include <cstring>
 #include <memory>
 #include <thread>
 

--- a/src/rogue/protocols/srp/SrpV3.cpp
+++ b/src/rogue/protocols/srp/SrpV3.cpp
@@ -20,8 +20,8 @@
 
 #include <inttypes.h>
 #include <stdint.h>
-#include <string.h>
 
+#include <cstring>
 #include <memory>
 #include <thread>
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -19,10 +19,10 @@
 #include "rogue/protocols/udp/Client.h"
 
 #include <inttypes.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <string>
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include <memory>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -19,10 +19,10 @@
 #include "rogue/protocols/udp/Server.h"
 
 #include <inttypes.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <memory>
 

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -21,14 +21,14 @@
 
 #include <arpa/inet.h>
 #include <dlfcn.h>
-#include <math.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <sys/socket.h>
 
-#include <string>
-#include <memory>
+#include <cmath>
 #include <cstdio>
+#include <memory>
+#include <string>
 
 namespace rpx = rogue::protocols::xilinx;
 
@@ -132,9 +132,7 @@ uint32_t rpx::JtagDriver::cvtPerNs(Header reply) {
     unsigned rawVal = (reply >> XID_SHIFT) & 0xff;
     double tmp;
 
-    if (0 == rawVal) {
-        return UNKNOWN_PERIOD;
-    }
+    if (0 == rawVal) { return UNKNOWN_PERIOD; }
 
     tmp = static_cast<double>(rawVal) * 4.0 / 256.0;
 
@@ -152,9 +150,7 @@ unsigned rpx::JtagDriver::getMemDepth() {
 rpx::JtagDriver::Header rpx::JtagDriver::getHdr(uint8_t* buf) {
     Header hdr;
     memcpy(&hdr, buf, sizeof(hdr));
-    if (!isLE()) {
-        hdr = ntohl(hdr);
-    }
+    if (!isLE()) { hdr = ntohl(hdr); }
     return hdr;
 }
 
@@ -204,9 +200,7 @@ int rpx::JtagDriver::xferRel(uint8_t* txb, unsigned txBytes, Header* phdr, uint8
                 throw(rogue::GeneralError::create("JtagDriver::xferRel()", "Protocol error"));
             }
             if (xid == XID_ANY || xid == getXid(hdr)) {
-                if (phdr) {
-                    *phdr = hdr;
-                }
+                if (phdr) { *phdr = hdr; }
                 return got;
             }
         } catch (rogue::GeneralError&) {}

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -27,6 +27,8 @@
 #include <sys/socket.h>
 
 #include <string>
+#include <memory>
+#include <cstdio>
 
 namespace rpx = rogue::protocols::xilinx;
 

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -132,7 +132,9 @@ uint32_t rpx::JtagDriver::cvtPerNs(Header reply) {
     unsigned rawVal = (reply >> XID_SHIFT) & 0xff;
     double tmp;
 
-    if (0 == rawVal) { return UNKNOWN_PERIOD; }
+    if (0 == rawVal) {
+        return UNKNOWN_PERIOD;
+    }
 
     tmp = static_cast<double>(rawVal) * 4.0 / 256.0;
 
@@ -150,7 +152,9 @@ unsigned rpx::JtagDriver::getMemDepth() {
 rpx::JtagDriver::Header rpx::JtagDriver::getHdr(uint8_t* buf) {
     Header hdr;
     memcpy(&hdr, buf, sizeof(hdr));
-    if (!isLE()) { hdr = ntohl(hdr); }
+    if (!isLE()) {
+        hdr = ntohl(hdr);
+    }
     return hdr;
 }
 
@@ -200,7 +204,9 @@ int rpx::JtagDriver::xferRel(uint8_t* txb, unsigned txBytes, Header* phdr, uint8
                 throw(rogue::GeneralError::create("JtagDriver::xferRel()", "Protocol error"));
             }
             if (xid == XID_ANY || xid == getXid(hdr)) {
-                if (phdr) { *phdr = hdr; }
+                if (phdr) {
+                    *phdr = hdr;
+                }
                 return got;
             }
         } catch (rogue::GeneralError&) {}

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -138,7 +138,7 @@ uint32_t rpx::JtagDriver::cvtPerNs(Header reply) {
 
     tmp = static_cast<double>(rawVal) * 4.0 / 256.0;
 
-    return (uint32_t)round(pow(10.0, tmp) * 1.0E9 / REF_FREQ_HZ());
+    return static_cast<uint32_t>(round(pow(10.0, tmp) * 1.0E9 / REF_FREQ_HZ()));
 }
 
 unsigned rpx::JtagDriver::getWordSize() {
@@ -237,7 +237,7 @@ uint64_t rpx::JtagDriver::query() {
     log_->debug("Query result: wordSize %" PRId32 ", memDepth %" PRId32 ", period %l" PRId32 "ns\n",
                 wordSize_,
                 memDepth_,
-                (uint64_t)periodNs_);
+                static_cast<uint64_t>(periodNs_));
 
     if (0 == memDepth_)
         retry_ = 0;
@@ -301,7 +301,7 @@ void rpx::JtagDriver::dumpInfo(FILE* f) {
     fprintf(f, "Word size:                  %d\n", getWordSize());
     fprintf(f, "Target Memory Depth (bytes) %d\n", getWordSize() * getMemDepth());
     fprintf(f, "Max. Vector Length  (bytes) %ld\n", getMaxVectorSize());
-    fprintf(f, "TCK Period             (ns) %ld\n", (uint64_t)getPeriodNs());
+    fprintf(f, "TCK Period             (ns) %ld\n", static_cast<uint64_t>(getPeriodNs()));
 }
 
 void rpx::JtagDriver::setup_python() {

--- a/src/rogue/protocols/xilinx/Xvc.cpp
+++ b/src/rogue/protocols/xilinx/Xvc.cpp
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <memory>
+#include <algorithm>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/xilinx/Xvc.cpp
+++ b/src/rogue/protocols/xilinx/Xvc.cpp
@@ -19,13 +19,12 @@
 #include "rogue/protocols/xilinx/Xvc.h"
 
 #include <dlfcn.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
-#include <algorithm>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -93,7 +93,9 @@ void rpx::XvcConnection::fill(uint64_t n) {
 void rpx::XvcConnection::bump(uint64_t n) {
     rp_ += n;
     rl_ -= n;
-    if (rl_ == 0) { rp_ = &rxb_[0]; }
+    if (rl_ == 0) {
+        rp_ = &rxb_[0];
+    }
 }
 
 void rpx::XvcConnection::allocBufs() {
@@ -192,7 +194,9 @@ void rpx::XvcConnection::run() {
                 fill(10);
 
                 bits = 0;
-                for (got = 9; got >= 6; got--) { bits = (bits << 8) | rp_[got]; }
+                for (got = 9; got >= 6; got--) {
+                    bits = (bits << 8) | rp_[got];
+                }
                 bytes = (bits + 7) / 8;
 
                 if (bytes > maxVecLen_)
@@ -209,7 +213,9 @@ void rpx::XvcConnection::run() {
                 // bother...).
                 for (off = 0, bitsLeft = bits; bitsLeft > 0; bitsLeft -= bitsSent, off += vecLen) {
                     bitsSent = 8 * vecLen;
-                    if (bitsLeft < bitsSent) { bitsSent = bitsLeft; }
+                    if (bitsLeft < bitsSent) {
+                        bitsSent = bitsLeft;
+                    }
 
                     drv_->sendVectors(bitsSent, rp_ + off, rp_ + bytes + off, &txb_[0] + off);
                 }

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -93,9 +93,7 @@ void rpx::XvcConnection::fill(uint64_t n) {
 void rpx::XvcConnection::bump(uint64_t n) {
     rp_ += n;
     rl_ -= n;
-    if (rl_ == 0) {
-        rp_ = &rxb_[0];
-    }
+    if (rl_ == 0) { rp_ = &rxb_[0]; }
 }
 
 void rpx::XvcConnection::allocBufs() {
@@ -194,9 +192,7 @@ void rpx::XvcConnection::run() {
                 fill(10);
 
                 bits = 0;
-                for (got = 9; got >= 6; got--) {
-                    bits = (bits << 8) | rp_[got];
-                }
+                for (got = 9; got >= 6; got--) { bits = (bits << 8) | rp_[got]; }
                 bytes = (bits + 7) / 8;
 
                 if (bytes > maxVecLen_)
@@ -213,9 +209,7 @@ void rpx::XvcConnection::run() {
                 // bother...).
                 for (off = 0, bitsLeft = bits; bitsLeft > 0; bitsLeft -= bitsSent, off += vecLen) {
                     bitsSent = 8 * vecLen;
-                    if (bitsLeft < bitsSent) {
-                        bitsSent = bitsLeft;
-                    }
+                    if (bitsLeft < bitsSent) { bitsSent = bitsLeft; }
 
                     drv_->sendVectors(bitsSent, rp_ + off, rp_ + bytes + off, &txb_[0] + off);
                 }

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -21,6 +21,8 @@
 #include <netinet/tcp.h>
 #include <sys/select.h>
 
+#include <cstdio>
+
 namespace rpx = rogue::protocols::xilinx;
 
 rpx::XvcConnection::XvcConnection(int sd, JtagDriver* drv, uint64_t maxVecLen)

--- a/src/rogue/protocols/xilinx/XvcServer.cpp
+++ b/src/rogue/protocols/xilinx/XvcServer.cpp
@@ -19,12 +19,12 @@
 
 #include <arpa/inet.h>
 #include <dlfcn.h>
-#include <math.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 
+#include <cmath>
 #include <string>
 
 #include "rogue/protocols/xilinx/XvcConnection.h"
@@ -75,9 +75,7 @@ void rpx::XvcServer::run(bool& threadEn, rogue::LoggingPtr log) {
             try {
                 XvcConnection conn(sd_, drv_, maxMsgSize_);
                 conn.run();
-            } catch (rogue::GeneralError& e) {
-                log->debug("Sub-connection failed");
-            }
+            } catch (rogue::GeneralError& e) { log->debug("Sub-connection failed"); }
         }
     }
 }

--- a/src/rogue/protocols/xilinx/XvcServer.cpp
+++ b/src/rogue/protocols/xilinx/XvcServer.cpp
@@ -75,7 +75,9 @@ void rpx::XvcServer::run(bool& threadEn, rogue::LoggingPtr log) {
             try {
                 XvcConnection conn(sd_, drv_, maxMsgSize_);
                 conn.run();
-            } catch (rogue::GeneralError& e) { log->debug("Sub-connection failed"); }
+            } catch (rogue::GeneralError& e) {
+                log->debug("Sub-connection failed");
+            }
         }
     }
 }

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -198,7 +198,9 @@ void ru::Prbs::flfsr(uint8_t* data) {
 void ru::Prbs::runThread() {
     txLog_->logThreadId();
 
-    while (threadEn_) { genFrame(txSize_); }
+    while (threadEn_) {
+        genFrame(txSize_);
+    }
 }
 
 //! Auto run data generation

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -20,12 +20,12 @@
 
 #include <inttypes.h>
 #include <stdarg.h>
-#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
-#include <memory>
 #include <cstdio>
+#include <cstring>
+#include <memory>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -198,9 +198,7 @@ void ru::Prbs::flfsr(uint8_t* data) {
 void ru::Prbs::runThread() {
     txLog_->logThreadId();
 
-    while (threadEn_) {
-        genFrame(txSize_);
-    }
+    while (threadEn_) { genFrame(txSize_); }
 }
 
 //! Auto run data generation

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include <memory>
+#include <cstdio>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -177,7 +177,9 @@ void ruf::LegacyStreamReader::runThread() {
             size = header & 0x0FFFFFFF;
             chan = header >> 28;
 
-            if (chan == 0) { size = size * 4; }
+            if (chan == 0) {
+                size = size * 4;
+            }
 
             // cout << "Frame with size" << size << "and channel" << chan;
             log.info("Got frame with header %" PRIx32 ", size %" PRIu32 " and channel %" PRIu8, header, size, chan);

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -21,13 +21,13 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <iostream>
 #include <memory>
-#include <thread>
 #include <string>
+#include <thread>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -177,9 +177,7 @@ void ruf::LegacyStreamReader::runThread() {
             size = header & 0x0FFFFFFF;
             chan = header >> 28;
 
-            if (chan == 0) {
-                size = size * 4;
-            }
+            if (chan == 0) { size = size * 4; }
 
             // cout << "Frame with size" << size << "and channel" << chan;
             log.info("Got frame with header %" PRIx32 ", size %" PRIu32 " and channel %" PRIu8, header, size, chan);

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -24,8 +24,8 @@
 #include <unistd.h>
 
 #include <memory>
-#include <thread>
 #include <string>
+#include <thread>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <thread>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -35,15 +35,14 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
-#include <string.h>
 #include <sys/time.h>
 #include <unistd.h>
 
 #include <cstring>
-#include <memory>
-#include <thread>
 #include <map>
+#include <memory>
 #include <string>
+#include <thread>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -42,6 +42,8 @@
 #include <cstring>
 #include <memory>
 #include <thread>
+#include <map>
+#include <string>
 
 #include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
@@ -298,7 +300,7 @@ void ruf::StreamWriter::intWrite(void* data, uint32_t size) {
     // Attempted write is larger than buffer, raw write
     // This is called if buffer is disabled
     if (size > buffSize_) {
-        if (write(fd_, data, size) != (int32_t)size) {
+        if (write(fd_, data, size) != static_cast<int32_t>(size)) {
             ::close(fd_);
             fd_ = -1;
             log_->error("Write failed, closing file!");
@@ -347,7 +349,7 @@ void ruf::StreamWriter::checkSize(uint32_t size) {
 //! Flush file
 void ruf::StreamWriter::flush() {
     if (currBuffer_ > 0) {
-        if (write(fd_, buffer_, currBuffer_) != (int32_t)currBuffer_) {
+        if (write(fd_, buffer_, currBuffer_) != static_cast<int32_t>(currBuffer_)) {
             ::close(fd_);
             fd_ = -1;
             log_->error("Write failed, closing file!");

--- a/tests/api_test/src/api_test.cpp
+++ b/tests/api_test/src/api_test.cpp
@@ -11,6 +11,9 @@
 
 #include "rogue/interfaces/api/Bsp.h"
 
+#include <string>
+#include <cstdio>
+
 void varListener(std::string path, std::string value) {
     printf("Var Listener: %s = %s\n", path.c_str(), value.c_str());
 }

--- a/tests/api_test/src/api_test.cpp
+++ b/tests/api_test/src/api_test.cpp
@@ -9,10 +9,10 @@
  * ----------------------------------------------------------------------------
  **/
 
-#include "rogue/interfaces/api/Bsp.h"
-
-#include <string>
 #include <cstdio>
+#include <string>
+
+#include "rogue/interfaces/api/Bsp.h"
 
 void varListener(std::string path, std::string value) {
     printf("Var Listener: %s = %s\n", path.c_str(), value.c_str());


### PR DESCRIPTION
### Description
- [NOLINT for the C-based drivers](https://github.com/slaclab/rogue/commit/e46fed247b33d891f319a1e01422cbfe9e40cabe)
- [./include/rogue/protocols/xilinx/JtagDriver.h:213:  Add #include <cstdio> for FILE  [build/include_what_you_use] [4]](https://github.com/slaclab/rogue/commit/8ee417280fc320c3306c65813bd0dbe9d58d3458)
- [Add #include <XXXXXX> for XXXXXX  [build/include_what_you_use] [4]](https://github.com/slaclab/rogue/commit/89ca11cff1068e0625cd17c1df72a8ae820ca34c)
- [Add #include <XXXXXX> for XXXXXX  [build/include_what_you_use] [4]](https://github.com/slaclab/rogue/commit/b4b6fed2b52e55ec6e8be549e8f2ef0286b655eb)
- [Using C-style cast.  Use static_cast<XXXXXXX>(...) instead  [readability/casting] [4]](https://github.com/slaclab/rogue/commit/96d72241de8a0d83511139d3d31b7e15cb9e763c)
- [Using deprecated casting style.  Use static_cast<uint32_t>(...) instead  [readability/casting] [4]](https://github.com/slaclab/rogue/commit/d64c015395e405b5ced006a4c7fe37dc11cad165)
- [Replace C header includes with C++ includes, rerun clang-format](https://github.com/slaclab/rogue/pull/1028/commits/0ef13515388cd31995995b18bda048d7124a2870)