### PR TITLE
Enhance PyRogue docs and typing across utilities and PyDM

### DIFF
--- a/docs/src/utilities/fileio/classes/reader.rst
+++ b/docs/src/utilities/fileio/classes/reader.rst
@@ -6,6 +6,10 @@ StreamReader
 
 The StreamReader class is the utilitiy for reading data from a Rogue file in a streaming fashion.
 
+The file format consumed by StreamReader is documented here:
+
+- :ref:`utilities_fileio_format`
+
 StreamReader objects in C++ are referenced by the following shared pointer typedef:
 
 .. doxygentypedef:: rogue::utilities::fileio::StreamReaderPtr

--- a/docs/src/utilities/fileio/classes/writer.rst
+++ b/docs/src/utilities/fileio/classes/writer.rst
@@ -4,27 +4,36 @@
 StreamWriter
 ============
 
-The StreamWriter class is the utilitiy for writing Rogue data to a file. The writer class
-can accept streams from multiple sources, with the :ref:`utilities_fileio_writer_channel` serving
-as the interface to each incoming stream. This class can be sub-classed to support custom formats,
-by overriding the writeFile method.
+The StreamWriter class writes Rogue stream frames to disk. It can accept frames
+from multiple incoming sources, with :ref:`utilities_fileio_writer_channel`
+providing the per-channel input interfaces. This class can be sub-classed to
+support custom formats by overriding ``writeFile()``.
 
-The default format is the following:
+The shared on-disk record format (headers and metadata field encoding) is
+documented here:
 
-The data file is a written as a series of banks, each associated with a written Frame.
-Each bank has a channel and frame flags. The channel is per source and the
-lower 24 bits of the incoming Frame flags are used as the flags.
+- :ref:`utilities_fileio_format`
 
-The bank is proceeded by 2 - 32-bit headers to indicate bank information and length:
+Raw Mode
+========
 
-.. code-block:: c
+When ``setRaw(True)`` is enabled, StreamWriter writes only payload bytes for
+each frame and omits per-record headers. In this mode, channel/error/flags
+metadata is not persisted.
 
-      headerA:
-          31:0  = Length of data block in bytes
-      headerB:
-         31:24  = Channel ID
-         23:16  = Frame error
-          15:0  = Frame flags
+File Splitting Behavior
+=======================
+
+If ``setMaxSize()`` is non-zero, StreamWriter rolls to a new output file before
+writing a record that would exceed the configured limit.
+
+Split files use incrementing numeric suffixes:
+
+.. code-block:: text
+
+   myFile.dat.1
+   myFile.dat.2
+   myFile.dat.3
 
 StreamWriter objects in C++ are referenced by the following shared pointer typedef:
 

--- a/docs/src/utilities/fileio/format.rst
+++ b/docs/src/utilities/fileio/format.rst
@@ -1,0 +1,55 @@
+.. _utilities_fileio_format:
+
+======================
+Rogue File Data Format
+======================
+
+This page documents the default on-disk record format used by
+:ref:`utilities_fileio_writer` and consumed by :ref:`utilities_fileio_reader`.
+
+Default Framed Mode
+===================
+
+In default mode (``raw`` disabled), each frame is written as one record:
+
+.. code-block:: text
+
+   record := headerA (4 bytes) + headerB (4 bytes) + payload (N bytes)
+
+Both headers are 32-bit little-endian words.
+
+Header field layout:
+
+.. code-block:: c
+
+      headerA:
+          31:0  = (payload_bytes + 4)
+                  // payload size plus the 4-byte headerB word
+
+      headerB:
+         31:24  = Channel ID passed to writeFile(channel, frame)
+         23:16  = Frame error field (frame->getError())
+          15:0  = Lower 16 bits of frame flags (frame->getFlags())
+
+Notes:
+
+- Payload bytes are written exactly as they appear in the source frame buffers.
+- The lower 16 bits of ``Frame.flags`` are persisted in the file.
+
+Metadata Semantics
+==================
+
+``Frame.flags`` is a 16-bit metadata field. In many AXI-Stream/SSI flows, it
+is used to carry TUSER sideband information:
+
+- bits ``[7:0]`` often represent first-tuser (SOF-side metadata)
+- bits ``[15:8]`` often represent last-tuser (EOF-side metadata)
+
+The exact interpretation is protocol-dependent. StreamWriter stores this value
+without modification so downstream software can decode it in the correct
+protocol context.
+
+``Frame.error`` is an 8-bit status field stored in ``headerB[23:16]``. Rogue
+typically treats non-zero values as errored frames, but specific bit meanings
+or enumerations are producer/protocol specific.
+

--- a/docs/src/utilities/fileio/index.rst
+++ b/docs/src/utilities/fileio/index.rst
@@ -10,6 +10,7 @@ The following are examples of using the fileio utilities in Rogue to write and r
    :maxdepth: 1
    :caption: Using The File I/O Utilities:
 
+   format
    writing
    reading
    custom

--- a/docs/src/utilities/fileio/reading.rst
+++ b/docs/src/utilities/fileio/reading.rst
@@ -11,6 +11,9 @@ written. Since multiple "channels" may have been used when writing the file, gen
 be tagged with a channel ID to match the channel value when written. A :ref:`interfaces_stream_filter`
 object can be used to direct the Frames based upon their channel IDs.
 
+For the canonical on-disk record format consumed by StreamReader, see
+:ref:`utilities_fileio_format`.
+
 There is also a python utilitiy for reading frames in python using a non-streaming method.
 
 The following code block describes how to create and connect a file reader in python:

--- a/docs/src/utilities/fileio/writing.rst
+++ b/docs/src/utilities/fileio/writing.rst
@@ -10,6 +10,9 @@ data file. The Channel 0 interface can be used to write frames which may have a 
 channel ID field value set. If this value is non-zero the Frame's channel ID will be used
 when writing the file.
 
+For the canonical on-disk record format (headers, flags/error encoding, raw mode,
+and split-file behavior), see :ref:`utilities_fileio_format`.
+
 The following code block describes how to create and connect a file writer in python:
 
 .. code-block:: python

--- a/docs/src/utilities/hls/index.rst
+++ b/docs/src/utilities/hls/index.rst
@@ -1,0 +1,15 @@
+.. _utilities_hls:
+
+=============
+HLS Utilities
+=============
+
+Utilities in this section help bridge High-Level Synthesis (HLS) register-map
+outputs into Rogue tree definitions.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: HLS Utilities:
+
+   reg_interf_parser
+

--- a/docs/src/utilities/hls/reg_interf_parser.rst
+++ b/docs/src/utilities/hls/reg_interf_parser.rst
@@ -1,0 +1,99 @@
+.. _utilities_hls_reg_interf_parser:
+
+==============================
+HLS Register Interface Parser
+==============================
+
+The module :py:mod:`pyrogue.utilities.hls._RegInterfParser` parses HLS-generated
+register header macros and generates a starter Rogue application file
+(``application.py``) containing `RemoteVariable`, `RemoteCommand`, or
+`MemoryDevice` definitions.
+
+Why this utility exists
+=======================
+
+HLS flows often generate AXI addressable register maps described in ``*_hw.h``
+header files. This utility helps convert those macro-based descriptions into a
+Rogue tree scaffold so software can quickly mirror the hardware map.
+
+CLI Usage
+=========
+
+Run the parser module with one output mode:
+
+.. code-block:: bash
+
+   python -m pyrogue.utilities.hls._RegInterfParser --remoteVariable
+   python -m pyrogue.utilities.hls._RegInterfParser --remoteCommand
+   python -m pyrogue.utilities.hls._RegInterfParser --memoryDevice
+
+At runtime, the tool prompts for a zip file path. It extracts the archive,
+searches for a ``*_hw.h`` file, parses ``#define`` macros, groups related macro
+families, and writes ``application.py`` in the current directory.
+
+Typical workflow
+================
+
+1. Build/export your HLS project artifacts.
+2. Provide the generated archive to this utility.
+3. Select output type (`RemoteVariable`, `RemoteCommand`, or `MemoryDevice`).
+4. Review/edit the generated ``application.py`` and integrate it into your
+   project's Rogue tree.
+
+Supported macro patterns
+========================
+
+The parser groups related register macros by common name stems and key suffixes:
+
+- ``ADDR``
+- ``BASE`` / ``HIGH``
+- ``BITS`` / ``WIDTH``
+- ``DEPTH``
+
+From these macros, it derives name, address offset, width/depth, and emits
+appropriate constructor arguments in the generated Python code.
+
+Function Reference
+==================
+
+``run()``
+---------
+
+Top-level CLI entry point.
+
+- Parses command-line options to select output mode.
+- Sets parser state for the selected target object type.
+- Calls ``parse()`` then ``write()``.
+
+``parse()``
+-----------
+
+Parses HLS register macros and returns normalized parameter records.
+
+- Prompts for zip file location.
+- Validates zip input and extracts archive contents.
+- Locates ``*_hw.h``.
+- Collects and groups ``#define`` macros.
+- Enforces a max width constraint (currently 64 bits).
+- Returns a list of namedtuple records matching selected output mode.
+
+``write(parameters)``
+---------------------
+
+Generates ``application.py`` from parsed records.
+
+- Writes an ``Application(pr.Device)`` class skeleton.
+- Emits one definition block per parsed record:
+  - ``pr.RemoteVariable(...)``
+  - ``pr.RemoteCommand(...)``
+  - ``pr.MemoryDevice(...)``
+- Leaves placeholders for user customization in ``initialize()``.
+
+Notes and limitations
+=====================
+
+- The utility creates a starting point; manual cleanup/refinement is expected.
+- Macro naming conventions in HLS output drive parsing quality.
+- Complex register semantics (arrays, packed bitfields, side effects) may need
+  hand-editing after generation.
+

--- a/docs/src/utilities/index.rst
+++ b/docs/src/utilities/index.rst
@@ -15,4 +15,5 @@ file operations, PRBS transmit and receive as well as stream compression.
 
    fileio/index
    prbs/index
+   hls/index
    compression/index

--- a/python/pyrogue/_DataWriter.py
+++ b/python/pyrogue/_DataWriter.py
@@ -233,15 +233,8 @@ class DataWriter(pr.Device):
         """
         return 0
 
-    def _getBandwidth(self, dev: pr.Device | None = None, var: pr.Variable | None = None) -> float:
+    def _getBandwidth(self) -> float:
         """Return instantaneous write bandwidth.
-
-        Parameters
-        ----------
-        dev : pyrogue.Device or None, optional
-            Optional callback context passed by LocalVariable polling.
-        var : pyrogue.Variable or None, optional
-            Optional callback context passed by LocalVariable polling.
 
         Returns
         -------

--- a/python/pyrogue/pydm/TimePlotTop.py
+++ b/python/pyrogue/pydm/TimePlotTop.py
@@ -18,18 +18,33 @@ from pyrogue.pydm.widgets import TimePlotter
 
 from pydm import Display
 
-from qtpy.QtWidgets import QVBoxLayout
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 
 
 Channel = 'rogue://0/root'
 
 class TimePlotTop(Display):
-    def __init__(self, parent=None, args=[], macros=None):
-        super().__init__(parent=parent, args=args, macros=None)
+    """Top-level PyDM display embedding the time-plotter widget.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    args : list[str] | None, optional
+        Display argument list (for example ``sizeX=...`` and ``sizeY=...``).
+    macros : dict[str, str] | None, optional
+        PyDM macro substitutions forwarded to :class:`pydm.Display`.
+    """
+
+    def __init__(self, parent: QWidget | None = None, args: list[str] | None = None, macros: dict[str, str] | None = None) -> None:
+        super().__init__(parent=parent, args=args, macros=macros)
 
         self.sizeX  = None
         self.sizeY  = None
         self.title  = None
+
+        if args is None:
+            args = []
 
         for a in args:
             if 'sizeX=' in a:
@@ -58,6 +73,6 @@ class TimePlotTop(Display):
 
         self.resize(self.sizeX, self.sizeY)
 
-    def ui_filepath(self):
-        # No UI file is being used
+    def ui_filepath(self) -> None:
+        """Return ``None`` because this display is code-constructed."""
         return None

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -13,21 +13,62 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 import os
-import sys
 import signal
+from types import FrameType
+
 import pydm
-import pyrogue
 import pydm.data_plugins
 from pyrogue.pydm.data_plugins.rogue_plugin import RoguePlugin
 
 # Define a signal handler to ensure the application quits gracefully
-def pydmSignalHandler(sig, frame):
+def pydmSignalHandler(sig: int, frame: FrameType | None) -> None:
+    """Handle process termination signals by closing all PyDM windows.
+
+    Parameters
+    ----------
+    sig : int
+        Received signal number.
+    frame : types.FrameType | None
+        Current stack frame provided by :mod:`signal`.
+    """
     app = pydm.PyDMApplication.instance()
     if app is not None:
         app.closeAllWindows()
 
 # Function to run the PyDM application with specified parameters
