### PR TITLE
Update rogue_ci.yml

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -12,7 +12,6 @@
 # The following environment variables are required for this process:
 # secrets.GH_TOKEN
 # secrets.CONDA_UPLOAD_TOKEN_TAG
-# secrets.DOCKERHUB_TOKEN
 
 name: Rogue Integration
 on: [push]


### PR DESCRIPTION
### Description
- `secrets.DOCKERHUB_TOKEN` is no longer used because publishing docker images on Github (instead of dockerhub) now
