### PR TITLE
Fix Python 3.12/3.13 type-annotation crash in TimePlotter legend row

### DIFF
--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -648,7 +648,7 @@ class LegendRow(Display):
         args: list[str] | None = None,
         macros: dict[str, str] | None = None,
         path: str | None = None,
-        main: "TimePlotter" | None = None,
+        main: TimePlotter | None = None,
     ) -> None:
         super(LegendRow, self).__init__(parent=parent, args=args, macros=None)
 


### PR DESCRIPTION
Fix for issue #1120 

### Description
This change fixes a runtime `TypeError` when launching the PyRogue GUI on Python 3.12/3.13:

`TypeError: unsupported operand type(s) for |: 'str' and 'NoneType'`

The issue was caused by a quoted forward reference combined with PEP 604 union syntax in `LegendRow.__init__`:

Before: main: `"TimePlotter" | None = None`
After: main: `TimePlotter | None = None`
#### Why this works
On Python < 3.14, a quoted type name in this context is treated as a string at runtime, so "Type" | None attempts a string bitwise-or and fails. Using the actual symbol avoids that runtime evaluation error.

