### PR TITLE
Add LocalVariable typeCheck flag and disable it for DataReceiver.Data

### DIFF
--- a/docs/src/pyrogue_tree/builtin_devices/data_receiver.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/data_receiver.rst
@@ -41,6 +41,10 @@ Most ``DataReceiver`` definitions revolve around:
 * ``value`` for the initial payload container
 * ``enableOnStart`` for whether ``RxEnable`` should come up enabled at start
 
+The built-in ``Data`` ``LocalVariable`` is created with ``typeCheck=False`` so
+subclasses can publish decoded objects without triggering ``LocalVariable``
+type warnings.
+
 In many practical subclasses, the main customization is not the constructor
 arguments but the ``process(frame)`` override.
 

--- a/docs/src/pyrogue_tree/builtin_devices/data_receiver.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/data_receiver.rst
@@ -43,7 +43,7 @@ Most ``DataReceiver`` definitions revolve around:
 
 The built-in ``Data`` ``LocalVariable`` is created with ``typeCheck=False`` so
 subclasses can publish decoded objects without triggering ``LocalVariable``
-type warnings.
+type errors.
 
 In many practical subclasses, the main customization is not the constructor
 arguments but the ``process(frame)`` override.

--- a/docs/src/pyrogue_tree/core/local_variable.rst
+++ b/docs/src/pyrogue_tree/core/local_variable.rst
@@ -74,8 +74,10 @@ Important implications:
 
 * ``LocalVariable`` does not automatically coerce later writes to match the
   seed type.
-* A type mismatch currently produces a warning during ``set()``, not an
-  exception.
+* With the default ``typeCheck=True``, a type mismatch currently produces a
+  warning during ``set()``, not an exception.
+* Set ``typeCheck=False`` when a ``LocalVariable`` intentionally needs to
+  accept multiple Python value types over its lifetime.
 * ``typeStr`` is display metadata; it does not enforce conversion by itself.
 
 If you define a callback-only ``LocalVariable`` with ``localGet`` and no

--- a/docs/src/pyrogue_tree/core/local_variable.rst
+++ b/docs/src/pyrogue_tree/core/local_variable.rst
@@ -74,8 +74,8 @@ Important implications:
 
 * ``LocalVariable`` does not automatically coerce later writes to match the
   seed type.
-* With the default ``typeCheck=True``, a type mismatch currently produces a
-  warning during ``set()``, not an exception.
+* With the default ``typeCheck=True``, a type mismatch during ``set()`` raises
+  an exception.
 * Set ``typeCheck=False`` when a ``LocalVariable`` intentionally needs to
   accept multiple Python value types over its lifetime.
 * ``typeStr`` is display metadata; it does not enforce conversion by itself.

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -391,7 +391,7 @@ class LocalBlock(object):
             if index >= 0:
                 self._value[index] = value
             else:
-                if not isinstance(value, var._nativeType):
+                if var._typeCheck and not isinstance(value, var._nativeType):
                     self._log.warning( f'{var.path}: Expecting {var._nativeType}: Currently a warning but in the future this will be an error' )
                     #raise TypeError(f"Error - {var.path}: Expecting {var._nativeType} but got {type(value)}")
 

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -392,8 +392,10 @@ class LocalBlock(object):
                 self._value[index] = value
             else:
                 if var._typeCheck and not isinstance(value, var._nativeType):
