### PR TITLE
Variable.h Signature Clarity

### DIFF
--- a/include/rogue/interfaces/memory/Variable.h
+++ b/include/rogue/interfaces/memory/Variable.h
@@ -520,7 +520,7 @@ class Variable {
      * @param value Pointer to input byte buffer.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setByteArray(uint8_t*, int32_t index = -1);
+    void setByteArray(uint8_t* value, int32_t index = -1);
 
     /**
      * @brief Gets value into a raw byte array.
@@ -532,7 +532,7 @@ class Variable {
      * @param value Pointer to output byte buffer.
      * @param index Value index, or `-1` for the full variable.
      */
-    void getByteArray(uint8_t*, int32_t index = -1);
+    void getByteArray(uint8_t* value, int32_t index = -1);
 
     /////////////////////////////////
     // C++ Uint
@@ -548,7 +548,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setUInt(uint64_t&, int32_t index = -1);
+    void setUInt(uint64_t& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setUInt`.
@@ -596,7 +596,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setInt(int64_t&, int32_t index = -1);
+    void setInt(int64_t& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setInt`.
@@ -644,7 +644,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setBool(bool&, int32_t index = -1);
+    void setBool(bool& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setBool`.
@@ -692,7 +692,7 @@ class Variable {
      * @param value Input string value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setString(const std::string&, int32_t index = -1);
+    void setString(const std::string& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setString`.
@@ -732,7 +732,7 @@ class Variable {
      * @param valueRet Output reference receiving the value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void getValue(std::string&, int32_t index = -1);
+    void getValue(std::string& valueRet, int32_t index = -1);
 
     /////////////////////////////////
     // C++ Float
@@ -748,7 +748,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setFloat(float&, int32_t index = -1);
+    void setFloat(float& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setFloat`.
@@ -796,7 +796,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setDouble(double&, int32_t index = -1);
+    void setDouble(double& value, int32_t index = -1);
 
     /**
      * @brief Convenience alias for `setDouble`.
@@ -845,7 +845,7 @@ class Variable {
      * @param value Input value.
      * @param index Value index, or `-1` for the full variable.
      */
-    void setFixed(double&, int32_t index = -1);
+    void setFixed(double& value, int32_t index = -1);
 
     /**
      * @brief Gets fixed-point value.

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -773,20 +773,20 @@ std::string rim::Variable::getDumpValue(bool read) {
 // C++ Byte Array
 /////////////////////////////////
 
-void rim::Variable::setByteArray(uint8_t* data, int32_t index) {
+void rim::Variable::setByteArray(uint8_t* value, int32_t index) {
     if (setByteArray_ == NULL)
         throw(rogue::GeneralError::create("Variable::setByteArray", "Wrong set type for variable %s", path_.c_str()));
 
-    (block_->*setByteArray_)(data, this, index);
+    (block_->*setByteArray_)(value, this, index);
     block_->write(this, index);
 }
 
-void rim::Variable::getByteArray(uint8_t* data, int32_t index) {
+void rim::Variable::getByteArray(uint8_t* value, int32_t index) {
     if (getByteArray_ == NULL)
         throw(rogue::GeneralError::create("Variable::getByteArray", "Wrong get type for variable %s", path_.c_str()));
 
     block_->read(this, index);
-    (block_->*getByteArray_)(data, this, index);
+    (block_->*getByteArray_)(value, this, index);
 }
 
 /////////////////////////////////
@@ -869,12 +869,12 @@ std::string rim::Variable::getString(int32_t index) {
     return (block_->*getString_)(this, index);
 }
 
-void rim::Variable::getValue(std::string& retString, int32_t index) {
+void rim::Variable::getValue(std::string& valueRet, int32_t index) {
     if (getString_ == NULL) {
         throw(rogue::GeneralError::create("Variable::getValue", "Wrong get type for variable %s", path_.c_str()));
     } else {
         block_->read(this, index);
-        block_->getValue(this, retString, index);
+        block_->getValue(this, valueRet, index);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR isolates the `Variable.h` API signature readability cleanup into a standalone change for easier review and merge sequencing.

## What Changed

Updated method declarations in:

- `include/rogue/interfaces/memory/Variable.h`

The change names previously unnamed first parameters in several method signatures, for example:

- `setByteArray(uint8_t* value, ...)`
- `getByteArray(uint8_t* value, ...)`
- `setUInt(uint64_t& value, ...)`
- `setInt(int64_t& value, ...)`
- `setBool(bool& value, ...)`
- `setString(const std::string& value, ...)`
- `getValue(std::string& valueRet, ...)`
- `setFloat(float& value, ...)`
- `setDouble(double& value, ...)`
- `setFixed(double& value, ...)`

### Source updates
- `src/rogue/interfaces/memory/Variable.cpp`
- Matched parameter names with the header for:
  - `setByteArray(uint8_t* value, ...)`
  - `getByteArray(uint8_t* value, ...)`
  - `getValue(std::string& valueRet, ...)`

## Why

- Improves readability of the public C++ interface.
- Makes signatures clearer in headers/docs/IDE hovers.
- No intended behavioral/runtime change.

## Scope / Risk

- Header declaration cleanup only (parameter naming).
- No logic changes.


