### PR TITLE
Fix pack=True collisions in Device.addRemoteVariables

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -354,13 +354,13 @@ class Device(pr.Node,rim.Hub):
         if pack:
             varList = getattr(self, kwargs['name']).values()
 
-            def linkedSet(dev: Any, var: pr.LinkVariable, val: str, write: bool) -> None:
+            def linkedSet(dev: Any, var: pr.LinkVariable, value: str, write: bool) -> None:
                 """Split a packed display string and write each element variable."""
-                if val == '':
+                if value == '':
                     return
-                values = reversed(val.split('_'))
-                for variable, value in zip(varList, values):
-                    variable.setDisp(value, write=write)
+                values = reversed(value.split('_'))
+                for variable, item in zip(varList, values):
+                    variable.setDisp(item, write=write)
 
             def linkedGet(dev: Any, var: pr.LinkVariable, read: bool) -> str:
                 """Join element display values into one packed underscore string."""
@@ -368,6 +368,9 @@ class Device(pr.Node,rim.Hub):
                 return '_'.join(reversed(values))
 
             name = kwargs.pop('name')
+            # Preserve the indexed array container at ``name`` and expose the
+            # packed LinkVariable using the historical ``<name>_All`` alias.
+            name += '_All'
             kwargs.pop('value', None)
 
             lv = pr.LinkVariable(name=name, value='', dependencies=varList, linkedGet=linkedGet, linkedSet=linkedSet, **kwargs)


### PR DESCRIPTION
## Bug Fixes

1. **`Device.addRemoteVariables(..., pack=True)` collided with the generated indexed container**

   What was broken:
   - `addRemoteVariables(..., pack=True)` first creates the indexed `RemoteVariable` container at the requested `name`.
   - It then tried to add the packed `LinkVariable` using that same `name`.
   - That caused a `NodeError` because the packed alias collided with the already-created array container.

   Inputs that triggered it:
   - Any use of `Device.addRemoteVariables(..., pack=True)`.

   Example failure:
   - A device doing:
     - `self.addRemoteVariables(name="PackedField", ..., pack=True)`
   - would fail during tree construction with a name-collision error.

   Fix:
   - Preserved the indexed array container at the original `name`.
   - Exposed the packed `LinkVariable` using the historical `<name>_All` alias instead.
   - Also updated the packed setter callback to match the current wrapped callback argument name (`value`).
