### PR TITLE
Fix PyDM debug_tree name corruption after long ZMQ transactions

### DIFF
--- a/docs/src/pydm/starting_gui.rst
+++ b/docs/src/pydm/starting_gui.rst
@@ -140,6 +140,8 @@ to :py:func:`pyrogue.pydm.runPyDM`:
            title='My System',
            sizeX=1000,
            sizeY=500,
+           linkTimeout=600.0,
+           requestStallTimeout=None,
        )
 
 In practice, ``runPyDM`` always connects through the Rogue client interface
@@ -160,11 +162,29 @@ The main :py:func:`pyrogue.pydm.runPyDM` options are:
 - ``title``: Window title.
 - ``sizeX`` and ``sizeY``: Initial window size.
 - ``maxListExpand`` and ``maxListSize``: Limits used by the debug-tree view.
+- ``linkTimeout``: Idle timeout for the cached ``VirtualClient`` instances
+  used by the GUI. This is the primary knob for tolerating long busy periods.
+- ``requestStallTimeout``: Optional per-request stall policy for the cached
+  ``VirtualClient`` instances. This is disabled by default and usually only
+  makes sense when the application has a strict upper bound for valid request
+  duration.
 
 The command-line launcher defaults to ``localhost:9099``. The Python helper's
 function signature currently defaults to ``localhost:9090``, so in practice it
 is better to pass ``serverList`` explicitly rather than rely on the helper
 default.
+
+For simulation or co-simulation applications, the common pattern is to leave
+``requestStallTimeout`` disabled and increase ``linkTimeout`` to match the
+expected busy period:
+
+.. code-block:: python
+
+   pyrogue.pydm.runPyDM(
+       serverList=root.zmqServer.address,
+       linkTimeout=600.0,
+       requestStallTimeout=None,
+   )
 
 Rogue Channel Prefix
 ====================

--- a/docs/src/pyrogue_tree/client_interfaces/virtual.rst
+++ b/docs/src/pyrogue_tree/client_interfaces/virtual.rst
@@ -93,6 +93,44 @@ Link-State Monitoring
        print(client.linked)
        client.remLinkMonitor(link_monitor)
 
+Timeout Tuning
+==============
+
+``VirtualClient`` has two separate timeout concepts:
+
+- ``linkTimeout``: how long the client may go without publish updates or a
+  successful request reply before it marks the link down
+- ``requestStallTimeout``: an optional policy timeout for declaring a single
+  in-flight request stalled
+
+In practice, ``linkTimeout`` is the normal tuning knob. It is useful when a
+system may legitimately spend a long time servicing a request, for example
+when a Rogue tree is backed by firmware co-simulation.
+
+``requestStallTimeout`` is disabled by default and is often best left that way.
+It is only useful when the deployment has a known upper bound for legitimate
+request duration and wants the client to declare a request hung after that
+threshold.
+
+.. code-block:: python
+
+   from pyrogue.interfaces import VirtualClient
+
+   with VirtualClient(
+       addr='localhost',
+       port=9099,
+       linkTimeout=600.0,
+       requestStallTimeout=None,
+   ) as client:
+       root = client.root
+       print(root.RogueVersion.valueDisp())
+
+If no explicit arguments are passed, the defaults can also be provided with
+environment variables:
+
+- ``ROGUE_VIRTUAL_LINK_TIMEOUT``
+- ``ROGUE_VIRTUAL_REQUEST_STALL_TIMEOUT``
+
 Logging
 =======
 

--- a/docs/src/pyrogue_tree/client_interfaces/zmq_server.rst
+++ b/docs/src/pyrogue_tree/client_interfaces/zmq_server.rst
@@ -112,6 +112,16 @@ Separately, ``ZmqServer._start()`` prints the selected ports and example client
 commands to stdout. Those startup messages are not controlled by the logging
 API.
 
+Client-side request/retry logging comes from ``pyrogue.ZmqClient`` rather than
+``ZmqServer``. During long waits, that logging is intentionally throttled:
+
+- one warning when the client first enters the retry loop
+- periodic "still waiting" warnings at a lower cadence
+- one recovery message when the response arrives
+
+This keeps long but valid transactions visible without generating a warning
+every socket-timeout interval.
+
 Related Topics
 ==============
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -13,6 +13,7 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import os
 import pyrogue as pr
 import rogue.interfaces
 import pickle