-def runPyDM(serverList='localhost:9090', ui=None, title=None, sizeX=800, sizeY=1000, maxListExpand=5, maxListSize=100):
+def runPyDM(
+    serverList: str = 'localhost:9090',
+    ui: str | None = None,
+    title: str | None = None,
+    sizeX: int = 800,
+    sizeY: int = 1000,
+    maxListExpand: int = 5,
+    maxListSize: int = 100,
+) -> None:
+    """Launch the default Rogue PyDM application.
+
+    Parameters
+    ----------
+    serverList : str, optional
+        Comma-separated list of ``host:port`` Rogue servers.
+    ui : str | None, optional
+        Optional UI file path. Defaults to ``pydmTop.py`` in this package.
+    title : str | None, optional
+        Optional window title. Defaults to ``"Rogue Server: <servers>"``.
+    sizeX : int, optional
+        Initial window width in pixels.
+    sizeY : int, optional
+        Initial window height in pixels.
+    maxListExpand : int, optional
+        Debug-tree auto-expand depth argument forwarded to the UI.
+    maxListSize : int, optional
+        Debug-tree list-size cap argument forwarded to the UI.
+
+    Returns
+    -------
+    None
+        This function runs the Qt event loop until the application exits.
+    """
 
     # Set the ROGUE_SERVERS environment variable
     os.environ['ROGUE_SERVERS'] = serverList

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -21,10 +21,12 @@ from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from PyQt5.QtCore import pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication
 from pydm import utilities
+from pydm.widgets.channel import PyDMChannel
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient
 from matplotlib.pyplot import Figure
+from pyrogue._Variable import VariableValue
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +34,20 @@ logger = logging.getLogger(__name__)
 AlarmToInt = {'None':0, 'Good':0, 'AlarmMinor':1, 'AlarmMajor':2}
 
 
-def parseAddress(address):
+def parseAddress(address: str) -> tuple[str, int, str, str, int]:
+    """Parse a Rogue PyDM address string.
+
+    Parameters
+    ----------
+    address : str
+        Address in the form ``rogue://index/path/mode/index`` or
+        ``rogue://host:port/path/mode/index``.
+
+    Returns
+    -------
+    tuple[str, int, str, str, int]
+        Parsed ``(host, port, path, mode, index)`` tuple.
+    """
     # "rogue://index/<path>/<mode>/<index>"
     # or
     # "rogue://host:port/<path>/<mode>/<index>"
@@ -63,15 +78,40 @@ def parseAddress(address):
     return (host,port,path,mode,index)
 
 
-def nodeFromAddress(address):
+def nodeFromAddress(address: str) -> pyrogue.Node | None:
+    """Resolve and return a Rogue node from a PyDM address string.
+
+    Parameters
+    ----------
+    address : str
+        Rogue PyDM address string.
+
+    Returns
+    -------
+    pyrogue.Node | None
+        Resolved node or ``None`` if lookup fails.
+    """
     host, port, path, mode, index = parseAddress(address)
     client = VirtualClient(host, port)
     return client.root.getNode(path)
 
 
 class RogueConnection(PyDMConnection):
+    """PyDM connection implementation backed by ``pyrogue.interfaces.VirtualClient``.
 
-    def __init__(self, channel, address, protocol=None, parent=None):
+    Parameters
+    ----------
+    channel : object
+        PyDM channel instance associated with this connection.
+    address : str
+        Raw address string for the connection.
+    protocol : str | None, optional
+        Protocol name as provided by PyDM.
+    parent : object | None, optional
+        Optional Qt parent object.
+    """
+
+    def __init__(self, channel: PyDMChannel, address: str, protocol: str | None = None, parent: object | None = None) -> None:
         super(RogueConnection, self).__init__(channel, address, protocol, parent)
 
         self.app = QApplication.instance()
@@ -107,14 +147,24 @@ class RogueConnection(PyDMConnection):
         self.add_listener(channel)
         self._client.addLinkMonitor(self.linkState)
 
-    def linkState(self, state):
+    def linkState(self, state: bool) -> None:
+        """Emit PyDM connection state updates from link-monitor callbacks."""
         if state:
             self.connection_state_signal.emit(True)
         else:
             self.connection_state_signal.emit(False)
 
 
-    def _updateVariable(self,path,varValue):
+    def _updateVariable(self, path: str, varValue: VariableValue) -> None:
+        """Forward Rogue variable updates into PyDM value/severity signals.
+
+        Parameters
+        ----------
+        path : str
+            Variable path for the update.
+        varValue : pyrogue._Variable.VariableValue
+            Updated value snapshot from the Rogue listener callback.
+        """
 
         if self._index != -1:
             varValue = self._node.getVariableValue(read=False, index=self._index)
@@ -142,7 +192,14 @@ class RogueConnection(PyDMConnection):
     @pyqtSlot(float)
     @pyqtSlot(str)
     @pyqtSlot(np.ndarray)
-    def put_value(self, new_value):
+    def put_value(self, new_value: int | float | str | np.ndarray | None) -> None:
+        """Handle write requests from PyDM widgets.
+
+        Parameters
+        ----------
+        new_value : int | float | str | numpy.ndarray | None
+            Incoming value from the bound PyDM widget signal.
+        """
         if self._node is None or not self._notDev:
             return
 
@@ -161,7 +218,14 @@ class RogueConnection(PyDMConnection):
             self._node.setDisp(val,index=self._index)
 
 
-    def add_listener(self, channel):
+    def add_listener(self, channel: PyDMChannel) -> None:
+        """Attach a PyDM channel listener and emit initial metadata/value.
+
+        Parameters
+        ----------
+        channel : PyDMChannel
+            PyDM channel to register for this connection.
+        """
         if self._node is None:
             return
 
@@ -214,7 +278,16 @@ class RogueConnection(PyDMConnection):
         else:
             self.new_value_signal[str].emit(self._node.name)
 
-    def remove_listener(self, channel, destroying):
+    def remove_listener(self, channel: PyDMChannel, destroying: bool) -> None:
+        """Detach listener resources associated with this connection.
+
+        Parameters
+        ----------
+        channel : PyDMChannel
+            PyDM channel being removed.
+        destroying : bool
+            Whether removal is part of channel/widget destruction.
+        """
         self._client.remLinkMonitor(self.linkState)
         self._client.stop()
         #if channel.value_signal is not None:
@@ -238,10 +311,12 @@ class RogueConnection(PyDMConnection):
         #super(RogueConnection, self).remove_listener(channel)
         pass
 
-    def close(self):
+    def close(self) -> None:
+        """Close connection resources (handled by listener teardown)."""
         pass
 
 
 class RoguePlugin(PyDMPlugin):
+    """PyDM plugin registration for the ``rogue://`` protocol."""
     protocol = "rogue"
     connection_class = RogueConnection

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -14,7 +14,7 @@
 #-----------------------------------------------------------------------------
 import os
 from pydm import Display
-from qtpy.QtWidgets import (QVBoxLayout, QTabWidget)
+from qtpy.QtWidgets import (QVBoxLayout, QTabWidget, QWidget)
 
 from pyrogue.pydm.widgets import DebugTree
 from pyrogue.pydm.widgets import SystemWindow
@@ -23,8 +23,20 @@ Channel = 'rogue://0/root'
 
 
 class DefaultTop(Display):
-    def __init__(self, parent=None, args=[], macros=None):
-        super(DefaultTop, self).__init__(parent=parent, args=args, macros=None)
+    """Default top-level Rogue PyDM display.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    args : list[str] | None, optional
+        Display argument list (for example ``sizeX=...`` and ``sizeY=...``).
+    macros : dict[str, str] | None, optional
+        PyDM macro substitutions forwarded to :class:`pydm.Display`.
+    """
+
+    def __init__(self, parent: QWidget | None = None, args: list[str] | None = None, macros: dict[str, str] | None = None) -> None:
+        super(DefaultTop, self).__init__(parent=parent, args=args, macros=macros)
 
         #self.setStyleSheet("*[dirty='true']\
         #                   {background-color: orange;}")
@@ -32,6 +44,9 @@ class DefaultTop(Display):
         self.sizeX  = None
         self.sizeY  = None
         self.title  = None
+
+        if args is None:
+            args = []
 
         for a in args:
             if 'sizeX=' in a:
@@ -70,6 +85,6 @@ class DefaultTop(Display):
 
         self.resize(self.sizeX, self.sizeY)
 
-    def ui_filepath(self):
-        # No UI file is being used
+    def ui_filepath(self) -> None:
+        """Return ``None`` because this display is code-constructed."""
         return None

--- a/python/pyrogue/pydm/tools/generic_file_tool.py
+++ b/python/pyrogue/pydm/tools/generic_file_tool.py
@@ -16,6 +16,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 from qtpy.QtWidgets import QFileDialog
 
 import pyrogue
@@ -26,8 +27,15 @@ logger = logging.getLogger(__name__)
 
 
 class OpenFileBrowse(ExternalTool):
+    """PyDM tool to browse for a file path and apply it to a node.
 
-    def __init__(self,save=False):
+    Parameters
+    ----------
+    save : bool, optional
+        If ``True``, use save-file dialog mode. Otherwise use open-file mode.
+    """
+
+    def __init__(self, save: bool = False) -> None:
         icon = IconFont().icon("cogs")
         self.save = save
 
@@ -40,7 +48,16 @@ class OpenFileBrowse(ExternalTool):
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Open file dialog and write selected path to the target node.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -73,17 +90,23 @@ class OpenFileBrowse(ExternalTool):
         else:
             logger.warning(f"File browser used with invalid node: {node.name}")
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration."""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration."""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret
 
 class SaveFileBrowse(OpenFileBrowse):
-    def __init__(self):
+    """Save-mode specialization of :class:`OpenFileBrowse`."""
+
+    def __init__(self) -> None:
+        """Initialize the save-file browser tool."""
         OpenFileBrowse.__init__(self, save=True)

--- a/python/pyrogue/pydm/tools/node_info_tool.py
+++ b/python/pyrogue/pydm/tools/node_info_tool.py
@@ -14,7 +14,6 @@
 #-----------------------------------------------------------------------------
 
 import logging
-from typing import Any
 
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
@@ -62,7 +61,15 @@ class NodeInformation(ExternalTool):
             self._command(node,channels[0])
 
     def _variable(self, node: pyrogue.BaseVariable, channel: PyDMChannel) -> None:
-        """Render variable metadata in a modal dialog."""
+        """Render variable metadata in a modal dialog.
+
+        Parameters
+        ----------
+        node : pyrogue.BaseVariable
+            Selected variable node.
+        channel : PyDMChannel
+            Triggering PyDM channel.
+        """
         attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum',
                  'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum',
                  'maximum', 'lowWarning', 'lowAlarm', 'highWarning',
@@ -120,7 +127,15 @@ class NodeInformation(ExternalTool):
 
 
     def _command(self, node: pyrogue.BaseCommand, channel: PyDMChannel) -> None:
-        """Render command metadata in a modal dialog."""
+        """Render command metadata in a modal dialog.
+
+        Parameters
+        ----------
+        node : pyrogue.BaseCommand
+            Selected command node.
+        channel : PyDMChannel
+            Triggering PyDM channel.
+        """
         attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum', 'typeStr', 'disp']
 
         if node.isinstance(pyrogue.RemoteCommand):
@@ -158,7 +173,15 @@ class NodeInformation(ExternalTool):
 
 
     def _device(self, node: pyrogue.Device, channel: PyDMChannel) -> None:
-        """Render device metadata in a modal dialog."""
+        """Render device metadata in a modal dialog.
+
+        Parameters
+        ----------
+        node : pyrogue.Device
+            Selected device node.
+        channel : PyDMChannel
+            Triggering PyDM channel.
+        """
         attrs = ['name', 'path', 'description', 'hidden', 'groups']
 
         msgBox = QDialog()

--- a/python/pyrogue/pydm/tools/node_info_tool.py
+++ b/python/pyrogue/pydm/tools/node_info_tool.py
@@ -14,8 +14,11 @@
 #-----------------------------------------------------------------------------
 
 import logging
+from typing import Any
+
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 from qtpy.QtWidgets import QVBoxLayout, QDialog, QPushButton, QFormLayout, QLineEdit
 from qtpy.QtCore import Qt
 
@@ -27,15 +30,25 @@ logger = logging.getLogger(__name__)
 
 
 class NodeInformation(ExternalTool):
