### PR TITLE
Bug fix _DataReceiver.py

### DIFF
--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -56,8 +56,8 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Updated',
                                   value=False,
-                                  mode = 'RO',
-                                  description='Data has been updated flag'))
+                                  mode = 'RW',
+                                  description='Data has been updated flag. Set in the TRUE in DataReceiver and reset to zero by application'))
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,


### PR DESCRIPTION
### Description
- Accidentally set to "RO" in #1023
- The intent of this variable to give application a mechanism for polling for when the data is ready then re-arm it by setting Update.Set(False)
- Making this variable to "RO" breaks existing application code