-                    self._log.warning( f'{var.path}: Expecting {var._nativeType}: Currently a warning but in the future this will be an error' )
-                    #raise TypeError(f"Error - {var.path}: Expecting {var._nativeType} but got {type(value)}")
+                    raise pr.VariableError(
+                        f"Type mismatch for {var.path}: expected {var._nativeType}, got {type(value)}. "
+                        "If this variable intentionally changes Python types, construct it with typeCheck=False."
+                    )
 
                 self._value = value
 

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -80,6 +80,7 @@ class DataReceiver(pr.Device,ris.Slave):
 
         self.add(pr.LocalVariable(name='Data',
                                   typeStr=typeStr,
+                                  typeCheck=False,
                                   disp='',
                                   groups=['NoState','NoStream', 'NoConfig'],
                                   value=value,

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -262,6 +262,8 @@ class BaseVariable(pr.Node):
         Enable update notifications.
     typeStr : str, optional (default = "Unknown")
         Type string for display.
+    typeCheck : bool, optional (default = True)
+        If True, warn when later writes change the seeded Python type.
     bulkOpEn : bool, optional (default = True)
         Enable bulk operations.
     offset : int, optional (default = 0)
@@ -299,6 +301,7 @@ class BaseVariable(pr.Node):
         pollInterval: Any = 0,
         updateNotify: bool = True,
         typeStr: str = 'Unknown',
+        typeCheck: bool = True,
         bulkOpEn: bool = True,
         offset: int = 0,
         guiGroup: str | None = None,
@@ -319,6 +322,7 @@ class BaseVariable(pr.Node):
         self._highAlarm     = highAlarm
         self._default       = value
         self._typeStr       = typeStr
+        self._typeCheck     = typeCheck
         self._block         = None
         self._pollInterval  = pollInterval
         self._nativeType    = None
@@ -1630,6 +1634,8 @@ class LocalVariable(BaseVariable):
         Enable update notifications.
     typeStr : str, optional (default = "Unknown")
         Type string for display.
+    typeCheck : bool, optional (default = True)
+        If True, warn when later writes change the seeded Python type.
     bulkOpEn : bool, optional (default = True)
         Enable bulk operations.
     guiGroup : str, optional
@@ -1659,6 +1665,7 @@ class LocalVariable(BaseVariable):
                  pollInterval: Any = 0,
                  updateNotify: bool = True,
                  typeStr: str = 'Unknown',
+                 typeCheck: bool = True,
                  bulkOpEn: bool = True,
                  guiGroup: str | None = None,
                  **kwargs: Any) -> None:
@@ -1673,7 +1680,7 @@ class LocalVariable(BaseVariable):
                               minimum=minimum, maximum=maximum, typeStr=typeStr,
                               lowWarning=lowWarning, lowAlarm=lowAlarm,
                               highWarning=highWarning, highAlarm=highAlarm,
-                              pollInterval=pollInterval,updateNotify=updateNotify, bulkOpEn=bulkOpEn,
+                              pollInterval=pollInterval,updateNotify=updateNotify, typeCheck=typeCheck, bulkOpEn=bulkOpEn,
                               guiGroup=guiGroup, **kwargs)
 
         self._block = pr.LocalBlock(variable=self,

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -263,7 +263,7 @@ class BaseVariable(pr.Node):
     typeStr : str, optional (default = "Unknown")
         Type string for display.
     typeCheck : bool, optional (default = True)
-        If True, warn when later writes change the seeded Python type.
+        If True, raise an error when later writes change the seeded Python type.
     bulkOpEn : bool, optional (default = True)
         Enable bulk operations.
     offset : int, optional (default = 0)
@@ -1635,7 +1635,7 @@ class LocalVariable(BaseVariable):
     typeStr : str, optional (default = "Unknown")
         Type string for display.
     typeCheck : bool, optional (default = True)
-        If True, warn when later writes change the seeded Python type.
+        If True, raise an error when later writes change the seeded Python type.
     bulkOpEn : bool, optional (default = True)
         Enable bulk operations.
     guiGroup : str, optional

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -9,6 +9,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import logging
 import pyrogue
 
 # Test values
@@ -176,6 +177,48 @@ def test_local_root():
         max_read=root.myDevice.var_with_properties.maximum
         if max_read != max_set:
             raise AssertionError('Minimum was set to {} but was read as {}'.format(max_set, max_read))
+
+
+def test_local_variable_type_check_warning(caplog):
+    with LocalRoot() as root:
+        caplog.clear()
+        caplog.set_level(logging.WARNING)
+
+        root.myDevice.var.set('wrong-type')
+
+        assert root.myDevice.var.get() == 'wrong-type'
+        assert 'Expecting' in caplog.text
+
+
+def test_local_variable_type_check_disable(caplog):
+    with pyrogue.Root(name='LocalRoot', description='Local root') as root:
+        root.add(pyrogue.Device(name='myDevice'))
+        root.myDevice.add(pyrogue.LocalVariable(
+            name='var',
+            value=0.0,
+            typeCheck=False,
+            mode='RW'))
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING)
+
+        root.myDevice.var.set('wrong-type')
+
+        assert root.myDevice.var.get() == 'wrong-type'
+        assert caplog.text == ''
+
+
+def test_data_receiver_disables_type_check(caplog):
+    with pyrogue.Root(name='LocalRoot', description='Local root') as root:
+        root.add(pyrogue.DataReceiver(name='Rx'))
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING)
+
+        root.Rx.Data.set({'decoded': 1}, write=True)
+
+        assert root.Rx.Data.get() == {'decoded': 1}
+        assert caplog.text == ''
 
 if __name__ == "__main__":
     test_local_root()

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -191,13 +191,15 @@ def test_local_variable_type_check_warning(caplog):
 
 
 def test_local_variable_type_check_disable(caplog):
