### PR TITLE
Fix RSSI maxPayload sizing

### DIFF
--- a/docs/src/built_in_modules/protocols/network.rst
+++ b/docs/src/built_in_modules/protocols/network.rst
@@ -45,8 +45,9 @@ Implementation Details
 - Packetizer selection by ``packVer``:
   ``packVer=1`` uses ``packetizer.Core(enSsi)``;
   ``packVer=2`` uses ``packetizer.CoreV2(False, True, enSsi)``.
-- RSSI segment size is derived from transport payload budget:
-  ``udp.maxPayload() - 8``.
+- RSSI segment size is derived from the full transport payload budget:
+  ``udp.maxPayload()``. The RSSI controller internally reserves its own
+  8-byte header within that segment size.
 
 When To Use
 ===========

--- a/docs/src/built_in_modules/protocols/rssi/client.rst
+++ b/docs/src/built_in_modules/protocols/rssi/client.rst
@@ -20,7 +20,7 @@ Construction
 
 ``Client(segSize)`` is shaped primarily by ``segSize``, the initial local
 maximum segment size in bytes. In real deployments this is usually derived from
-the lower transport payload budget, for example ``udp.maxPayload() - 8``.
+the full lower transport payload budget, for example ``udp.maxPayload()``.
 
 Use ``transport()`` to connect the lower transport and ``application()`` to
 connect upper protocol blocks such as packetizer or SRP.
@@ -73,7 +73,7 @@ Python Example
    import rogue.protocols.rssi
 
    udp = rogue.protocols.udp.Client("127.0.0.1", 8200, True)
-   rssi = rogue.protocols.rssi.Client(udp.maxPayload() - 8)
+   rssi = rogue.protocols.rssi.Client(udp.maxPayload())
 
    # Link-layer stream connection.
    udp == rssi.transport()
@@ -89,7 +89,7 @@ Standalone script pattern:
 .. code-block:: python
 
    udp = rogue.protocols.udp.Client("127.0.0.1", 8200, True)
-   rssi = rogue.protocols.rssi.Client(udp.maxPayload() - 8)
+   rssi = rogue.protocols.rssi.Client(udp.maxPayload())
    udp == rssi.transport()
 
    rssi._start()

--- a/docs/src/built_in_modules/protocols/rssi/index.rst
+++ b/docs/src/built_in_modules/protocols/rssi/index.rst
@@ -138,7 +138,7 @@ shape:
 
    # Server side
    s_udp = rogue.protocols.udp.Server(0, True)
-   s_rssi = rogue.protocols.rssi.Server(s_udp.maxPayload() - 8)
+   s_rssi = rogue.protocols.rssi.Server(s_udp.maxPayload())
    s_pack = rogue.protocols.packetizer.CoreV2(True, True, True)
 
    s_udp == s_rssi.transport()
@@ -146,7 +146,7 @@ shape:
 
    # Client side
    c_udp = rogue.protocols.udp.Client("127.0.0.1", s_udp.getPort(), True)
-   c_rssi = rogue.protocols.rssi.Client(c_udp.maxPayload() - 8)
+   c_rssi = rogue.protocols.rssi.Client(c_udp.maxPayload())
    c_pack = rogue.protocols.packetizer.CoreV2(True, True, True)
 
    c_udp == c_rssi.transport()
@@ -172,10 +172,10 @@ C++ Example
    namespace rpr = rogue::protocols::rssi;
 
    auto sUdp  = rpu::Server::create(0, true);
-   auto sRssi = rpr::Server::create(sUdp->maxPayload() - 8);
+   auto sRssi = rpr::Server::create(sUdp->maxPayload());
 
    auto cUdp  = rpu::Client::create("127.0.0.1", sUdp->getPort(), true);
-   auto cRssi = rpr::Client::create(cUdp->maxPayload() - 8);
+   auto cRssi = rpr::Client::create(cUdp->maxPayload());
 
    sUdp == sRssi->transport();
    cUdp == cRssi->transport();

--- a/docs/src/built_in_modules/protocols/rssi/server.rst
+++ b/docs/src/built_in_modules/protocols/rssi/server.rst
@@ -73,7 +73,7 @@ Python Example
    import rogue.protocols.rssi
 
    udp = rogue.protocols.udp.Server(0, True)
-   rssi = rogue.protocols.rssi.Server(udp.maxPayload() - 8)
+   rssi = rogue.protocols.rssi.Server(udp.maxPayload())
 
    # Link-layer stream connection.
    udp == rssi.transport()
@@ -89,7 +89,7 @@ Standalone script pattern:
 .. code-block:: python
 
    udp = rogue.protocols.udp.Server(0, True)
-   rssi = rogue.protocols.rssi.Server(udp.maxPayload() - 8)
+   rssi = rogue.protocols.rssi.Server(udp.maxPayload())
    udp == rssi.transport()
 
    rssi._start()

--- a/docs/src/built_in_modules/protocols/udp/index.rst
+++ b/docs/src/built_in_modules/protocols/udp/index.rst
@@ -56,9 +56,9 @@ Payload Sizing And MTU
 - Jumbo mode (``jumbo=True``): ``8972`` bytes payload
 - Standard mode (``jumbo=False``): ``1472`` bytes payload
 
