### PR TITLE
Register Rogue PyDM plugin manually in cases where it's not loaded automatically

### DIFF
--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -94,7 +94,7 @@ Local Install
    $ cmake .. -DROGUE_INSTALL=local
    $ make -j$(nproc)
    $ make install
-   $ source ../setup_rogue.sh (or .csh)
+   $ source ../setup_rogue.sh (or .csh, or .fish)
 
 Custom Install
 --------------
@@ -111,7 +111,7 @@ Make sure you have permission to install into the passed install directory, if n
    $ cmake .. -DROGUE_INSTALL=custom -DROGUE_DIR=/path/to/custom/dir
    $ make -j$(nproc)
    $ make install
-   $ source /path/to/custom/dir/setup_rogue.sh (or .csh)
+   $ source /path/to/custom/dir/setup_rogue.sh (or .csh, or .fish)
 
 
 System Install

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -17,7 +17,8 @@ import sys
 import signal
 import pydm
 import pyrogue
-import pyrogue.pydm.data_plugins.rogue_plugin
+import pydm.data_plugins
+from pyrogue.pydm.data_plugins.rogue_plugin import RoguePlugin
 
 # Define a signal handler to ensure the application quits gracefully
 def pydmSignalHandler(sig, frame):
@@ -46,6 +47,12 @@ def runPyDM(serverList='localhost:9090', ui=None, title=None, sizeX=800, sizeY=1
     args.append(f"title='{title}'")
     args.append(f"maxListExpand={maxListExpand}")
     args.append(f"maxListSize={maxListSize}")
+
+    pydm.data_plugins.initialize_plugins_if_needed()
+
+    # Add Rogue plugin manually, if it hasn't already been added based on $PYDM_DATA_PLUGINS_PATH
+    if 'rogue' not in pydm.data_plugins.plugin_modules:
+        pydm.data_plugins.add_plugin(RoguePlugin)
 
     # Initialize the PyDM application with specified parameters
     app = pydm.PyDMApplication(ui_file=ui,


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail. This could include code examples, etc. -->
<!--- If you leave this blank your PR will not be accepted. -->
<!--- What you enter here will go into the release notes when this change is included in a release, it is important that it be clean and readable. -->

I was running into a strange issue with the Rogue conda environments on /sdf where the rogue PyDM plugin wasn't being registered despite $PYDM_DATA_PLUGINS_PATH being set correctly. Registering the plugin manually fixed the issue.

Additionally, conda environments on my Debian desktop weren't setting $PYDM_DATA_PLUGINS at all, leading to the same type of error. I think it makes sense to have fallback logic here, just in case auto-registration doesn't work.