### PR TITLE
Fix FileReader config parsing and StreamReader IsOpen wrapper

### DIFF
--- a/python/pyrogue/utilities/fileio/_FileReader.py
+++ b/python/pyrogue/utilities/fileio/_FileReader.py
@@ -20,8 +20,9 @@ from typing import Any, Iterator
 
 import numpy
 import numpy.typing as npt
-import yaml
 import logging
+
+import pyrogue as pr
 
 RogueHeaderSize  = 8
 RogueHeaderPack  = 'IHBB'
@@ -170,7 +171,7 @@ class FileReader(object):
 
             # Process meta data
             if self._configChan is not None and self._header.channel == self._configChan:
-                self._updateConfig(yaml.load(self._currFile.read(self._header.size).decode('utf-8')))
+                self._updateConfig(pr.yamlToData(stream=self._currFile.read(self._header.size).decode('utf-8')))
 
             # This is a data channel
             else:

--- a/python/pyrogue/utilities/fileio/_StreamReader.py
+++ b/python/pyrogue/utilities/fileio/_StreamReader.py
@@ -57,7 +57,9 @@ class StreamReader(pyrogue.Device):
 
         self.add(pyrogue.LocalVariable(
             name='isOpen',
-            function=self._isOpen,
+            mode='RO',
+            value=False,
+            localGet=self._isOpen,
             description='Data file is open.'))
 
     def _open(self) -> None:


### PR DESCRIPTION
## Bug Fixes

1. **FileReader config/status frames used bare `yaml.load()`**

   What was broken:
   - `FileReader` parsed config-channel records with `yaml.load(...)` and no `Loader=`.
   - Modern PyYAML rejects that call.

   Inputs that triggered it:
   - Any file containing an embedded config/status frame, for example a file whose first record is a config payload like:
     - `{"root.Child.Value": 9}`

   Observed failure:
   - `TypeError: load() missing 1 required positional argument: 'Loader'`

   Fix:
   - Switched config record parsing to `pyrogue.yamlToData(...)`, which uses the project’s supported YAML loader path.

2. **StreamReader wrapper built `IsOpen` incorrectly**

   What was broken:
   - The wrapper’s `IsOpen` local variable was not created with the correct local getter/value pattern.

   Inputs that triggered it:
   - Constructing the Python `StreamReader` wrapper.

   Result:
   - Wrapper construction/runtime issues around the open-state variable.

   Fix:
   - Declared `IsOpen` with `mode='RO'`, `value=False`, and `localGet=self._isOpen`.
