### PR TITLE
Don't allow default set to RO register to result in stale state

### DIFF
--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -650,7 +650,7 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
     std::lock_guard<std::mutex> lock(mtx_);
 
     // Set stale flag
-    stale_ = true;
+    if (var->mode_ != "RO") stale_ = true;
 
     // Change byte order, need to make a copy
     if (var->byteReverse_) {
@@ -677,19 +677,23 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
         else
             copyBits(blockData_, var->bitOffset_[0] + (index * var->valueStride_), buff, 0, var->valueBits_);
 
-        if (var->stale_) {
-            if (var->lowTranByte_[index] < var->staleLowByte_) var->staleLowByte_ = var->lowTranByte_[index];
+        if (var->mode_ != "RO") {
+           if (var->stale_) {
+               if (var->lowTranByte_[index] < var->staleLowByte_) var->staleLowByte_ = var->lowTranByte_[index];
 
-            if (var->highTranByte_[index] > var->staleHighByte_) var->staleHighByte_ = var->highTranByte_[index];
-        } else {
-            var->staleLowByte_  = var->lowTranByte_[index];
-            var->staleHighByte_ = var->highTranByte_[index];
+               if (var->highTranByte_[index] > var->staleHighByte_) var->staleHighByte_ = var->highTranByte_[index];
+           } else {
+               var->staleLowByte_  = var->lowTranByte_[index];
+               var->staleHighByte_ = var->highTranByte_[index];
+           }
         }
 
         // Standard variable
     } else {
-        var->staleLowByte_  = var->lowTranByte_[0];
-        var->staleHighByte_ = var->highTranByte_[0];
+        if (var->mode_ != "RO") {
+           var->staleLowByte_  = var->lowTranByte_[0];
+           var->staleHighByte_ = var->highTranByte_[0];
+        }
 
         // Fast copy
         if (var->fastByte_ != NULL) {
@@ -706,7 +710,7 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
             }
         }
     }
-    var->stale_ = true;
+    if ( var->mode_ != "RO" ) var->stale_ = true;
     if (var->byteReverse_) free(buff);
 }
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -39,7 +39,7 @@ class EnumDev(pr.Device):
             },
         ))
 
-        self.add(pr.RemoteVariable(
+        self.add(pr.LocalVariable(
             name         = 'Status',
             description  = 'ENUM Test Field',
             offset       = 0x4,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -94,7 +94,7 @@ class MemDev(pr.Device):
                     offset       = 0x000+4*i,
                     bitSize      = 8,
                     bitOffset    = 8*j,
-                    mode         = modeConfig,
+                    mode         = "RW",
                     value        = value
                 ))
 
@@ -106,7 +106,7 @@ class MemDev(pr.Device):
                 offset       = 0x100,
                 bitSize      = 9,
                 bitOffset    = 9*i,
-                mode         = modeConfig,
+                mode         = "RW",
                 value        = i
             ))
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -81,7 +81,7 @@ class SimpleDev(pr.Device):
 
 class MemDev(pr.Device):
 
-    def __init__(self,modeConfig='RW',**kwargs):
+    def __init__(self,**kwargs):
 
         super().__init__(**kwargs)
 
@@ -95,7 +95,7 @@ class MemDev(pr.Device):
                     bitSize      = 8,
                     bitOffset    = 8*j,
                     mode         = modeConfig,
-                    value        = None if modeConfig=='RW' else value,
+                    value        = value
                 ))
 
         for i in range(256):
@@ -107,7 +107,7 @@ class MemDev(pr.Device):
                 bitSize      = 9,
                 bitOffset    = 9*i,
                 mode         = modeConfig,
-                value        = None if modeConfig=='RW' else i,
+                value        = i
             ))
 
 
@@ -137,12 +137,10 @@ class DummyTree(pr.Root):
         self.addInterface(mc)
 
         # Add Device
-        modeConfig = ['RW','RW','RO','RO']
         for i in range(4):
             self.add(MemDev(
                 name       = f'MemDev[{i}]',
                 offset     = i*0x10000,
-                modeConfig = modeConfig[i],
                 memBase    = mc,
             ))
 


### PR DESCRIPTION
This PR blocks a set to a RO variable from impacting the stale state of the variable or the underlying block.

This is necessary to allow a default value in a RO register. 

