### PR TITLE
Fix zip-directory YAML load ordering in Root.loadYaml

### DIFF
--- a/docs/src/pyrogue_tree/core/yaml_configuration.rst
+++ b/docs/src/pyrogue_tree/core/yaml_configuration.rst
@@ -80,12 +80,26 @@ implementation, the input can be:
 * A single ``.yml`` or ``.yaml`` file.
 * A directory, in which case all ``.yml`` and ``.yaml`` files in that
   directory are loaded in sorted order.
-* A zip-file subdirectory path.
+* A zip-file subdirectory path, using the same sorted-order rule on the
+  matching member names in that directory.
 * A Python list of those entries.
 * A comma-separated string of entries.
 
 ``Root.setYaml(...)`` applies YAML text directly without going through the
 filesystem.
+
+YAML content is parsed through :func:`pyrogue.yamlToData`, so the same
+``!include`` handling is available during ``loadYaml(...)`` as when parsing
+YAML directly. Relative includes are resolved relative to the file being read.
+
+For directory-like inputs, "sorted order" means an ascending lexicographic sort
+of the full path strings being loaded. For one directory, that is effectively
+lexicographic filename order. For example:
+
+* ``00-defaults.yml``
+* ``10-overrides.yml``
+
+load in that order, so later files can intentionally override earlier values.
 
 For ``loadYaml(..., writeEach=False)`` and ``setYaml(..., writeEach=False)``,
 the application workflow is:
@@ -101,13 +115,23 @@ Implications:
 * If a Variable is assigned more than once while loading, the last assignment
   wins in shadow memory before commit
 * Hardware is not touched until the bulk commit step
+* For directory and zip-directory loads, "last assignment wins" follows the
+  lexicographic file/member order described above
+* For explicit Python lists or comma-separated file lists, it follows the
+  order you passed to ``loadYaml(...)``
 
 If ``writeEach=True``, each ``setDisp`` write is issued immediately while YAML
-is being traversed (no final consolidated ``Root._write()`` pass).
+is being traversed (no final consolidated ``Root._write()`` pass). That means
+later YAML entries can still overwrite earlier values, but the intermediate
+hardware writes have already occurred.
 
 The load path is wrapped in both ``Root.pollBlock()`` and ``Root.updateGroup()``
 so polling does not race with the configuration operation and listeners see a
 coalesced update batch.
+
+For zip-file subdirectory loads, only YAML files in the immediate requested
+directory are considered. Nested subdirectories are ignored, matching the
+normal directory behavior.
 
 The staged values are then committed using the normal tree transaction path.
 For the bulk write, verify, read, and check model behind that commit step, see

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -879,6 +879,7 @@ class Root(pr.Device):
                         raise Exception("loadYaml: Invalid load file: {}, must be a directory or end in .yml or .yaml".format(rl))
 
                     else:
+                        zip_yaml = []
 
                         # Iterate through directory contents
                         for zfn in myzip.namelist():
@@ -889,7 +890,11 @@ class Root(pr.Device):
 
                                 # Entry ends in .yml or *.yml and is in current directory
                                 if '/' not in spt and (spt[-4:] == '.yml' or spt[-5:] == '.yaml'):
-                                    lst.append(base + '/' + zfn)
+                                    zip_yaml.append(base + '/' + zfn)
+
+                        # Keep zip-directory loads aligned with normal directory
+                        # loads by applying a lexicographic pathname sort.
+                        lst.extend(sorted(zip_yaml))
 
             # Entry is a directory
             elif os.path.isdir(rl):


### PR DESCRIPTION
## Bug Fixes

1. **Zip-directory YAML loads depended on archive insertion order**

   What was broken:
   - Normal directory loads were lexicographically sorted before application.
   - Zip-directory loads iterated raw `ZipFile.namelist()` order instead.
   - That meant precedence depended on how the zip archive had been created, not on member names.

   Inputs that triggered it:
   - Any `Root.loadYaml()` call using a zip-directory path such as:
     - `configs.zip/cfg`

   Example failure:
   - Two zip archives containing the same files:
     - `00-defaults.yml`
     - `10-overrides.yml`
   - could apply them in different orders if the archive member insertion order differed.

   Fix:
   - Collected matching zip-directory YAML members and sorted them lexicographically before loading.
   - This now aligns zip-directory precedence with normal directory loading semantics.
