### PR TITLE
Documentation and CI Updates

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -74,7 +74,7 @@ jobs:
           python -c "import numpy; print(numpy.get_include())"
           mkdir build; cd build
           cmake .. -DROGUE_INSTALL=local
-          make -j4 install
+          make -j$(nproc) install
 
       # Run Tests
       - name: Rogue Tests
@@ -141,7 +141,7 @@ jobs:
         run: |
           mkdir build; cd build
           cmake .. -DROGUE_INSTALL=local -DNO_PYTHON=1 -DSTATIC_LIB=1
-          make -j4 install
+          make -j$(nproc) install
 
 
 # ----------------------------------------------------------------------------

--- a/docs/src/installing/anaconda.rst
+++ b/docs/src/installing/anaconda.rst
@@ -58,7 +58,7 @@ Alternatively you can install a specific released version of Rogue:
 
 .. code::
 
-   $ conda create -n rogue_v6.1.3 -c conda-forge -c tidair-tag rogue=v6.1.3
+   $ conda create -n rogue_v6.5.0 -c conda-forge -c tidair-tag rogue=v6.5.0
 
 Using Rogue In Anaconda
 =======================
@@ -71,7 +71,7 @@ To activate:
 
    $ conda activate rogue_tag
 
-Replace rogue_tag with the name you used when creating your environment (e.g. rogue_v6.1.3).
+Replace rogue_tag with the name you used when creating your environment (e.g. rogue_v6.5.0).
 
 
 To deactivate:

--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -13,28 +13,44 @@ Installing Packages Required For Rogue
 
 The following packages are required to build the rogue library:
 
-* cmake   >= 3.5
+* cmake   >= 3.15
 * Boost   >= 1.58
-* python3 >= 3.6
+* python3 >= 3.7
 * bz2
 
 Package Manager Install
 -----------------------
 
-Ubuntu 18.04 (or later)
+Ubuntu 22.04 (Debian-based systems)
 ########################
 
 .. code::
 
-   $ apt-get install cmake
-   $ apt-get install python3
-   $ apt-get install libboost-all-dev
-   $ apt-get install libbz2-dev
-   $ apt-get install python3-pip
-   $ apt-get install git
-   $ apt-get install libzmq3-dev
-   $ apt-get install python3-pyqt5
-   $ apt-get install python3-pyqt5.qtsvg
+   $ sudo apt install cmake
+   $ sudo apt install python3
+   $ sudo apt install libboost-all-dev
+   $ sudo apt install libbz2-dev
+   $ sudo apt install python3-pip
+   $ sudo apt install git
+   $ sudo apt install libzmq3-dev
+   $ sudo apt install python3-pyqt5
+   $ sudo apt install python3-pyqt5.qtsvg
+
+Rocky 9 (RHEL-based systems)
+########################
+
+.. code::
+
+   $ sudo dnf install -y cmake
+   $ sudo dnf install -y python3
+   $ sudo dnf install -y boost-devel
+   $ sudo dnf install -y bzip2-devel
+   $ sudo dnf install -y python3-pip
+   $ sudo dnf install -y git
+   $ sudo dnf install -y zeromq-devel
+   $ sudo dnf install -y python3-qt5
+   $ sudo dnf install -y python3-pyqt5-sip
+   $ sudo dnf install -y qt5-qtsvg-devel
 
 archlinux:
 ##########

--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -93,7 +93,7 @@ Local Install
    $ cmake .. -DROGUE_INSTALL=local
    $ make
    $ make install
-   $ source ../setup_rogue.csh (or .sh)
+   $ source ../setup_rogue.sh (or .csh)
 
 Custom Install
 --------------
@@ -110,7 +110,7 @@ Make sure you have permission to install into the passed install directory, if n
    $ cmake .. -DROGUE_INSTALL=custom -DROGUE_DIR=/path/to/custom/dir
    $ make
    $ make install
-   $ source /path/to/custom/dir/setup_rogue.csh (or .sh)
+   $ source /path/to/custom/dir/setup_rogue.sh (or .csh)
 
 
 System Install

--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -91,7 +91,7 @@ Local Install
    $ mkdir build
    $ cd build
    $ cmake .. -DROGUE_INSTALL=local
