### PR TITLE
Fix malformed child sections and prologue loss in CPSW export

### DIFF
--- a/python/pyrogue/utilities/cpsw.py
+++ b/python/pyrogue/utilities/cpsw.py
@@ -188,7 +188,7 @@ def exportSubDevice(device: pyrogue.Device, indent: int, deviceList: dict[str, l
         dn = f"{device.__class__.__name__}"
 
     dat  = " " * indent +  "#########################################################\n"
-    dat += " " * indent + f"{device.name}\n"
+    dat += " " * indent + f"{device.name}:\n"
     dat += " " * indent + f"    <<: *{dn}\n"
     dat += " " * indent +  "    at:\n"
     dat += " " * indent + f"      offset: {device.offset:#x}\n"
@@ -263,7 +263,7 @@ def exportDevice(device: pyrogue.Device, deviceList: dict[str, list[str]], dataD
         ddat +=  f"#once {tname}\n"
         ddat +=  include + "\n"
         ddat +=  f"{tname}: &{tname}\n"
-        ddat  =  "  class: MMIODev\n"
+        ddat +=  "  class: MMIODev\n"
         ddat +=  "  configPrio: 1\n"
         ddat += f"  description: {device.description}\n"
         ddat += f"  size: {size:#x}\n"


### PR DESCRIPTION
## Bug Fixes

1. **CPSW child-device export omitted the `:` after the device name**

   What was broken:
   - Child-device sections were emitted without valid YAML mapping syntax.

   Inputs that triggered it:
   - Exporting nested devices with the CPSW utilities.

   Result:
   - Malformed output for child-device sections.

   Fix:
   - Added the missing `:` after child device names.

2. **CPSW export overwrote the generated file prologue**

   What was broken:
   - Header/prologue content such as `#once` and `#include` was accumulated and then overwritten by later body assignment.

   Inputs that triggered it:
   - Full-file/root CPSW export.

   Result:
   - Generated files missing the expected header/include prologue.

   Fix:
   - Preserved the accumulated prefix and appended body content instead of overwriting it.
