### PR TITLE
Add option for raw data file writes

### DIFF
--- a/include/rogue/utilities/fileio/StreamWriter.h
+++ b/include/rogue/utilities/fileio/StreamWriter.h
@@ -18,6 +18,8 @@
  *          23:16  = Frame error
  *          15:0   = Frame flags
  *
+ *    Optionally a flag can be set which writes the raw frame data directly to the file.
+ *
  *-----------------------------------------------------------------------------
  * This file is part of the rogue software platform. It is subject to
  * the license terms in the LICENSE.txt file found in the top-level directory
@@ -107,6 +109,9 @@ class StreamWriter : public rogue::EnableSharedFromThis<rogue::utilities::fileio
     //! Flush file
     void flush();
 
+    //! Write raw data
+    bool raw_;
+
     //! condition
     std::condition_variable cond_;
 
@@ -136,6 +141,12 @@ class StreamWriter : public rogue::EnableSharedFromThis<rogue::utilities::fileio
 
     //! Get open status
     bool isOpen();
+
+    //! Set raw mode
+    void setRaw(bool raw);
+
+    //! Get raw mode flag
+    bool getRaw();
 
     //! Set buffering size, 0 to disable
     void setBufferSize(uint32_t size);

--- a/python/pyrogue/examples/_ExampleRoot.py
+++ b/python/pyrogue/examples/_ExampleRoot.py
@@ -63,7 +63,7 @@ class ExampleRoot(pyrogue.Root):
         self.add(self._prbsTx)
 
         # Add Data Writer, configuration goes to channel 1
-        self._fw = pyrogue.utilities.fileio.StreamWriter(configStream={1: stream})
+        self._fw = pyrogue.utilities.fileio.StreamWriter(configStream={1: stream},rawMode=True)
         self.add(self._fw)
         self._prbsTx >> self._fw.getChannel(0)
 

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -21,7 +21,7 @@ import rogue
 class StreamWriter(pyrogue.DataWriter):
     """Stream Writer Wrapper"""
 
-    def __init__(self, *, configStream={}, writer=None, **kwargs):
+    def __init__(self, *, configStream={}, writer=None, rawMode=False, **kwargs):
         pyrogue.DataWriter.__init__(self, **kwargs)
         self._configStream = configStream
 
@@ -29,6 +29,9 @@ class StreamWriter(pyrogue.DataWriter):
             self._writer = rogue.utilities.fileio.StreamWriter()
         else:
             self._writer = writer
+
+        if rawMode:
+            self_writer.setRaw(True)
 
         # Connect configuration stream
         for k,v in self._configStream.items():

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -31,7 +31,7 @@ class StreamWriter(pyrogue.DataWriter):
             self._writer = writer
 
         if rawMode:
-            self_writer.setRaw(True)
+            self._writer.setRaw(True)
 
         # Connect configuration stream
         for k,v in self._configStream.items():

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -71,6 +71,8 @@ void ruf::StreamWriter::setup_python() {
         .def("open", &ruf::StreamWriter::open)
         .def("close", &ruf::StreamWriter::close)
         .def("isOpen", &ruf::StreamWriter::isOpen)
+        .def("setRaw", &ruf::StreamWriter::setRaw)
+        .def("getRaw", &ruf::StreamWriter::getRaw)
         .def("setBufferSize", &ruf::StreamWriter::setBufferSize)
         .def("setMaxSize", &ruf::StreamWriter::setMaxSize)
         .def("setDropErrors", &ruf::StreamWriter::setDropErrors)

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -95,6 +95,7 @@ ruf::StreamWriter::StreamWriter() {
     currBuffer_ = 0;
     dropErrors_ = false;
     isOpen_     = false;
+    raw_        = false;
 
     log_ = rogue::Logging::create("fileio.StreamWriter");
 }
@@ -154,6 +155,16 @@ void ruf::StreamWriter::close() {
 //! Get open status
 bool ruf::StreamWriter::isOpen() {
     return (isOpen_);
+}
+
+//! Set raw mode
+void ruf::StreamWriter::setRaw(bool raw) {
+   raw_ = raw;
+}
+
+//! Get raw mode flag
+bool ruf::StreamWriter::getRaw() {
+   return raw_;
 }
 
 //! Set buffering size, 0 to disable
@@ -265,20 +276,31 @@ void ruf::StreamWriter::writeFile(uint8_t channel, std::shared_ptr<rogue::interf
     std::unique_lock<std::mutex> lock(mtx_);
 
     if (fd_ >= 0) {
-        // Written size has extra 4 bytes
-        size = frame->getPayload() + 4;
 
+        // Raw mode
+        if ( raw_ ) {
+           size = frame->getPayload();
+           checkSize(size);
+        }
+
+        // Written size has extra 4 bytes in non raw mode
         // Check file size, including size header
-        checkSize(size + 4);
+        else {
+           size = frame->getPayload() + 4;
+           checkSize(size + 4);
+        }
 
-        // First write size
-        intWrite(&size, 4);
+        if ( ! raw_ ) {
 
-        // Create EVIO header
-        value = frame->getFlags();
-        value |= (frame->getError() << 16);
-        value |= (channel << 24);
-        intWrite(&value, 4);
+           // First write size
+           intWrite(&size, 4);
+
+           // Create EVIO header
+           value = frame->getFlags();
+           value |= (frame->getError() << 16);
+           value |= (channel << 24);
+           intWrite(&value, 4);
+        }
 
         // Write buffers
         for (it = frame->beginBuffer(); it != frame->endBuffer(); ++it) intWrite((*it)->begin(), (*it)->getPayload());

--- a/src/rogue/utilities/fileio/StreamWriter.cpp
+++ b/src/rogue/utilities/fileio/StreamWriter.cpp
@@ -278,22 +278,19 @@ void ruf::StreamWriter::writeFile(uint8_t channel, std::shared_ptr<rogue::interf
     std::unique_lock<std::mutex> lock(mtx_);
 
     if (fd_ >= 0) {
-
         // Raw mode
         if ( raw_ ) {
            size = frame->getPayload();
            checkSize(size);
-        }
 
         // Written size has extra 4 bytes in non raw mode
         // Check file size, including size header
-        else {
+        } else {
            size = frame->getPayload() + 4;
            checkSize(size + 4);
         }
 
-        if ( ! raw_ ) {
-
+        if (!raw_) {
            // First write size
            intWrite(&size, 4);
 


### PR DESCRIPTION
Add option for raw data file writes. This eliminates the need to create per-project custom raw writers which seem to be used in a number of projects.
