### PR TITLE
Use a better compare for DataReceiver.RxEnable

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -88,7 +88,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
         """
         # Do nothing if not yet started or enabled
-        if self.running is False or self.RxEnable.value() == False:
+        if self.running is False or not self.RxEnable.value():
             return
 
         # Lock frame

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -88,7 +88,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
         """
         # Do nothing if not yet started or enabled
-        if self.running is False or self.RxEnable.value() is False:
+        if self.running is False or self.RxEnable.value() == False:
             return
 
         # Lock frame

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -31,6 +31,8 @@ class EnableVariable(pr.BaseVariable):
             groups='Enable',
             disp={False: 'False', True: 'True', 'parent': 'ParentFalse', 'deps': 'ExtDepFalse'})
 
+        self.allowed_values = {True, False, 'parent', 'deps'}
+
         if deps is None:
             self._deps   = []
             self._depDis = False
@@ -97,6 +99,10 @@ class EnableVariable(pr.BaseVariable):
         -------
 
         """
+        if value not in self.allowed_values:
+            raise pr.VariableError(
+                f'Error calling {self.path}.set({value=}) - value must be one of {self.allowed_values}')
+        
         if value != 'parent' and value != 'deps':
             old = self.value()
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -31,8 +31,6 @@ class EnableVariable(pr.BaseVariable):
             groups='Enable',
             disp={False: 'False', True: 'True', 'parent': 'ParentFalse', 'deps': 'ExtDepFalse'})
 
-        self.allowed_values = {True, False, 'parent', 'deps'}
-
         if deps is None:
             self._deps   = []
             self._depDis = False
@@ -99,10 +97,6 @@ class EnableVariable(pr.BaseVariable):
         -------
 
         """
-        if value not in self.allowed_values:
-            raise pr.VariableError(
-                f'Error calling {self.path}.set({value=}) - value must be one of {self.allowed_values}')
-        
         if value != 'parent' and value != 'deps':
             old = self.value()
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->
This fixes a quirk where setting `DataReceiver.RxEnable.set(0)` would enable frame reception. `RxEnable` expects a boolean, but will accept an type and then exhibit this behavior. The key is to compare `not RxEnable.value()` instead of `RxEnable.value() is False`.

