### PR TITLE
Work around for a CI pytest randomly failing

### DIFF
--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -92,6 +92,7 @@ def test_enum():
 
         for i in range(3):
             root.Dev.Config.setDisp(f'Config{i}')
+            root.Dev.Config.write() # Work around for a race condition between setDisp() and get() with Emulate()?????
             config =  root.Dev.Config.get()
             if ( config != (2-i) ):
                 raise AssertionError( f'root.Dev.config.get()={config}' )

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -14,6 +14,8 @@ import pyrogue as pr
 import pyrogue.interfaces.simulation
 import rogue.interfaces.memory
 
+import time
+
 #rogue.Logging.setLevel(rogue.Logging.Warning)
 #import logging
 #logger = logging.getLogger('pyrogue')
@@ -86,13 +88,18 @@ class DummyTree(pr.Root):
             memBase    = mc,
         ))
 
+    def start(self, **kwargs):
+        super().start(**kwargs)
+
+        # Allow time for TCP connection to establish
+        time.sleep(1.0)
+
 def test_enum():
 
     with DummyTree() as root:
 
         for i in range(3):
             root.Dev.Config.setDisp(f'Config{i}')
-            root.Dev.Config.write() # Work around for a race condition between setDisp() and get() with Emulate()?????
             config =  root.Dev.Config.get()
             if ( config != (2-i) ):
                 raise AssertionError( f'root.Dev.config.get()={config}' )


### PR DESCRIPTION
### Description
 - https://jira.slac.stanford.edu/browse/ESROGUE-721
 - It appears to be a race condition between when the TCP client/server establish the connection at start of root.  Adding a 1 second time out to root.start() seems to be the work around.  Not a very good solution.  It would be better with the TCP server/client had something like a "getOpen" variable to poll on in root.start() for determining when the TCP links are established