### PR TITLE
Fix boost variable in both rogue CmakeLists and external library RogueConfig template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if ( NOT NO_PYTHON )
 
    # Hint for boost on anaconda
    if (DEFINED ENV{CONDA_PREFIX})
-      set(Boost_ROOT $ENV{CONDA_PREFIX})
+      set(BOOST_ROOT $ENV{CONDA_PREFIX})
    endif()
 
    # libboost_python3.7 style libraries

--- a/templates/RogueConfig.cmake.in
+++ b/templates/RogueConfig.cmake.in
@@ -49,7 +49,7 @@ if ( NOT NO_PYTHON )
 
    # Hint for boost on anaconda
    if (DEFINED ENV{CONDA_PREFIX})
-      set(Boost_ROOT $ENV{CONDA_PREFIX})
+      set(BOOST_ROOT $ENV{CONDA_PREFIX})
    endif()
 
    # libboost_python3.7 style libraries


### PR DESCRIPTION
Fix boost variable in both rogue CmakeLists and external library RogueConfig template