### PR TITLE
Allow rogue builds on macOS arm64

### DIFF
--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -161,7 +161,11 @@ jobs:
       - name: Install Python test/documentation dependencies
         shell: bash -el {0}
         run: |
-          python -m pip install -r pip_requirements.txt
+          # hwcounter uses x86 inline assembly (rdtsc/eax/edx) and fails to
+          # build on macOS arm64 GitHub runners. Exclude it for this job.
+          # Linux CI still installs full requirements and covers hwcounter.
+          grep -vE '^hwcounter$' pip_requirements.txt > /tmp/pip_requirements_macos.txt
+          python -m pip install -r /tmp/pip_requirements_macos.txt
 
       # Rogue
       - name: Build Rogue

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -158,6 +158,11 @@ jobs:
           environment-file: conda.yml
           use-mamba: true
 
+      - name: Install Python test/documentation dependencies
+        shell: bash -el {0}
+        run: |
+          python -m pip install -r pip_requirements.txt
+
       # Rogue
       - name: Build Rogue
         shell: bash -el {0}

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -137,6 +137,59 @@ jobs:
 
 # ----------------------------------------------------------------------------
 
+  macos_arm64_build_test:
+    name: macOS arm64 Build Test
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+
+      # This step checks out a copy of your repository.
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Miniforge Environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          auto-activate-base: false
+          activate-environment: rogue_build
+          environment-file: conda.yml
+          use-mamba: true
+
+      # Rogue
+      - name: Build Rogue
+        shell: bash -el {0}
+        run: |
+          python -c "import numpy; print(numpy.get_include())"
+          mkdir build; cd build
+          cmake .. -DROGUE_INSTALL=conda
+          cmake --build . -j$(sysctl -n hw.ncpu)
+          make install
+
+      - name: Rogue Import Smoke Test
+        shell: bash -el {0}
+        run: |
+          python -c "import rogue, pyrogue; print('rogue import ok')"
+
+      # Compile API Test
+      - name: Compile API Test
+        shell: bash -el {0}
+        run: |
+          cd tests/api_test
+          mkdir build; cd build
+          cmake ..
+          cmake --build .
+
+      # Run API Test
+      - name: Run API Test
+        shell: bash -el {0}
+        run: |
+          tests/api_test/bin/api_test
+
+# ----------------------------------------------------------------------------
+
   gen_release:
     needs: [full_build_test, small_build_test]
     uses: slaclab/ruckus/.github/workflows/gen_release.yml@main

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -182,11 +182,6 @@ jobs:
           cmake ..
           cmake --build .
 
-      # Run API Test
-      - name: Run API Test
-        shell: bash -el {0}
-        run: |
-          tests/api_test/bin/api_test
 
 # ----------------------------------------------------------------------------
 

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -161,11 +161,7 @@ jobs:
       - name: Install Python test/documentation dependencies
         shell: bash -el {0}
         run: |
-          # hwcounter uses x86 inline assembly (rdtsc/eax/edx) and fails to
-          # build on macOS arm64 GitHub runners. Exclude it for this job.
-          # Linux CI still installs full requirements and covers hwcounter.
-          grep -vE '^hwcounter$' pip_requirements.txt > /tmp/pip_requirements_macos.txt
-          python -m pip install -r /tmp/pip_requirements_macos.txt
+          python -m pip install -r pip_requirements.txt
 
       # Rogue
       - name: Build Rogue

--- a/.github/workflows/rogue_ci.yml
+++ b/.github/workflows/rogue_ci.yml
@@ -173,14 +173,11 @@ jobs:
         run: |
           python -c "import rogue, pyrogue; print('rogue import ok')"
 
-      # Compile API Test
-      - name: Compile API Test
+      # Run Python tests (exclude separate C++ api_test job on macOS)
+      - name: Rogue Tests
         shell: bash -el {0}
         run: |
-          cd tests/api_test
-          mkdir build; cd build
-          cmake ..
-          cmake --build .
+          python -m pytest
 
 
 # ----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ bld-dir/*
 /rhel7-x86_64
 rogue.egg-info*
 .vscode/