+    """PyDM tool for displaying read-only metadata about a selected node."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         icon = IconFont().icon("cogs")
         name = "Node Information"
         group = "Rogue"
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Display node information dialog for the selected channel.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -48,7 +61,8 @@ class NodeInformation(ExternalTool):
         elif node.isinstance(pyrogue.BaseCommand):
             self._command(node,channels[0])
 
-    def _variable(self, node, channel):
+    def _variable(self, node: pyrogue.BaseVariable, channel: PyDMChannel) -> None:
+        """Render variable metadata in a modal dialog."""
         attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum',
                  'typeStr', 'disp', 'precision', 'mode', 'units', 'minimum',
                  'maximum', 'lowWarning', 'lowAlarm', 'highWarning',
@@ -105,7 +119,8 @@ class NodeInformation(ExternalTool):
         msgBox.exec()
 
 
-    def _command(self, node, channel):
+    def _command(self, node: pyrogue.BaseCommand, channel: PyDMChannel) -> None:
+        """Render command metadata in a modal dialog."""
         attrs = ['name', 'path', 'description', 'hidden', 'groups', 'enum', 'typeStr', 'disp']
 
         if node.isinstance(pyrogue.RemoteCommand):
@@ -142,7 +157,8 @@ class NodeInformation(ExternalTool):
         msgBox.exec()
 
 
-    def _device(self, node, channel):
+    def _device(self, node: pyrogue.Device, channel: PyDMChannel) -> None:
+        """Render device metadata in a modal dialog."""
         attrs = ['name', 'path', 'description', 'hidden', 'groups']
 
         msgBox = QDialog()
@@ -175,13 +191,16 @@ class NodeInformation(ExternalTool):
 
         msgBox.exec()
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration. (Empty string)"""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration. (Does nothing)"""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret

--- a/python/pyrogue/pydm/tools/read_node_tool.py
+++ b/python/pyrogue/pydm/tools/read_node_tool.py
@@ -16,6 +16,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient
@@ -25,15 +26,25 @@ logger = logging.getLogger(__name__)
 
 
 class ReadNode(ExternalTool):
+    """PyDM tool to read a node or device from the Rogue tree."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         icon = IconFont().icon("cogs")
         name = "Read Node"
         group = "Rogue"
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Execute a read operation against the selected node.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -52,13 +63,16 @@ class ReadNode(ExternalTool):
         else:
             logger.warning("Invalid node for read: {}".format(node.path))
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration."""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration."""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret

--- a/python/pyrogue/pydm/tools/read_recursive_tool.py
+++ b/python/pyrogue/pydm/tools/read_recursive_tool.py
@@ -16,6 +16,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient
@@ -25,15 +26,25 @@ logger = logging.getLogger(__name__)
 
 
 class ReadRecursive(ExternalTool):
+    """PyDM tool to recursively read a device subtree."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         icon = IconFont().icon("cogs")
         name = "Read Device Recursive"
         group = "Rogue"
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Execute a recursive read operation against the selected node.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -45,13 +56,16 @@ class ReadRecursive(ExternalTool):
         else:
             logger.warning("Invalid node for recursive read: {}".format(node.path))
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration."""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration."""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret

--- a/python/pyrogue/pydm/tools/write_node_tool.py
+++ b/python/pyrogue/pydm/tools/write_node_tool.py
@@ -16,6 +16,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient
@@ -25,15 +26,25 @@ logger = logging.getLogger(__name__)
 
 
 class WriteVariable(ExternalTool):
+    """PyDM tool to write a node or device from the Rogue tree."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         icon = IconFont().icon("cogs")
         name = "Write Node"
         group = "Rogue"
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Execute a write operation against the selected node.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -52,13 +63,16 @@ class WriteVariable(ExternalTool):
         else:
             logger.warning("Invalid node for write: {}".format(node.path))
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration."""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration."""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret

--- a/python/pyrogue/pydm/tools/write_recursive_tool.py
+++ b/python/pyrogue/pydm/tools/write_recursive_tool.py
@@ -15,6 +15,7 @@
 import logging
 from pydm.tools import ExternalTool
 from pydm.utilities.iconfont import IconFont
+from pydm.widgets.channel import PyDMChannel
 
 import pyrogue
 from pyrogue.interfaces import VirtualClient
@@ -24,15 +25,25 @@ logger = logging.getLogger(__name__)
 
 
 class WriteVariable(ExternalTool):
+    """PyDM tool to recursively write a device subtree."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         icon = IconFont().icon("cogs")
         name = "Write Device Recursive"
         group = "Rogue"
         use_with_widgets = True
         ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
-    def call(self, channels, sender):
+    def call(self, channels: list[PyDMChannel], sender: object) -> None:
+        """Execute a recursive write operation against the selected node.
+
+        Parameters
+        ----------
+        channels : list[PyDMChannel]
+            Channels associated with the invoking PyDM widget.
+        sender : object
+            Widget or window that triggered the tool.
+        """
         addr, port, path, mode, index = parseAddress(channels[0].address)
         self._client = VirtualClient(addr, port)
         node = self._client.root.getNode(path)
@@ -44,13 +55,16 @@ class WriteVariable(ExternalTool):
         else:
             logger.warning("Invalid node for recursive write: {}".format(node.path))
 
-    def to_json(self):
+    def to_json(self) -> str:
+        """Return serialized tool configuration."""
         return ""
 
-    def from_json(self, content):
+    def from_json(self, content: str) -> None:
+        """Load serialized tool configuration."""
         pass
 
-    def get_info(self):
+    def get_info(self) -> dict[str, object]:
+        """Return metadata for PyDM tool registration."""
         ret = ExternalTool.get_info(self)
         ret.update({'file': __file__})
         return ret

--- a/python/pyrogue/pydm/widgets/data_writer.py
+++ b/python/pyrogue/pydm/widgets/data_writer.py
@@ -24,11 +24,22 @@ import datetime
 
 
 class DataWriter(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """PyDM widget for controlling a ``pyrogue.DataWriter`` device.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
         self._node = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build controls after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(DataWriter, self).connection_changed(connected)
 
@@ -138,7 +149,8 @@ class DataWriter(PyDMFrame):
         fl.addRow('Total File Size:',w)
 
     @Slot()
-    def _closeDataFile(self):
+    def _closeDataFile(self) -> None:
+        """Update button enable state after closing the data file."""
         self._dataFile.setEnabled(True)
         self._browsebutton.setEnabled(True)
         self._openbutton.setEnabled(True)
@@ -146,7 +158,8 @@ class DataWriter(PyDMFrame):
         self._closebutton.setEnabled(False)
 
     @Slot()
-    def _openDataFile(self):
+    def _openDataFile(self) -> None:
+        """Update button enable state after opening the data file."""
         self._dataFile.setEnabled(False)
         self._browsebutton.setEnabled(False)
         self._openbutton.setEnabled(False)
@@ -154,7 +167,8 @@ class DataWriter(PyDMFrame):
         self._closebutton.setEnabled(True)
 
     @Slot()
-    def _browse(self):
+    def _browse(self) -> None:
+        """Open file browser and apply selected output file path."""
         dlg = QFileDialog()
         sug = datetime.datetime.now().strftime("data_%Y%m%d_%H%M%S.dat")
 

--- a/python/pyrogue/pydm/widgets/debug_tree.py
+++ b/python/pyrogue/pydm/widgets/debug_tree.py
@@ -22,7 +22,7 @@ from pydm.widgets import PyDMLabel, PyDMPushButton, PyDMEnumComboBox
 
 from qtpy.QtCore import Property, Slot, QEvent, Qt, QPoint
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QHeaderView
-from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel
+from qtpy.QtWidgets import QTreeWidgetItem, QTreeWidget, QLabel, QWidget
 from qtpy.QtGui import QFontMetrics, QGuiApplication
 
 class Col:
@@ -43,8 +43,23 @@ class Col:
 
 
 class DebugDev(QTreeWidgetItem):
+    """Tree item representing a Rogue device node.
 
-    def __init__(self,*, path, top, parent, dev, noExpand):
+    Parameters
+    ----------
+    path : str
+        Full Rogue node path for this device.
+    top : DebugTree
+        Owning debug-tree widget.
+    parent : QTreeWidget | QTreeWidgetItem
+        Parent tree widget/item.
+    dev : pyrogue.Device
+        Backing Rogue device object.
+    noExpand : bool
+        If ``True``, delay child expansion until user expands the row.
+    """
+
+    def __init__(self, *, path: str, top: "DebugTree", parent: QTreeWidget | QTreeWidgetItem, dev: pyrogue.Device, noExpand: bool) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._top      = top
         self._parent   = parent
@@ -90,7 +105,7 @@ class DebugDev(QTreeWidgetItem):
             self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
             self.setExpanded(False)
 
-    def _setup(self,noExpand):
+    def _setup(self, noExpand: bool) -> None:
 
         # Get dictionary of variables followed by commands
         lst = self._dev.variablesByGroup(incGroups=self._top._incGroups,
@@ -122,7 +137,7 @@ class DebugDev(QTreeWidgetItem):
             else:
                 DebugDev(path=self._path + '.' + val.name, top=self._top, parent=self, dev=val, noExpand=noExpand)
 
-    def _expand(self):
+    def _expand(self) -> None:
         if self._dummy is None:
             return
 
@@ -132,8 +147,21 @@ class DebugDev(QTreeWidgetItem):
 
 
 class DebugGroup(QTreeWidgetItem):
+    """Tree item representing a GUI grouping node.
 
-    def __init__(self,*, path, top, parent, name):
+    Parameters
+    ----------
+    path : str
+        Parent Rogue node path for this group.
+    top : DebugTree
+        Owning debug-tree widget.
+    parent : QTreeWidgetItem
+        Parent tree item.
+    name : str
+        GUI group name.
+    """
+
+    def __init__(self, *, path: str, top: "DebugTree", parent: QTreeWidgetItem, name: str) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._top      = top
         self._parent   = parent
@@ -149,7 +177,7 @@ class DebugGroup(QTreeWidgetItem):
         self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
         self.setExpanded(False)
 
-    def _setup(self):
+    def _setup(self) -> None:
 
         # Create variables
         for n in self._list:
@@ -165,7 +193,7 @@ class DebugGroup(QTreeWidgetItem):
                             parent=self,
                             variable=n)
 
-    def _expand(self):
+    def _expand(self) -> None:
         if self._dummy is None:
             return
 
@@ -173,10 +201,11 @@ class DebugGroup(QTreeWidgetItem):
         self._dummy = None
         self._setup()
 
-    def addNode(self,node):
+    def addNode(self, node: pyrogue.Node) -> None:
         self._list.append(node)
 
-def makeVariableViewWidget(parent):
+def makeVariableViewWidget(parent: "DebugHolder") -> QWidget:
+    """Create an editor/view widget for a variable or command row."""
     if parent._var.isCommand and not parent._var.arg:
         w = PyDMPushButton(label='Exec',
                            pressValue=1,
@@ -195,8 +224,28 @@ def makeVariableViewWidget(parent):
 
 
 class DebugHolder(QTreeWidgetItem):
+    """Tree item representing a variable or command node.
 
-    def __init__(self,*,path,top,parent,variable):
+    Parameters
+    ----------
+    path : str
+        Full Rogue node path for the variable/command.
+    top : DebugTree
+        Owning debug-tree widget.
+    parent : QTreeWidgetItem
+        Parent tree item.
+    variable : pyrogue.BaseVariable | pyrogue.BaseCommand
+        Backing Rogue variable or command object.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        top: "DebugTree",
+        parent: QTreeWidgetItem,
+        variable: pyrogue.BaseVariable | pyrogue.BaseCommand,
+    ) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._top    = top
         self._parent = parent
@@ -248,7 +297,27 @@ class DebugHolder(QTreeWidgetItem):
 
 
 class DebugTree(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+    """Interactive tree view for browsing and controlling Rogue nodes.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    incGroups : list[str] | None, optional
+        Include filter for Rogue groups.
+    excGroups : list[str] | None, optional
+        Exclude filter for Rogue groups.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        init_channel: str | None = None,
+        incGroups: list[str] | None = None,
+        excGroups: list[str] | None = ['Hidden'],
+    ) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._node = None
@@ -260,7 +329,8 @@ class DebugTree(PyDMFrame):
 
         self._colWidths = Col.ColumnWidths.copy()
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build tree controls after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(DebugTree, self).connection_changed(connected)
 
@@ -306,29 +376,29 @@ class DebugTree(PyDMFrame):
         DebugDev(path = self._path, top=self, parent=self._tree, dev=self._node, noExpand=False)
         self.setUpdatesEnabled(True)
 
-    def _copyPath(self, checked, point):
+    def _copyPath(self, checked: bool, point: QPoint) -> None:
         item = self._tree.itemAt(point)
         if item is not None and hasattr(item, '_path'):
             QGuiApplication.clipboard().setText(item._path)
 
-    def _copyColumnText(self, checked, point: QPoint):
+    def _copyColumnText(self, checked: bool, point: QPoint) -> None:
         item = self._tree.itemAt(point)
         if item is not None:
             QGuiApplication.clipboard().setText(
                 item.text(self._tree.columnAt(point.x()))
             )
 
