### PR TITLE
Conda CI Release Updates

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -4,21 +4,16 @@ python:
   - 3.10
   - 3.11
   - 3.12
-
-# Use NumPy minors that exist for each Python
-numpy:
-  - 1.26    # py39
-  - 1.26    # py310
-  - 1.26    # py311
-  - 1.26    # py312
+  - 3.13
 
 ###############################################################################################
 # Notes for checking if conda solution exist before doing the actual conda build
 ###############################################################################################
-# conda render conda-recipe --variants "{python: 3.9,  numpy: 1.26, python_abi: '3.9  *_cp39' }"
-# conda render conda-recipe --variants "{python: 3.10, numpy: 1.26, python_abi: '3.10 *_cp310'}"
-# conda render conda-recipe --variants "{python: 3.11, numpy: 1.26, python_abi: '3.11 *_cp311'}"
-# conda render conda-recipe --variants "{python: 3.12, numpy: 1.26, python_abi: '3.12 *_cp312'}"
+# conda render conda-recipe --variants "{python: 3.9,  python_abi: '3.9  *_cp39' }"
+# conda render conda-recipe --variants "{python: 3.10, python_abi: '3.10 *_cp310'}"
+# conda render conda-recipe --variants "{python: 3.11, python_abi: '3.11 *_cp311'}"
+# conda render conda-recipe --variants "{python: 3.12, python_abi: '3.12 *_cp312'}"
+# conda render conda-recipe --variants "{python: 3.13, python_abi: '3.13 *_cp313'}"
 ###############################################################################################
 
 # Lock to CPython ABI, not PyPy
@@ -27,15 +22,17 @@ python_abi:
   - 3.10 *_cp310
   - 3.11 *_cp311
   - 3.12 *_cp312
+  - 3.13 *_cp313
 
 python_impl:
   - cpython   # py39
   - cpython   # py310
   - cpython   # py311
   - cpython   # py312
+  - cpython   # py313
 
 zip_keys:
-  - [python, numpy, python_abi, python_impl]
+  - [python, python_abi, python_impl]
 
 pin_run_as_build:
   python: {min_pin: x.x, max_pin: x.x}

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -4,7 +4,6 @@ python:
   - 3.10
   - 3.11
   - 3.12
-  - 3.13
 
 ###############################################################################################
 # Notes for checking if conda solution exist before doing the actual conda build
@@ -13,7 +12,6 @@ python:
 # conda render conda-recipe --variants "{python: 3.10, python_abi: '3.10 *_cp310'}"
 # conda render conda-recipe --variants "{python: 3.11, python_abi: '3.11 *_cp311'}"
 # conda render conda-recipe --variants "{python: 3.12, python_abi: '3.12 *_cp312'}"
-# conda render conda-recipe --variants "{python: 3.13, python_abi: '3.13 *_cp313'}"
 ###############################################################################################
 
 # Lock to CPython ABI, not PyPy
@@ -22,14 +20,12 @@ python_abi:
   - 3.10 *_cp310
   - 3.11 *_cp311
   - 3.12 *_cp312
-  - 3.13 *_cp313
 
 python_impl:
   - cpython   # py39
   - cpython   # py310
   - cpython   # py311
   - cpython   # py312
-  - cpython   # py313
 
 zip_keys:
   - [python, python_abi, python_impl]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,13 +20,13 @@ requirements:
      - bzip2
      - zeromq
      - python {{ python }} # declare python variants in conda_build_config.yaml
-     - numpy {{ numpy }}   # declare numpy  variants in conda_build_config.yaml
+     - numpy>=2.0
    run:
      - python
      - boost
      - bzip2
      - zeromq
-     - numpy
+     - numpy>=2.0
      - ipython
      - pyyaml
      - jsonpickle


### PR DESCRIPTION
- Moving numpy constraint from `==1.26` to `>= 2.0`
  - NumPy 1.x, including the final release in the 1.x line (NumPy 1.26.x), reaches its official End-of-Life (EOL) in September 2025
  - This PR is part of rogue's NumPy migration to NumPy 2.x