### PR TITLE
bug fix for PRBS module for high bandwidth rates (>8Gb/s)

### DIFF
--- a/include/rogue/utilities/Prbs.h
+++ b/include/rogue/utilities/Prbs.h
@@ -77,7 +77,7 @@ class Prbs : public rogue::interfaces::stream::Slave, public rogue::interfaces::
     uint32_t rxCount_;
 
     // Rx bytes
-    uint32_t rxBytes_;
+    uint64_t rxBytes_;
 
     // tx sequence tracking
     uint32_t txSeq_;
@@ -92,7 +92,7 @@ class Prbs : public rogue::interfaces::stream::Slave, public rogue::interfaces::
     uint32_t txCount_;
 
     // TX bytes
-    uint32_t txBytes_;
+    uint64_t txBytes_;
 
     // Check payload
     bool checkPl_;
@@ -111,13 +111,13 @@ class Prbs : public rogue::interfaces::stream::Slave, public rogue::interfaces::
 
     // Stats
     uint32_t lastRxCount_;
-    uint32_t lastRxBytes_;
+    uint64_t lastRxBytes_;
     struct timeval lastRxTime_;
     double rxRate_;
     double rxBw_;
 
     uint32_t lastTxCount_;
-    uint32_t lastTxBytes_;
+    uint64_t lastTxBytes_;
     struct timeval lastTxTime_;
     double txRate_;
     double txBw_;
@@ -246,7 +246,7 @@ class Prbs : public rogue::interfaces::stream::Slave, public rogue::interfaces::
      * @brief Returns RX byte count.
      * @return Total received payload bytes.
      */
-    uint32_t getRxBytes();
+    uint64_t getRxBytes();
 
     /**
      * @brief Returns computed RX frame rate.
@@ -300,7 +300,7 @@ class Prbs : public rogue::interfaces::stream::Slave, public rogue::interfaces::
      * @brief Returns TX byte count.
      * @return Total transmitted payload bytes.
      */
-    uint32_t getTxBytes();
+    uint64_t getTxBytes();
 
     /**
      * @brief Enables or disables payload checking.

--- a/src/rogue/utilities/Prbs.cpp
+++ b/src/rogue/utilities/Prbs.cpp
@@ -257,7 +257,7 @@ uint32_t ru::Prbs::getRxCount() {
 }
 
 //! Get rx bytes
-uint32_t ru::Prbs::getRxBytes() {
+uint64_t ru::Prbs::getRxBytes() {
     return (rxBytes_);
 }
 
@@ -302,7 +302,7 @@ double ru::Prbs::getTxBw() {
 }
 
 //! Get TX bytes
-uint32_t ru::Prbs::getTxBytes() {
+uint64_t ru::Prbs::getTxBytes() {
     return (txBytes_);
 }
 
@@ -397,8 +397,8 @@ void ru::Prbs::genFrame(uint32_t size) {
     txBytes_ += size;
 
     if ((per = updateTime(&lastTxTime_)) > 0.0) {
-        txRate_      = static_cast<float>(txCount_ - lastTxCount_) / per;
-        txBw_        = static_cast<float>(txBytes_ - lastTxBytes_) / per;
+        txRate_      = static_cast<double>(txCount_ - lastTxCount_) / per;
+        txBw_        = static_cast<double>(txBytes_ - lastTxBytes_) / per;
         lastTxCount_ = txCount_;
         lastTxBytes_ = txBytes_;
     }
@@ -511,8 +511,8 @@ void ru::Prbs::acceptFrame(ris::FramePtr frame) {
     rxBytes_ += size;
 
     if ((per = updateTime(&lastRxTime_)) > 0.0) {
-        rxRate_      = static_cast<float>(rxCount_ - lastRxCount_) / per;
-        rxBw_        = static_cast<float>(rxBytes_ - lastRxBytes_) / per;
+        rxRate_      = static_cast<double>(rxCount_ - lastRxCount_) / per;
+        rxBw_        = static_cast<double>(rxBytes_ - lastRxBytes_) / per;
         lastRxCount_ = rxCount_;
         lastRxBytes_ = rxBytes_;
     }


### PR DESCRIPTION
### Description
- https://jira.slac.stanford.edu/browse/ESROGUE-714
- **Fix counter overflow:** Byte counters were `uint32_t` and could wrap around at ~4 GB during high-bandwidth operation, causing incorrect bandwidth deltas. Switching to `uint64_t` prevents overflow in normal operation.
- **Improve bandwidth precision:** Bandwidth calculations used `float`, which loses precision for large byte counts. Changing the computation to use `double` ensures accurate `getRxBw()` and `getTxBw()` values at high data rates.
