### PR TITLE
Rogue debug UI changes

### DIFF
--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -38,8 +38,8 @@ class Col:
     Command = 5
 
     NumCols = 6
-    ColumnNames =  ['Node', 'Mode', 'Type', 'Offset:BitOffset', 'Value', 'Command']
-    ColumnWidths = [ 300,    50,     75,     75,                 400,     75]       # Default column widths
+    ColumnNames =  ['Node', 'Mode', 'Type', 'ByteOffset [BitRange]', 'Value', 'Command']
+    ColumnWidths = [ 300,    50,     75,     100,                400,     75]       # Default column widths
 
 
 
@@ -75,7 +75,7 @@ class DebugDev(QTreeWidgetItem):
             pressValue=True,
             init_channel=self._path + '.ReadDevice')
 
-        self._top._tree.setItemWidget(self, Col.Value, w)
+        self._top._tree.setItemWidget(self, Col.Command, w)
 
 
         if self._top._node == dev:
@@ -240,8 +240,9 @@ class DebugHolder(QTreeWidgetItem):
 
         self.setText(Col.Mode, self._var.mode)
         self.setText(Col.Type, f'{self._var.typeStr}   ') # Pad to look nicer
-        if hasattr(self._var, 'offset') and hasattr(self._var, 'bitOffset'):
-            self.setText(Col.Offset, f'0x{self._var.offset:X}:{self._var.bitOffset[0]}')
+        if hasattr(self._var, 'offset') and hasattr(self._var, 'bitOffset') and hasattr(self._var, 'bitSize'):
+            bo = self._var.bitOffset[0]
+            self.setText(Col.Offset, f'0x{self._var.offset:X} [{bo+self._var.bitSize[0]-1}:{bo}]')
         self.setToolTip(Col.Node,self._var.description)
 
         w = makeVariableViewWidget(self)
@@ -295,6 +296,8 @@ class DebugTree(PyDMFrame):
         header = self._tree.header()
         header.setStretchLastSection(False)
         header.setSectionResizeMode(Col.Value, QHeaderView.Stretch)
+
+        self._tree.setColumnHidden(Col.Offset, True)
 
         self._tree.itemExpanded.connect(self._expandCb)
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

* Added an "Offset:BitOffset" column to the debug UI displaying register offsets relative to their parent
* Added actions to the context menu to allow toggling columns, copying text for current item, and copying the path of the selected row.
* Slight cleanup to the debug_tree.py code

If the offset column causes too much visual noise, it can be disabled by default and toggled via the context menu.

### Details
![image](https://github.com/user-attachments/assets/8b1c3bc4-43c3-414c-bf48-6113f1628abd)

![Screenshot_20250328_132942](https://github.com/user-attachments/assets/b050a845-61c6-4558-b02f-52a7c7de436c)