@@ -336,7 +337,28 @@ class VirtualClient(rogue.interfaces.ZmqClient):
     """
     ClientCache = {}
 
-    def __new__(cls: type["VirtualClient"], addr: str = "localhost", port: int = 9099) -> "VirtualClient":
+    @staticmethod
+    def _defaultLinkTimeout() -> float:
+        """Return the default idle link timeout in seconds."""
+        return float(os.getenv("ROGUE_VIRTUAL_LINK_TIMEOUT", "10.0"))
+
+    @staticmethod
+    def _defaultRequestStallTimeout() -> float | None:
+        """Return the default request-stall timeout in seconds, if configured."""
+        value = os.getenv("ROGUE_VIRTUAL_REQUEST_STALL_TIMEOUT")
+        if value is None or value == "":
+            return None
+
+        stall = float(value)
+        return None if stall <= 0 else stall
+
+    def __new__(
+        cls: type["VirtualClient"],
+        addr: str = "localhost",
+        port: int = 9099,
+        linkTimeout: float | None = None,
+        requestStallTimeout: float | None = None,
+    ) -> "VirtualClient":
         """Return cached client instances keyed by ``(addr, port)``."""
         newHash = hash((addr, port))
 
@@ -345,11 +367,20 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         else:
             return super(VirtualClient, cls).__new__(cls, addr, port)
 
-    def __init__(self, addr: str = "localhost", port: int = 9099) -> None:
-        if hash((addr,port)) in VirtualClient.ClientCache:
+    def __init__(
+        self,
+        addr: str = "localhost",
+        port: int = 9099,
+        linkTimeout: float | None = None,
+        requestStallTimeout: float | None = None,
+    ) -> None:
+        if getattr(self, "_vcInitialized", False):
+            if linkTimeout is not None or requestStallTimeout is not None:
+                self.setTimeoutConfig(linkTimeout=linkTimeout, requestStallTimeout=requestStallTimeout)
             return
 
         VirtualClient.ClientCache[hash((addr, port))] = self
+        self._vcInitialized = True
 
         rogue.interfaces.ZmqClient.__init__(self,addr,port,False)
         self._varListeners = []
@@ -357,6 +388,13 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._root  = None
         self._link  = False
         self._ltime = time.time()
+        self._reqLock = threading.Lock()
+        self._reqCount = 0
+        self._reqSince = None
+        self._linkTimeout = self._defaultLinkTimeout()
+        self._requestStallTimeout = self._defaultRequestStallTimeout()
+
+        self.setTimeoutConfig(linkTimeout=linkTimeout, requestStallTimeout=requestStallTimeout)
 
         # Setup logging
         self._log = pr.logInit(cls=self,name="VirtualClient",path=None)
@@ -429,29 +467,113 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         """Whether the client is currently linked to the server."""
         return self._link
 
+    @property
+    def linkTimeout(self) -> float:
+        """Idle timeout in seconds before the link is considered down."""
+        return self._linkTimeout
+
+    @property
+    def requestStallTimeout(self) -> float | None:
+        """Maximum in-flight request age before it is treated as stalled."""
+        return self._requestStallTimeout
+
+    def setTimeoutConfig(
+        self,
+        *,
+        linkTimeout: float | None = None,
+        requestStallTimeout: float | None = None,
+    ) -> None:
+        """Update link and request-stall timeout settings."""
+        if linkTimeout is not None:
+            self._linkTimeout = float(linkTimeout)
+
+        if requestStallTimeout is not None:
+            stall = float(requestStallTimeout)
+            self._requestStallTimeout = None if stall <= 0 else stall
+
     def _monWorker(self) -> None:
         """Monitor link heartbeat and emit link-state callbacks."""
         while self._monEnable:
             time.sleep(1)
+            self._checkLinkState()
 
-            if self._link and (time.time() - self._ltime) > 10.0:
-                self._link = False
-                self._log.warning(f"I have not heard from {self._root.name} in 10 seconds. It may be busy, continuing to wait...")
-                for mon in self._monitors:
-                    mon(self._link)
+    def _requestStart(self) -> None:
+        """Record that a request/reply transaction is in flight."""
+        with self._reqLock:
+            if self._reqCount == 0:
+                self._reqSince = time.time()
+            self._reqCount += 1
 
-            elif (not self._link) and (time.time() - self._ltime) < 10.0:
+    def _requestDone(self, success: bool) -> None:
+        """Record request completion and treat successful replies as activity."""
+        with self._reqLock:
+            self._reqCount = max(0, self._reqCount - 1)
+            if self._reqCount == 0:
+                self._reqSince = None
+
+        if success:
+            self._ltime = time.time()
+            if not self._link:
                 self._link = True
                 self._log.warning(f"I have finally heard from {self._root.name}. All is good!")
                 for mon in self._monitors:
                     mon(self._link)
 
+    def _requestPending(self) -> bool:
+        """Whether at least one request/reply transaction is in flight."""
+        with self._reqLock:
+            return self._reqCount > 0
+
+    def _requestAge(self) -> float | None:
+        """Return the age of the oldest in-flight request, if any."""
+        with self._reqLock:
+            if self._reqCount == 0 or self._reqSince is None:
+                return None
+            return time.time() - self._reqSince
+
+    def _checkLinkState(self) -> None:
+        """Update link state from recent activity while tolerating busy requests."""
+        delta = time.time() - self._ltime
+
+        if self._link and delta > self._linkTimeout:
+            if self._requestPending():
+                reqAge = self._requestAge()
+                if self._requestStallTimeout is None or reqAge is None or reqAge <= self._requestStallTimeout:
+                    return
+
+                self._link = False
+                self._log.warning(
+                    f"Request has been pending for {reqAge:0.1f} seconds without updates. "
+                    f"Declaring link to {self._root.name} stalled."
+                )
+                for mon in self._monitors:
+                    mon(self._link)
+                return
+
+            self._link = False
+            self._log.warning(
+                f"I have not heard from {self._root.name} in {self._linkTimeout:0.1f} seconds. "
+                "It may be busy, continuing to wait..."
+            )
+            for mon in self._monitors:
+                mon(self._link)
+
+        elif (not self._link) and delta < self._linkTimeout:
+            self._link = True
+            self._log.warning(f"I have finally heard from {self._root.name}. All is good!")
+            for mon in self._monitors:
+                mon(self._link)
+
 
     def _remoteAttr(self, path: str, attr: str, *args: Any, **kwargs: Any) -> Any:
         """Invoke a remote attribute on the server."""
+        self._requestStart()
+
         try:
             ret = pickle.loads(self._send(pickle.dumps({ 'path':path, 'attr':attr, 'args':args, 'kwargs':kwargs })))
+            self._requestDone(True)
         except Exception as e:
+            self._requestDone(False)
             raise Exception(f"ZMQ Interface Exception: {e}")
 
         if isinstance(ret,Exception):

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -326,6 +326,18 @@ class VirtualClient(rogue.interfaces.ZmqClient):
     port : int
         host port
 
+    linkTimeout : float, optional
+        Idle timeout in seconds before the client marks the link down when no
+        publish updates or successful replies have been observed. This is the
+        primary operational timeout knob for both hardware and simulation
+        applications.
+
+    requestStallTimeout : float | None, optional
+        Optional policy timeout for how long a single in-flight request may
+        remain outstanding before the client declares the connection stalled.
+        This is disabled by default and is typically only useful when a
+        deployment has a well-defined upper bound for legitimate request time.
+
     Attributes
     ----------
     linked: bool
@@ -359,7 +371,12 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         linkTimeout: float | None = None,
         requestStallTimeout: float | None = None,
     ) -> "VirtualClient":
-        """Return cached client instances keyed by ``(addr, port)``."""
+        """Return cached client instances keyed by ``(addr, port)``.
+
+        Timeout arguments configure the cached instance for that server. If a
+        client already exists for the same ``(addr, port)``, new timeout values
+        are applied to the shared instance.
+        """
         newHash = hash((addr, port))
 
         if newHash in cls.ClientCache:
@@ -374,6 +391,24 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         linkTimeout: float | None = None,
         requestStallTimeout: float | None = None,
     ) -> None:
+        """Create or reconfigure a cached virtual client instance.
+
+        Parameters
+        ----------
+        addr : str, optional
+            Server host name or address.
+        port : int, optional
+            Base ZMQ server port.
+        linkTimeout : float | None, optional
+            Idle timeout in seconds before the link is considered down. If not
+            provided, the default is 10 seconds or the value from
+            ``ROGUE_VIRTUAL_LINK_TIMEOUT``.
+        requestStallTimeout : float | None, optional
+            Optional maximum age of an in-flight request before the client
+            treats it as stalled. ``None`` or non-positive values disable this
+            policy. In practice this is usually left disabled unless a system
+            has a known upper bound for valid request duration.
+        """
         if getattr(self, "_vcInitialized", False):
             if linkTimeout is not None or requestStallTimeout is not None:
                 self.setTimeoutConfig(linkTimeout=linkTimeout, requestStallTimeout=requestStallTimeout)
@@ -474,7 +509,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     @property
     def requestStallTimeout(self) -> float | None:
-        """Maximum in-flight request age before it is treated as stalled."""
+        """Optional maximum in-flight request age before it is treated as stalled."""
         return self._requestStallTimeout
 
     def setTimeoutConfig(
@@ -483,7 +518,13 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         linkTimeout: float | None = None,
         requestStallTimeout: float | None = None,
     ) -> None:
-        """Update link and request-stall timeout settings."""
+        """Update link and request-stall timeout settings.
+
+        ``linkTimeout`` is the normal tuning knob for clients that need to
+        tolerate longer busy periods. ``requestStallTimeout`` is an optional
+        policy threshold and is most useful only when a deployment has a clear,
+        finite upper bound for legitimate request duration.
+        """
         if linkTimeout is not None:
             self._linkTimeout = float(linkTimeout)
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -364,6 +364,11 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         stall = float(value)
         return None if stall <= 0 else stall
 
+    @staticmethod
+    def _defaultConnectTimeout() -> float:
+        """Return the startup handshake timeout in seconds."""
+        return max(0.1, float(os.getenv("ROGUE_VIRTUAL_CONNECT_TIMEOUT", "5.0")))
+
     def __new__(
         cls: type["VirtualClient"],
         addr: str = "localhost",
@@ -414,10 +419,18 @@ class VirtualClient(rogue.interfaces.ZmqClient):
                 self.setTimeoutConfig(linkTimeout=linkTimeout, requestStallTimeout=requestStallTimeout)
             return
 
-        VirtualClient.ClientCache[hash((addr, port))] = self
+        self._cacheKey = hash((addr, port))
+        self._monEnable = False
+        self._monThread = None
         self._vcInitialized = True
+        VirtualClient.ClientCache[self._cacheKey] = self
 
-        rogue.interfaces.ZmqClient.__init__(self,addr,port,False)
+        try:
+            rogue.interfaces.ZmqClient.__init__(self,addr,port,False)
+        except Exception:
+            self._removeFromCache()
+            self._vcInitialized = False
+            raise
         self._varListeners = []
         self._monitors = []
         self._root  = None
@@ -439,8 +452,9 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self.setTimeout(1000,False)
 
         try:
-            self._root = self._remoteAttr('__ROOT__',None)
+            self._root = self._waitForRoot()
         except Exception:
+            self._cleanupFailedInit()
             error_message = (
                 f"\n\nFailed to connect to {addr}:{port}!\n\n"
                 "Possible causes for the issue:\n"
@@ -470,6 +484,37 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._monEnable = True
         self._monThread = threading.Thread(target=self._monWorker)
         self._monThread.start()
+
+    def _removeFromCache(self) -> None:
+        """Remove this client from the shared cache when it is no longer valid."""
+        if getattr(self, "_cacheKey", None) in VirtualClient.ClientCache and VirtualClient.ClientCache[self._cacheKey] is self:
+            del VirtualClient.ClientCache[self._cacheKey]
+
+    def _cleanupFailedInit(self) -> None:
+        """Release transport resources after a failed bootstrap handshake."""
+        self._monEnable = False
+        self._removeFromCache()
+        self._vcInitialized = False
+        try:
+            rogue.interfaces.ZmqClient._stop(self)
+        except Exception:
+            pass
+
+    def _waitForRoot(self) -> "VirtualNode":
+        """Retry the initial ``__ROOT__`` handshake for a bounded startup window."""
+        deadline = time.monotonic() + self._defaultConnectTimeout()
+        last_error = None
+
+        while time.monotonic() < deadline:
+            try:
+                return self._remoteAttr('__ROOT__',None)
+            except Exception as exc:
+                last_error = exc
+
+        if last_error is not None:
+            raise last_error
+
+        raise Exception("Timed out waiting for initial root handshake")
 
     def addLinkMonitor(self, function: Callable[[bool], None]) -> None:
         """

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -18,6 +18,7 @@ from types import FrameType
 
 import pydm
 import pydm.data_plugins