-    def _hideColumn(self, checked, point: QPoint):
+    def _hideColumn(self, checked: bool, point: QPoint) -> None:
         self._tree.setColumnHidden(self._tree.columnAt(point.x()), True)
 
-    def _toggleColumn(self, checked, col: int):
+    def _toggleColumn(self, checked: bool, col: int) -> None:
         self._tree.setColumnHidden(col, not checked)
 
-    def _showAllCols(self, checked):
+    def _showAllCols(self, checked: bool) -> None:
         for i in range(Col.NumCols):
             self._tree.setColumnHidden(i, False)
 
-    def _openContextMenu(self, point):
+    def _openContextMenu(self, point: QPoint) -> None:
         # Generate base context menu from PyDM. We can't override generate_context_menu because
         # it doesn't give us the point where the mouse right clicked, which we need to implement the 'copy' actions
         menu = super(DebugTree, self).generate_context_menu()
@@ -357,7 +427,7 @@ class DebugTree(PyDMFrame):
         menu.exec_(self._tree.viewport().mapToGlobal(point))
 
     @Slot(QTreeWidgetItem)
-    def _expandCb(self,item):
+    def _expandCb(self, item: QTreeWidgetItem) -> None:
         self.setUpdatesEnabled(False)
         item._expand()
         self._tree.setColumnWidth(Col.Node, self._colWidths[Col.Node])
@@ -367,34 +437,34 @@ class DebugTree(PyDMFrame):
         self.setUpdatesEnabled(True)
 
     @Property(str)
-    def incGroups(self):
+    def incGroups(self) -> str:
         if self._incGroups is None or len(self._incGroups) == 0:
             return ''
         else:
             return ','.join(self._incGroups)
 
     @incGroups.setter
-    def incGroups(self, value):
+    def incGroups(self, value: str) -> None:
         if value == '':
             self._incGroups = None
         else:
             self._incGroups = value.split(',')
 
     @Property(str)
-    def excGroups(self):
+    def excGroups(self) -> str:
         if self._excGroups is None or len(self._excGroups) == 0:
             return ''
         else:
             return ','.join(self._excGroups)
 
     @excGroups.setter
-    def excGroups(self, value):
+    def excGroups(self, value: str) -> None:
         if value == '':
             self._excGroups = None
         else:
             self._excGroups = value.split(',')
 
-    def eventFilter(self, obj, event):
+    def eventFilter(self, obj: object, event: QEvent) -> bool:
         if event.type() == QEvent.Wheel:
             return True
         else:

--- a/python/pyrogue/pydm/widgets/label.py
+++ b/python/pyrogue/pydm/widgets/label.py
@@ -14,12 +14,25 @@
 #-----------------------------------------------------------------------------
 from pydm.widgets import PyDMLabel
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QHBoxLayout
+from qtpy.QtWidgets import QHBoxLayout, QWidget
 from pydm.widgets.base import str_types
 from pydm.widgets.display_format import parse_value_for_display
+import numpy as np
 
 class PyRogueLabel(PyDMLabel):
-    def __init__(self, parent, init_channel=None, show_units=True):
+    """PyDM label variant with optional engineering-unit display.
+
+    Parameters
+    ----------
+    parent : QWidget
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    show_units : bool, optional
+        If ``True``, display channel units in a dedicated unit label.
+    """
+
+    def __init__(self, parent: QWidget, init_channel: str | None = None, show_units: bool = True) -> None:
         super().__init__(parent, init_channel=init_channel)
 
         self._show_units = show_units
@@ -35,18 +48,19 @@ class PyRogueLabel(PyDMLabel):
         hbox.setContentsMargins(0, 0, 0, 0)
         self.setLayout(hbox)
 
-    def unit_changed(self, new_unit):
+    def unit_changed(self, new_unit: str) -> None:
+        """Update displayed engineering units."""
         if self._show_units:
             self._unitWidget.setText(new_unit)
 
-    def value_changed(self, new_value):
+    def value_changed(self, new_value: str | int | float | bool | np.ndarray) -> None:
         """
         Callback invoked when the Channel value is changed.
         Sets the value of new_value accordingly at the Label.
 
         Parameters
         ----------
-        new_value : str, int, float, bool or np.ndarray
+        new_value : str | int | float | bool | np.ndarray
             The new value from the channel. The type depends on the channel.
         """
         super(PyDMLabel, self).value_changed(new_value)

--- a/python/pyrogue/pydm/widgets/line_edit.py
+++ b/python/pyrogue/pydm/widgets/line_edit.py
@@ -18,14 +18,35 @@ import ast
 import logging
 from pydm.widgets import PyDMLineEdit, PyDMLabel
 from qtpy.QtCore import Property, Qt
-from qtpy.QtWidgets import QHBoxLayout
+from qtpy.QtGui import QFocusEvent
+from qtpy.QtWidgets import QHBoxLayout, QWidget
 from pydm.widgets.base import refresh_style, str_types
 from pydm.widgets.display_format import DisplayFormat, parse_value_for_display
 
 logger = logging.getLogger(__name__)
 
 class PyRogueLineEdit(PyDMLineEdit):
-    def __init__(self, parent, init_channel=None, show_units=True, read_only=False):
+    """PyDM line edit with Rogue-specific display and unit handling.
+
+    Parameters
+    ----------
+    parent : QWidget
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    show_units : bool, optional
+        If ``True``, display channel units in a dedicated unit label.
+    read_only : bool, optional
+        Unused compatibility parameter retained for legacy call sites.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget,
+        init_channel: str | None = None,
+        show_units: bool = True,
+        read_only: bool = False,
+    ) -> None:
         super().__init__(parent, init_channel=init_channel)
 
         self._show_units = show_units
@@ -49,31 +70,36 @@ class PyRogueLineEdit(PyDMLineEdit):
         self.setLayout(hbox)
 
 
-    def text_edited(self):
+    def text_edited(self) -> None:
+        """Mark widget dirty when user edits text."""
         self._dirty = True
         refresh_style(self)
 
-    def focusOutEvent(self, event):
+    def focusOutEvent(self, event: QFocusEvent) -> None:
+        """Clear dirty state when focus leaves the widget."""
         self._dirty = False
         super(PyRogueLineEdit, self).focusOutEvent(event)
         refresh_style(self)
 
 
-    def check_enable_state(self):
+    def check_enable_state(self) -> None:
+        """Update read-only state based on channel write access."""
         status = self._write_access and self._connected
         self.setReadOnly(not status)
         refresh_style(self)
 
     @Property(bool)
-    def dirty(self):
+    def dirty(self) -> bool:
+        """Whether user-edited text is pending commit."""
         return self._dirty
 
-    def unit_changed(self, new_unit):
+    def unit_changed(self, new_unit: str) -> None:
+        """Update displayed units text."""
         super().unit_changed(new_unit)
         if self._show_units:
             self._unitWidget.setText(new_unit)
 
-    def send_value(self):
+    def send_value(self) -> None:
         """
         Emit a :attr:`send_value_signal` to update channel value.
 
@@ -133,7 +159,7 @@ class PyRogueLineEdit(PyDMLineEdit):
 
 
 
-    def set_display(self):
+    def set_display(self) -> None:
         """
         Set the text display of the PyDMLineEdit.
 

--- a/python/pyrogue/pydm/widgets/plot.py
+++ b/python/pyrogue/pydm/widgets/plot.py
@@ -15,12 +15,22 @@
 
 from pydm.widgets.frame import PyDMFrame
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from qtpy.QtWidgets import QVBoxLayout
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 
 class Plotter(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """PyDM widget that displays an incoming matplotlib figure published by a pyrogue Variable.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._systemLog = None
@@ -28,7 +38,8 @@ class Plotter(PyDMFrame):
         self._canvas = None
         self._fig = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build the layout after the first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(Plotter, self).connection_changed(connected)
 
@@ -40,7 +51,8 @@ class Plotter(PyDMFrame):
         self._vb = QVBoxLayout()
         self.setLayout(self._vb)
 
-    def value_changed(self, new_val):
+    def value_changed(self, new_val: object) -> None:
+        """Replace the displayed plot with the latest figure object."""
         if self._canvas is not None:
             self._vb.removeWidget(self._canvas)
             self._vb.removeWidget(self._nav)