-   $ make
+   $ make -j$(nproc)
    $ make install
    $ source ../setup_rogue.sh (or .csh)
 
@@ -108,7 +108,7 @@ Make sure you have permission to install into the passed install directory, if n
    $ mkdir build
    $ cd build
    $ cmake .. -DROGUE_INSTALL=custom -DROGUE_DIR=/path/to/custom/dir
-   $ make
+   $ make -j$(nproc)
    $ make install
    $ source /path/to/custom/dir/setup_rogue.sh (or .csh)
 
@@ -126,7 +126,7 @@ Make sure you have permission to install into the /usr/local/ directory, if not 
    $ mkdir build
    $ cd build
    $ cmake .. -DROGUE_INSTALL=system
-   $ make
+   $ make -j$(nproc)
    $ make install
 
 Updating Rogue

--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -21,7 +21,7 @@ The following packages are required to build the rogue library:
 Package Manager Install
 -----------------------
 
-Ubuntu 22.04 (Debian-based systems)
+Debian-based systems (Ubuntu 22.04 or later)
 ########################
 
 .. code::
@@ -36,7 +36,7 @@ Ubuntu 22.04 (Debian-based systems)
    $ sudo apt install python3-pyqt5
    $ sudo apt install python3-pyqt5.qtsvg
 
-Rocky 9 (RHEL-based systems)
+RHEL-based systems (E.g. Rocky 9)
 ########################
 
 .. code::

--- a/docs/src/installing/petalinux.rst
+++ b/docs/src/installing/petalinux.rst
@@ -21,24 +21,24 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
    #
    # This file is the rogue recipe and tested on Petalinux 2024.2
    #
-   
-   ROGUE_VERSION = "6.4.3"
-   ROGUE_MD5SUM  = "4e7bac5a2098c9b33f6aca5d5ba5a96a"
-   
+
+   ROGUE_VERSION = "6.5.0"
+   ROGUE_MD5SUM  = "bfa8b7ef6ee883c5a9381b377b67c7a3"
+
    SUMMARY = "Recipe to build Rogue"
    HOMEPAGE ="https://github.com/slaclab/rogue"
    LICENSE = "MIT"
    LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-   
+
    SRC_URI = "https://github.com/slaclab/rogue/archive/v${ROGUE_VERSION}.tar.gz"
    SRC_URI[md5sum] = "${ROGUE_MD5SUM}"
-   
+
    S = "${WORKDIR}/rogue-${ROGUE_VERSION}"
    PROVIDES = "rogue"
    EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DROGUE_VERSION=v${ROGUE_VERSION}"
-   
+
    inherit cmake python3native setuptools3
-   
+
    DEPENDS += " \
       python3 \
       python3-native \
@@ -55,7 +55,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       boost \
       cmake \
    "
-   
+
    RDEPENDS:${PN} += " \
       python3-numpy \
       python3-pyzmq \
@@ -67,10 +67,10 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       python3-json \
       python3-logging \
    "
-   
+
    FILES:${PN}-dev += "/usr/include/rogue/*"
    FILES:${PN} += "/usr/lib/*"
-   
+
    do_configure() {
       setup_target_config
       cmake_do_configure
@@ -79,7 +79,7 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       bbplain $(sed -i "s/..\/python/python/" ${S}/setup.py)
       setuptools3_do_configure
    }
-   
+
    do_install() {
       setup_target_config
       cmake_do_install
@@ -89,7 +89,6 @@ You will want to replace the file project-spec/meta-user/recipes-apps/rogue/rogu
       # Install the rogue.so file into the Python site-packages directory
       install -m 0755 ${S}/python/rogue.so ${D}${PYTHON_SITEPACKAGES_DIR}
    }
-
 
 Update the ROGUE_VERSION line for an updated version when appropriate. You will need to first download the tar.gz file and compute the MD5SUM using the following commands if you update the ROGUE_VERSION line:
 


### PR DESCRIPTION
### Description
- Updating anaconda install instructions for rogue v6.5.0 (latest release)
- Updating petalinux install instructions for rogue v6.5.0 (latest release)
- Updating build from source instructions for Ubuntu 2022.04 and adding Rocky 9 install packages
- Update rogue_ci.yml to use max available CPU cores when building source code
