### PR TITLE
migrating CI from ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -20,7 +20,7 @@ on: [push]
 jobs:
   full_build_test:
     name: Full Build Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
       # This step checks out a copy of your repository.
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
           cache: 'pip'
           cache-dependency-path: 'pip_requirements.txt'
 

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev
+          sudo apt-get install doxygen doxygen-doc libzmq3-dev libboost-all-dev bzip2 libbz2-dev
           pip install -r pip_requirements.txt
 
       # Python Linter

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -180,7 +180,7 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
 
 # Breath configuration
 breathe_projects = { 'rogue' : '../build/doxyxml' }


### PR DESCRIPTION
### Description
- The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025
- [Newer doxygen expects expects a two-element tuple or list for intersphinx_mapping](https://github.com/slaclab/rogue/pull/1043/commits/2896fbce68f496401513095d8b2242056ed26222)
  - https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