+.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bld-dir/*
 /rhel6-x86_64
 /rhel7-x86_64
 rogue.egg-info*
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ endif()
 # Project name
 project (rogue)
 
+# Current Apple support target is arm64 only.
+if (APPLE AND NOT ((CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") OR (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")))
+   message(FATAL_ERROR "macOS builds are only supported on arm64")
+endif()
+
 # C/C++
 enable_language(CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-deprecated")
@@ -116,11 +121,17 @@ find_package(ZeroMQ QUIET)
 # ZeroMQ does not always support cmake, use brute force
 if (NOT ZeroMQ_FOUND)
 
-   # Convert LD_LIBRARY PATH for search
+   set(HINT_PATHS "")
+
+   # Convert library path hints for search.
    if(DEFINED ENV{LD_LIBRARY_PATH})
-      string(REPLACE ":" ";" HINT_PATHS $ENV{LD_LIBRARY_PATH})
-   else()
-      set(HINT_PATHS, "")
+      string(REPLACE ":" ";" LD_HINT_PATHS $ENV{LD_LIBRARY_PATH})
+      list(APPEND HINT_PATHS ${LD_HINT_PATHS})
+   endif()
+
+   if(APPLE AND DEFINED ENV{DYLD_LIBRARY_PATH})
+      string(REPLACE ":" ";" DYLD_HINT_PATHS $ENV{DYLD_LIBRARY_PATH})
+      list(APPEND HINT_PATHS ${DYLD_HINT_PATHS})
    endif()
 
    # See if zmq library is in LD_LIBRARY_PATH
@@ -227,12 +238,6 @@ include_directories(system ${Python3_NumPy_INCLUDE_DIRS})
 include_directories(system ${ZeroMQ_INCLUDE_DIR})
 include_directories(system ${BZIP2_INCLUDE_DIR})
 
-if (APPLE)
-   SET(CMAKE_SHARED_LIBRARY_SUFFIX ".dylib")
-else()
-   SET(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-endif()
-
 # Create rogue core library
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_library(rogue-core OBJECT "")
@@ -243,7 +248,11 @@ add_subdirectory(src/rogue)
 # Always build shared library
 add_library(rogue-core-shared SHARED $<TARGET_OBJECTS:rogue-core> "")
 set_target_properties(rogue-core-shared PROPERTIES OUTPUT_NAME librogue-core)
-set_target_properties(rogue-core-shared PROPERTIES PREFIX "" SUFFIX ".so")
+if (APPLE)
+   set_target_properties(rogue-core-shared PROPERTIES PREFIX "" SUFFIX ".dylib")
+else()
+   set_target_properties(rogue-core-shared PROPERTIES PREFIX "" SUFFIX ".so")
+endif()
 set_target_properties(rogue-core-shared PROPERTIES VERSION ${ROGUE_VERSION} SOVERSION ${ROGUE_SOVER})
 
 TARGET_LINK_LIBRARIES(rogue-core-shared PUBLIC ${Boost_LIBRARIES})
@@ -268,7 +277,9 @@ if(STATIC_LIB)
     TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC ${ZeroMQ_LIBRARY})
     TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC ${BZIP2_LIBRARIES})
     TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC ${Python3_LIBRARIES})
-    TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC rt)
+    if (NOT APPLE)
+       TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC rt)
+    endif()
 endif()
 
 
@@ -422,4 +433,3 @@ endif()
 
 message("----------------------------------------------------------------------")
 message("")
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,17 @@ endif()
 cmake_minimum_required(VERSION 3.15)
 include(InstallRequiredSystemLibraries)
 
+# CMake policy compatibility:
+# - CMP0144: honor upper-case <PACKAGENAME>_ROOT variables in find_package.
+# - CMP0167: keep FindBoost module behavior for the current Boost discovery flow.
+if(POLICY CMP0144)
+   cmake_policy(SET CMP0144 NEW)
+endif()
+
+if(POLICY CMP0167)
+   cmake_policy(SET CMP0167 OLD)
+endif()
+
 # Set default release type
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
   if (NOT CMAKE_BUILD_TYPE)
@@ -75,6 +86,7 @@ if ( NOT NO_PYTHON )
    # Hint for boost on miniforge
    if (DEFINED ENV{CONDA_PREFIX})
       set(BOOST_ROOT $ENV{CONDA_PREFIX})
+      set(Boost_ROOT $ENV{CONDA_PREFIX})
    endif()
 
    # Loop through potential Boost Python component names

--- a/conda.yml
+++ b/conda.yml
@@ -2,8 +2,8 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.7
-  - gcc_linux-64
-  - gxx_linux-64
+  - c-compiler
+  - cxx-compiler
   - make
   - git
   - git-lfs
@@ -27,4 +27,4 @@ dependencies:
   - matplotlib
   - pytest
   - pytest-cov
-  - pyqt=5.12
+  - pyqt>=5.15

--- a/conda.yml
+++ b/conda.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python
   - c-compiler
   - cxx-compiler
   - make

--- a/docs/src/installing/index.rst
+++ b/docs/src/installing/index.rst
@@ -7,16 +7,17 @@ Installing & Compiling Rogue
 This section describes how to obtain and install Rogue. 
 After installation is completed, consider following one of our :ref:`tutorials` to learn the basics. 
 
-The recommended method for installing rogue is on Linux systems through :ref:`installing_miniforge`. 
+The recommended method for installing rogue is through :ref:`installing_miniforge` and
+:ref:`installing_miniforge_build`.
 If you chose to build rogue from source instead of using miniforge, the following list 
 is the recommendation for each operating system.
 
-**Note:** rogue installations are not currently supported on mac or windows hardware. 
-A Linux(Ubuntu) VM or docker image will be required to build rogue. 
+**Note:** Native source builds are currently supported on Linux and macOS arm64.
+Windows users should use Ubuntu (WSL) or Docker.
 
 * Linux - :ref:`installing_full_build`
 * Windows - :ref:`installing_docker`
-* Mac - :ref:`installing_docker`
+* Mac (arm64) - :ref:`installing_miniforge_build`
 
 
 .. toctree::

--- a/docs/src/installing/miniforge.rst
+++ b/docs/src/installing/miniforge.rst
@@ -4,10 +4,11 @@
 Installing Rogue With Miniforge
 ===============================
 
-The following instructions describe how to install a pre-built Rogue package inside an miniforge environment. These instructions are relevant for Linux, Ubuntu on Windows and MacOS.
+The following instructions describe how to install a pre-built Rogue package inside an miniforge environment.
+These instructions are relevant for Linux and Ubuntu on Windows.
 
-Windows installations will require you to install Ubuntu. Reference the section :ref:`installing_windows` for required steps. 
-Mac is not currently supported for rogue, and a VM or docker image is needed. Proceed to :ref:`installing_docker`. 
+Windows installations will require you to install Ubuntu. Reference the section :ref:`installing_windows` for required steps.
+For macOS arm64, build from source inside miniforge using :ref:`installing_miniforge_build`.
 
 Instructions for s3df setup are also available on `Confluence <https://confluence.slac.stanford.edu/spaces/ppareg/pages/591664140/Configure+miniforge+conda+and+Rogue+on+S3DF>`. 
 
@@ -105,4 +106,3 @@ Run the following commands to delete the miniforge environment.
 .. code::
 
    $ conda env remove -n rogue_tag
-

--- a/docs/src/installing/miniforge_build.rst
+++ b/docs/src/installing/miniforge_build.rst
@@ -5,17 +5,35 @@ Building Rogue Inside Miniforge
 ===============================
 
 This section provides instructions for downloading and building rogue inside an miniforge environment. These
-instructions are relevant for Linux
+instructions are relevant for Linux and macOS arm64.
+
+Prerequisites
+=============
+
+On macOS, install Apple Command Line Tools before creating the environment:
+
+.. code::
+
+   $ xcode-select --install
 
 Getting Miniforge
 ==================
 
 Download and install miniforge if you don't already have it installed on your machine. Choose an install location with a lot of available diskspace (> 5GB). Miniforge appears to only work reliably in the bash shell.
 
+*Linux*
+
 .. code::
 
    $ wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
    $ bash Miniforge3-Linux-x86_64.sh
+
+*macOS (arm64)*
+
+.. code::
+
+   $ curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+   $ bash Miniforge3-MacOSX-arm64.sh
 
 Use the following command to add miniforge to your environment. This can be added to your .bash_profile.
 
@@ -63,7 +81,7 @@ Once the rogue environment is activated, you can build and install rogue
    $ mkdir build
    $ cd build
    $ cmake ..
-   $ make -j$(nproc)
+   $ make 
    $ make install
 
 The Rogue build system will automatically detect that it is in a conda environment and it will be installed
@@ -99,7 +117,7 @@ If you want to update and re-install rogue, run the following commands.
    $ mkdir build
    $ cd build
    $ cmake ..
-   $ make
+   $ cmake --build .
    $ make install
 
 Building and Viewing the Docs
@@ -114,7 +132,7 @@ Note: if edits are made to the source files, the full build process needs to be 
    $ make html
 
    # view output on web browser
-   $ google-chrome build/html/index.html
+   $ open build/html/index.html
 
 Deleting Miniforge Environment
 ==============================

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -24,4 +24,4 @@ gitpython
 pygithub
 pydm
 matplotlib
-hwcounter
+hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -25,6 +25,7 @@
 #include <pthread.h>
 #include <sys/socket.h>
 
+#include <cinttypes>
 #include <cmath>
 #include <cstdio>
 #include <memory>
@@ -298,10 +299,12 @@ void rpx::JtagDriver::sendVectors(uint64_t bits, uint8_t* tms, uint8_t* tdi, uin
 }
 
 void rpx::JtagDriver::dumpInfo(FILE* f) {
-    fprintf(f, "Word size:                  %d\n", getWordSize());
-    fprintf(f, "Target Memory Depth (bytes) %d\n", getWordSize() * getMemDepth());
-    fprintf(f, "Max. Vector Length  (bytes) %ld\n", getMaxVectorSize());
-    fprintf(f, "TCK Period             (ns) %ld\n", static_cast<uint64_t>(getPeriodNs()));
+    fprintf(f, "Word size:                  %" PRIu64 "\n", static_cast<uint64_t>(getWordSize()));
+    fprintf(f,
+            "Target Memory Depth (bytes) %" PRIu64 "\n",
+            static_cast<uint64_t>(getWordSize()) * static_cast<uint64_t>(getMemDepth()));
+    fprintf(f, "Max. Vector Length  (bytes) %" PRIu64 "\n", getMaxVectorSize());
+    fprintf(f, "TCK Period             (ns) %" PRIu64 "\n", static_cast<uint64_t>(getPeriodNs()));
 }
 
 void rpx::JtagDriver::setup_python() {

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -21,6 +21,7 @@
 #include <netinet/tcp.h>
 #include <sys/select.h>
 
+#include <cinttypes>
 #include <cstdio>
 
 namespace rpx = rogue::protocols::xilinx;
@@ -169,7 +170,8 @@ void rpx::XvcConnection::run() {
 
                 drv_->query();  // informs the driver that there is a new connection
 
-                tl_ = snprintf(reinterpret_cast<char*>(&txb_[0]), txb_.size(), "xvcServer_v1.0:%ld\n", maxVecLen_);
+                tl_ = snprintf(
+                    reinterpret_cast<char*>(&txb_[0]), txb_.size(), "xvcServer_v1.0:%" PRIu64 "\n", maxVecLen_);
 
                 bump(8);
             } else if (0 == ::memcmp(rp_, "se", 2)) {

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -19,12 +19,36 @@ from setuptools import setup, find_packages
 
 rawVersion = '${ROGUE_VERSION}'
 
-fields = rawVersion[1:].split('-')
+def normalize_version(raw):
+    # Expected git-describe formats:
+    #   vX.Y.Z
+    #   vX.Y.Z-N-g<sha>
+    #   vX.Y.Z-dirty
+    #   vX.Y.Z-N-g<sha>-dirty
+    core = raw[1:] if raw.startswith('v') else raw
+    fields = core.split('-')
 
-if len(fields) == 1:
-    pyVersion = fields[0]
-else:
-    pyVersion = fields[0] + '.dev' + fields[1]
+    if len(fields) == 1:
+        return fields[0]
+
+    base = fields[0]
+    if fields[1].isdigit():
+        dev = fields[1]
+        local_fields = fields[2:]
+    else:
+        dev = "0"
+        local_fields = fields[1:]
+
+    version = f"{base}.dev{dev}"
+
+    if local_fields:
+        # PEP 440 local version labels allow [a-zA-Z0-9.] segments.
+        local = ".".join(local_fields).replace("_", ".").replace("-", ".")
+        version = f"{version}+{local}"
+
+    return version
+
+pyVersion = normalize_version(rawVersion)
 
 setup (
     name='rogue',
@@ -34,4 +58,3 @@ setup (
     package_data={'':['../rogue.so'], 'pyrogue.pydm':['examples/*.ui']},
     include_package_data=True,
 )
-

--- a/templates/setup_rogue.csh.in
+++ b/templates/setup_rogue.csh.in
@@ -7,6 +7,10 @@ if ( ! $?LD_LIBRARY_PATH ) then
    setenv LD_LIBRARY_PATH ""
 endif
 
+if ( ! $?DYLD_LIBRARY_PATH ) then
+   setenv DYLD_LIBRARY_PATH ""
+endif
+
 # Rogue directory
 setenv ROGUE_DIR @ROGUE_DIR@
 setenv ROGUE_VERSION @ROGUE_VERSION@
@@ -16,6 +20,7 @@ setenv PYTHONPATH ${ROGUE_DIR}/python:${PYTHONPATH}
 
 # Setup library path
 setenv LD_LIBRARY_PATH ${ROGUE_DIR}/lib:${LD_LIBRARY_PATH}
+setenv DYLD_LIBRARY_PATH ${ROGUE_DIR}/lib:${DYLD_LIBRARY_PATH}
 
 # PYDM environment
 setenv PYQTDESIGNERPATH ${ROGUE_DIR}/python/pyrogue/pydm:${PYQTDESIGNERPATH}

--- a/templates/setup_rogue.fish.in
+++ b/templates/setup_rogue.fish.in
@@ -3,6 +3,10 @@ if test -z "$LD_LIBRARY_PATH"
    set LD_LIBRARY_PATH ""
 end
 
+if test -z "$DYLD_LIBRARY_PATH"
+   set DYLD_LIBRARY_PATH ""
+end
+
 if test -z "$PYTHONPATH"
    set PYTHONPATH ""
 end
@@ -16,9 +20,9 @@ export PYTHONPATH={$ROGUE_DIR}/python:{$PYTHONPATH}
 
 # Setup library path
 export LD_LIBRARY_PATH={$ROGUE_DIR}/lib:{$LD_LIBRARY_PATH}
+export DYLD_LIBRARY_PATH={$ROGUE_DIR}/lib:{$DYLD_LIBRARY_PATH}
 
 # PYDM environment
 export PYQTDESIGNERPATH={$ROGUE_DIR}/python/pyrogue/pydm:{$PYQTDESIGNERPATH}
 export PYDM_DATA_PLUGINS_PATH={$ROGUE_DIR}/python/pyrogue/pydm/data_plugins
 export PYDM_TOOLS_PATH={$ROGUE_DIR}/python/pyrogue/pydm/tools
-

--- a/templates/setup_rogue.sh.in
+++ b/templates/setup_rogue.sh.in
@@ -4,6 +4,11 @@ then
    LD_LIBRARY_PATH=""
 fi
 
+if [ -z "$DYLD_LIBRARY_PATH" ]
+then
+   DYLD_LIBRARY_PATH=""
+fi
+
 if [ -z "$PYTHONPATH" ]
 then
    PYTHONPATH=""
@@ -18,9 +23,9 @@ export PYTHONPATH=${ROGUE_DIR}/python:${PYTHONPATH}
 
 # Setup library path
 export LD_LIBRARY_PATH=${ROGUE_DIR}/lib:${LD_LIBRARY_PATH}
+export DYLD_LIBRARY_PATH=${ROGUE_DIR}/lib:${DYLD_LIBRARY_PATH}
 
 # PYDM environment
 export PYQTDESIGNERPATH=${ROGUE_DIR}/python/pyrogue/pydm:${PYQTDESIGNERPATH}
 export PYDM_DATA_PLUGINS_PATH=${ROGUE_DIR}/python/pyrogue/pydm/data_plugins
 export PYDM_TOOLS_PATH=${ROGUE_DIR}/python/pyrogue/pydm/tools
-

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -29,13 +29,24 @@ except ImportError:
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
 
-MaxAvgNs = { 'remoteSetRate'   : 1.0e6,
-             'remoteSetNvRate' : 1.0e6,
-             'remoteGetRate'   : 1.0e6,
-             'localSetRate'    : 1.0e6,
-             'localGetRate'    : 1.0e6,
-             'linkedSetRate'   : 1.0e6,
-             'linkedGetRate'   : 1.0e6 }
+# Pre-existing tuned thresholds from the original x86/hwcounter-based test.
+MaxCycles = { 'remoteSetRate'   : 8.0e9,
+              'remoteSetNvRate' : 7.0e9,
+              'remoteGetRate'   : 6.0e9,
+              'localSetRate'    : 8.0e9,
+              'localGetRate'    : 6.0e9,
+              'linkedSetRate'   : 9.0e9,
+              'linkedGetRate'   : 8.0e9 }
+
+BENCH_COUNT = 100000
+NOMINAL_CPU_HZ = 3.0e9
+
+# Cross-platform fallback thresholds in ns/op derived from MaxCycles assuming
+# NOMINAL_CPU_HZ and BENCH_COUNT.
+MaxAvgNs = {
+    k: (v * 1.0e9) / (NOMINAL_CPU_HZ * BENCH_COUNT)
+    for k, v in MaxCycles.items()
+}
 
 class LocalDev(pr.Device):
 
@@ -140,7 +151,7 @@ def test_rate():
     #pr.enable()
 
     with DummyTree() as root:
-        count = 100000
+        count = BENCH_COUNT
         operations = {
             'remoteSetRate': lambda i: root.LocalDev.TestRemote.set(i),
             'remoteSetNvRate': lambda i: root.LocalDev.TestRemoteNoVerify.set(i),
@@ -157,14 +168,23 @@ def test_rate():
             result = _measure_operation(root, count, operation)
 
             msg = (
-                f"{name} avg_ns {result['avg_ns']:.2e}, "
-                f"maximum {MaxAvgNs[name]:.2e}, rate {result['rate_hz']}"
+                f"{name}: avg {result['avg_ns']:.2e} ns/op, "
+                f"maximum {MaxAvgNs[name]:.2e} ns/op, "
+                f"rate {result['rate_hz']:.2e} ops/s"
             )
             if HAS_HWCOUNTER:
-                msg += f", cycles {result['cycles']:.2e}"
+                msg += (
+                    f", cycles {result['cycles']:.2e} cycles, "
+                    f"maximum {MaxCycles[name]:.2e} cycles"
+                )
             print(msg)
 
-            if result['avg_ns'] > MaxAvgNs[name]:
+            if HAS_HWCOUNTER:
+                if result['cycles'] > MaxCycles[name]:
+                    failures.append(
+                        f"{name}: cycles {result['cycles']:.2e} > {MaxCycles[name]:.2e}"
+                    )
+            elif result['avg_ns'] > MaxAvgNs[name]:
                 failures.append(
                     f"{name}: avg_ns {result['avg_ns']:.2e} > {MaxAvgNs[name]:.2e}"
                 )

--- a/tests/test_rate.py
+++ b/tests/test_rate.py
@@ -14,7 +14,12 @@ import pyrogue as pr
 import pyrogue.interfaces.simulation
 import rogue.interfaces.memory
 import time
-import hwcounter
+
+try:
+    import hwcounter
+    HAS_HWCOUNTER = True
+except ImportError:
+    HAS_HWCOUNTER = False
 
 #import cProfile, pstats, io
 #from pstats import SortKey
@@ -24,13 +29,13 @@ import hwcounter
 #logger = logging.getLogger('pyrogue')
 #logger.setLevel(logging.DEBUG)
 
-MaxCycles = { 'remoteSetRate'   : 8.0e9,
-              'remoteSetNvRate' : 7.0e9,
-              'remoteGetRate'   : 6.0e9,
-              'localSetRate'    : 8.0e9,
-              'localGetRate'    : 6.0e9,
-              'linkedSetRate'   : 9.0e9,
-              'linkedGetRate'   : 8.0e9 }
+MaxAvgNs = { 'remoteSetRate'   : 1.0e6,
+             'remoteSetNvRate' : 1.0e6,
+             'remoteGetRate'   : 1.0e6,
+             'localSetRate'    : 1.0e6,
+             'localGetRate'    : 1.0e6,
+             'linkedSetRate'   : 1.0e6,
+             'linkedGetRate'   : 1.0e6 }
 
 class LocalDev(pr.Device):
 
@@ -106,6 +111,29 @@ class DummyTree(pr.Root):
         ))
 
 
+def _run_update_loop(root, count, operation):
+    with root.updateGroup():
+        for i in range(count):
+            operation(i)
+
+
+def _measure_operation(root, count, operation):
+    start_ns = time.perf_counter_ns()
+    start_cycles = hwcounter.count() if HAS_HWCOUNTER else None
+    _run_update_loop(root, count, operation)
+    elapsed_ns = time.perf_counter_ns() - start_ns
+
+    result = {
+        'avg_ns': float(elapsed_ns) / count,
+        'rate_hz': int(count / (elapsed_ns / 1.0e9)),
+    }
+
+    if HAS_HWCOUNTER:
+        result['cycles'] = float(hwcounter.count_end() - start_cycles)
+
+    return result
+
+
 def test_rate():
 
     #pr = cProfile.Profile()
@@ -113,76 +141,35 @@ def test_rate():
 
     with DummyTree() as root:
         count = 100000
-        resultRate = {}
-        resultCycles = {}
+        operations = {
+            'remoteSetRate': lambda i: root.LocalDev.TestRemote.set(i),
+            'remoteSetNvRate': lambda i: root.LocalDev.TestRemoteNoVerify.set(i),
+            'remoteGetRate': lambda i: root.LocalDev.TestRemote.get(),
+            'localSetRate': lambda i: root.LocalDev.TestLocal.set(i),
+            'localGetRate': lambda i: root.LocalDev.TestLocal.get(),
+            'linkedSetRate': lambda i: root.LocalDev.TestLink.set(i),
+            'linkedGetRate': lambda i: root.LocalDev.TestLink.get(i),
+        }
 
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestRemote.set(i)
-        resultCycles['remoteSetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['remoteSetRate'] = int(1/((time.time()-stime) / count))
+        failures = []
 
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestRemoteNoVerify.set(i)
-        resultCycles['remoteSetNvRate'] = float(hwcounter.count_end() - scount)
-        resultRate['remoteSetNvRate'] = int(1/((time.time()-stime) / count))
+        for name, operation in operations.items():
+            result = _measure_operation(root, count, operation)
 
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestRemote.get()
-        resultCycles['remoteGetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['remoteGetRate'] = int(1/((time.time()-stime) / count))
+            msg = (
+                f"{name} avg_ns {result['avg_ns']:.2e}, "
+                f"maximum {MaxAvgNs[name]:.2e}, rate {result['rate_hz']}"
+            )
+            if HAS_HWCOUNTER:
+                msg += f", cycles {result['cycles']:.2e}"
+            print(msg)
 
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestLocal.set(i)
-        resultCycles['localSetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['localSetRate'] = int(1/((time.time()-stime) / count))
+            if result['avg_ns'] > MaxAvgNs[name]:
+                failures.append(
+                    f"{name}: avg_ns {result['avg_ns']:.2e} > {MaxAvgNs[name]:.2e}"
+                )
 
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestLocal.get()
-        resultCycles['localGetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['localGetRate'] = int(1/((time.time()-stime) / count))
-
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestLink.set(i)
-        resultCycles['linkedSetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['linkedSetRate'] = int(1/((time.time()-stime) / count))
-
-        stime = time.time()
-        scount = hwcounter.count()
-        with root.updateGroup():
-            for i in range(count):
-                root.LocalDev.TestLink.get(i)
-        resultCycles['linkedGetRate'] = float(hwcounter.count_end() - scount)
-        resultRate['linkedGetRate'] = int(1/((time.time()-stime) / count))
-
-        passed = True
-
-        for k,v in MaxCycles.items():
-
-            print(f"{k} cyles {resultCycles[k]:.2e}, maximum {v:.2e}, rate {resultRate[k]}")
-
-            if resultCycles[k] > v:
-                passed = False
-
-        if passed is False:
-            raise AssertionError('Rate check failed')
+        assert not failures, "Rate check failed:\n" + "\n".join(failures)
 
 
     #pr.disable()


### PR DESCRIPTION
## Summary

This PR adds native **macOS arm64** build/install support for Rogue using **Conda/Miniforge**, while keeping Linux workflows intact.  
It also fixes packaging and formatting issues found during macOS validation.

## What Changed

### Build system and platform support
- Added explicit macOS architecture guard: only `arm64` is supported.
- Fixed macOS shared library handling:
  - `rogue-core-shared` now uses `.dylib` on macOS.
- Added macOS runtime library path support in setup scripts:
  - `DYLD_LIBRARY_PATH` exported in `setup_rogue.sh/.csh/.fish`.
- Improved ZeroMQ fallback lookup to include `DYLD_LIBRARY_PATH` on macOS.
- Avoided linking `rt` on Apple static builds.
- Added CMake policy handling for newer CMake versions:
  - `CMP0144` set to `NEW`
  - `CMP0167` set to `OLD`
- Added `Boost_ROOT` hint (in addition to `BOOST_ROOT`) for conda/miniforge environments.

### Dependency environment
- Updated `conda.yml` to be cross-platform:
  - replaced `gcc_linux-64` / `gxx_linux-64` with `c-compiler` / `cxx-compiler`.
- Updated Qt dependency pin to a modern compatible range:
  - `pyqt>=5.15`.

### Python packaging/install fix
- Fixed `make install` failure from invalid version strings when working tree is dirty.
- Reworked version normalization in `templates/setup.py.in` to produce PEP 440-compliant versions, including:
  - `vX.Y.Z-dirty`
  - `vX.Y.Z-N-g<sha>`
  - `vX.Y.Z-N-g<sha>-dirty`.

### CI updates
- Add macos-15 build to github actions CI pipeline.
- Added/expanded dedicated `macos_arm64_build_test` path.
- macOS job now runs `pytest` (excluding separate `api_test` flow on macOS).
- Added pip dependency install step in macOS workflow.
- `pip_requirements.txt` now uses environment marker for `hwcounter`:
  - `hwcounter; platform_system == "Linux" and platform_machine == "x86_64"`.

### Test portability improvements
- Refactored `tests/test_rate.py`:
  - table-driven/cleaner benchmark structure
  - supports optional `hwcounter`
  - cross-platform fallback timing based on `perf_counter_ns`
  - clearer printed output with explicit units
  - restored/retained tuned cycle thresholds where `hwcounter` is available.

### Portability/format-string fixes
- Replaced non-portable printf specifiers in Xilinx protocol code with fixed-width-safe formatting (`PRIu64`) in:
  - `XvcConnection.cpp`
  - `JtagDriver.cpp`.

### Documentation updates
- Updated install docs to reflect current support:
  - Native source build supported on **Linux + macOS arm64**.
  - Windows guidance remains Docker/WSL.
- Added macOS-specific Miniforge build prerequisites and commands:
  - `xcode-select --install`
  - macOS Miniforge installer path
  - cross-platform build command examples.



### Repo hygiene
- Added `.vscode/` to `.gitignore` to avoid committing local editor settings.


