### PR TITLE
updating UdpRssiPack to updating the RSSI configuration before the RSSI connection is started

### DIFF
--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -64,32 +64,6 @@ class UdpRssiPack(pr.Device):
             if key in defaults:
                 setter(defaults[key])
 
-        # Start the RSSI connection
-        self._rssi._start()
-
-        if wait and not server:
-            curr = int(time.time())
-            last = curr
-            cnt = 0
-
-            while not self._rssi.getOpen():
-                time.sleep(.0001)
-                curr = int(time.time())
-                if last != curr:
-                    last = curr
-
-                    if jumbo:
-                        cnt += 1
-
-                    if cnt < 10:
-                        self._log.warning("host=%s, port=%d -> Establishing link ..." % (host,port))
-
-                    else:
-                        self._log.warning('host=%s, port=%d -> Failing to connect using jumbo frames! Be sure to check interface MTU settings with ifconig -a' % (host,port))
-
-
-        self._udp.setRxBufferCount(self._rssi.curMaxBuffers())
-
         # Add variables
         self.add(pr.LocalVariable(
             name        = 'rssiOpen',
@@ -312,6 +286,35 @@ class UdpRssiPack(pr.Device):
 
     def countReset(self):
         self._rssi.resetCounters()
+
+    def _start(self):
+        # Start the RSSI connection
+        self._rssi._start()
+
+        if wait and not server:
+            curr = int(time.time())
+            last = curr
+            cnt = 0
+
+            while not self._rssi.getOpen():
+                time.sleep(.0001)
+                curr = int(time.time())
+                if last != curr:
+                    last = curr
+
+                    if jumbo:
+                        cnt += 1
+
+                    if cnt < 10:
+                        self._log.warning("host=%s, port=%d -> Establishing link ..." % (host,port))
+
+                    else:
+                        self._log.warning('host=%s, port=%d -> Failing to connect using jumbo frames! Be sure to check interface MTU settings with ifconig -a' % (host,port))
+
+
+        self._udp.setRxBufferCount(self._rssi.curMaxBuffers())
+
+        super()._start()
 
     def _stop(self):
         self._rssi._stop()

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -27,6 +27,9 @@ class UdpRssiPack(pr.Device):
         # Local copy host/port arg values
         self._host = host
         self._port = port
+        self._wait = wait
+        self._jumbo = jumbo
+        self._server = server
 
         # Check if running as server
         if server:
@@ -291,7 +294,7 @@ class UdpRssiPack(pr.Device):
         # Start the RSSI connection
         self._rssi._start()
 
-        if wait and not server:
+        if self._wait and not self._server:
             curr = int(time.time())
             last = curr
             cnt = 0
@@ -302,14 +305,14 @@ class UdpRssiPack(pr.Device):
                 if last != curr:
                     last = curr
 
-                    if jumbo:
+                    if self._jumbo:
                         cnt += 1
 
                     if cnt < 10:
-                        self._log.warning("host=%s, port=%d -> Establishing link ..." % (host,port))
+                        self._log.warning("host=%s, port=%d -> Establishing link ..." % (self._host,self._port))
 
                     else:
-                        self._log.warning('host=%s, port=%d -> Failing to connect using jumbo frames! Be sure to check interface MTU settings with ifconig -a' % (host,port))
+                        self._log.warning('host=%s, port=%d -> Failing to connect using jumbo frames! Be sure to check interface MTU settings with ifconig -a' % (self._host,self._port))
 
 
         self._udp.setRxBufferCount(self._rssi.curMaxBuffers())

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -315,6 +315,8 @@ class UdpRssiPack(pr.Device):
                         self._log.warning('host=%s, port=%d -> Failing to connect using jumbo frames! Be sure to check interface MTU settings with ifconig -a' % (self._host,self._port))
 
 
+        # Sleep is bad, nee to figure this out
+        time.sleep(0.25)
         self._udp.setRxBufferCount(self._rssi.curMaxBuffers())
 
         super()._start()


### PR DESCRIPTION
### Description
- Give the user the ability to tune the RSSI configuration before the RSSI connection is started
- This is useful for debugging or supporting up to 256 segments at start of a connection for a "long latency" connection.

### Example
```python
            # Create the ETH interface @ IP Address = ip
            self.rudp[i] = pr.protocols.UdpRssiPack(
                name    = f'SwRudpClient[{i}]',
                host    = ip,
                port    = 8192+i,
                packVer = 2,
                jumbo   = False,
                defaults={'locMaxCumAck': 1}, # your custom override
            )
```