-When UDP is used under RSSI, RSSI payload is typically derived from UDP payload
-budget (for example ``udp.maxPayload() - 8`` as used in integration tests and
-wrapper patterns).
+When UDP is used under RSSI, the RSSI segment size is typically derived from
+the full UDP payload budget (for example ``udp.maxPayload()``). RSSI then
+reserves its own 8-byte header within that segment size.
 
 Threading And Lifecycle
 =======================
@@ -96,8 +96,8 @@ Python Example
    serv = rogue.protocols.udp.Server(0, True)
    cli = rogue.protocols.udp.Client("127.0.0.1", serv.getPort(), True)
 
-   s_rssi = rogue.protocols.rssi.Server(serv.maxPayload() - 8)
-   c_rssi = rogue.protocols.rssi.Client(cli.maxPayload() - 8)
+   s_rssi = rogue.protocols.rssi.Server(serv.maxPayload())
+   c_rssi = rogue.protocols.rssi.Client(cli.maxPayload())
 
    s_pkt = rogue.protocols.packetizer.CoreV2(True, True, True)
    c_pkt = rogue.protocols.packetizer.CoreV2(True, True, True)

--- a/include/rogue/protocols/rssi/Client.h
+++ b/include/rogue/protocols/rssi/Client.h
@@ -63,7 +63,8 @@ class Client {
      * is shared across Rogue graph connections or exposed to Python.
      * It returns `std::shared_ptr` ownership compatible with Rogue pointer typedefs.
      *
-     * @param segSize Initial local maximum segment size.
+     * @param segSize Initial local maximum segment size, including the RSSI
+     * header bytes carried on the lower transport.
      * @return Shared pointer to the created client bundle.
      */
     static std::shared_ptr<rogue::protocols::rssi::Client> create(uint32_t segSize);
@@ -78,7 +79,8 @@ class Client {
      * This constructor is a low-level C++ allocation path.
      * Prefer `create()` when shared ownership or Python exposure is required.
      *
-     * @param segSize Initial local maximum segment size.
+     * @param segSize Initial local maximum segment size, including the RSSI
+     * header bytes carried on the lower transport.
      */
     explicit Client(uint32_t segSize);
 

--- a/include/rogue/protocols/rssi/Server.h
+++ b/include/rogue/protocols/rssi/Server.h
@@ -63,7 +63,8 @@ class Server {
      * is shared across Rogue graph connections or exposed to Python.
      * It returns `std::shared_ptr` ownership compatible with Rogue pointer typedefs.
      *
-     * @param segSize Initial local maximum segment size.
+     * @param segSize Initial local maximum segment size, including the RSSI
+     * header bytes carried on the lower transport.
      * @return Shared pointer to the created server bundle.
      */
     static std::shared_ptr<rogue::protocols::rssi::Server> create(uint32_t segSize);
@@ -78,7 +79,8 @@ class Server {
      * This constructor is a low-level C++ allocation path.
      * Prefer `create()` when shared ownership or Python exposure is required.
      *
-     * @param segSize Initial local maximum segment size.
+     * @param segSize Initial local maximum segment size, including the RSSI
+     * header bytes carried on the lower transport.
      */
     explicit Server(uint32_t segSize);
 

--- a/python/pyrogue/protocols/_Network.py
+++ b/python/pyrogue/protocols/_Network.py
@@ -77,12 +77,12 @@ class UdpRssiPack(pr.Device):
         # Check if running as server
         if server:
             self._udp  = rogue.protocols.udp.Server(port,jumbo)
-            self._rssi = rogue.protocols.rssi.Server(self._udp.maxPayload()-8)
+            self._rssi = rogue.protocols.rssi.Server(self._udp.maxPayload())
 
         # Else running as client
         else:
             self._udp  = rogue.protocols.udp.Client(host,port,jumbo)
-            self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload()-8)
+            self._rssi = rogue.protocols.rssi.Client(self._udp.maxPayload())
 
         # Check if Packeterizer Version 2: https://confluence.slac.stanford.edu/x/3nh4DQ
         if packVer == 2:

--- a/tests/test_udpPacketizer.py
+++ b/tests/test_udpPacketizer.py
@@ -79,8 +79,8 @@ def data_path(ver,jumbo):
     client = rogue.protocols.udp.Client("127.0.0.1",port,jumbo)
 
     # RSSI
-    sRssi = rogue.protocols.rssi.Server(serv.maxPayload() - 8)
-    cRssi = rogue.protocols.rssi.Client(client.maxPayload() - 8)
+    sRssi = rogue.protocols.rssi.Server(serv.maxPayload())
+    cRssi = rogue.protocols.rssi.Client(client.maxPayload())
 
     # Packetizer
     if ver == 1:


### PR DESCRIPTION
## Summary
- restore RSSI segment sizing to use the full UDP payload budget via `udp.maxPayload()`
- update `UdpRssiPack`, the UDP packetizer regression test, and the RSSI/UDP docs to match the controller semantics
- clarify in the RSSI client/server headers that `segSize` already includes the RSSI header budget on the lower transport

## Root Cause
RSSI `segSize` is already the total on-wire segment budget. Subtracting 8 at the call site double-counted the RSSI header and reduced the effective segment size, which broke the `CoreV2` non-jumbo UDP packetizer path under reordering.

## Verification
- ran `tests.test_udpPacketizer.test_data_path()` in the branch worktree
- verified all four combinations pass, including `ver=2 jumbo=False`