--- a/python/pyrogue/pydm/widgets/process.py
+++ b/python/pyrogue/pydm/widgets/process.py
@@ -19,15 +19,26 @@ from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from pyrogue.pydm.widgets import PyRogueLineEdit
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox, QWidget
 
 
 class Process(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """PyDM widget for controlling a ``pyrogue.Process`` node.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
         self._node = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build controls after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(Process, self).connection_changed(connected)
 

--- a/python/pyrogue/pydm/widgets/root_control.py
+++ b/python/pyrogue/pydm/widgets/root_control.py
@@ -17,17 +17,28 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMPushButton, PyDMEnumComboBox
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Slot, Qt
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, QGroupBox, QLineEdit, QFormLayout
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, QGroupBox, QLineEdit, QFormLayout, QWidget
 from pyrogue.pydm.widgets import PyRogueLineEdit
 import datetime
 
 
 class RootControl(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """PyDM widget exposing common root control actions.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
         self._node = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build controls after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(RootControl, self).connection_changed(connected)
 
@@ -159,7 +170,8 @@ class RootControl(PyDMFrame):
 
 
     @Slot(str)
-    def _loadConfigChanged(self,value):
+    def _loadConfigChanged(self, value: str) -> None:
+        """Update the load-config command argument from text entry."""
         self._loadConfigCmd.pressValue = value
         if not self._loadConfigValue.text():
             self._loadConfigCmd.setEnabled(False)
@@ -167,7 +179,8 @@ class RootControl(PyDMFrame):
             self._loadConfigCmd.setEnabled(True)
 
     @Slot()
-    def _loadConfigBrowse(self):
+    def _loadConfigBrowse(self) -> None:
+        """Open file browser and populate load-config path field."""
         dlg = QFileDialog()
 
         loadFile = dlg.getOpenFileNames(caption='Read config file', filter='Config Files(*.yml);;All Files(*.*)')
@@ -181,7 +194,8 @@ class RootControl(PyDMFrame):
             self._loadConfigCmd.setEnabled(True)
 
     @Slot(str)
-    def _saveConfigChanged(self,value):
+    def _saveConfigChanged(self, value: str) -> None:
+        """Update the save-config command argument from text entry."""
         self._saveConfigCmd.pressValue = value
         if not self._saveConfigValue.text():
             self._saveConfigCmd.setEnabled(False)
@@ -189,7 +203,8 @@ class RootControl(PyDMFrame):
             self._saveConfigCmd.setEnabled(True)
 
     @Slot()
-    def _saveConfigBrowse(self):
+    def _saveConfigBrowse(self) -> None:
+        """Open file browser and populate save-config path field."""
         dlg = QFileDialog()
         sug = datetime.datetime.now().strftime("config_%Y%m%d_%H%M%S.yml")
 
@@ -205,7 +220,8 @@ class RootControl(PyDMFrame):
 
 
     @Slot(str)
-    def _saveStateChanged(self,value):
+    def _saveStateChanged(self, value: str) -> None:
+        """Update the save-state command argument from text entry."""
         self._saveStateCmd.pressValue = value
         if not self._saveStateValue.text():
             self._saveStateCmd.setEnabled(False)
@@ -213,7 +229,8 @@ class RootControl(PyDMFrame):
             self._saveStateCmd.setEnabled(True)
 
     @Slot()
-    def _saveStateBrowse(self):
+    def _saveStateBrowse(self) -> None:
+        """Open file browser and populate save-state path field."""
         dlg = QFileDialog()
         sug = datetime.datetime.now().strftime("state_%Y%m%d_%H%M%S.yml.zip")
 

--- a/python/pyrogue/pydm/widgets/run_control.py
+++ b/python/pyrogue/pydm/widgets/run_control.py
@@ -17,15 +17,26 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMEnumComboBox, PyDMLabel
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox, QWidget
 
 
 class RunControl(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """PyDM widget for controlling a ``pyrogue.RunControl`` node.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
         self._node = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build controls after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(RunControl, self).connection_changed(connected)
 

--- a/python/pyrogue/pydm/widgets/system_log.py
+++ b/python/pyrogue/pydm/widgets/system_log.py
@@ -17,21 +17,38 @@ from pydm.widgets.frame import PyDMFrame
 from pydm.widgets import PyDMPushButton
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QVBoxLayout, QTreeWidgetItem, QTreeWidget, QGroupBox
+from qtpy.QtWidgets import QVBoxLayout, QTreeWidgetItem, QTreeWidget, QGroupBox, QWidget
 import json
 import time
 
 
 class SystemLog(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None,
-                 title="System Log (20 most recent entries)"):
+    """Widget for displaying recent Rogue system log entries.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    title : str, optional
+        Group box title shown above the log table.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        init_channel: str | None = None,
+        title: str = "System Log (20 most recent entries)",
+    ) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._systemLog = None
         self._node = None
         self._title = title
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build log UI elements after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(SystemLog, self).connection_changed(connected)
 
@@ -60,7 +77,8 @@ class SystemLog(PyDMFrame):
         self._pb = PyDMPushButton(label='Clear Log',pressValue=1,init_channel=self._path)
         vb.addWidget(self._pb)
 
-    def value_changed(self, new_val):
+    def value_changed(self, new_val: str) -> None:
+        """Render JSON log entries into the tree widget."""
         lst = json.loads(new_val)
 
         self._systemLog.clear()

--- a/python/pyrogue/pydm/widgets/system_window.py
+++ b/python/pyrogue/pydm/widgets/system_window.py
@@ -16,7 +16,7 @@
 from pydm.widgets.frame import PyDMFrame
 import pyrogue
 from pyrogue.pydm.data_plugins.rogue_plugin import nodeFromAddress
-from qtpy.QtWidgets import QVBoxLayout
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 from pyrogue.pydm.widgets import RootControl
 from pyrogue.pydm.widgets import DataWriter
 from pyrogue.pydm.widgets import RunControl
@@ -24,11 +24,22 @@ from pyrogue.pydm.widgets import SystemLog
 
 
 class SystemWindow(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """Top-level system summary window for a Rogue root.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
         self._node = None
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
+        """Build sub-widgets after first successful channel connection."""
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(SystemWindow, self).connection_changed(connected)
 

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -37,8 +37,34 @@ import random
 
 
 class DebugDev(QTreeWidgetItem):
+    """Tree item representing a device in the time-plot selection tree.
 
-    def __init__(self,main,*, path, top, parent, dev, noExpand):
+    Parameters
+    ----------
+    main : TimePlotter
+        Owning time-plotter widget.
+    path : str
+        Full Rogue node path for this device.
+    top : SelectionTree
+        Owning selection-tree widget.
+    parent : QTreeWidget | QTreeWidgetItem
+        Parent tree widget/item.
+    dev : pyrogue.Device
+        Backing Rogue device object.
+    noExpand : bool
+        If ``True``, delay child expansion until user expands the row.
+    """
+
+    def __init__(
+        self,
+        main: "TimePlotter",
+        *,
+        path: str,
+        top: "SelectionTree",
+        parent: QTreeWidget | QTreeWidgetItem,
+        dev: pyrogue.Device,
+        noExpand: bool,
+    ) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._main=main
         self._top      = top
@@ -75,7 +101,7 @@ class DebugDev(QTreeWidgetItem):
             self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
             self.setExpanded(False)
 
-    def _setup(self,noExpand):
+    def _setup(self, noExpand: bool) -> None:
 
         # Get dictionary of variables followed by commands
         lst = self._dev.variablesByGroup(incGroups=self._top._incGroups,
@@ -109,7 +135,7 @@ class DebugDev(QTreeWidgetItem):
             else:
                 DebugDev(main = self._main,path=self._path + '.' + val.name, top=self._top, parent=self, dev=val, noExpand=noExpand)
 
-    def _expand(self):
+    def _expand(self) -> None:
         if self._dummy is None:
             return
 
@@ -119,8 +145,23 @@ class DebugDev(QTreeWidgetItem):
 
 
 class DebugGroup(QTreeWidgetItem):
+    """Tree item representing a GUI group in the selection tree.
 
-    def __init__(self,main,*, path, top, parent, name):
+    Parameters
+    ----------
+    main : TimePlotter
+        Owning time-plotter widget.
+    path : str
+        Parent Rogue node path for this group.
+    top : SelectionTree
+        Owning selection-tree widget.
+    parent : QTreeWidgetItem
+        Parent tree item.
+    name : str
+        GUI group name.
+    """
+
+    def __init__(self, main: "TimePlotter", *, path: str, top: "SelectionTree", parent: QTreeWidgetItem, name: str) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._main = main
         self._top      = top
@@ -137,7 +178,7 @@ class DebugGroup(QTreeWidgetItem):
         self._dummy = QTreeWidgetItem(self) # One dummy item to add expand control
         self.setExpanded(False)
 
-    def _setup(self):
+    def _setup(self) -> None:
 
         # Create variables
         for n in self._list:
@@ -157,7 +198,7 @@ class DebugGroup(QTreeWidgetItem):
                             parent=self,
                             variable=n)
 
-    def _expand(self):
+    def _expand(self) -> None:
         if self._dummy is None:
             return
 
@@ -165,13 +206,36 @@ class DebugGroup(QTreeWidgetItem):
         self._dummy = None
         self._setup()
 
-    def addNode(self,node):
+    def addNode(self, node: pyrogue.Node) -> None:
         self._list.append(node)
 
 
 class DebugHolder(QTreeWidgetItem):
+    """Tree item representing a variable entry in the selection tree.
 
-    def __init__(self,main,*,path,top,parent,variable):
+    Parameters
+    ----------
+    main : TimePlotter
+        Owning time-plotter widget.
+    path : str
+        Full Rogue node path for this variable/command.
+    top : SelectionTree
+        Owning selection-tree widget.
+    parent : QTreeWidgetItem
+        Parent tree item.
+    variable : pyrogue.BaseVariable | pyrogue.BaseCommand
+        Backing Rogue variable/command object.
+    """
+
+    def __init__(
+        self,
+        main: "TimePlotter",
+        *,
+        path: str,
+        top: "SelectionTree",
+        parent: QTreeWidgetItem,
+        variable: pyrogue.BaseVariable | pyrogue.BaseCommand,
+    ) -> None:
         QTreeWidgetItem.__init__(self,parent)
         self._main   = main
         self._top    = top
@@ -244,7 +308,30 @@ class DebugHolder(QTreeWidgetItem):
 
 
 class SelectionTree(PyDMFrame):
-    def __init__(self, main, parent=None, init_channel=None, incGroups=None, excGroups=['Hidden']):
+    """Rogue node selection tree used by :class:`TimePlotter`.
+
+    Parameters
+    ----------
+    main : TimePlotter
+        Parent plotter widget coordinating add/remove actions.
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    incGroups : list[str] | None, optional
+        Include filter for Rogue groups.
+    excGroups : list[str] | None, optional
+        Exclude filter for Rogue groups.
+    """
+
+    def __init__(
+        self,
+        main: "TimePlotter",
+        parent: QWidget | None = None,
+        init_channel: str | None = None,
+        incGroups: list[str] | None = None,
+        excGroups: list[str] | None = ['Hidden'],
+    ) -> None:
         PyDMFrame.__init__(self, parent, init_channel)
 
         self._main = main
@@ -257,7 +344,7 @@ class SelectionTree(PyDMFrame):
 
         self._colWidths = [250,50,150,50,50]
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
 
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(SelectionTree, self).connection_changed(connected)
@@ -297,7 +384,7 @@ class SelectionTree(PyDMFrame):
         self.setUpdatesEnabled(True)
 
     @Slot(QTreeWidgetItem)
-    def _expandCb(self,item):
+    def _expandCb(self, item: QTreeWidgetItem) -> None:
         self.setUpdatesEnabled(False)
         item._expand()
 
@@ -314,41 +401,53 @@ class SelectionTree(PyDMFrame):
         self.setUpdatesEnabled(True)
 
     @Property(str)
-    def incGroups(self):
+    def incGroups(self) -> str:
         if self._incGroups is None or len(self._incGroups) == 0:
             return ''
         else:
             return ','.join(self._incGroups)
 
     @incGroups.setter
-    def incGroups(self, value):
+    def incGroups(self, value: str) -> None:
         if value == '':
             self._incGroups = None
         else:
             self._incGroups = value.split(',')
 
     @Property(str)
-    def excGroups(self):
+    def excGroups(self) -> str:
         if self._excGroups is None or len(self._excGroups) == 0:
             return ''
         else:
             return ','.join(self._excGroups)
 
     @excGroups.setter
-    def excGroups(self, value):
+    def excGroups(self, value: str) -> None:
         if value == '':
             self._excGroups = None
         else:
             self._excGroups = value.split(',')
 
-    def eventFilter(self, obj, event):
+    def eventFilter(self, obj: object, event: QEvent) -> bool:
         if event.type() == QEvent.Wheel:
             return True
         else:
             return False
 
 class ToggleButton(QPushButton):
-    def __init__(self,main,state,path):
+    """Add/remove button with state-aware styling for selected plot channels.
+
+    Parameters
+    ----------
+    main : TimePlotter
+        Owning time-plotter widget.
+    state : bool
+        Initial toggle state.
+    path : str
+        Rogue node path represented by this button.
+    """
+
+    def __init__(self, main: "TimePlotter", state: bool, path: str) -> None:
         super().__init__()
         self._main = main
         self._state = state
@@ -360,7 +459,7 @@ class ToggleButton(QPushButton):
 
         self.setStyleSheet(self.styleSheet%self._main._addColor)
 
-    def toggle(self):
+    def toggle(self) -> None:
         if self._state is True:
             self.setText('Add')
             self._state = False
@@ -371,18 +470,28 @@ class ToggleButton(QPushButton):
             self.setStyleSheet(self.styleSheet%self._main._colorSelector.current_color())
 
 
-    def setStyle(self,color):
+    def setStyle(self, color: str) -> None:
         self.setStyleSheet(self.styleSheet%color)
 
 class TimePlotter(PyDMFrame):
-    def __init__(self, parent=None, init_channel=None):
+    """Widget combining variable selection tree and live time plots.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Initial Rogue channel address.
+    """
+
+    def __init__(self, parent: QWidget | None = None, init_channel: str | None = None) -> None:
         super().__init__(parent, init_channel)
         self._node = None
 
         self._addColor = '#dddddd'
         self._colorSelector = ColorSelector()
 
-    def connection_changed(self, connected):
+    def connection_changed(self, connected: bool) -> None:
 
         build = (self._node is None) and (self._connected != connected and connected is True)
         super(TimePlotter, self).connection_changed(connected)
@@ -393,7 +502,7 @@ class TimePlotter(PyDMFrame):
         self._node = nodeFromAddress(self.channel)
         self.setup_ui()
 
-    def setup_ui(self):
+    def setup_ui(self) -> None:
 
         vb = QVBoxLayout()
         self.setLayout(vb)
@@ -478,7 +587,7 @@ class TimePlotter(PyDMFrame):
 
         vb.addWidget(main_box)
 
-    def do_add(self,path):
+    def do_add(self, path: str) -> None:
         self.plots.addYChannel(y_channel=path,
                 color = self._colorSelector.take_color(path),
                 lineWidth = 5)
@@ -488,7 +597,7 @@ class TimePlotter(PyDMFrame):
         disp.setMaximumHeight(50)
         self.legend_layout.addWidget(disp)
 
-    def do_remove(self,path):
+    def do_remove(self, path: str) -> None:
         curve = self.plots.findCurve(path)
         self.plots.removeYChannel(curve)
         for widget in self.frm_legend.findChildren(QWidget):
@@ -496,7 +605,7 @@ class TimePlotter(PyDMFrame):
                 widget.setParent(None)
                 widget.deleteLater()
 
-    def do_setwidth(self):
+    def do_setwidth(self) -> None:
         text = self.width_edit.text()
 
         try:
@@ -505,19 +614,42 @@ class TimePlotter(PyDMFrame):
         except Exception:
             pass
 
-    def do_autoheight(self):
+    def do_autoheight(self) -> None:
         # self.plots.setAutoRangeY(True)
         # self.plots.autoRangeY = True
         self.plots.plotItem.enableAutoRange(ViewBox.YAxis, enable=True)
 
-    def minimumSizeHint(self):
+    def minimumSizeHint(self) -> QtCore.QSize:
         return QtCore.QSize(1500, 900)
 
-    def ui_filepath(self):
+    def ui_filepath(self) -> None:
         return None
 
 class LegendRow(Display):
-    def __init__(self, parent=None, args=[], macros=None,path=None,main=None):
+    """Legend row widget for one plotted channel.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    args : list[str] | None, optional
+        Display argument list forwarded to :class:`pydm.Display`.
+    macros : dict[str, str] | None, optional
+        Macro substitutions forwarded to :class:`pydm.Display`.
+    path : str | None, optional
+        Rogue path of the plotted variable represented by this legend row.
+    main : TimePlotter | None, optional
+        Owning time-plotter widget.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        args: list[str] | None = None,
+        macros: dict[str, str] | None = None,
+        path: str | None = None,
+        main: "TimePlotter" | None = None,
+    ) -> None:
         super(LegendRow, self).__init__(parent=parent, args=args, macros=None)
 
         self._path = path
@@ -528,7 +660,7 @@ class LegendRow(Display):
         self.setMaximumHeight(50)
         self.setup_ui()
 
-    def setup_ui(self):
+    def setup_ui(self) -> None:
 
         #setup main layout
         main_layout = QHBoxLayout()
@@ -556,18 +688,19 @@ class LegendRow(Display):
 
         self.setLayout(main_layout)
 
-    def ui_filepath(self):
+    def ui_filepath(self) -> None:
         # No UI file is being used
         return None
 
 class ColorSelector():
+    """Allocates reusable colors for plot channels."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._colorList = ['#F94144', '#F3722C', '#F8961E', '#F9844A', '#F9C74F', '#90BE6D', '#43AA8B', '#4D908E', '#577590', '#277DA1','#f70a0a','#f75d0a','#f7a00a','#f7f30a','#98f70a','#1af70a','#0af7c0','#0accf7','#0a75f7','#0a1ef7','#710af7','#e70af7','#f70a71','#8a2d06','#838a06''#188a06','#188a06','#188a06']
         self._currentDict = {}
         self._currentColor = None
 
-    def take_color(self,channel):
+    def take_color(self, channel: str) -> str:
 
         if len(self._colorList) == 0:
             self._colorList.append(self.generate_new_color())
@@ -578,16 +711,16 @@ class ColorSelector():
         self._currentColor = color
         return color
 
-    def give_back_color(self,channel):
+    def give_back_color(self, channel: str) -> None:
 
         color = self.currentDict.pop(channel)
         self._colorList.append(color)
         random.shuffle(self._colorList)
 
-    def current_color(self):
+    def current_color(self) -> str | None:
 
         return self._currentColor
 
-    def generate_new_color(self):
+    def generate_new_color(self) -> str:
 
         return '#' + hex(random.randint(0x100000,0xffffff))[2:] #<----------Change this

--- a/python/pyrogue/utilities/cpsw.py
+++ b/python/pyrogue/utilities/cpsw.py
@@ -12,15 +12,30 @@
 # copied, modified, propagated, or distributed except according to the terms
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
-import pyrogue
 import math
 
+import pyrogue
 
-def exportRemoteVariable(variable,indent):
+
+def exportRemoteVariable(variable: pyrogue.RemoteVariable, indent: int) -> tuple[str, int]:
+    """Export a ``RemoteVariable`` into CPSW YAML text.
+
+    Parameters
+    ----------
+    variable : pyrogue.RemoteVariable
+        PyRogue remote variable instance.
+    indent : int
+        Number of leading spaces for generated YAML lines.
+
+    Returns
+    -------
+    tuple[str, int]
+        Generated YAML snippet and discovered byte size.
+    """
 
     if variable.ndType is not None or not ('Bool' in variable.typeStr or 'String' in variable.typeStr or 'Int' in variable.typeStr):
         print(f"Error: Found variable {variable.path} with unsupported type {variable.typeStr}, error exporting")
-        return ""
+        return "", 0
 
     #if len(variable.bitOffset) > 1:
     #    print(f"Warning: Splitting multiple bit offset variable {variable.path}")
@@ -68,10 +83,24 @@ def exportRemoteVariable(variable,indent):
             dat += " " * indent +  "    class: Enum\n"
             dat += " " * indent +  "    value: {}\n".format(int(k))
 
-    return dat,size
+    return dat, size
 
 
-def exportLinkVariable(variable, indent):
+def exportLinkVariable(variable: pyrogue.LinkVariable, indent: int) -> str:
+    """Export a placeholder block for an unsupported ``LinkVariable``.
+
+    Parameters
+    ----------
+    variable : pyrogue.LinkVariable
+        Link variable to describe in the generated placeholder comment block.
+    indent : int
+        Number of leading spaces for generated YAML lines.
+
+    Returns
+    -------
+    str
+        YAML comment block describing the unsupported link variable.
+    """
     dat  = " " * indent +  "#########################################################\n"
     dat += " " * indent +  "#Unsupported Link Variable\n"
     dat += " " * indent + f"#{variable.name}\n"
@@ -83,7 +112,21 @@ def exportLinkVariable(variable, indent):
     return dat
 
 
-def exportLocalVariable(variable, indent):
+def exportLocalVariable(variable: pyrogue.LocalVariable, indent: int) -> str:
+    """Export a placeholder block for an unsupported ``LocalVariable``.
+
+    Parameters
+    ----------
+    variable : pyrogue.LocalVariable
+        Local variable to describe in the generated placeholder comment block.
+    indent : int
+        Number of leading spaces for generated YAML lines.
+
+    Returns
+    -------
+    str
+        YAML comment block describing the unsupported local variable.
+    """
     dat  = " " * indent +  "#########################################################\n"
     dat += " " * indent +  "#Unsupported Local Variable\n"
     dat += " " * indent + f"#{variable.name}\n"
@@ -94,7 +137,21 @@ def exportLocalVariable(variable, indent):
     return dat
 
 
-def exportCommand(command, indent):
+def exportCommand(command: pyrogue.LocalCommand, indent: int) -> str:
+    """Export a placeholder block for an unsupported command node.
+
+    Parameters
+    ----------
+    command : pyrogue.LocalCommand
+        Command node to describe in the generated placeholder comment block.
+    indent : int
+        Number of leading spaces for generated YAML lines.
+
+    Returns
+    -------
+    str
+        YAML comment block describing the unsupported command node.
+    """
     dat  = " " * indent +  "#########################################################\n"
     dat += " " * indent +  "#Unsupported Command\n"
     dat += " " * indent + f"#{command.name}\n"
@@ -104,8 +161,26 @@ def exportCommand(command, indent):
     return dat
 
 
-def exportSubDevice(device, indent, deviceList, dataDir):
-    index,size = exportDevice(device, deviceList, dataDir)
+def exportSubDevice(device: pyrogue.Device, indent: int, deviceList: dict[str, list[str]], dataDir: str) -> tuple[str, str, int]:
+    """Export a child device and its reference include block.
+
+    Parameters
+    ----------
+    device : pyrogue.Device
+        Child device to export.
+    indent : int
+        Number of leading spaces for generated YAML lines.
+    deviceList : dict[str, list[str]]
+        Cache of generated class YAML bodies keyed by class name.
+    dataDir : str
+        Output directory for generated YAML files.
+
+    Returns
+    -------
+    tuple[str, str, int]
+        Child include YAML block, generated anchor name, and computed size.
+    """
+    index, size = exportDevice(device, deviceList, dataDir)
 
     if index > 0:
         dn = f"{device.__class__.__name__}_{index}"
@@ -119,11 +194,27 @@ def exportSubDevice(device, indent, deviceList, dataDir):
     dat += " " * indent + f"      offset: {device.offset:#x}\n"
 
     size += device.offset
-    return dat,dn,size
+    return dat, dn, size
 
 
-def exportDevice(device, deviceList, dataDir):
-    imp = []
+def exportDevice(device: pyrogue.Device, deviceList: dict[str, list[str]], dataDir: str) -> tuple[int, int]:
+    """Export a device tree into CPSW YAML files.
+
+    Parameters
+    ----------
+    device : pyrogue.Device
+        Root or child PyRogue device to export.
+    deviceList : dict[str, list[str]]
+        Cache of generated class YAML bodies keyed by class name.
+    dataDir : str
+        Output directory for generated YAML files.
+
+    Returns
+    -------
+    tuple[int, int]
+        Generated device-class index and discovered size.
+    """
+    imp: list[str] = []
     size = 0
     dat  = ""
 
@@ -133,7 +224,7 @@ def exportDevice(device, deviceList, dataDir):
         elif node.isinstance(pyrogue.LocalVariable):
             dat += exportLocalVariable(node,4)
         elif node.isinstance(pyrogue.RemoteVariable):
-            d,s = exportRemoteVariable(node,4)
+            d, s = exportRemoteVariable(node, 4)
             dat += d
             if s > size:
                 size = s
@@ -142,7 +233,7 @@ def exportDevice(device, deviceList, dataDir):
         elif node.isinstance(pyrogue.Command):
             dat += exportCommand(node,4)
         elif node.isinstance(pyrogue.Device):
-            ld,dn,s = exportSubDevice(node,4,deviceList, dataDir)
+            ld, dn, s = exportSubDevice(node, 4, deviceList, dataDir)
             dat += ld
             if s > size:
                 size = s
@@ -184,15 +275,24 @@ def exportDevice(device, deviceList, dataDir):
         elif deviceList[device.__class__.__name__][i] == ddat:
             break
 
-    with open(dataDir + "/" + tname + ".yaml","w") as f:
+    with open(dataDir + "/" + tname + ".yaml", "w") as f:
         f.write(ddat)
 
-    return i,size
+    return i, size
 
 
-def exportRoot(root,dataDir):
-    dlist = {}
+def exportRoot(root: pyrogue.Root, dataDir: str) -> None:
+    """Export all top-level devices from a PyRogue root node.
 
-    for k,node in root.nodes.items():
+    Parameters
+    ----------
+    root : pyrogue.Root
+        Root node containing top-level device children to export.
+    dataDir : str
+        Output directory for generated YAML files.
+    """
+    dlist: dict[str, list[str]] = {}
+
+    for _, node in root.nodes.items():
         if node.isinstance(pyrogue.Device):
-            exportDevice(node,dlist,dataDir)
+            exportDevice(node, dlist, dataDir)

--- a/python/pyrogue/utilities/fileio/_FileReader.py
+++ b/python/pyrogue/utilities/fileio/_FileReader.py
@@ -16,7 +16,10 @@
 from dataclasses import dataclass
 import os
 import struct
+from typing import Any, Iterator
+
 import numpy
+import numpy.typing as npt
 import yaml
 import logging
 
@@ -26,28 +29,24 @@ RogueHeaderPack  = 'IHBB'
 # Default header as a named tuple
 @dataclass
 class RogueHeader:
-    size : int     # 4 Bytes, uint32, I
-    flags: int     # 2 bytes, uint16, H
-    error: int     # 1 bytes, uint8,  B
-    channel: int   # 1 bytes, uint8,  B
-
-""" Rogue Header data
+    """Rogue frame header.
 
     Attributes
     ----------
     size : int
-        Size of the record, minus the header
-
+        Payload size of the record in bytes (header-adjusted by this reader).
     flags : int
-        Frame flags for the record
-
+        Frame flags for the record.
     error : int
-        Error status for the record
-
+        Error status for the record.
     channel : int
-        Channel id for the record
+        Channel id for the record.
+    """
 
-"""
+    size : int     # 4 Bytes, uint32, I
+    flags: int     # 2 bytes, uint16, H
+    error: int     # 1 bytes, uint8,  B
+    channel: int   # 1 bytes, uint8,  B
 
 BatchHeaderSize  = 8
 BatchHeaderPack  = 'IBBBB'
@@ -55,37 +54,34 @@ BatchHeaderPack  = 'IBBBB'
 # Batcher Header
 @dataclass
 class BatchHeader:
+    """Batch sub-frame header.
+
+    Attributes
+    ----------
+    size : int
+        Sub-frame payload size in bytes.
+    tdest : int
+        TDEST value from AXI Stream frame metadata.
+    fUser : int
+        First USER value from AXI Stream frame metadata.
+    lUser : int
+        Last USER value from AXI Stream frame metadata.
+    width : int
+        Width of the batched data in bytes.
+    """
+
     size: int   # 4 Bytes, uint32, I
     tdest: int  # 1 Byte, uint8, B
     fUser: int  # 1 Byte, uint8, B
     lUser: int  # 1 Byte, uint8, B
     width: int  # 1 Byte, uint8, B
 
-
-""" Batcher Header data
-
-    Attributes
-    ----------
-    size: int
-        Sub frame size in bytes
-
-    tdest: int
-        TDEST value from AXI Stream Frame
-
-    fUser: int
-        First USER value from AXI Stream Frame
-
-    lUser: int
-        Last USER value from AXI Stream Frame
-
-    width : int
-        Width of the batched data in bytes
-
-"""
+DataArray = npt.NDArray[numpy.int8]
+Record = tuple[RogueHeader, DataArray]
+BatchRecord = tuple[RogueHeader, BatchHeader, DataArray]
 
 class FileReaderException(Exception):
-    """ File reader exception """
-    pass
+    """File reader exception."""
 
 
 class FileReader(object):
@@ -94,17 +90,16 @@ class FileReader(object):
 
     Parameters
     ----------
-    files : str or list
-        Filename or list of filenams to read data from
-
-    configChan : int
-        Channel id of configuration/status stream in the data file. Set to None to disable processing configuration.
-
-    log : obj
-        Logging object to use. If set to None a new logger will be created with the name "pyrogue.FileReader".
-
+    files : str or list[str]
+        Filename or list of filenames to read data from.
+    configChan : int | None
+        Channel id of configuration/status stream in the data file. Set to
+        ``None`` to disable configuration processing.
+    log : logging.Logger | None
+        Logger to use. If ``None``, a new logger with name
+        ``"pyrogue.FileReader"`` is created.
     batched : bool
-        Flag to indicate if data file contains batched data
+        Flag indicating if the data file contains batched data.
 
     Attributes
     ----------
@@ -114,11 +109,17 @@ class FileReader(object):
     totCount: int
         Total number of data records processed from
 
-    configDig: obj
-        Current configuration/status dictionary
+    configDict : dict[str, Any]
+        Current configuration/status dictionary.
     """
 
-    def __init__(self, files, configChan=None, log=None, batched=False):
+    def __init__(
+        self,
+        files: str | list[str],
+        configChan: int | None = None,
+        log: logging.Logger | None = None,
+        batched: bool = False,
+    ) -> None:
         self._configChan = configChan
         self._currFile   = None
         self._fileSize   = 0
@@ -144,7 +145,7 @@ class FileReader(object):
             if not os.access(fn,os.R_OK):
                 raise FileReaderException("Failed to read file {}".format(fn))
 
-    def _nextRecord(self):
+    def _nextRecord(self) -> bool:
         while True:
 
             # Hit end of file
@@ -178,18 +179,15 @@ class FileReader(object):
                 self._totCount += 1
                 return True
 
-    def records(self):
+    def records(self) -> Iterator[Record | BatchRecord]:
         """
-        Generator which returns (header, data) tuples
+        Yield data records from all configured files.
 
         Returns
         -------
-        RogueHeader, bytearray
-            (header, data) tuple where header is a dictionary and data is a byte array, for batched = False.
-
-        RogueHeader, BatchHeader, bytearray
-            (header, header, data) tuple where header are dictionaried and data is a byte array, for batched = True.
-
+        Iterator[Record | BatchRecord]
+            For ``batched=False``, yields ``(RogueHeader, numpy.ndarray[int8])``.
+            For ``batched=True``, yields ``(RogueHeader, BatchHeader, numpy.ndarray[int8])``.
         """
         self._config = {}
         self._currCount = 0
@@ -258,18 +256,21 @@ class FileReader(object):
         self._log.debug(f"Processed a total of {self._totCount} data records")
 
     @property
-    def currCount(self):
+    def currCount(self) -> int:
+        """Return number of records read from the current file."""
         return self._currCount
 
     @property
-    def totCount(self):
+    def totCount(self) -> int:
+        """Return total number of records read across all files."""
         return self._totCount
 
     @property
-    def configDict(self):
+    def configDict(self) -> dict[str, Any]:
+        """Return merged configuration/status dictionary."""
         return self._config
 
-    def configValue(self, path):
+    def configValue(self, path: str) -> Any:
         """
         Get a configuration or status value
 
@@ -300,7 +301,8 @@ class FileReader(object):
 
         return obj
 
-    def _updateConfig(self, new):
+    def _updateConfig(self, new: dict[str, Any]) -> None:
+        """Merge a status/config update dictionary into ``self._config``."""
         # Combination of dictUpdate and keyValueUpdate from pyrogue helpers
 
         for k,v in new.items():
@@ -317,8 +319,10 @@ class FileReader(object):
             else:
                 self._config[k] = v
 
-    def __enter__(self):
+    def __enter__(self) -> "FileReader":
+        """Return self for context-manager use."""
         return self
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, exc_type: Any, value: Any, tb: Any) -> None:
+        """No-op context-manager exit hook."""
         pass

--- a/python/pyrogue/utilities/fileio/_StreamReader.py
+++ b/python/pyrogue/utilities/fileio/_StreamReader.py
@@ -16,12 +16,26 @@ import rogue.utilities
 import rogue.utilities.fileio
 import pyrogue
 import rogue
+from typing import Any
 
 
 class StreamReader(pyrogue.Device):
-    """Stream Reader Wrapper"""
+    """Wrapper ``pyrogue.Device`` around ``rogue.utilities.fileio.StreamReader``.
 
-    def __init__(self, **kwargs):
+    See Also
+    --------
+    :ref:`utilities_fileio_reader`
+        StreamReader utility documentation.
+    :ref:`utilities_fileio_format`
+        Canonical Rogue file record format consumed by StreamReader.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Additional keyword arguments forwarded to ``pyrogue.Device``.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
         pyrogue.Device.__init__(self, **kwargs)
         self._reader = rogue.utilities.fileio.StreamReader()
 
@@ -46,17 +60,23 @@ class StreamReader(pyrogue.Device):
             function=self._isOpen,
             description='Data file is open.'))
 
