### PR TITLE
Rogue debug UI improvements

### DIFF
--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -16,15 +16,14 @@ import pyrogue
 import pyrogue.pydm.widgets
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from pyrogue.pydm.widgets import PyRogueLineEdit
-from pyrogue import RemoteVariable, BaseVariable
 
 from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMLabel, PyDMSpinbox, PyDMPushButton, PyDMEnumComboBox
 
 from qtpy.QtCore import Property, Slot, QEvent, Qt, QPoint
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QHeaderView, QMenu
-from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel, QAction
-from qtpy.QtGui import QFontMetrics, QClipboard, QGuiApplication
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QHeaderView
+from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel
+from qtpy.QtGui import QFontMetrics, QGuiApplication
 
 class Col:
     """
@@ -331,7 +330,6 @@ class DebugTree(PyDMFrame):
             )
 
     def _hideColumn(self, checked, point: QPoint):
-        col = self._tree.columnAt(point.x())
         self._tree.setColumnHidden(self._tree.columnAt(point.x()), True)
 
     def _toggleColumn(self, checked, col: int):

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -38,8 +38,8 @@ class Col:
     Command = 5
 
     NumCols = 6
-    ColumnNames =  ['Node', 'Mode', 'Type', 'Offset:BitOffset', 'Value', 'Command']
-    ColumnWidths = [ 300,    50,     75,     75,                 400,     75]       # Default column widths
+    ColumnNames =  ['Node', 'Mode', 'Type', 'ByteOffset [BitRange]', 'Value', 'Command']
+    ColumnWidths = [ 300,    50,     75,     100,                400,     75]       # Default column widths
 
 
 
@@ -75,7 +75,7 @@ class DebugDev(QTreeWidgetItem):
             pressValue=True,
             init_channel=self._path + '.ReadDevice')
 
-        self._top._tree.setItemWidget(self, Col.Value, w)
+        self._top._tree.setItemWidget(self, Col.Command, w)
 
 
         if self._top._node == dev:
@@ -240,8 +240,9 @@ class DebugHolder(QTreeWidgetItem):
 
         self.setText(Col.Mode, self._var.mode)
         self.setText(Col.Type, f'{self._var.typeStr}   ') # Pad to look nicer
-        if hasattr(self._var, 'offset') and hasattr(self._var, 'bitOffset'):
-            self.setText(Col.Offset, f'0x{self._var.offset:X}:{self._var.bitOffset[0]}')
+        if hasattr(self._var, 'offset') and hasattr(self._var, 'bitOffset') and hasattr(self._var, 'bitSize'):
+            bo = self._var.bitOffset[0]
+            self.setText(Col.Offset, f'0x{self._var.offset:X} [{bo+self._var.bitSize[0]-1}:{bo}]')
         self.setToolTip(Col.Node,self._var.description)
 
         w = makeVariableViewWidget(self)
@@ -295,6 +296,8 @@ class DebugTree(PyDMFrame):
         header = self._tree.header()
         header.setStretchLastSection(False)
         header.setSectionResizeMode(Col.Value, QHeaderView.Stretch)
+
+        self._tree.setColumnHidden(Col.Offset, True)
 
         self._tree.itemExpanded.connect(self._expandCb)
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

* Added an "Offset:BitOffset" column to the debug UI displaying register offsets relative to their parent
* Added actions to the context menu to allow toggling columns, copying text for current item, and copying the path of the selected row.
* Slight cleanup to the debug_tree.py code

Resubmitted #1054 as a branch so CI will actually trigger.
