### PR TITLE
Fix Int conversions and LocalBlock in-place operators

### DIFF
--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -443,76 +443,76 @@ class LocalBlock(object):
     def _iadd(self, other: Any) -> None:
         """In-place add helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) + other)
+            self.set(self._variable, self.get(self._variable) + other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _isub(self, other: Any) -> None:
         """In-place subtract helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) - other)
+            self.set(self._variable, self.get(self._variable) - other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imul(self, other: Any) -> None:
         """In-place multiply helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) * other)
+            self.set(self._variable, self.get(self._variable) * other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imatmul(self, other: Any) -> None:
         """In-place matrix multiply helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) @ other)
+            self.set(self._variable, self.get(self._variable) @ other)
             self._variable._queueUpdate()
 
     def _itruediv(self, other: Any) -> None:
         """In-place true division helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) / other)
+            self.set(self._variable, self.get(self._variable) / other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ifloordiv(self, other: Any) -> None:
         """In-place floor division helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) // other)
+            self.set(self._variable, self.get(self._variable) // other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _imod(self, other: Any) -> None:
         """In-place modulo helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) % other)
+            self.set(self._variable, self.get(self._variable) % other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ipow(self, other: Any) -> None:
         """In-place power helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) ** other)
+            self.set(self._variable, self.get(self._variable) ** other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ilshift(self, other: Any) -> None:
         """In-place left shift helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) << other)
+            self.set(self._variable, self.get(self._variable) << other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _irshift(self, other: Any) -> None:
         """In-place right shift helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) >> other)
+            self.set(self._variable, self.get(self._variable) >> other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _iand(self, other: Any) -> None:
         """In-place bitwise-and helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) & other)
+            self.set(self._variable, self.get(self._variable) & other)
             if self._enable:
                 self._variable._queueUpdate()
 
@@ -520,13 +520,13 @@ class LocalBlock(object):
         """In-place bitwise-xor helper for local blocks."""
 
         with self._lock:
-            self.set(None, self.get(None) ^ other)
+            self.set(self._variable, self.get(self._variable) ^ other)
             if self._enable:
                 self._variable._queueUpdate()
 
     def _ior(self, other: Any) -> None:
         """In-place bitwise-or helper for local blocks."""
         with self._lock:
-            self.set(None, self.get(None) | other)
+            self.set(self._variable, self.get(self._variable) | other)
             if self._enable:
                 self._variable._queueUpdate()

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -455,7 +455,7 @@ class Int(UInt):
         else:
             value = int.from_bytes(ba, self.endianness, signed=True)
 
-        return
+        return value
 
     def fromString(self, string: str) -> int:
         """
@@ -475,7 +475,7 @@ class Int(UInt):
         """
         i = int(string, 0)
         # perform twos complement if necessary
-        if i>0 and ((i >> self.bitSize) & 0x1 == 1):
+        if i >= 2**(self.bitSize-1):
             i = i - (1 << self.bitSize)
         return i
 


### PR DESCRIPTION
## Bug Fixes

1. **`Int.fromBytes()` returned `None`**

   What was broken:
   - The method computed a decoded integer but returned `None`.

   Inputs that triggered it:
   - Any direct model-level call path using `Int.fromBytes()`.

   Example:
   - Decoding a signed integer model from raw bytes.

   Fix:
   - Returned the computed decoded value.

2. **`Int.fromString()` mishandled sign-extended literals for non-byte-aligned widths**

   What was broken:
   - Sign-extended literals like `0xfff` on a 12-bit signed model were not interpreted as negative values.

   Inputs that triggered it:
   - Signed model widths like 12 bits or 17 bits, with hex strings representing sign-extended negative values.

   Example:
   - 12-bit signed model:
     - input: `"0xfff"`
     - expected: `-1`

   Fix:
   - Corrected two’s-complement/sign handling for sub-byte-aligned widths.

3. **LocalBlock in-place operators passed `None` where `LocalBlock.set()` requires a real variable**

   What was broken:
   - In-place helpers called:
     - `self.set(None, self.get(None) - other)`
   - But `LocalBlock.set()` dereferences `var._nativeType` and `var.path`.

   Inputs that triggered it:
   - In-place operations on `LocalVariable`.

   Examples:
   - `local_var -= 1`
   - `local_var |= 4`
   - `local_var <<= 2`

   Fix:
   - Updated the helpers to use `self._variable` consistently for `get()` and `set()`.