-    def _open(self):
+    def _open(self) -> None:
+        """Open the configured input file."""
         self._reader.open(self.DataFile.value())
 
-    def _close(self):
+    def _close(self) -> None:
+        """Close the current input file."""
         self._reader.close()
 
-    def _isOpen(self):
+    def _isOpen(self) -> bool:
+        """Return whether the reader has an open file."""
         return self._reader.isOpen()
 
-    def _getStreamMaster(self):
+    def _getStreamMaster(self) -> rogue.utilities.fileio.StreamReader:
+        """Return wrapped stream reader endpoint."""
         return self._reader
 
-    def __rshift__(self,other):
-        pyrogue.streamConnect(self,other)
+    def __rshift__(self, other: Any) -> Any:
+        """Connect this reader to ``other`` via stream API."""
+        pyrogue.streamConnect(self, other)
+        return other

--- a/python/pyrogue/utilities/fileio/_StreamWriter.py
+++ b/python/pyrogue/utilities/fileio/_StreamWriter.py
@@ -16,14 +16,44 @@ import rogue.utilities
 import rogue.utilities.fileio
 import pyrogue
 import rogue
+from typing import Any
 
 
 class StreamWriter(pyrogue.DataWriter):
-    """Stream Writer Wrapper"""
+    """Wrapper ``pyrogue.DataWriter`` around ``rogue.utilities.fileio.StreamWriter``.
 
-    def __init__(self, *, configStream={}, writer=None, rawMode=False, **kwargs):
+    See Also
+    --------
+    :ref:`utilities_fileio_format`
+        Canonical Rogue file record format written by StreamWriter.
+    :ref:`utilities_fileio_reading`
+        Notes on how files are decoded back into stream frames.
+
+    Parameters
+    ----------
+    configStream : dict[int, rogue.interfaces.stream.Master], optional
+        Mapping of stream channel index to configuration/status source object.
+    writer : rogue.utilities.fileio.StreamWriter, optional
+        Existing Rogue stream writer instance. When ``None``, a new one is created.
+    rawMode : bool, optional (default = False)
+        If ``False`` (default), each frame is written in Rogue file format with
+        per-frame metadata headers (payload length, channel, error, and flags)
+        followed by payload bytes. If ``True``, only raw frame payload bytes are
+        written, with no per-frame Rogue headers.
+    **kwargs : Any
+        Additional keyword arguments forwarded to ``pyrogue.DataWriter``.
+    """
+
+    def __init__(
+        self,
+        *,
+        configStream: dict[int, rogue.interfaces.stream.Master] | None = None,
+        writer: rogue.utilities.fileio.StreamWriter | None = None,
+        rawMode: bool = False,
+        **kwargs: Any,
+    ) -> None:
         pyrogue.DataWriter.__init__(self, **kwargs)