+from pyrogue.interfaces import VirtualClient
 from pyrogue.pydm.data_plugins.rogue_plugin import RoguePlugin
 
 # Define a signal handler to ensure the application quits gracefully
@@ -35,6 +36,27 @@ def pydmSignalHandler(sig: int, frame: FrameType | None) -> None:
     if app is not None:
         app.closeAllWindows()
 
+
+def _configureVirtualClients(
+    serverList: str,
+    *,
+    linkTimeout: float,
+    requestStallTimeout: float | None,
+) -> None:
+    """Preconfigure cached VirtualClient instances for each GUI server."""
+    for server in serverList.split(","):
+        server = server.strip()
+        if server == "":
+            continue
+
+        host, port = server.rsplit(":", 1)
+        VirtualClient(
+            addr=host,
+            port=int(port),
+            linkTimeout=linkTimeout,
+            requestStallTimeout=requestStallTimeout,
+        )
+
 # Function to run the PyDM application with specified parameters
 def runPyDM(
     serverList: str = 'localhost:9090',
@@ -44,6 +66,8 @@ def runPyDM(
     sizeY: int = 1000,
     maxListExpand: int = 5,
     maxListSize: int = 100,
+    linkTimeout: float = 10.0,
+    requestStallTimeout: float | None = None,
 ) -> None:
     """Launch the default Rogue PyDM application.
 
@@ -63,6 +87,11 @@ def runPyDM(
         Debug-tree auto-expand depth argument forwarded to the UI.
     maxListSize : int, optional
         Debug-tree list-size cap argument forwarded to the UI.
+    linkTimeout : float, optional
+        Idle timeout in seconds for VirtualClient link-state detection.
+    requestStallTimeout : float | None, optional
+        In-flight request age in seconds before the VirtualClient declares the
+        server stalled. ``None`` disables stalled-request detection.
 
     Returns
     -------
@@ -72,6 +101,12 @@ def runPyDM(
 
     # Set the ROGUE_SERVERS environment variable
     os.environ['ROGUE_SERVERS'] = serverList
+
+    _configureVirtualClients(
+        serverList,
+        linkTimeout=linkTimeout,
+        requestStallTimeout=requestStallTimeout,
+    )
 
     # Set the UI file to a default value if not provided
     if ui is None or ui == '':

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -43,7 +43,12 @@ def _configureVirtualClients(
     linkTimeout: float,
     requestStallTimeout: float | None,
 ) -> None:
-    """Preconfigure cached VirtualClient instances for each GUI server."""
+    """Preconfigure cached VirtualClient instances for each GUI server.
+
+    The GUI shares one cached VirtualClient per ``host:port`` endpoint. This
+    helper applies timeout settings before PyDM widgets create channels so the
+    whole session uses consistent link-state behavior.
+    """
     for server in serverList.split(","):
         server = server.strip()
         if server == "":
@@ -88,10 +93,14 @@ def runPyDM(
     maxListSize : int, optional
         Debug-tree list-size cap argument forwarded to the UI.
     linkTimeout : float, optional
-        Idle timeout in seconds for VirtualClient link-state detection.
+        Idle timeout in seconds for VirtualClient link-state detection. This is
+        the normal tuning knob for long-running hardware or simulation
+        transactions and defaults to 10 seconds.
     requestStallTimeout : float | None, optional
         In-flight request age in seconds before the VirtualClient declares the
-        server stalled. ``None`` disables stalled-request detection.
+        server stalled. ``None`` disables stalled-request detection, which is
+        usually the right default unless the application has a strict upper
+        bound for valid request duration.
 
     Returns
     -------

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -149,10 +149,29 @@ class RogueConnection(PyDMConnection):
 
     def linkState(self, state: bool) -> None:
         """Emit PyDM connection state updates from link-monitor callbacks."""
+        self.connection_state_signal.emit(state)
+
+        # PyDM labels display the raw channel string while disconnected.
+        # Static Rogue channels such as '/name' do not necessarily receive a
+        # fresh monitor update after the server becomes responsive again, so
+        # push the current value on reconnection to restore the intended text.
         if state:
-            self.connection_state_signal.emit(True)
+            self._emitCurrentValue()
+
+    def _emitCurrentValue(self) -> None:
+        """Emit the current node value/name without changing listener wiring."""
+        if self._node is None:
+            return
+
+        if self._notDev:
+            if self._mode == 'name':
+                self.new_value_signal[str].emit(self._node.name)
+            elif self._mode == 'path':
+                self.new_value_signal[str].emit(self._node.path)
+            else:
+                self._updateVariable(self._node.path, self._node.getVariableValue(read=False, index=self._index))
         else:
-            self.connection_state_signal.emit(False)
+            self.new_value_signal[str].emit(self._node.name)
 
 
     def _updateVariable(self, path: str, varValue: VariableValue) -> None:
@@ -265,18 +284,15 @@ class RogueConnection(PyDMConnection):
 
             self.prec_signal.emit(self._node.precision)
 
-            if self._mode == 'name':
+            if self._mode == 'name' or self._mode == 'path':
                 self.write_access_signal.emit(False)
-                self.new_value_signal[str].emit(self._node.name)
-            elif self._mode == 'path' or self._mode == 'path':
-                self.write_access_signal.emit(False)
-                self.new_value_signal[str].emit(self._node.path)
             else:
                 self.write_access_signal.emit(self._cmd or self._node.mode!='RO')
-                self._updateVariable(self._node.path,self._node.getVariableValue(read=False, index=self._index))
+
+            self._emitCurrentValue()
 
         else:
-            self.new_value_signal[str].emit(self._node.name)
+            self._emitCurrentValue()
 
     def remove_listener(self, channel: PyDMChannel, destroying: bool) -> None:
         """Detach listener resources associated with this connection.

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -117,6 +117,10 @@ rogue::interfaces::ZmqClient::ZmqClient(const std::string& addr, uint16_t port, 
         if (zmq_setsockopt(this->zmqSub_, ZMQ_LINGER, &val, sizeof(int32_t)) != 0)
             throw(rogue::GeneralError("ZmqClient::ZmqClient", "Failed to set socket linger"));
 
+        val = 100;
+        if (zmq_setsockopt(this->zmqSub_, ZMQ_RCVTIMEO, &val, sizeof(int32_t)) != 0)
+            throw(rogue::GeneralError("ZmqClient::ZmqClient", "Failed to set socket timeout"));
+
         if (zmq_connect(this->zmqSub_, temp.c_str()) < 0)
             throw(rogue::GeneralError::create("ZmqClient::ZmqClient",
                                               "Failed to connect to port %" PRIu16 " at address %s",
@@ -353,6 +357,8 @@ void rogue::interfaces::ZmqClient::runThread() {
             bp::object dat = bp::object(handle);
             this->doUpdate(dat);
 #endif
+            zmq_msg_close(&msg);
+        } else {
             zmq_msg_close(&msg);
         }
     }

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -35,6 +35,39 @@
 namespace bp = boost::python;
 #endif
 
+namespace {
+
+constexpr uint32_t kRetryLogIntervalSeconds = 30;
+
+void logWaitRetry(rogue::LoggingPtr log, double seconds, uint32_t& lastLoggedSeconds) {
+    uint32_t elapsedSeconds = static_cast<uint32_t>(seconds);
+
+    if (elapsedSeconds == 0) return;
+
+    if (lastLoggedSeconds == 0) {
+        log->warning(
+            "Timeout waiting for response after %" PRIu32 " seconds, server may be busy. Continuing to wait...",
+            elapsedSeconds);
+        lastLoggedSeconds = elapsedSeconds;
+        return;
+    }
+
+    if (elapsedSeconds >= (lastLoggedSeconds + kRetryLogIntervalSeconds)) {
+        log->warning("Still waiting for response after %" PRIu32 " seconds, server may be busy...", elapsedSeconds);
+        lastLoggedSeconds = elapsedSeconds;
+    }
+}
+
+void logWaitRecovered(rogue::LoggingPtr log, double seconds) {
+    uint32_t elapsedSeconds = static_cast<uint32_t>(seconds);
+
+    if (elapsedSeconds != 0) {
+        log->warning("Received response from server after %" PRIu32 " seconds.", elapsedSeconds);
+    }
+}
+
+}  // namespace
+
 rogue::interfaces::ZmqClientPtr rogue::interfaces::ZmqClient::create(const std::string& addr, uint16_t port, bool doString) {
     rogue::interfaces::ZmqClientPtr ret = std::make_shared<rogue::interfaces::ZmqClient>(addr, port, doString);
     return (ret);
@@ -172,6 +205,7 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
     zmq_msg_t msg;
     std::string data;
     double seconds = 0;
+    uint32_t lastLoggedSeconds = 0;
 
     if (!doString_) throw rogue::GeneralError::create("ZmqClient::sendString", "Invalid send call in standard mode");
 
@@ -190,7 +224,7 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
         if (zmq_recvmsg(this->zmqReq_, &msg, 0) <= 0) {
             seconds += static_cast<double>(timeout_) / 1000.0;
             if (waitRetry_) {
-                log_->error("Timeout waiting for response after %d Seconds, server may be busy! Waiting...", static_cast<int>(seconds));
+                logWaitRetry(log_, seconds, lastLoggedSeconds);
                 zmq_msg_close(&msg);
             } else {
                 throw rogue::GeneralError::create("ZmqClient::sendString",
@@ -202,7 +236,7 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
         }
     }
 
-    if (seconds != 0) log_->error("Finally got response from server after %d seconds!", static_cast<int>(seconds));
+    logWaitRecovered(log_, seconds);
 
     data = std::string((const char*)zmq_msg_data(&msg), zmq_msg_size(&msg));
     zmq_msg_close(&msg);
@@ -233,6 +267,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
     Py_buffer valueBuf;
     bp::object ret;
     double seconds = 0;
+    uint32_t lastLoggedSeconds = 0;
 
     if (doString_) throw rogue::GeneralError::create("ZmqClient::send", "Invalid send call in string mode");
 
@@ -252,8 +287,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
             if (zmq_recvmsg(this->zmqReq_, &rxMsg, 0) <= 0) {
                 seconds += static_cast<double>(timeout_) / 1000.0;
                 if (waitRetry_) {
-                    log_->error("Timeout waiting for response after %d Seconds, server may be busy! Waiting...",
-                                static_cast<int>(seconds));
+                    logWaitRetry(log_, seconds, lastLoggedSeconds);
                     zmq_msg_close(&rxMsg);
                 } else {
                     throw rogue::GeneralError::create(
@@ -267,7 +301,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
         }
     }
 
-    if (seconds != 0) log_->error("Finally got response from server after %d seconds!", static_cast<int>(seconds));
+    logWaitRecovered(log_, seconds);
 
     PyObject* val = Py_BuildValue("y#", zmq_msg_data(&rxMsg), zmq_msg_size(&rxMsg));
 

--- a/tests/test_pydm_rogue_plugin.py
+++ b/tests/test_pydm_rogue_plugin.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from pyrogue.pydm.data_plugins.rogue_plugin import RogueConnection
+except Exception as exc:
+    pytest.skip(f"PyDM/Qt test dependencies unavailable: {exc}", allow_module_level=True)
+
+
+class _SignalRecorder:
+    def __init__(self):
+        self.values = []
+
+    def __getitem__(self, _key):
+        return self
+
+    def emit(self, value):
+        self.values.append(value)
+
+
+def test_rogue_connection_link_state_refreshes_static_name_channels():
+    conn = object.__new__(RogueConnection)
+    conn._node = SimpleNamespace(name="MyVar", path="root.MyVar")
+    conn._notDev = True
+    conn._mode = "name"
+    conn._index = -1
+    conn.connection_state_signal = _SignalRecorder()
+    conn.new_value_signal = _SignalRecorder()
+
+    RogueConnection.linkState(conn, False)
+    assert conn.connection_state_signal.values == [False]
+    assert conn.new_value_signal.values == []
+
+    RogueConnection.linkState(conn, True)
+    assert conn.connection_state_signal.values == [False, True]
+    assert conn.new_value_signal.values == ["MyVar"]

--- a/tests/test_pydm_run_config.py
+++ b/tests/test_pydm_run_config.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_pydm_module(call_log):
+    module_path = Path(__file__).resolve().parents[1] / "python/pyrogue/pydm/__init__.py"
+
+    fake_pydm = types.ModuleType("pydm")
+    fake_pydm.PyDMApplication = type("FakeApp", (), {"instance": staticmethod(lambda: None)})
+
+    fake_pydm_data_plugins = types.ModuleType("pydm.data_plugins")
+    fake_pydm_data_plugins.plugin_modules = {}
+    fake_pydm_data_plugins.initialize_plugins_if_needed = lambda: None
+    fake_pydm_data_plugins.add_plugin = lambda plugin: None
+    fake_pydm.data_plugins = fake_pydm_data_plugins
+
+    fake_pyrogue = types.ModuleType("pyrogue")
+    fake_pyrogue.__path__ = []
+
+    fake_pyrogue_interfaces = types.ModuleType("pyrogue.interfaces")
+
+    class FakeVirtualClient:
+        def __init__(self, **kwargs):
+            call_log.append(kwargs)
+
+    fake_pyrogue_interfaces.VirtualClient = FakeVirtualClient
+
+    fake_pyrogue_pydm = types.ModuleType("pyrogue.pydm")
+    fake_pyrogue_pydm.__path__ = []
+
+    fake_rogue_plugin_module = types.ModuleType("pyrogue.pydm.data_plugins.rogue_plugin")
+    fake_rogue_plugin_module.RoguePlugin = object()
+
+    saved_modules = {}
+    for name, module in {
+        "pydm": fake_pydm,
+        "pydm.data_plugins": fake_pydm_data_plugins,
+        "pyrogue": fake_pyrogue,
+        "pyrogue.interfaces": fake_pyrogue_interfaces,
+        "pyrogue.pydm": fake_pyrogue_pydm,
+        "pyrogue.pydm.data_plugins.rogue_plugin": fake_rogue_plugin_module,
+    }.items():
+        saved_modules[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        spec = importlib.util.spec_from_file_location("rogue_test_pydm_module", module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_configure_virtual_clients_applies_timeouts_to_each_server():
+    call_log = []
+    module = _load_pydm_module(call_log)
+
+    module._configureVirtualClients(
+        "host-a:9099, host-b:9103",
+        linkTimeout=25.0,
+        requestStallTimeout=None,
+    )
+
+    assert call_log == [
+        {
+            "addr": "host-a",
+            "port": 9099,
+            "linkTimeout": 25.0,
+            "requestStallTimeout": None,
+        },
+        {
+            "addr": "host-b",
+            "port": 9103,
+            "linkTimeout": 25.0,
+            "requestStallTimeout": None,
+        },
+    ]

--- a/tests/test_pydm_run_config.py
+++ b/tests/test_pydm_run_config.py
@@ -20,12 +20,22 @@ def _load_pydm_module(call_log):
 
     fake_pydm = types.ModuleType("pydm")
     fake_pydm.PyDMApplication = type("FakeApp", (), {"instance": staticmethod(lambda: None)})
+    fake_pydm.Display = type("FakeDisplay", (), {})
 
     fake_pydm_data_plugins = types.ModuleType("pydm.data_plugins")
     fake_pydm_data_plugins.plugin_modules = {}
     fake_pydm_data_plugins.initialize_plugins_if_needed = lambda: None
     fake_pydm_data_plugins.add_plugin = lambda plugin: None
     fake_pydm.data_plugins = fake_pydm_data_plugins
+
+    fake_pydm_widgets = types.ModuleType("pydm.widgets")
+    fake_pydm_widgets.__path__ = []
+
+    fake_pydm_widgets_rules = types.ModuleType("pydm.widgets.rules")
+    fake_pydm_widgets_rules.register_widget_rules = lambda widget: None
+
+    fake_pydm_utilities = types.ModuleType("pydm.utilities")
+    fake_pydm_utilities.establish_widget_connections = lambda widget: None
 
     fake_pyrogue = types.ModuleType("pyrogue")
     fake_pyrogue.__path__ = []
@@ -48,6 +58,9 @@ def _load_pydm_module(call_log):
     for name, module in {
         "pydm": fake_pydm,
         "pydm.data_plugins": fake_pydm_data_plugins,
+        "pydm.widgets": fake_pydm_widgets,
+        "pydm.widgets.rules": fake_pydm_widgets_rules,
+        "pydm.utilities": fake_pydm_utilities,
         "pyrogue": fake_pyrogue,
         "pyrogue.interfaces": fake_pyrogue_interfaces,
         "pyrogue.pydm": fake_pyrogue_pydm,

--- a/tests/test_virtual_client_connect.py
+++ b/tests/test_virtual_client_connect.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import os
+import time
+
+import pyrogue
+import pyrogue.interfaces
+import pytest
+
+
+def _test_port(index: int) -> int:
+    """Return a stable high port for the current process."""
+    return 22000 + ((os.getpid() % 1000) * 16) + (index * 4)
+
+
+def _clear_virtual_client_cache() -> None:
+    """Stop any cached VirtualClient instances left by the test process."""
+    for client in list(pyrogue.interfaces.VirtualClient.ClientCache.values()):
+        try:
+            client.stop()
+            client._stop()
+        except Exception:
+            pass
+
+    pyrogue.interfaces.VirtualClient.ClientCache.clear()
+
+
+class SlowFirstRootServer(pyrogue.interfaces.ZmqServer):
+    def __init__(self, *, root, addr: str, port: int, initial_root_delay: float = 0.0):
+        super().__init__(root=root, addr=addr, port=port)
+        self._initial_root_delay = initial_root_delay
+        self._root_delay_done = False
+
+    def _doOperation(self, d):
+        if (not self._root_delay_done) and d.get('path') == '__ROOT__' and self._initial_root_delay > 0.0:
+            self._root_delay_done = True
+            time.sleep(self._initial_root_delay)
+
+        return super()._doOperation(d)
+
+
+class VirtualConnectRoot(pyrogue.Root):
+    def __init__(self, *, name: str, port: int, initial_root_delay: float = 0.0):
+        super().__init__(name=name, pollEn=False)
+        self.add(pyrogue.LocalVariable(name='Value', value=5, mode='RO'))
+        self.zmqServer = SlowFirstRootServer(
+            root=self,
+            addr='127.0.0.1',
+            port=port,
+            initial_root_delay=initial_root_delay,
+        )
+        self.addInterface(self.zmqServer)
+
+
+def test_virtual_client_retries_initial_root_handshake(monkeypatch):
+    port = _test_port(0)
+    _clear_virtual_client_cache()
+    monkeypatch.setenv('ROGUE_VIRTUAL_CONNECT_TIMEOUT', '5.0')
+
+    try:
+        with VirtualConnectRoot(name='ConnectRoot', port=port, initial_root_delay=1.5):
+            client = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+
+            try:
+                assert client.root is not None
+                assert client.root.name == 'ConnectRoot'
+                assert client.root.Value.value() == 5
+            finally:
+                client.stop()
+                client._stop()
+    finally:
+        _clear_virtual_client_cache()
+
+
+def test_virtual_client_does_not_cache_failed_bootstrap(monkeypatch):
+    port = _test_port(1)
+    cache_key = hash(('127.0.0.1', port))
+    _clear_virtual_client_cache()
+    monkeypatch.setenv('ROGUE_VIRTUAL_CONNECT_TIMEOUT', '1.0')
+
+    try:
+        failed = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+
+        assert failed.root is None
+        assert cache_key not in pyrogue.interfaces.VirtualClient.ClientCache
+
+        with VirtualConnectRoot(name='RecoveredRoot', port=port):
+            recovered = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+
+            try:
+                assert recovered.root is not None
+                assert recovered.root.name == 'RecoveredRoot'
+                assert recovered.root.Value.value() == 5
+            finally:
+                recovered.stop()
+                recovered._stop()
+    finally:
+        _clear_virtual_client_cache()

--- a/tests/test_virtual_client_connect.py
+++ b/tests/test_virtual_client_connect.py
@@ -14,7 +14,6 @@ import time
 
 import pyrogue
 import pyrogue.interfaces
-import pytest
 
 
 def _test_port(index: int) -> int:

--- a/tests/test_virtual_client_link.py
+++ b/tests/test_virtual_client_link.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import importlib.util
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_virtual_client():
+    module_path = Path(__file__).resolve().parents[1] / "python/pyrogue/interfaces/_Virtual.py"
+    spec = importlib.util.spec_from_file_location("rogue_test_virtual_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.VirtualClient
+
+
+VirtualClient = _load_virtual_client()
+
+
+class _LogRecorder:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, message):
+        self.messages.append(message)
+
+
+def _make_client(link_timeout=10.0, request_stall_timeout=None):
+    client = VirtualClient.__new__(VirtualClient, "localhost", 9099)
+    client._monitors = []
+    client._root = SimpleNamespace(name="root")
+    client._log = _LogRecorder()
+    client._reqLock = threading.Lock()
+    client._reqCount = 0
+    client._reqSince = None
+    client._ltime = time.time()
+    client._link = True
+    client._linkTimeout = link_timeout
+    client._requestStallTimeout = request_stall_timeout
+    return client
+
+
+def test_virtual_client_stays_linked_while_request_is_pending():
+    client = _make_client()
+    states = []
+    client._monitors.append(states.append)
+    client._ltime = time.time() - 30.0
+    client._requestStart()
+
+    client._checkLinkState()
+
+    assert client.linked is True
+    assert states == []
+
+
+def test_virtual_client_disconnects_after_idle_timeout():
+    client = _make_client()
+    states = []
+    client._monitors.append(states.append)
+    client._ltime = time.time() - 30.0
+
+    client._checkLinkState()
+
+    assert client.linked is False
+    assert states == [False]
+
+
+def test_virtual_client_successful_request_restores_link_state():
+    client = _make_client()
+    states = []
+    client._monitors.append(states.append)
+    client._link = False
+    client._requestStart()
+
+    client._requestDone(True)
+
+    assert client.linked is True
+    assert states == [True]
+
+
+def test_virtual_client_declares_stalled_request_after_configured_timeout():
+    client = _make_client(request_stall_timeout=5.0)
+    states = []
+    client._monitors.append(states.append)
+    client._ltime = time.time() - 30.0
+    client._requestStart()
+    client._reqSince = time.time() - 6.0
+
+    client._checkLinkState()
+
+    assert client.linked is False
+    assert states == [False]


### PR DESCRIPTION
## Summary
This PR fixes a long-standing PyDM `debug_tree` display bug that shows fully qualified Rogue channel paths in every tree row after a long-running device read completes through `ZmqServer` / `VirtualClient`.

It also includes transport-side fixes that came out of debugging that behavior:

- `VirtualClient` link-state handling now treats long in-flight requests as busy work instead of transient disconnects.
- `VirtualClient` startup now tolerates a slow initial `__ROOT__` reply instead of caching a failed half-initialized client.
- `ZmqClient` retry logging is throttled so long transactions do not emit a timeout warning every second.
- `ZmqClient` shutdown is more reliable when a client bootstrap attempt fails.

## Long Name Bug
### Symptom
When a PyDM GUI is connected to a Rogue tree through `ZmqServer`, a long-running recursive read such as `ReadDevice` can leave the `debug_tree` widget in a broken state:

- the GUI shows repeated messages like `Timeout waiting for response after XX Seconds, server may be busy!`
- once the long transaction finally completes, each `debug_tree` leaf shows the full Rogue channel path instead of the short node name
- reading an individual variable from the GUI fixes that one row because it forces a fresh value update

### Root Cause
The bug was caused by an interaction between three pieces of behavior:

1. `debug_tree` renders node names with `PyDMLabel` widgets connected to `<path>/name`.
2. `PyDMLabel` falls back to displaying the raw channel string while the channel is disconnected.
3. `VirtualClient` only used publish/update traffic as proof of life. During a long blocking request, the client could go more than 10 seconds without receiving publish traffic, so it marked the link down even though the request was still legitimately in flight.

That caused the `PyDMLabel` widgets in the tree to switch from short names to the full channel string.

When the server eventually responded, the link state recovered, but static channels such as `/name` did not necessarily receive a fresh monitor update. As a result, the labels stayed stuck on the full path until some other action refreshed that specific node.

### Fix
The Rogue PyDM data plugin now explicitly re-emits the current cached value when the shared `VirtualClient` link comes back up.

That reconnect refresh restores the intended text for:

- `/name`
- `/path`
- device-name rows
- cached variable displays

This makes the `debug_tree` recover immediately once the long request finishes instead of waiting for another manual read.

## VirtualClient Timeout Handling
### Problem
The label bug exposed a more general issue in `VirtualClient`: long-running requests were treated like disconnects because lack of publish updates was interpreted as lack of connectivity.

That is not correct for firmware co-simulation or any backend where a legitimate memory transaction can remain in flight for many seconds or minutes.

### Fix
`VirtualClient` now tracks outstanding request/reply activity separately from publish traffic.

- while a request is in flight, the client remains linked instead of declaring the server disconnected after the idle heartbeat window
- a successful request reply now counts as proof of life and refreshes the link state immediately

The client also now supports explicit timeout configuration:

- `linkTimeout`: idle timeout before the link is considered down
- `requestStallTimeout`: optional maximum age for an in-flight request before it is considered stalled

In practice:

- `linkTimeout` is the primary operational knob and is the one most applications should tune
- `requestStallTimeout` is a niche policy knob and is usually best left disabled unless a deployment has a clear upper bound for legitimate request duration

By default:

- `linkTimeout` remains 10 seconds
- `requestStallTimeout` is disabled so long co-sim transactions are treated as busy rather than dead

These settings can now be passed directly through `pyrogue.pydm.runPyDM(...)`, which preconfigures the cached `VirtualClient` instances used by the PyDM plugin.

## VirtualClient Startup Bootstrap
### Problem
While testing the timeout changes, this branch also exposed an older startup bug in `VirtualClient` bootstrap.

The initial `__ROOT__` request was treated as a one-shot 1 second operation. If the server took slightly longer to answer, `VirtualClient` returned early but had already inserted itself into the shared client cache. That left a poisoned cached object with no root tree attached, and every later `VirtualClient(addr, port)` in that process reused the broken instance.

This was especially visible in PyDM because the branch now eagerly preconfigures cached `VirtualClient` instances before widgets attach.

### Fix
`VirtualClient` startup now uses a bounded bootstrap window for the initial `__ROOT__` handshake instead of a single 1 second failure path.

- the initial connect retries until a short deadline expires
- the default bootstrap timeout is 5 seconds
- the timeout can be overridden with `ROGUE_VIRTUAL_CONNECT_TIMEOUT`
- failed bootstrap clients are removed from the cache and their transport is shut down cleanly

This preserves normal startup behavior for a healthy server, avoids poisoning the shared cache, and makes PyDM attach more robust when the server is busy during startup.

## ZmqClient Logging And Shutdown
### Problem
The previous retry behavior emitted a timeout log message once per receive-timeout interval, which meant an intentional long transaction produced log spam every second.

The same code path also made cleanup of a failed startup client awkward because the subscriber thread could block indefinitely waiting on traffic.

### Fix
`ZmqClient` now logs retry waits at a much lower rate:

- one warning when the client first enters the wait-retry path
- periodic "still waiting" warnings every 30 seconds
- one recovery message when the response finally arrives

It also now applies a receive timeout on the subscriber socket so failed bootstrap clients can stop cleanly during teardown.

This preserves visibility into a busy server without flooding the log during long operations and makes failed startup cleanup deterministic.

## Documentation
The user-facing docs and docstrings were updated to explain:

- why `linkTimeout` is the normal timeout to tune
- why `requestStallTimeout` is optional and often unnecessary
- how to pass these settings through `VirtualClient(...)` and `pyrogue.pydm.runPyDM(...)`
- how `ZmqClient` retry logging now behaves during long waits
- how `ROGUE_VIRTUAL_CONNECT_TIMEOUT` affects initial bootstrap only

## Tests
- `conda run -n rogue_build python -m pytest -q tests/test_virtual_client_link.py`
- `conda run -n rogue_build python -m pytest -q tests/test_virtual_client_connect.py`
- `conda run -n rogue_build python -m pytest -q tests/test_pydm_run_config.py`

`tests/test_pydm_rogue_plugin.py` was added for the PyDM reconnect refresh logic, but it requires a Qt/PyDM environment that is not available in the current shell configuration.