-    with pyrogue.Root(name='LocalRoot', description='Local root') as root:
-        root.add(pyrogue.Device(name='myDevice'))
-        root.myDevice.add(pyrogue.LocalVariable(
-            name='var',
-            value=0.0,
-            typeCheck=False,
-            mode='RW'))
+    root = pyrogue.Root(name='LocalRoot', description='Local root')
+    root.add(pyrogue.Device(name='myDevice'))
+    root.myDevice.add(pyrogue.LocalVariable(
+        name='var',
+        value=0.0,
+        typeCheck=False,
+        mode='RW'))
+
+    with root:
 
         caplog.clear()
         caplog.set_level(logging.WARNING)
@@ -209,8 +211,10 @@ def test_local_variable_type_check_disable(caplog):
 
 
 def test_data_receiver_disables_type_check(caplog):
-    with pyrogue.Root(name='LocalRoot', description='Local root') as root:
-        root.add(pyrogue.DataReceiver(name='Rx'))
+    root = pyrogue.Root(name='LocalRoot', description='Local root')
+    root.add(pyrogue.DataReceiver(name='Rx'))
+
+    with root:
 
         caplog.clear()
         caplog.set_level(logging.WARNING)

--- a/tests/test_localvars.py
+++ b/tests/test_localvars.py
@@ -9,7 +9,6 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-import logging
 import pyrogue
 
 # Test values
@@ -179,18 +178,17 @@ def test_local_root():
             raise AssertionError('Minimum was set to {} but was read as {}'.format(max_set, max_read))
 
 
-def test_local_variable_type_check_warning(caplog):
+def test_local_variable_type_check_error():
     with LocalRoot() as root:
-        caplog.clear()
-        caplog.set_level(logging.WARNING)
+        try:
+            root.myDevice.var.set('wrong-type')
+            raise AssertionError('Changing a LocalVariable type did not raise an exception')
+        except pyrogue.VariableError as exc:
+            assert 'typeCheck=False' in str(exc)
+            assert 'expected' in str(exc)
 
-        root.myDevice.var.set('wrong-type')
 
-        assert root.myDevice.var.get() == 'wrong-type'
-        assert 'Expecting' in caplog.text
-
-
-def test_local_variable_type_check_disable(caplog):
+def test_local_variable_type_check_disable():
     root = pyrogue.Root(name='LocalRoot', description='Local root')
     root.add(pyrogue.Device(name='myDevice'))
     root.myDevice.add(pyrogue.LocalVariable(
@@ -200,29 +198,19 @@ def test_local_variable_type_check_disable(caplog):
         mode='RW'))
 
     with root:
-
-        caplog.clear()
-        caplog.set_level(logging.WARNING)
-
         root.myDevice.var.set('wrong-type')
 
         assert root.myDevice.var.get() == 'wrong-type'
-        assert caplog.text == ''
 
 
-def test_data_receiver_disables_type_check(caplog):
+def test_data_receiver_disables_type_check():
     root = pyrogue.Root(name='LocalRoot', description='Local root')
     root.add(pyrogue.DataReceiver(name='Rx'))
 
     with root:
-
-        caplog.clear()
-        caplog.set_level(logging.WARNING)
-
         root.Rx.Data.set({'decoded': 1}, write=True)
 
         assert root.Rx.Data.get() == {'decoded': 1}
-        assert caplog.text == ''
 
 if __name__ == "__main__":
     test_local_root()


### PR DESCRIPTION
## Summary
- add a `typeCheck` parameter to `LocalVariable`, defaulting to `True`
- gate the LocalBlock type-mismatch warning on that flag
- disable type checking for `DataReceiver.Data` and document the new behavior
- add tests covering the default warning path and the opt-out path
- add documentation of this feature
