### PR TITLE
Fix variable array write semantics and VariableWait state handling

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -876,7 +876,14 @@ class BaseVariable(pr.Node):
         -------
         None
         """
-        self.set(self.parseDisp(sValue), write=write, index=index)
+        value = self.parseDisp(sValue)
+
+        # Indexed writes into ndarray-backed variables expect a scalar element,
+        # not the 0-D ndarray produced by np.array(ast.literal_eval(...)).
+        if index >= 0 and isinstance(value, np.ndarray) and value.ndim == 0:
+            value = value.item()
+
+        self.set(value, write=write, index=index)
 
     @property
     def nativeType(self) -> Type[object]:
@@ -970,7 +977,11 @@ class BaseVariable(pr.Node):
 
                     # Single entry item
                     if ':' not in keys[0]:
-                        self.setDisp(d, write=writeEach, index=idxSlice[0])
+                        if isinstance(idxSlice, list):
+                            idx = idxSlice[0]
+                        else:
+                            idx = idxSlice
+                        self.setDisp(d, write=writeEach, index=idx)
 
                     # Multi entry item
                     else:

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -992,11 +992,22 @@ class BaseVariable(pr.Node):
                             s = shlex.shlex(" " + d.lstrip('[').rstrip(']') + " ",posix=True)
                             s.whitespace_split=True
                             s.whitespace=','
+                            values = [val.strip() for val in s]
+                        elif isinstance(d, Iterable):
+                            values = list(d)
                         else:
-                            s = d
+                            values = [d]
 
-                        for val,i in zip(s,idxSlice):
-                            self.setDisp(val.strip(), write=writeEach, index=i)
+                        # A scalar YAML value should broadcast across the
+                        # entire selected slice, matching the documented
+                        # ``Array[1:3]: value`` semantics.
+                        if len(values) == 1 and len(idxSlice) > 1:
+                            values *= len(idxSlice)
+
+                        for val,i in zip(values,idxSlice):
+                            if isinstance(val, str):
+                                val = val.strip()
+                            self.setDisp(val, write=writeEach, index=i)
             else:
                 self._log.warning(f"Skipping set for Entry {self.name} with mode {self._mode}. Enabled Modes={modes}.")
 

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -104,6 +104,7 @@ class VariableWaitClass(object):
             for v in self._vlist:
                 v.addListener(self._varUpdate)
                 self._values[v.path]  = v.getVariableValue(read=False)
+                self._values[v.path].updated = False
                 self._updated[v.path] = False
 
     def wait(self) -> bool:
@@ -126,12 +127,13 @@ class VariableWaitClass(object):
 
     def get_values(self) -> dict:
         """Return the latest collected variable values."""
-        return {k: self._values[k] for k in self._vlist}
+        return {k: self._values[k.path] for k in self._vlist}
 
     def _varUpdate(self, path: str, varValue: Any) -> None:
         """Listener callback used to capture variable updates."""
         with self._cv:
             if path in self._values:
+                varValue.updated = True
                 self._values[path] = varValue
                 self._updated[path] = True
                 self._cv.notify()
@@ -199,6 +201,7 @@ class VariableValue(object):
         self.valueDisp = var.genDisp(self.value)
         self.disp      = var.disp
         self.enum      = var.enum
+        self.updated   = False
 
         self.status, self.severity = var._alarmState(self.value)
 


### PR DESCRIPTION
## Bug Fixes

1. **BaseVariable `_setDict()` failed on single-index array keys**

   What was broken:
   - Single-index expressions like `"1"` were evaluated to scalar `1`, but the code assumed a subscriptable result and indexed `[0]`.

   Inputs that triggered it:
   - Array-element config updates through `_setDict()`.

   Example:
   - `root.CmdDev.RemoteArray._setDict("99", writeEach=False, modes=["RW"], keys=["1"])`

   Previous failure:
   - `TypeError: 'int' object is not subscriptable`

   Fix:
   - Handled scalar index results and slice/list results separately.

2. **Indexed `setDisp()` on ndarray-backed variables passed a 0-D ndarray instead of a scalar**

   What was broken:
   - `parseDisp("99")` for ndarray-backed variables can produce a 0-D ndarray.
   - Indexed writes need a scalar element.

   Inputs that triggered it:
   - Indexed display-string writes into ndarray-backed variables.

   Example:
   - `root.CmdDev.RemoteArray.setDisp("99", index=1)`

   Result:
   - Invalid ndarray-dimension/type failure during the element write path.

   Fix:
   - Unwrapped 0-D ndarrays with `.item()` before indexed `set()` calls.

3. **`VariableWaitClass.get_values()` used variable objects instead of stored path keys**

   What was broken:
   - Internal state is keyed by `v.path`.
   - `get_values()` tried to fetch entries using the variable objects themselves.

   Inputs that triggered it:
   - Calling `get_values()` after `VariableWaitClass.wait()`.

   Example:
   - `waiter = VariableWaitClass(root.Dev.Counter, timeout=...)`
   - `waiter.wait()`
   - `waiter.get_values()`

   Fix:
   - Returned `{variable_object: cached_value_by_path}` using `k.path` internally.

4. **Documented `VariableValue.updated` field did not actually exist**

   What was broken:
   - `VariableWait` docs describe `varValues[i].updated`.
   - `VariableValue` had no such field, and wait updates never set it.

   Inputs that triggered it:
   - Any `VariableWait` predicate using update-state semantics rather than raw value comparisons.

   Example:
   - `VariableWait([var1, var2], lambda vals: vals[0].updated and vals[1].updated, timeout=...)`

   Fix:
   - Added `updated = False` to `VariableValue`
   - Set it `False` on arm
   - Set it `True` in `VariableWaitClass._varUpdate()`

5. **Variable-array YAML slices did not support scalar broadcast**

   What was broken:
   - Variable-level YAML array selectors already supported:
     - `SomeArrayValue[*]: value`
     - `SomeArrayValue[:]: value`
   - But slice selectors like:
     - `SomeArrayValue[1:3]: value`
     did not support a scalar value.
   - The implementation assumed slice assignments were always iterable and tried to iterate the scalar.

   Inputs that triggered it:
   - Any YAML load or `setYaml()` call that assigned a scalar to an array-variable slice.

   Example failure:
   - YAML like:
     - `SomeArrayValue[1:3]: 7`
   - raised:
     - `TypeError: 'int' object is not iterable`

   Fix:
   - Updated `BaseVariable._setDict()` so a single scalar value broadcasts across the selected slice.
   - Preserved support for iterable and comma-separated multi-value slice assignments.