-        self._configStream = configStream
+        self._configStream = {} if configStream is None else configStream
 
         if writer is None:
             self._writer = rogue.utilities.fileio.StreamWriter()
@@ -37,7 +67,8 @@ class StreamWriter(pyrogue.DataWriter):
         for k,v in self._configStream.items():
             pyrogue.streamConnect(v, self._writer.getChannel(k))
 
-    def _open(self):
+    def _open(self) -> None:
+        """Open output file and emit initial configuration records."""
         self._writer.open(self.DataFile.value())
 
         # Dump config/status to file
@@ -47,7 +78,8 @@ class StreamWriter(pyrogue.DataWriter):
         self.FrameCount.set(0)
         self.IsOpen.get()
 
-    def _close(self):
+    def _close(self) -> None:
+        """Emit final configuration records and close output file."""
 
         # Dump config/status to file
         for k,v in self._configStream.items():
@@ -56,36 +88,46 @@ class StreamWriter(pyrogue.DataWriter):
         self._writer.close()
         self.IsOpen.get()
 
-    def _isOpen(self):
+    def _isOpen(self) -> bool:
+        """Return whether the writer currently has an open file."""
         return self._writer.isOpen()
 
-    def _setBufferSize(self,dev,var,value):
+    def _setBufferSize(self, value: int) -> None:
+        """Update writer file buffer size."""
         self._writer.setBufferSize(value)
 
-    def _setMaxFileSize(self,dev,var,value):
+    def _setMaxFileSize(self, value: int) -> None:
+        """Update writer maximum file size."""
         self._writer.setMaxSize(value)
 
-    def _getCurrentSize(self,dev,var):
+    def _getCurrentSize(self) -> int:
+        """Return current output file size in bytes."""
         return self._writer.getCurrentSize()
 
-    def _getTotalSize(self,dev,var):
-
+    def _getTotalSize(self) -> int:
+        """Return total bytes written across files."""
         return self._writer.getTotalSize()
 
-    def _getBandwidth(self,dev,var):
+    def _getBandwidth(self) -> float:
+        """Return file-write bandwidth in bytes/second over the recent ~1 second window."""
         return self._writer.getBandwidth()
 
-    def _getFrameCount(self,dev,var):
+    def _getFrameCount(self) -> int:
+        """Return total written frame count."""
         return self._writer.getFrameCount()
 
-    def _waitFrameCount(self, count, timeout=0):
-        return self._writer.waitFrameCount(count,timeout*1000000)
+    def _waitFrameCount(self, count: int, timeout: float = 0) -> bool:
+        """Wait for total frame count to reach ``count`` within timeout seconds."""
+        return self._writer.waitFrameCount(count, timeout * 1000000)
 
-    def _waitFrameChannelCount(self, chan, count, timeout=0):
-        return self._writer.getChannel(chan).waitFrameCount(count,timeout*1000000)
+    def _waitFrameChannelCount(self, chan: int, count: int, timeout: float = 0) -> bool:
+        """Wait for channel frame count to reach ``count`` within timeout seconds."""
+        return self._writer.getChannel(chan).waitFrameCount(count, timeout * 1000000)
 
-    def getChannel(self,chan):
+    def getChannel(self, chan: int) -> rogue.interfaces.stream.Slave:
+        """Return writer channel object by index."""
         return self._writer.getChannel(chan)
 
-    def setDropErrors(self,drop):
+    def setDropErrors(self, drop: bool) -> None:
+        """Enable or disable dropping errored frames."""
         self._writer.setDropErrors(drop)

--- a/python/pyrogue/utilities/hls/_RegInterfParser.py
+++ b/python/pyrogue/utilities/hls/_RegInterfParser.py
@@ -19,30 +19,45 @@ import os
 import argparse
 import zipfile
 from collections import namedtuple
+from typing import Any
 from zipfile import ZipFile
 
 ##############################################################################
 # Supported types of rogue devices and variables                             #
 ##############################################################################
 # RemoteVariable type
-RemoteVariable = namedtuple('RemoteVariable', ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base',
-                                               'mode'], defaults=['VarName', 'description', 0x00000, 8, 0, 'pr.Int',
-                                                                  'RW'])
+RemoteVariable = namedtuple(
+    'RemoteVariable',
+    ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base', 'mode'],
+    defaults=['VarName', 'description', 0x00000, 8, 0, 'pr.Int', 'RW'],
+)
 
 # RemoteCommand type
-RemoteCommand = namedtuple('RemoteCommand', ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base',
-                                             'function'], defaults=['CmdName', 'description', 0x00000, 8, 0, 'pr.UInt',
-                                                                    'lambda cmd: cmd.post(1)'])
+RemoteCommand = namedtuple(
+    'RemoteCommand',
+    ['name', 'description', 'offset', 'bitSize', 'bitOffset', 'base', 'function'],
+    defaults=['CmdName', 'description', 0x00000, 8, 0, 'pr.UInt', 'lambda cmd: cmd.post(1)'],
+)
 
 # MemoryDevice type
-MemoryDevice = namedtuple('MemoryDevice', ['name', 'offset', 'size', 'wordBitSize', 'stride', 'base'],
-                          defaults=['DevName', 0x00000, 16, 8, 16, 'pr.Int'])
+MemoryDevice = namedtuple(
+    'MemoryDevice',
+    ['name', 'offset', 'size', 'wordBitSize', 'stride', 'base'],
+    defaults=['DevName', 0x00000, 16, 8, 16, 'pr.Int'],
+)
 ##############################################################################
 
 vartype = ''
 maxwidth = 64
 
-def parse():
+def parse() -> list[Any]:
+    """Parse an HLS register header archive into parameter tuples.
+
+    Returns
+    -------
+    list[Any]
+        List of namedtuple parameter records for the selected output type.
+    """
     # Get the path to the zip file
     zname = input('Enter the path to the zipfile: ')
 
