### PR TITLE
Fix version discovery for non-release Git tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,9 @@ if ( NOT ROGUE_VERSION )
    find_package(Git QUIET)
    if (GIT_FOUND)
       execute_process (
-         COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_SOURCE_DIR}/.git --work-tree=${CMAKE_SOURCE_DIR} describe --tags --dirty
+         # Restrict auto-versioning to release tags so helper tags do not
+         # produce invalid Python package versions.
+         COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_SOURCE_DIR}/.git --work-tree=${CMAKE_SOURCE_DIR} describe --tags --dirty --match v*
          RESULT_VARIABLE ROGUE_GIT_DESCRIBE_RESULT
          OUTPUT_VARIABLE ROGUE_GIT_DESCRIBE_OUTPUT
          ERROR_QUIET

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -16,6 +16,7 @@
 # ----------------------------------------------------------------------------
 
 from setuptools import setup, find_packages
+import re
 
 rawVersion = '${ROGUE_VERSION}'
 
@@ -27,23 +28,37 @@ def normalize_version(raw):
     #   vX.Y.Z-N-g<sha>-dirty
     core = raw[1:] if raw.startswith('v') else raw
     fields = core.split('-')
+    release_re = re.compile(r'^\d+(?:\.\d+)*$')
+
+    def clean_field(field):
+        return re.sub(r'[^A-Za-z0-9]+', '.', field).strip('.')
 
     if len(fields) == 1:
-        return fields[0]
+        return fields[0] if release_re.match(fields[0]) else f"0.dev0+{clean_field(fields[0])}"
 
-    base = fields[0]
-    if fields[1].isdigit():
-        dev = fields[1]
-        local_fields = fields[2:]
+    if release_re.match(fields[0]):
+        base = fields[0]
+        if fields[1].isdigit():
+            dev = fields[1]
+            local_fields = fields[2:]
+        else:
+            dev = "0"
+            local_fields = fields[1:]
     else:
-        dev = "0"
-        local_fields = fields[1:]
+        # Fallback for non-release tags or branch/helper describe strings.
+        base = "0"
+        if len(fields) >= 2 and fields[-2].isdigit():
+            dev = fields[-2]
+            local_fields = fields[:-2] + fields[-1:]
+        else:
+            dev = "0"
+            local_fields = fields
 
     version = f"{base}.dev{dev}"
 
     if local_fields:
         # PEP 440 local version labels allow [a-zA-Z0-9.] segments.
-        local = ".".join(local_fields).replace("_", ".").replace("-", ".")
+        local = ".".join(clean_field(field) for field in local_fields if clean_field(field))
         version = f"{version}+{local}"
 
     return version


### PR DESCRIPTION
## Bug Fixes

1. **Version generation could select non-release Git tags and produce invalid Python package versions**

   What was broken:
   - CMake used:
     - `git describe --tags --dirty`
   - That allowed helper/non-release tags to win over release tags.
   - In this branch, Git resolved to:
     - `builtin-reorg-prestart-142-g45d8beb82`
   - The generated Python setup logic normalized that into an invalid version string.

   Inputs that triggered it:
   - Building from a commit closer to a non-PEP440 helper tag than to a real `v*` release tag.

   Example failure:
   - `packaging.version.InvalidVersion: Invalid version: 'builtin.dev0+reorg.prestart.142.g45d8beb82'`

   Fix:
   - Restricted CMake auto-version discovery to `--match 'v*'`
   - Hardened Python version normalization so odd describe strings still normalize to valid PEP 440 versions if they do slip through
