### PR TITLE
Add warning for type changes in non-array LocalVariable values

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -253,7 +253,7 @@ class LocalBlock(object):
             else:
                 if not isinstance(value, var._nativeType):
                     self._log.warning( f'{var.path}: Expecting {var._nativeType}: Currently a warning but in the future this will be an error' )
-                     #raise TypeError(f"Error - {var.path}: Expecting {var._nativeType} but got {type(value)}")
+                    #raise TypeError(f"Error - {var.path}: Expecting {var._nativeType} but got {type(value)}")
 
                 self._value = value
 


### PR DESCRIPTION
### Summary
This update introduces a **warning** when a `LocalVariable` is assigned a value whose type does not match its default type. This helps prevent users from unintentionally assigning incorrect value types.

### Details
- Type consistency is now checked for all `LocalVariable` instances **except arrays**.
- Arrays remain dynamic and are excluded from type checking.
- This change currently issues a **warning** instead of an error to allow users time to adapt.
- In a future release, this behavior will be upgraded to an **error** to enforce stricter type safety.

### Motivation
The goal is to improve type safety and prevent subtle bugs caused by inconsistent value types while maintaining backward compatibility during the transition period.