@@ -178,19 +193,26 @@ def parse():
                 dname.remove(t)
                 dname = "_".join(dname)
 
-        if vartype is RemoteVariable.__name__:
+        if vartype == RemoteVariable.__name__:
             var = RemoteVariable(name=dname, description='remote variable', offset=addr, bitSize=width)
             params.append(var)
-        elif vartype is MemoryDevice.__name__:
+        elif vartype == MemoryDevice.__name__:
             var = MemoryDevice(name=dname, offset=addr, size=depth, wordBitSize=width)
             params.append(var)
-        elif vartype is RemoteCommand.__name__:
+        elif vartype == RemoteCommand.__name__:
             var = RemoteCommand(name=dname, description='remote command', offset=addr, bitSize=width)
             params.append(var)
 
     return params
 
-def write(parameters):
+def write(parameters: list[Any]) -> None:
+    """Write a generated ``application.py`` from parsed parameter records.
+
+    Parameters
+    ----------
+    parameters : list[Any]
+        Parsed records returned by :func:`parse`.
+    """
     with open('application.py', 'w+') as fhand:
 
         fhand.write('#-----------------------------------------------------------------------------\n')
@@ -214,7 +236,7 @@ def write(parameters):
 
         for param in parameters:
             print(param)
-            if vartype is RemoteVariable.__name__:
+            if vartype == RemoteVariable.__name__:
                 fhand.write('        pr.RemoteVariable(\n')
                 argline = \
                     '                        name=' + '\'' + param.name + '\'' + ',\n' + \
@@ -226,7 +248,7 @@ def write(parameters):
                     '                        mode=' + '\'' + str(param.mode) + '\'' + ',\n'
                 fhand.write(argline)
                 fhand.write('                       )\n\n')
-            elif vartype is MemoryDevice.__name__:
+            elif vartype == MemoryDevice.__name__:
                 fhand.write('        pr.MemoryDevice(\n')
                 argline = \
                     '                        name=' + '\'' + param.name + '\'' + ',\n' + \
@@ -237,7 +259,7 @@ def write(parameters):
                     '                        base=' + str(param.base) + ',\n'
                 fhand.write(argline)
                 fhand.write('                       )\n\n')
-            elif vartype is RemoteCommand.__name__:
+            elif vartype == RemoteCommand.__name__:
                 fhand.write('        self.add(pr.RemoteCommand(\n')
                 argline = \
                     '                        name=' + '\'' + param.name + '\'' + ',\n' + \
@@ -257,7 +279,8 @@ def write(parameters):
         fhand.write('        # Add and execute the relevant commands below\n')
         fhand.write('\n\n')
 
-def run():
+def run() -> None:
+    """Run CLI flow for parsing and generating Rogue application code."""
     # Read command line option (i.e. output type)
     parser = argparse.ArgumentParser(description='Specify type of output.')
     parser.add_argument('--remoteCommand', action='store_true', required=False, help='set up remote commands')

--- a/python/pyrogue/utilities/prbs.py
+++ b/python/pyrogue/utilities/prbs.py
@@ -14,10 +14,13 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import pyrogue
 import rogue.utilities
+
+if TYPE_CHECKING:
+    import rogue.interfaces.stream as ris
 
 
 class PrbsRx(pyrogue.Device):
@@ -26,13 +29,21 @@ class PrbsRx(pyrogue.Device):
     Parameters
     ----------
     width : int, optional
-        PRBS data width. If ``None``, the Rogue default is used.
+        PRBS word width in bits. The underlying Rogue PRBS engine requires a
+        multiple of 32 bits. If ``None``, the C++ default is 32 bits.
     checkPayload : bool, optional (default = True)
         Enable payload checking when ``True``.
-    taps : int, optional
-        PRBS taps value. If ``None``, the Rogue default is used.
-    stream : object, optional
-        Optional stream to connect as the RX source.
+    taps : bytes-like, optional
+        LFSR feedback tap bit positions used by the PRBS generator/checker.
+        Provide a bytes-like sequence (for example ``bytes([1, 2, 6, 31])``)
+        where each entry is a tapped bit index in the PRBS state. If ``None``,
+        Rogue uses the C++ default taps ``[1, 2, 6, 31]``.
+        For a 32-bit state in Rogue's left-shift Fibonacci form, this means
+        ``new_bit0 = bit1 ^ bit2 ^ bit6 ^ bit31``, which corresponds to the
+        polynomial ``x^32 + x^7 + x^3 + x^2 + 1`` (equivalent forms may use
+        reciprocal indexing conventions).
+    stream : rogue.interfaces.stream.Master, optional
+        Optional stream endpoint to connect as the RX source upon initialization.
     **kwargs : Any
         Additional arguments forwarded to ``pyrogue.Device``.
     """
@@ -42,8 +53,8 @@ class PrbsRx(pyrogue.Device):
         *,
         width: int | None = None,
         checkPayload: bool = True,
-        taps: int | None = None,
-        stream: Any | None = None,
+        taps: bytes | bytearray | memoryview | None = None,
+        stream: ris.Master | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a software PRBS receiver."""
@@ -107,11 +118,11 @@ class PrbsRx(pyrogue.Device):
         return other
 
     def setWidth(self, width: int) -> None:
-        """Set the PRBS width."""
+        """Set PRBS word width in bits (must be a multiple of 32)."""
         self._prbs.setWidth(width)
 
-    def setTaps(self, taps: int) -> None:
-        """Set the PRBS taps value."""
+    def setTaps(self, taps: bytes | bytearray | memoryview) -> None:
+        """Set LFSR feedback tap bit positions."""
         self._prbs.setTaps(taps)
 
 
@@ -123,11 +134,19 @@ class PrbsTx(pyrogue.Device):
     sendCount : bool, optional (default = False)
         Enable count transmission when ``True``.
     width : int, optional
-        PRBS data width. If ``None``, the Rogue default is used.
-    taps : int, optional
-        PRBS taps value. If ``None``, the Rogue default is used.
-    stream : object, optional
-        Optional stream to connect as the TX destination.
+        PRBS word width in bits. The underlying Rogue PRBS engine requires a
+        multiple of 32 bits. If ``None``, the C++ default is 32 bits.
+    taps : bytes-like, optional
+        LFSR feedback tap bit positions used by the PRBS generator/checker.
+        Provide a bytes-like sequence (for example ``bytes([1, 2, 6, 31])``)
+        where each entry is a tapped bit index in the PRBS state. If ``None``,
+        Rogue uses the C++ default taps ``[1, 2, 6, 31]``.
+        For a 32-bit state in Rogue's left-shift Fibonacci form, this means
+        ``new_bit0 = bit1 ^ bit2 ^ bit6 ^ bit31``, which corresponds to the
+        polynomial ``x^32 + x^7 + x^3 + x^2 + 1`` (equivalent forms may use
+        reciprocal indexing conventions).
+    stream : rogue.interfaces.stream.Slave, optional
+        Optional stream endpoint to connect as the TX destination.
     **kwargs : Any
         Additional arguments forwarded to ``pyrogue.Device``.
     """
@@ -137,8 +156,8 @@ class PrbsTx(pyrogue.Device):
         *,
         sendCount: bool = False,
         width: int | None = None,
-        taps: int | None = None,
-        stream: Any | None = None,
+        taps: bytes | bytearray | memoryview | None = None,
+        stream: ris.Slave | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a software PRBS transmitter."""
@@ -227,11 +246,11 @@ class PrbsTx(pyrogue.Device):
         return other
 
     def setWidth(self, width: int) -> None:
-        """Set the PRBS width."""
+        """Set PRBS word width in bits (must be a multiple of 32)."""
         self._prbs.setWidth(width)
 
-    def setTaps(self, taps: int) -> None:
-        """Set the PRBS taps value."""
+    def setTaps(self, taps: bytes | bytearray | memoryview) -> None:
+        """Set LFSR feedback tap bit positions."""
         self._prbs.setTaps(taps)
 
     def sendCount(self, en: bool) -> None:
@@ -249,15 +268,23 @@ class PrbsPair(pyrogue.Device):
     Parameters
     ----------
     width : int, optional
-        PRBS data width. If ``None``, the Rogue default is used.
-    taps : int, optional
-        PRBS taps value. If ``None``, the Rogue default is used.
+        PRBS word width in bits. The underlying Rogue PRBS engine requires a
+        multiple of 32 bits. If ``None``, the C++ default is 32 bits.
+    taps : bytes-like, optional
+        LFSR feedback tap bit positions used by the PRBS generator/checker.
+        Provide a bytes-like sequence (for example ``bytes([1, 2, 6, 31])``)
+        where each entry is a tapped bit index in the PRBS state. If ``None``,
+        Rogue uses the C++ default taps ``[1, 2, 6, 31]``.
+        For a 32-bit state in Rogue's left-shift Fibonacci form, this means
+        ``new_bit0 = bit1 ^ bit2 ^ bit6 ^ bit31``, which corresponds to the
+        polynomial ``x^32 + x^7 + x^3 + x^2 + 1`` (equivalent forms may use
+        reciprocal indexing conventions).
     sendCount : bool, optional (default = False)
         Forward the TX count through the stream.
-    txStream : object, optional
-        Optional TX stream destination.
-    rxStream : object, optional
-        Optional RX stream source.
+    txStream : rogue.interfaces.stream.Master or rogue.interfaces.stream.Slave, optional
+        Optional TX stream endpoint.
+    rxStream : rogue.interfaces.stream.Master or rogue.interfaces.stream.Slave, optional
+        Optional RX stream endpoint.
     **kwargs : Any
         Additional arguments forwarded to ``pyrogue.Device``.
     """
@@ -265,24 +292,23 @@ class PrbsPair(pyrogue.Device):
     def __init__(
         self,
         width: int | None = None,
-        taps: int | None = None,
+        taps: bytes | bytearray | memoryview | None = None,
         sendCount: bool = False,
-        txStream: Any | None = None,
-        rxStream: Any | None = None,
+        txStream: ris.Master | ris.Slave | None = None,
+        rxStream: ris.Master | ris.Slave | None = None,
         **kwargs: Any,
     ) -> None:
-        """Initialize a PRBS TX/RX pair."""
-        super().__init__(self, **kwargs)
-        self.add(PrbsTx(width=width, taps=taps, stream=txStream))
-        self.add(PrbsRx(sendCount=sendCount, width=width, taps=taps, stream=rxStream))
+        super().__init__(**kwargs)
+        self.add(PrbsTx(sendCount=sendCount, width=width, taps=taps, stream=txStream))
+        self.add(PrbsRx(width=width, taps=taps, stream=rxStream))
 
     def setWidth(self, width: int) -> None:
-        """Set PRBS width on both devices."""
+        """Set PRBS word width in bits on both devices."""
         self.PrbsTx.setWidth(width)
         self.PrbsRx.setWidth(width)
 
-    def setTaps(self, taps: int) -> None:
-        """Set PRBS taps on both devices."""
+    def setTaps(self, taps: bytes | bytearray | memoryview) -> None:
+        """Set LFSR feedback tap bit positions on both devices."""
         self.PrbsTx.setTaps(taps)
         self.PrbsRx.setTaps(taps)
 
@@ -298,13 +324,16 @@ class PrbsPair(pyrogue.Device):
         """Return the stream slave endpoint."""
         return self.PrbsTx._getStreamSlave()
 
-    def __rshift__(self,other):
-        pyrogue.streamConnect(self,other)
+    def __rshift__(self, other: Any) -> Any:
+        """Connect this pair output to ``other``."""
+        pyrogue.streamConnect(self, other)
         return other
 
-    def __lshift__(self,other):
-        pyrogue.streamConnect(other,self)
+    def __lshift__(self, other: Any) -> Any:
+        """Connect ``other`` output to this pair input."""
+        pyrogue.streamConnect(other, self)
         return other
 
-    def __eq__(self,other):
-        pyrogue.streamConnectBiDir(other,self)
+    def __eq__(self, other: Any) -> None:
+        """Create a bidirectional stream connection to ``other``."""
+        pyrogue.streamConnectBiDir(other, self)


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description
- Add and reorganize docs for file I/O format and HLS register parser utilities:
  - add canonical Rogue file format page and cross-links from reader/writer docs
  - add HLS utility docs for `pyrogue.utilities.hls._RegInterfParser` (workflow, CLI usage, and function behavior)
- Improve typing and docstrings in utilities modules (`cpsw`, `fileio`, `prbs`, HLS parser), including clearer parameter/return docs and callback signatures.
- Perform broad PyDM/UI docstring and type hint cleanup:
  - strengthen type hints (including `QWidget`/`PyDMChannel` where applicable)
  - add/complete class and method docstrings
  - ensure class docstrings document `__init__` parameters consistently.

