### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -68,13 +68,13 @@ class Logging {
     static const uint32_t Info     = 20;
     static const uint32_t Debug    = 10;
 
-    static std::shared_ptr<rogue::Logging> create(std::string name, bool quiet = false);
+    static std::shared_ptr<rogue::Logging> create(const std::string& name, bool quiet = false);
 
-    explicit Logging(std::string name, bool quiet = false);
+    explicit Logging(const std::string& name, bool quiet = false);
     ~Logging();
 
     static void setLevel(uint32_t level);
-    static void setFilter(std::string filter, uint32_t level);
+    static void setFilter(const std::string& filter, uint32_t level);
 
     void log(uint32_t level, const char* fmt, ...);
     void critical(const char* fmt, ...);

--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -27,7 +27,7 @@ namespace rogue {
 //! Version
 class Version {
     static void init();
-    static void extract(std::string compare, uint32_t* major, uint32_t* minor, uint32_t* maint);
+    static void extract(const std::string& compare, uint32_t* major, uint32_t* minor, uint32_t* maint);
 
     static const char _version[];
 
@@ -41,19 +41,19 @@ class Version {
 
     static std::string current();
 
-    static bool greaterThanEqual(std::string compare);
+    static bool greaterThanEqual(const std::string& compare);
 
-    static bool greaterThan(std::string compare);
+    static bool greaterThan(const std::string& compare);
 
-    static bool lessThanEqual(std::string compare);
+    static bool lessThanEqual(const std::string& compare);
 
-    static bool lessThan(std::string compare);
+    static bool lessThan(const std::string& compare);
 
-    static void minVersion(std::string compare);
+    static void minVersion(const std::string& compare);
 
-    static void maxVersion(std::string compare);
+    static void maxVersion(const std::string& compare);
 
-    static void exactVersion(std::string compare);
+    static void exactVersion(const std::string& compare);
 
     static void setup_python();
 

--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -57,25 +57,25 @@ class ZmqClient {
     void runThread();
 
   public:
-    static std::shared_ptr<rogue::interfaces::ZmqClient> create(std::string addr, uint16_t port, bool doString);
+    static std::shared_ptr<rogue::interfaces::ZmqClient> create(const std::string& addr, uint16_t port, bool doString);
 
     //! Setup class in python
     static void setup_python();
 
-    ZmqClient(std::string addr, uint16_t port, bool doString);
+    ZmqClient(const std::string& addr, uint16_t port, bool doString);
     virtual ~ZmqClient();
 
     void setTimeout(uint32_t msecs, bool waitRetry);
 
-    std::string sendString(std::string path, std::string attr, std::string arg);
+    std::string sendString(const std::string& path, const std::string& attr, const std::string& arg);
 
-    std::string getDisp(std::string path);
+    std::string getDisp(const std::string& path);
 
-    void setDisp(std::string path, std::string value);
+    void setDisp(const std::string& path, const std::string& value);
 
-    std::string exec(std::string path, std::string arg = "");
+    std::string exec(const std::string& path, const std::string& arg = "");
 
-    std::string valueDisp(std::string path);
+    std::string valueDisp(const std::string& path);
 
 #ifndef NO_PYTHON
     boost::python::object send(boost::python::object data);
@@ -92,7 +92,7 @@ typedef std::shared_ptr<rogue::interfaces::ZmqClient> ZmqClientPtr;
 //! Stream slave class, wrapper to enable python overload of virtual methods
 class ZmqClientWrap : public rogue::interfaces::ZmqClient, public boost::python::wrapper<rogue::interfaces::ZmqClient> {
   public:
-    ZmqClientWrap(std::string addr, uint16_t port, bool doString);
+    ZmqClientWrap(const std::string& addr, uint16_t port, bool doString);
 
     void doUpdate(boost::python::object data);
 

--- a/include/rogue/interfaces/ZmqServer.h
+++ b/include/rogue/interfaces/ZmqServer.h
@@ -61,12 +61,12 @@ class ZmqServer {
     bool tryConnect();
 
   public:
-    static std::shared_ptr<rogue::interfaces::ZmqServer> create(std::string addr, uint16_t port);
+    static std::shared_ptr<rogue::interfaces::ZmqServer> create(const std::string& addr, uint16_t port);
 
     //! Setup class in python
     static void setup_python();
 
-    ZmqServer(std::string addr, uint16_t port);
+    ZmqServer(const std::string& addr, uint16_t port);
     virtual ~ZmqServer();
 
 #ifndef NO_PYTHON
@@ -75,7 +75,7 @@ class ZmqServer {
     virtual boost::python::object doRequest(boost::python::object data);
 #endif
 
-    virtual std::string doString(std::string data);
+    virtual std::string doString(const std::string& data);
 
     uint16_t port();
 
@@ -95,9 +95,9 @@ class ZmqServerWrap : public rogue::interfaces::ZmqServer, public boost::python:
 
     boost::python::object defDoRequest(boost::python::object data);
 
-    std::string doString(std::string data);
+    std::string doString(const std::string& data);
 
-    std::string defDoString(std::string data);
+    std::string defDoString(const std::string& data);
 };
 
 typedef std::shared_ptr<rogue::interfaces::ZmqServerWrap> ZmqServerWrapPtr;

--- a/include/rogue/interfaces/stream/TcpCore.h
+++ b/include/rogue/interfaces/stream/TcpCore.h
@@ -91,13 +91,13 @@ class TcpCore : public rogue::interfaces::stream::Master, public rogue::interfac
      * @param server Server flag. Set to True to run in server mode.
      * @return TcpCore object as a TcpCorePtr
      */
-    static std::shared_ptr<rogue::interfaces::stream::TcpCore> create(std::string addr, uint16_t port, bool server);
+    static std::shared_ptr<rogue::interfaces::stream::TcpCore> create(const std::string& addr, uint16_t port, bool server);
 
     // Setup class for use in python
     static void setup_python();
 
     // Create a TcpCore object
-    TcpCore(std::string addr, uint16_t port, bool server);
+    TcpCore(const std::string& addr, uint16_t port, bool server);
 
     // Destroy the TcpCore
     ~TcpCore();

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -57,12 +57,12 @@ std::mutex rogue::Logging::levelMtx_;
 std::vector<rogue::LogFilter*> rogue::Logging::filters_;
 
 // Crate logger
-rogue::LoggingPtr rogue::Logging::create(std::string name, bool quiet) {
+rogue::LoggingPtr rogue::Logging::create(const std::string& name, bool quiet) {
     rogue::LoggingPtr log = std::make_shared<rogue::Logging>(name, quiet);
     return log;
 }
 
-rogue::Logging::Logging(std::string name, bool quiet) {
+rogue::Logging::Logging(const std::string& name, bool quiet) {
     std::vector<rogue::LogFilter*>::iterator it;
 
     name_ = "pyrogue." + name;
@@ -89,7 +89,7 @@ void rogue::Logging::setLevel(uint32_t level) {
     levelMtx_.unlock();
 }
 
-void rogue::Logging::setFilter(std::string name, uint32_t level) {
+void rogue::Logging::setFilter(const std::string& name, uint32_t level) {
     levelMtx_.lock();
 
     rogue::LogFilter* flt = new rogue::LogFilter(name, level);

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -58,7 +58,7 @@ void rogue::Version::init() {
         throw(rogue::GeneralError("Version:init", "Invalid compiled version string"));
 }
 
-void rogue::Version::extract(std::string compare, uint32_t* major, uint32_t* minor, uint32_t* maint) {
+void rogue::Version::extract(const std::string& compare, uint32_t* major, uint32_t* minor, uint32_t* maint) {
     if (sscanf(compare.c_str(), "%" PRIu32 ".%" PRIu32 ".%" PRIu32, major, minor, maint) != 3)
         throw(rogue::GeneralError("Version:extract", "Invalid version string"));
 }
@@ -68,7 +68,7 @@ std::string rogue::Version::current() {
     return ret;
 }
 
-bool rogue::Version::greaterThanEqual(std::string compare) {
+bool rogue::Version::greaterThanEqual(const std::string& compare) {
     uint32_t cmajor, cminor, cmaint;
     init();
     extract(compare, &cmajor, &cminor, &cmaint);
@@ -78,7 +78,7 @@ bool rogue::Version::greaterThanEqual(std::string compare) {
     return (true);
 }
 
-bool rogue::Version::greaterThan(std::string compare) {
+bool rogue::Version::greaterThan(const std::string& compare) {
     uint32_t cmajor, cminor, cmaint;
     init();
     extract(compare, &cmajor, &cminor, &cmaint);
@@ -88,7 +88,7 @@ bool rogue::Version::greaterThan(std::string compare) {
     return (false);
 }
 
-bool rogue::Version::lessThanEqual(std::string compare) {
+bool rogue::Version::lessThanEqual(const std::string& compare) {
     uint32_t cmajor, cminor, cmaint;
     init();
     extract(compare, &cmajor, &cminor, &cmaint);
@@ -98,7 +98,7 @@ bool rogue::Version::lessThanEqual(std::string compare) {
     return (true);
 }
 
-bool rogue::Version::lessThan(std::string compare) {
+bool rogue::Version::lessThan(const std::string& compare) {
     uint32_t cmajor, cminor, cmaint;
     init();
     extract(compare, &cmajor, &cminor, &cmaint);
@@ -108,17 +108,17 @@ bool rogue::Version::lessThan(std::string compare) {
     return (false);
 }
 
-void rogue::Version::minVersion(std::string compare) {
+void rogue::Version::minVersion(const std::string& compare) {
     if (lessThan(compare))
         throw(rogue::GeneralError("Version:minVersion", "Installed rogue is less than minimum version"));
 }
 
-void rogue::Version::maxVersion(std::string compare) {
+void rogue::Version::maxVersion(const std::string& compare) {
     if (greaterThan(compare))
         throw(rogue::GeneralError("Version:maxVersion", "Installed rogue is greater than maximum version"));
 }
 
-void rogue::Version::exactVersion(std::string compare) {
+void rogue::Version::exactVersion(const std::string& compare) {
     if (lessThan(compare) || greaterThan(compare))
         throw(rogue::GeneralError("Version:exactVersion", "Installed rogue is not exact version"));
 }

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -35,7 +35,7 @@
 namespace bp = boost::python;
 #endif
 
-rogue::interfaces::ZmqClientPtr rogue::interfaces::ZmqClient::create(std::string addr, uint16_t port, bool doString) {
+rogue::interfaces::ZmqClientPtr rogue::interfaces::ZmqClient::create(const std::string& addr, uint16_t port, bool doString) {
     rogue::interfaces::ZmqClientPtr ret = std::make_shared<rogue::interfaces::ZmqClient>(addr, port, doString);
     return (ret);
 }
@@ -58,7 +58,7 @@ void rogue::interfaces::ZmqClient::setup_python() {
 #endif
 }
 
-rogue::interfaces::ZmqClient::ZmqClient(std::string addr, uint16_t port, bool doString) {
+rogue::interfaces::ZmqClient::ZmqClient(const std::string& addr, uint16_t port, bool doString) {
     std::string temp;
     uint32_t val;
     uint32_t reqPort;
@@ -166,7 +166,7 @@ void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs, bool waitRetry) {
         throw(rogue::GeneralError("ZmqClient::setTimeout", "Failed to set socket timeout"));
 }
 
-std::string rogue::interfaces::ZmqClient::sendString(std::string path, std::string attr, std::string arg) {
+std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, const std::string& attr, const std::string& arg) {
     std::string snd;
     std::string ret;
     zmq_msg_t msg;
@@ -209,19 +209,19 @@ std::string rogue::interfaces::ZmqClient::sendString(std::string path, std::stri
     return data;
 }
 
-std::string rogue::interfaces::ZmqClient::getDisp(std::string path) {
+std::string rogue::interfaces::ZmqClient::getDisp(const std::string& path) {
     return sendString(path, "getDisp", "");
 }
 
-void rogue::interfaces::ZmqClient::setDisp(std::string path, std::string value) {
+void rogue::interfaces::ZmqClient::setDisp(const std::string& path, const std::string& value) {
     sendString(path, "setDisp", value);
 }
 
-std::string rogue::interfaces::ZmqClient::exec(std::string path, std::string arg) {
+std::string rogue::interfaces::ZmqClient::exec(const std::string& path, const std::string& arg) {
     return sendString(path, "__call__", arg);
 }
 
-std::string rogue::interfaces::ZmqClient::valueDisp(std::string path) {
+std::string rogue::interfaces::ZmqClient::valueDisp(const std::string& path) {
     return sendString(path, "valueDisp", "");
 }
 
@@ -282,7 +282,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
 
 void rogue::interfaces::ZmqClient::doUpdate(bp::object data) {}
 
-rogue::interfaces::ZmqClientWrap::ZmqClientWrap(std::string addr, uint16_t port, bool doString)
+rogue::interfaces::ZmqClientWrap::ZmqClientWrap(const std::string& addr, uint16_t port, bool doString)
     : rogue::interfaces::ZmqClient(addr, port, doString) {}
 
 void rogue::interfaces::ZmqClientWrap::doUpdate(bp::object data) {

--- a/src/rogue/interfaces/ZmqServer.cpp
+++ b/src/rogue/interfaces/ZmqServer.cpp
@@ -34,7 +34,7 @@
 namespace bp = boost::python;
 #endif
 
-rogue::interfaces::ZmqServerPtr rogue::interfaces::ZmqServer::create(std::string addr, uint16_t port) {
+rogue::interfaces::ZmqServerPtr rogue::interfaces::ZmqServer::create(const std::string& addr, uint16_t port) {
     rogue::interfaces::ZmqServerPtr ret = std::make_shared<rogue::interfaces::ZmqServer>(addr, port);
     return (ret);
 }
@@ -55,7 +55,7 @@ void rogue::interfaces::ZmqServer::setup_python() {
 #endif
 }
 
-rogue::interfaces::ZmqServer::ZmqServer(std::string addr, uint16_t port) {
+rogue::interfaces::ZmqServer::ZmqServer(const std::string& addr, uint16_t port) {
     log_ = rogue::Logging::create("ZmqServer");
 
     this->addr_     = addr;
@@ -208,7 +208,7 @@ uint16_t rogue::interfaces::ZmqServer::port() {
     return this->basePort_;
 }
 
-std::string rogue::interfaces::ZmqServer::doString(std::string data) {
+std::string rogue::interfaces::ZmqServer::doString(const std::string& data) {
     return "";
 }
 
@@ -254,7 +254,7 @@ bp::object rogue::interfaces::ZmqServerWrap::defDoRequest(bp::object data) {
     return (rogue::interfaces::ZmqServer::doRequest(data));
 }
 
-std::string rogue::interfaces::ZmqServerWrap::doString(std::string data) {
+std::string rogue::interfaces::ZmqServerWrap::doString(const std::string& data) {
     {
         rogue::ScopedGil gil;
         if (bp::override f = this->get_override("_doString")) {
@@ -268,7 +268,7 @@ std::string rogue::interfaces::ZmqServerWrap::doString(std::string data) {
     return (rogue::interfaces::ZmqServer::doString(data));
 }
 
-std::string rogue::interfaces::ZmqServerWrap::defDoString(std::string data) {
+std::string rogue::interfaces::ZmqServerWrap::defDoString(const std::string& data) {
     return (rogue::interfaces::ZmqServer::doString(data));
 }
 

--- a/src/rogue/interfaces/stream/TcpCore.cpp
+++ b/src/rogue/interfaces/stream/TcpCore.cpp
@@ -41,13 +41,13 @@ namespace bp = boost::python;
 #endif
 
 //! Class creation
-ris::TcpCorePtr ris::TcpCore::create(std::string addr, uint16_t port, bool server) {
+ris::TcpCorePtr ris::TcpCore::create(const std::string& addr, uint16_t port, bool server) {
     ris::TcpCorePtr r = std::make_shared<ris::TcpCore>(addr, port, server);
     return (r);
 }
 
 //! Creator
-ris::TcpCore::TcpCore(std::string addr, uint16_t port, bool server) {
+ris::TcpCore::TcpCore(const std::string& addr, uint16_t port, bool server) {
     int32_t opt;
     std::string logstr;
 

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -169,7 +169,7 @@ void rpx::XvcConnection::run() {
 
                 drv_->query();  // informs the driver that there is a new connection
 
-                tl_ = snprintf(reinterpret_cast<char*>(&txb_[0]), sizeof(txb_), "xvcServer_v1.0:%ld\n", maxVecLen_);
+                tl_ = snprintf(reinterpret_cast<char*>(&txb_[0]), txb_.size(), "xvcServer_v1.0:%ld\n", maxVecLen_);
 
                 bump(8);
             } else if (0 == ::memcmp(rp_, "se", 2)) {

--- a/src/rogue/utilities/fileio/LegacyStreamReader.cpp
+++ b/src/rogue/utilities/fileio/LegacyStreamReader.cpp
@@ -82,9 +82,9 @@ void ruf::LegacyStreamReader::open(std::string file) {
     intClose();
 
     // Determine if we read a group of files
-    if (file.substr(file.find_last_of(".")) == ".1") {
+    if (file.substr(file.find_last_of('.')) == ".1") {
         fdIdx_    = 1;
-        baseName_ = file.substr(0, file.find_last_of("."));
+        baseName_ = file.substr(0, file.find_last_of('.'));
     } else {
         fdIdx_    = 0;
         baseName_ = file;

--- a/src/rogue/utilities/fileio/StreamReader.cpp
+++ b/src/rogue/utilities/fileio/StreamReader.cpp
@@ -80,9 +80,9 @@ void ruf::StreamReader::open(std::string file) {
     intClose();
 
     // Determine if we read a group of files
-    if (file.substr(file.find_last_of(".")) == ".1") {
+    if (file.substr(file.find_last_of('.')) == ".1") {
         fdIdx_    = 1;
-        baseName_ = file.substr(0, file.find_last_of("."));
+        baseName_ = file.substr(0, file.find_last_of('.'));
     } else {
         fdIdx_    = 0;
         baseName_ = file;


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Ok, let's try this again...

Some cleanup of warnings reported by clang-tidy. Most are relatively small performance "problems" involving std::string being passed by value. 

It did find a buggy sizeof in `src/rogue/protocols/xilinx/XvcConnection.cpp` though.