### PR TITLE
rim:Emulator - renaming MAP_TYPE to EMULATE_MAP_TYPE

### DIFF
--- a/include/rogue/interfaces/memory/Emulate.h
+++ b/include/rogue/interfaces/memory/Emulate.h
@@ -31,7 +31,7 @@
     #include <boost/python.hpp>
 #endif
 
-#define MAP_TYPE std::map<uint64_t, uint8_t*>
+#define EMULATE_MAP_TYPE std::map<uint64_t, uint8_t*>
 
 namespace rogue {
 namespace interfaces {
@@ -43,7 +43,7 @@ namespace memory {
  */
 class Emulate : public Slave {
     // Map to store 4K address space chunks
-    MAP_TYPE memMap_;
+    EMULATE_MAP_TYPE memMap_;
 
     // Lock
     std::mutex mtx_;

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -54,7 +54,7 @@ rim::Emulate::Emulate(uint32_t min, uint32_t max) : Slave(min, max) {
 
 //! Destroy a block
 rim::Emulate::~Emulate() {
-    MAP_TYPE::iterator it = memMap_.begin();
+    EMULATE_MAP_TYPE::iterator it = memMap_.begin();
     while (it != memMap_.end()) {
         free(it->second);
         ++it;


### PR DESCRIPTION
### Description
- a conflicting definition exists in mman-linux.h where #define MAP_TYPE 0x0f
```cpp
#define MAP_TYPE 0x0f /* Mask for type of mapping. */
```