### PR TITLE
Fix SqlLogger syslog decoding for VariableValue payloads

### DIFF
--- a/python/pyrogue/interfaces/_SqlLogging.py
+++ b/python/pyrogue/interfaces/_SqlLogging.py
@@ -113,7 +113,10 @@ class SqlLogger(object):
 
         # Syslog
         if entry[0] == self._sysLogPath:
-            val = json.loads(entry[1])
+            # Root listeners hand us VariableValue objects, so unwrap the JSON
+            # payload from .value() before decoding the system-log entry.
+            log_entry = entry[1].value if hasattr(entry[1], 'value') else entry[1]
+            val = json.loads(log_entry)
 
             ins = self._logTable.insert().values(
                 name=val['name'],

--- a/python/pyrogue/interfaces/_SqlLogging.py
+++ b/python/pyrogue/interfaces/_SqlLogging.py
@@ -99,24 +99,21 @@ class SqlLogger(object):
         self._thread.join()
         print('Sql logger stopped')
 
-    def insert_from_q(self, entry: tuple[str, Any], conn: sqlalchemy.Connection) -> None:
+    def insert_from_q(self, entry: tuple[str, pr.VariableValue], conn: sqlalchemy.Connection) -> None:
         """
         Insert a single queue entry into the database.
 
         Parameters
         ----------
         entry : tuple
-            (path, value) for variables or (path, log_data) for syslog.
+            ``(path, var_value)`` from a root variable listener callback.
         conn : object
             SQLAlchemy connection for the transaction.
         """
 
         # Syslog
         if entry[0] == self._sysLogPath:
-            # Root listeners hand us VariableValue objects, so unwrap the JSON
-            # payload from .value() before decoding the system-log entry.
-            log_entry = entry[1].value if hasattr(entry[1], 'value') else entry[1]
-            val = json.loads(log_entry)
+            val = json.loads(entry[1].value)
 
             ins = self._logTable.insert().values(
                 name=val['name'],


### PR DESCRIPTION
## Bug Fixes

1. **SqlLogger syslog handling decoded `VariableValue`, not the underlying JSON string**

   What was broken:
   - Syslog updates from `SystemLogLast` arrived as `VariableValue`, but the logger passed that wrapper to `json.loads()`.

   Inputs that triggered it:
   - Any `SystemLogLast` update routed into SQL logging.

   Result:
   - Valid syslog entries failed to decode and log correctly.

   Fix:
   - Unwrapped the stored string payload before JSON decoding.
