### PR TITLE
Add EPICS V4 RPC test coverage and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bld-dir/*
 rogue.egg-info*
 .vscode/
 .cursor/
+.claude/

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,177 @@
+# Architecture
+
+**Analysis Date:** 2026-03-24
+
+## Pattern Overview
+
+**Overall:** Dual-layer hardware abstraction framework (C++ core with Python orchestration layer)
+
+**Key Characteristics:**
+- C++ core library (`rogue-core`) provides high-performance stream and memory interfaces, compiled as a shared library
+- Boost.Python bindings expose the C++ core as the `rogue` Python module (compiled as `rogue.so`)
+- Pure Python layer (`pyrogue`) builds a device tree, configuration management, and GUI on top of the C++ `rogue` module
+- Master/Slave pattern governs all data flow (both stream and memory interfaces)
+- The framework is designed for FPGA register access and data streaming at SLAC National Accelerator Laboratory
+
+## Layers
+
+**C++ Core Library (`rogue-core`):**
+- Purpose: High-performance stream I/O, memory transaction management, protocol implementations, and hardware drivers
+- Location: `src/rogue/`, `include/rogue/`
+- Contains: Stream/memory interface abstractions, protocol encoders/decoders (SRP, RSSI, packetizer, UDP, batcher, Xilinx XVC), hardware drivers (AXI DMA, memory-mapped I/O), utilities (PRBS, compression, file I/O), logging, error handling
+- Depends on: Boost.Python, ZeroMQ, BZip2, NumPy, POSIX/Linux APIs
+- Used by: Python `rogue` module, C++ API consumers via `librogue-core.so`
+
+**Boost.Python Binding Layer:**
+- Purpose: Expose C++ classes to Python with virtual method overriding support
+- Location: `src/package.cpp` (BOOST_PYTHON_MODULE entry), `src/rogue/module.cpp` (module registration), each C++ class has a `setup_python()` static method
+- Contains: Python module initialization, `*Wrap` classes that enable Python subclassing of C++ virtual methods
+- Depends on: `rogue-core`, Boost.Python
+- Used by: Python `pyrogue` layer
+
+**Python Orchestration Layer (`pyrogue`):**
+- Purpose: Device tree management, variable/command abstraction, configuration load/save, polling, GUI integration, remote client/server
+- Location: `python/pyrogue/`
+- Contains: Node/Device/Root tree classes, Variable/Command abstractions, Block memory grouping, Model data type conversions, PollQueue, ZMQ server/client, PyDM GUI widgets, EPICS interface, simulation support
+- Depends on: `rogue` (C++ module), PyYAML, NumPy, ZMQ (Python), optionally PyDM/Qt for GUI
+- Used by: End-user applications that define hardware device trees
+
+## Data Flow
+
+**Stream Interface (Frame-Based):**
+
+1. `stream::Master` requests a `Frame` from its primary `Slave` via `reqFrame()` -- `Slave` inherits `Pool` which allocates `Buffer` objects
+2. `Master` populates the frame payload using `FrameIterator` to write across `Buffer` boundaries
+3. `Master` calls `sendFrame()` which delivers the frame to all attached `Slave` objects via `acceptFrame()`
+4. Secondary slaves receive frames first (in attachment order), primary slave receives last
+5. `Slave` subclasses override `acceptFrame()` to process, transform, or forward data
+6. Bridge classes inherit both `Master` and `Slave` for transform/protocol-layer chaining
+
+**Connection operators:** `master >> slave` or `slave << master` (both C++ and Python). The `==` operator also attaches slaves.
+
+**Memory Interface (Transaction-Based):**
+
+1. `memory::Master` calls `reqTransaction()` specifying address, size, data pointer, and type (Read/Write/Post/Verify)
+2. Transaction propagates down through `memory::Hub` nodes, each applying its address offset
+3. Leaf `memory::Slave` receives the transaction via `doTransaction()` and performs hardware I/O
+4. Transaction completion is signaled back; `Master` calls `waitTransaction()` to block until done
+5. At the pyrogue level, `Device` extends `Hub` and groups variables into `Block` objects for batched transactions
+
+**Connection:** `master >> slave` or `master._setSlave(slave)` in Python.
+
+**PyRogue Device Tree Data Flow:**
+
+1. `Root` (extends `Device`) is the top-level container; user adds `Device` sub-nodes via `root.add(device)`
+2. Each `Device` contains `Variable` and `Command` nodes; variables map to `Block` objects that manage memory transactions
+3. `Root.start()` initializes the tree, optionally performs initial read/write, starts `PollQueue` and update worker threads
+4. Variable changes queue to `UpdateTracker` which batches and dispatches to registered `VarListener` callbacks
+5. Configuration is saved/loaded as YAML; state includes all RW/RO variables; config includes RW/WO only
+
+**State Management:**
+- Variable state is tracked in `Block` objects (C++ `rogue::interfaces::memory::Block`) with stale/verify masks
+- `PollQueue` schedules periodic reads of polled variables using a heap-based priority queue
+- `UpdateTracker` batches variable updates and delivers them to listeners via a queue-based worker thread
+- `Root` provides `updateGroup()` context manager for atomic batched updates
+
+## Key Abstractions
+
+**Node (`pyrogue._Node.Node`):**
+- Purpose: Base class for all tree elements with name, path, parent, children, groups, logging
+- Examples: `python/pyrogue/_Node.py`
+- Pattern: Composite pattern - each node has `_nodes` (OrderedDict of children), attribute-based navigation (`root.device.variable`)
+
+**Device (`pyrogue._Device.Device`):**
+- Purpose: Represents a hardware component with memory-mapped registers
+- Examples: `python/pyrogue/_Device.py`, `python/pyrogue/examples/_AxiVersion.py`
+- Pattern: Extends both `Node` and `rogue.interfaces.memory.Hub`; contains `Variable`, `Command`, and sub-`Device` nodes; manages `Block` objects
+
+**Variable (`pyrogue._Variable.py`):**
+- Purpose: Represents a single register field or local value with get/set, type conversion, polling
+- Examples: `python/pyrogue/_Variable.py` (BaseVariable, RemoteVariable, LocalVariable, LinkVariable)
+- Pattern: `RemoteVariable` maps to bits within a `Block`; `LocalVariable` stores value in Python; `LinkVariable` derives value from other variables
+
+**Command (`pyrogue._Command.py`):**
+- Purpose: Represents an executable action, optionally writing to hardware
+- Examples: `python/pyrogue/_Command.py` (BaseCommand, LocalCommand, RemoteCommand)
+- Pattern: Extends `BaseVariable`; `function` callback receives `root`, `dev`, `cmd`, `arg` keyword arguments
+
+**Block (`rogue.interfaces.memory.Block` / `pyrogue._Block.py`):**
+- Purpose: Groups contiguous register variables for batch memory transactions
+- Examples: `include/rogue/interfaces/memory/Block.h`, `python/pyrogue/_Block.py`
+- Pattern: Each block owns a byte array; variables reference bit ranges within it; transactions are block-level Read/Write/Post/Verify
+
+**Frame (`rogue.interfaces.stream.Frame`):**
+- Purpose: Container for streaming data payloads
+- Examples: `include/rogue/interfaces/stream/Frame.h`
+- Pattern: Owns an ordered list of `Buffer` objects; `FrameIterator` provides byte-level traversal across buffer boundaries; carries metadata (flags, channel, error)
+
+**Pool (`rogue.interfaces.stream.Pool`):**
+- Purpose: Memory allocator for stream frames and buffers
+- Examples: `include/rogue/interfaces/stream/Pool.h`
+- Pattern: Base class for `Slave`; supports fixed-size buffers and pooled reuse for high-rate streaming
+
+**Hub (`rogue.interfaces.memory.Hub`):**
+- Purpose: Intermediate node in memory bus tree; applies address offsets and forwards transactions
+- Examples: `include/rogue/interfaces/memory/Hub.h`
+- Pattern: Inherits both `memory::Master` and `memory::Slave`; can act as virtual root with its own access limits
+
+## Entry Points
+
+**Python Module (`python -m pyrogue`):**
+- Location: `python/pyrogue/__main__.py`
+- Triggers: Command-line invocation as `python -m pyrogue <cmd>`
+- Responsibilities: Client-side operations (GUI launch, system log monitoring, variable get/set/monitor) connecting to a running `ZmqServer`
+
+**C++ Shared Library:**
+- Location: `src/package.cpp` (BOOST_PYTHON_MODULE entry point)
+- Triggers: `import rogue` in Python
+- Responsibilities: Initializes Boost.Python module, registers all C++ types via hierarchical `setup_module()` calls, prints version
+
+**Root.start() / Root.stop():**
+- Location: `python/pyrogue/_Root.py`
+- Triggers: User application calls `root.start()` (or uses context manager `with Root() as root:`)
+- Responsibilities: Builds memory blocks, resolves variable overlaps, starts poll queue, starts ZMQ server, performs optional initial read/write, starts update worker threads
+
+**CMake Build:**
+- Location: `CMakeLists.txt`
+- Triggers: `cmake . && make`
+- Responsibilities: Builds `librogue-core.so` (C++ core) and `rogue.so` (Python extension module)
+
+## Error Handling
+
+**Strategy:** Hierarchical exception types with C++ to Python translation
+
+**Patterns:**
+- `rogue::GeneralError` (`include/rogue/GeneralError.h`): Primary C++ exception type, formatted as `source: message`, translated to Python via `setup_python()` / `translate()`
+- `pyrogue.MemoryError`: Memory transaction errors, logged at error level (not exception level) via `logException()` in `python/pyrogue/_Node.py`
+- `pyrogue.VariableError`, `pyrogue.CommandError`, `pyrogue.NodeError`, `pyrogue.DeviceError`: Domain-specific Python exceptions in their respective modules
+- C++ `GilRelease` (`include/rogue/GilRelease.h`) and `ScopedGil` (`include/rogue/ScopedGil.h`): RAII wrappers for Python GIL management to prevent deadlocks in cross-language calls
+- Transaction error strings stored per-`Master` via `getError()`/`clearError()` for asynchronous error reporting
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- C++ layer: Custom `rogue::Logging` class (`include/rogue/Logging.h`) with named loggers, global and per-name level filtering, severity constants (Critical=50, Error=40, Warning=30, Info=20, Debug=10)
+- Python layer: Standard `logging` module with hierarchical names (`pyrogue.{Type}.{Class}.{Path}`), initialized via `logInit()` in `python/pyrogue/_Node.py`
+- Integration: `RootLogHandler` captures Python log records into `SystemLog` / `SystemLogLast` variables for remote monitoring
+
+**Validation:**
+- Variable-level: Type conversion via `Model` classes (`python/pyrogue/_Model.py`), min/max bounds, enum validation, bit-width constraints
+- Block-level: Overlap detection during `Root.start()`, stale tracking for write optimization, verify masks for readback checking
+
+**Authentication:**
+- Not applicable (hardware control framework, no user authentication)
+
+**Remote Access:**
+- ZeroMQ-based server/client (`rogue.interfaces.ZmqServer/ZmqClient`) on 3 sockets per instance (publish, binary req/rep, string req/rep)
+- `pyrogue.interfaces.ZmqServer` wraps C++ server with Python operation dispatch
+- `pyrogue.interfaces.SimpleClient` provides synchronous client API
+- `pyrogue.interfaces.VirtualClient` provides full virtual device tree over ZMQ
+
+**GIL Management:**
+- `GilRelease` (`include/rogue/GilRelease.h`): RAII class that releases the Python GIL during long C++ operations (I/O, blocking calls)
+- `ScopedGil` (`include/rogue/ScopedGil.h`): RAII class that acquires the GIL when C++ callbacks need to invoke Python
+
+---
+
+*Architecture analysis: 2026-03-24*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,205 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-24
+
+## Tech Debt
+
+**C++ Standard Conflict in CMakeLists.txt:**
+- Issue: `CMakeLists.txt` line 53 sets `-std=c++11` in `CMAKE_CXX_FLAGS`, while line 56 sets `CMAKE_CXX_STANDARD 14`. The flag-based setting takes precedence over the CMake variable in many toolchains, meaning the project may compile as C++11 even though C++14 is intended. Both standards are outdated; C++17 is widely available and would enable `std::optional`, `std::string_view`, structured bindings, and other simplifications.
+- Files: `CMakeLists.txt` (lines 53, 56)
+- Impact: Prevents use of C++14/17 features. The `-Wno-deprecated` flag also silences useful deprecation warnings.
+- Fix approach: Remove the `-std=c++11` flag from `CMAKE_CXX_FLAGS`. Update `CMAKE_CXX_STANDARD` to 17 after verifying all dependencies (Boost.Python, ZeroMQ, bzip2) support it. Remove `-Wno-deprecated` or scope it to specific third-party headers.
+
+**Manual Memory Management (malloc/free) in C++:**
+- Issue: Core classes use raw `malloc`/`free` for buffer allocation instead of RAII containers or smart pointers. This pattern is error-prone and has already produced at least one bug (see Pool destructor below).
+- Files: `src/rogue/interfaces/memory/Block.cpp` (lines 104-114, 122-125, 658, 715), `src/rogue/interfaces/memory/Variable.cpp` (lines 180-217, 445-447), `src/rogue/interfaces/memory/Emulate.cpp` (lines 59, 90), `src/rogue/interfaces/stream/Pool.cpp` (lines 53, 96, 161), `src/rogue/utilities/Prbs.cpp` (lines 81, 103, 147, 149)
+- Impact: Risk of memory leaks if exceptions are thrown between allocation and deallocation. Potential double-free or use-after-free bugs. Makes code harder to reason about ownership.
+- Fix approach: Replace `malloc`/`free` with `std::vector<uint8_t>` or `std::unique_ptr<uint8_t[]>` where possible. For `Pool` and `Block`, performance-sensitive paths may justify raw allocation, but should wrap in RAII classes. The `Variable` destructor pattern (check NULL then free) is a candidate for `std::unique_ptr`.
+
+**Wildcard Star Imports in pyrogue `__init__.py`:**
+- Issue: All submodule exports are imported via `from pyrogue._Foo import *` without any `__all__` definitions in the submodules. This pollutes the `pyrogue` namespace with every public symbol from every submodule.
+- Files: `python/pyrogue/__init__.py` (lines 18-30), all `python/pyrogue/_*.py` files (no `__all__` defined)
+- Impact: Namespace pollution makes it difficult to determine which symbols are part of the public API. IDE autocomplete becomes noisy. Risk of accidental name collisions between submodules.
+- Fix approach: Add `__all__` lists to each `_*.py` submodule, or switch to explicit named imports in `__init__.py`.
+
+**Python 3.6 Minimum Version:**
+- Issue: `python/pyrogue/__init__.py` line 14 checks for Python 3.6 minimum, but the codebase uses type hints like `X | Y` union syntax (PEP 604, Python 3.10+) and `from __future__ import annotations` throughout. The CI runs Python 3.12. The stated minimum is misleading.
+- Files: `python/pyrogue/__init__.py` (line 14)
+- Impact: Misleads users about compatibility. Code will not actually run on Python 3.6-3.9.
+- Fix approach: Update the minimum version check to Python 3.10 or higher to match the actual feature usage.
+
+**`eval()` Usage for Dynamic Code Generation:**
+- Issue: `eval()` is used to construct lambda wrappers dynamically from string interpolation. While the inputs are derived from function introspection (not user input), this pattern is fragile and hard to debug.
+- Files: `python/pyrogue/_HelperFunctions.py` (lines 433, 450), `python/pyrogue/_Node.py` (line 982), `python/pyrogue/_Variable.py` (line 973)
+- Impact: Difficult to debug when the generated lambda has issues. Static analysis tools cannot inspect the generated code. Minor injection risk if callback argument names contain unexpected characters.
+- Fix approach: Replace `eval()` lambda generation with `functools.partial` or explicit closure construction. For the slice evaluation in `_Node.py` and `_Variable.py`, use `slice()` built-in with explicit parsing.
+
+**Commented-Out Code:**
+- Issue: Several files contain commented-out debug print statements, disabled commands, and dead code that clutters the codebase.
+- Files: `python/pyrogue/_Root.py` (lines 72, 361-365), `python/pyrogue/_Device.py` (line 84), `tests/test_memory.py` (lines 17-20)
+- Impact: Minor clutter. Could confuse contributors about intended behavior.
+- Fix approach: Remove commented-out code. Use logging at DEBUG level instead of commented print statements.
+
+## Known Bugs
+
+**Pool Destructor Infinite Loop:**
+- Symptoms: The `Pool::~Pool()` destructor enters an infinite loop and hangs the process on cleanup.
+- Files: `src/rogue/interfaces/stream/Pool.cpp` (lines 51-55)
+- Trigger: Any normal teardown of a Pool object that has cached buffers in `dataQ_`. The while loop calls `free(dataQ_.front())` but never calls `dataQ_.pop()`, so the queue never becomes empty.
+- Workaround: In practice, Pool objects may persist for the lifetime of the process so this may rarely trigger, but it will hang on clean shutdown.
+- Fix: Add `dataQ_.pop()` after the `free(dataQ_.front())` call inside the while loop.
+
+**Exception Caught by Value in Block.cpp:**
+- Symptoms: Exception slicing when catching `rogue::GeneralError` by value instead of by reference.
+- Files: `src/rogue/interfaces/memory/Block.cpp` (lines 292, 332)
+- Trigger: Any transaction retry that catches a `GeneralError`. If a subclass of `GeneralError` is thrown, the subclass data is sliced off.
+- Workaround: None needed currently if no `GeneralError` subclasses exist, but the pattern is incorrect.
+- Fix: Change `catch (rogue::GeneralError err)` to `catch (const rogue::GeneralError& err)` at both locations.
+
+**EPICS V4 Module Has Unresolved TODO:**
+- Symptoms: The module header states "TODO: Not clear on to force a read on get" indicating incomplete behavior for EPICS get operations.
+- Files: `python/pyrogue/protocols/epicsV4.py` (lines 6-7)
+- Trigger: EPICS get operations may not trigger hardware reads when they should.
+- Workaround: Not documented.
+
+## Security Considerations
+
+**`eval()` for Dynamic Lambda Construction:**
+- Risk: While `eval()` inputs come from introspected function argument names (not user input), if a custom Device or Variable ever had argument names containing malicious content, code injection would be possible. The `_Node.py` and `_Variable.py` uses pass user-provided slice strings through `eval()` (e.g., `eval(f'tmpList[{keys[0]}]')` where `keys[0]` comes from node path parsing).
+- Files: `python/pyrogue/_HelperFunctions.py` (lines 433, 450), `python/pyrogue/_Node.py` (line 982), `python/pyrogue/_Variable.py` (line 973)
+- Current mitigation: The inputs are typically constrained to valid Python identifiers or slice syntax. The docstring in `_HelperFunctions.py` notes that `callArgs` "should contain trusted identifier strings."
+- Recommendations: Replace `eval()` with `slice()` parsing for index/slice expressions. Use explicit closure construction instead of string-based lambda generation.
+
+**ZMQ Server Without Authentication:**
+- Risk: The `ZmqServer` binds to a network port and accepts arbitrary requests. There is no authentication or authorization mechanism for incoming ZMQ connections.
+- Files: `src/rogue/interfaces/ZmqServer.cpp`, `python/pyrogue/interfaces/_ZmqServer.py`
+- Current mitigation: Typically deployed on internal lab networks behind firewalls. The default bind address can be configured.
+- Recommendations: For deployments outside trusted networks, add authentication (ZMQ CURVE or application-level tokens). Document the security model clearly.
+
+## Performance Bottlenecks
+
+**Busy-Wait Spin Loops with `usleep(10)`:**
+- Problem: Multiple protocol controllers use `usleep(10)` in tight loops to wait for conditions, consuming CPU time unnecessarily.
+- Files: `src/rogue/protocols/rssi/Controller.cpp` (line 399), `src/rogue/protocols/packetizer/ControllerV1.cpp` (line 205), `src/rogue/protocols/packetizer/ControllerV2.cpp` (line 278), `src/rogue/interfaces/api/Bsp.cpp` (line 55)
+- Cause: Polling approach instead of event-driven signaling. The RSSI controller waits for `txListCount_ < curMaxBuffers_` in a spin loop.
+- Improvement path: Use condition variables (`std::condition_variable`) with `wait()` / `notify_one()` instead of busy-wait loops. The `Bsp.cpp` startup wait should use a callback or event mechanism instead of `usleep(10)` polling.
+
+**JSON Serialization of System Log on Every Log Entry:**
+- Problem: Every log record triggers JSON parsing and serialization of the entire system log list. With `_maxLog` entries, this grows linearly.
+- Files: `python/pyrogue/_Root.py` (lines 119-146, `RootLogHandler.emit`)
+- Cause: The entire system log is stored as a JSON string in a `LocalVariable`, requiring full deserialization and re-serialization on each new log entry. A recent fix (PR #1153) addressed a memory leak in this path, but the O(n) serialization per log entry remains.
+- Improvement path: Store the log as a native Python list internally and only serialize to JSON on demand (e.g., when the variable value is read by a GUI or remote client).
+
+**`gettimeofday()` Usage Instead of Monotonic Clock:**
+- Problem: Extensive use of `gettimeofday()` for timing in protocol controllers. This call is not monotonic -- NTP adjustments, daylight saving changes, or manual clock changes can cause incorrect timeout behavior.
+- Files: `src/rogue/protocols/rssi/Controller.cpp` (14 calls), `src/rogue/protocols/packetizer/ControllerV1.cpp`, `src/rogue/protocols/packetizer/ControllerV2.cpp`, `src/rogue/interfaces/memory/Transaction.cpp`, `src/rogue/utilities/fileio/StreamWriter.cpp`, `src/rogue/utilities/fileio/StreamWriterChannel.cpp`, `src/rogue/interfaces/stream/RateDrop.cpp`
+- Cause: Legacy code pattern. `gettimeofday()` was common before `clock_gettime(CLOCK_MONOTONIC)` became widely available.
+- Improvement path: Replace all timing uses with `std::chrono::steady_clock` (C++11) or `clock_gettime(CLOCK_MONOTONIC)`.
+
+## Fragile Areas
+
+**Block.cpp -- Memory Transaction Engine (2088 lines):**
+- Files: `src/rogue/interfaces/memory/Block.cpp` (2088 lines), `include/rogue/interfaces/memory/Block.h` (908 lines)
+- Why fragile: This is the largest file in the codebase and handles the critical path for all hardware register access. It manages raw byte buffers with manual `malloc`/`free`, complex bit-level operations (`copyBits`, `reverseBytes`), stale tracking across multiple variables, and retry logic with exception handling. The class mixes concerns: buffer management, transaction orchestration, variable indexing, bit manipulation, and Python binding.
+- Safe modification: Any change should be accompanied by tests in `tests/test_memory.py`, `tests/test_list_memory.py`, and `tests/test_block_overlap.py`. Run the full test suite; regressions in Block often cascade through the entire variable system.
+- Test coverage: Moderate -- `test_memory.py` (200 lines) and `test_list_memory.py` (479 lines) cover basic read/write scenarios, but edge cases in bit manipulation, stale tracking, and retry logic have limited coverage.
+
+**GIL Management Across C++/Python Boundary:**
+- Files: `src/rogue/GilRelease.cpp`, `src/rogue/ScopedGil.cpp`, and ~55 source files using `GilRelease` or `ScopedGil`
+- Why fragile: Every C++ function that calls into Python or is called from Python must correctly manage the GIL. Missing a GIL release before blocking operations causes Python thread starvation. Missing a GIL acquire before Python API calls causes segfaults. The `GilRelease` constructor checks `Py_IsInitialized()` and `PyGILState_Check()` which adds conditional complexity.
+- Safe modification: Always use the RAII wrappers (`GilRelease` for releasing, `ScopedGil` for acquiring). Never mix raw `PyEval_SaveThread`/`PyEval_RestoreThread` with the wrappers. Test with multi-threaded Python clients.
+- Test coverage: No dedicated GIL-handling tests. Failures manifest as deadlocks or segfaults.
+
+**RSSI Controller State Machine (984 lines):**
+- Files: `src/rogue/protocols/rssi/Controller.cpp`, `include/rogue/protocols/rssi/Controller.h`
+- Why fragile: Implements a reliable transport protocol with complex state machine logic (StClosed, StWaitSyn, StSendSeqAck, StOpen, etc.), retransmission tracking, sequence number management, and bidirectional flow control. Uses multiple mutexes and condition variables with busy-wait fallbacks. Recent commits addressed race conditions (`udp-rssi-startup-race`).
+- Safe modification: Changes require testing with `tests/test_udpPacketizer.py` and ideally integration testing with actual RSSI firmware. Timing-sensitive changes are especially risky.
+- Test coverage: `test_udpPacketizer.py` (169 lines) provides basic integration coverage but does not test error recovery, retransmission, or connection state transitions.
+
+**Root._updateWorker and Update Tracking:**
+- Files: `python/pyrogue/_Root.py` (lines 37-88, 511-540, 1111-1178)
+- Why fragile: The `UpdateTracker` mechanism uses per-thread dictionaries keyed by `threading.get_ident()`, with a fallback exception-based initialization pattern (`try/except Exception` to check if tracker exists). Thread ID reuse could theoretically cause stale tracker references. The update queue worker uses `queue.Queue.get()` with `None` as a sentinel, which works but is fragile if other code accidentally puts `None` into the queue.
+- Safe modification: Test with `tests/test_root.py` and verify update listeners fire correctly. Add logging around the update path when debugging.
+- Test coverage: `test_root.py` is only 26 lines and does not test the update worker, variable listeners, or update grouping.
+
+## Scaling Limits
+
+**32-bit Allocation Counters in Pool:**
+- Current capacity: `allocBytes_` and `allocCount_` are `uint32_t`, limiting tracking to ~4GB total allocated and ~4 billion buffers.
+- Limit: Long-running high-rate data acquisition systems could overflow these counters.
+- Files: `include/rogue/interfaces/stream/Pool.h` (lines 76-82), `src/rogue/interfaces/stream/Pool.cpp`
+- Scaling path: Change to `uint64_t` or `std::atomic<uint64_t>` for long-running deployments.
+
+**SystemLog JSON String Growth:**
+- Current capacity: Bounded by `_maxLog` (default not explicitly set in constructor; managed by truncation in emit). Each log entry is JSON-serialized.
+- Limit: High-frequency logging causes O(n) serialization on each entry. With `_maxLog` of 1000+ entries, this becomes a measurable overhead.
+- Files: `python/pyrogue/_Root.py` (lines 119-146)
+- Scaling path: Use a deque or ring buffer internally, serialize only on read.
+
+## Dependencies at Risk
+
+**Boost.Python:**
+- Risk: Boost.Python is in maintenance mode; the Python community has moved to `pybind11` which is header-only, has better template support, and produces smaller binaries. Boost.Python requires matching the Boost version with the Python version, which causes build friction (see the 5-candidate search loop in `CMakeLists.txt` lines 93-108).
+- Impact: Build complexity, slower compilation, larger binary size. The `CMakeLists.txt` has an elaborate fallback search for the correct Boost.Python component name.
+- Files: `CMakeLists.txt` (lines 64-118), all `src/rogue/**/*.cpp` files
+- Migration plan: Migrating to pybind11 is a major effort but would simplify builds significantly. The current Boost.Python binding patterns (class wrappers, `bp::class_`, `bp::init<>`, `bp::extract<>`) have near-direct equivalents in pybind11.
+
+**ZeroMQ CMake Discovery:**
+- Risk: ZeroMQ CMake package detection is unreliable, requiring a manual fallback in `CMakeLists.txt` (lines 130-159) that searches `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH`.
+- Impact: Build failures on systems where ZeroMQ is installed but its cmake config is missing.
+- Files: `CMakeLists.txt` (lines 127-159)
+- Migration plan: Use `pkg-config` as a more reliable fallback, or pin to a ZeroMQ version that ships cmake configs.
+
+## Missing Critical Features
+
+**No C++ Test Coverage Measurement:**
+- Problem: The CI runs `python -m pytest --cov` which only measures Python code coverage. The C++ code (18,974 lines across 78 source files) has no coverage measurement.
+- Blocks: Cannot identify untested C++ code paths, especially in critical areas like `Block.cpp`, `Controller.cpp`, and GIL management.
+- Files: `.github/workflows/rogue_ci.yml` (lines 72-74)
+
+**No Thread Sanitizer or Address Sanitizer in CI:**
+- Problem: Given the heavy use of threading (20+ thread launches across Python code, C++ threads in protocols and ZMQ), there is no TSan or ASan build in CI to catch data races and memory errors.
+- Blocks: Race conditions and memory errors may go undetected until they manifest in production. Recent commits show this is an active concern (`udp-rssi-startup-race`, `pre-release-logging-mem-leak-fix`).
+- Files: `.github/workflows/rogue_ci.yml`, `CMakeLists.txt`
+
+## Test Coverage Gaps
+
+**Root Lifecycle and Update Workers:**
+- What's not tested: Variable listener callbacks, update grouping (`updateGroup` context manager), heartbeat worker, poll enable/disable interactions, log handler memory management.
+- Files: `tests/test_root.py` (26 lines -- only tests basic start/stop)
+- Risk: The recent logging memory leak fix (PR #1153) and system log record filtering (commit ec209400b) indicate active bugs in this area.
+- Priority: High
+
+**RSSI Protocol State Machine:**
+- What's not tested: Connection establishment/teardown sequences, retransmission logic, flow control back-pressure, out-of-order packet handling, connection ID negotiation.
+- Files: `tests/test_udpPacketizer.py` (169 lines -- basic data transfer only)
+- Risk: Race conditions have been found and fixed (commit 87ee6ffaa). The state machine is complex (984 lines) with 5+ states and timing-dependent transitions.
+- Priority: High
+
+**GIL Management:**
+- What's not tested: No tests exercise concurrent Python and C++ threads to validate GIL release/acquire correctness. Deadlocks and segfaults from GIL misuse are only caught by integration testing.
+- Files: `src/rogue/GilRelease.cpp`, `src/rogue/ScopedGil.cpp`
+- Risk: GIL-related bugs cause hard-to-reproduce crashes. The complexity of having 182 GIL management calls across 55 source files means any new code path is at risk.
+- Priority: Medium
+
+**ZMQ Server/Client:**
+- What's not tested: Connection loss handling, message serialization edge cases, concurrent request handling in `ZmqServer::runThread()`.
+- Files: `src/rogue/interfaces/ZmqServer.cpp`, `src/rogue/interfaces/ZmqClient.cpp`
+- Risk: ZMQ errors in `runThread()` throw `GeneralError` but are not caught, which could crash the server thread. The `PyBuffer_Release` call at line 305 could leak if `zmq_sendmsg` fails.
+- Priority: Medium
+
+**FileIO Stream Writer/Reader:**
+- What's not tested: File rotation, concurrent write access, corrupted file recovery, large file handling beyond buffer size limits.
+- Files: `tests/test_file.py` (108 lines -- basic read/write only)
+- Risk: Recent bugfixes in `bugfix/fileio-readers` branch (commits 5fcfaca75, 582133155) indicate active issues in this area.
+- Priority: Medium
+
+**Bsp (Board Support Package) C++ API:**
+- What's not tested: The `Bsp.cpp` API catches all exceptions with `catch(...)` and re-throws as `GeneralError`, losing the original exception context. The C++ API test (`tests/api_test/src/api_test.cpp`) exists but error paths are not tested.
+- Files: `src/rogue/interfaces/api/Bsp.cpp` (11 `catch(...)` blocks), `tests/api_test/src/api_test.cpp`
+- Risk: Original exception information is lost, making debugging difficult for C++ API users. The `Bsp::get()` and `Bsp::readGet()` methods use the wrong error string (`"Bsp::set"` instead of `"Bsp::get"` at lines 176, 185).
+- Priority: Low
+
+---
+
+*Concerns audit: 2026-03-24*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,350 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-24
+
+## Languages
+
+**Primary:** Python 3.6+ (`python/pyrogue/`) and C++14 (`src/rogue/`, `include/rogue/`)
+**Build:** CMake 3.15+ (`CMakeLists.txt`)
+
+## File Header
+
+Every source file begins with a license header block. Follow these templates exactly.
+
+**Python:**
+```python
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       [Module description]
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+```
+
+**C++:**
+```cpp
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * [Module description]
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+```
+
+## Naming Patterns
+
+### Python
+
+**Files:**
+- Core pyrogue module files use underscore prefix with PascalCase: `_Node.py`, `_Variable.py`, `_Device.py`, `_Root.py`
+- Subpackage modules use underscore prefix with PascalCase or lowercase: `_Network.py`, `simulation.py`, `epicsV4.py`
+- Test files use `test_` prefix with snake_case: `test_memory.py`, `test_localvars.py`
+
+**Classes:**
+- PascalCase: `Node`, `Device`, `Root`, `BaseVariable`, `BaseCommand`, `RemoteVariable`, `LocalVariable`
+- Exception classes end with `Error`: `NodeError`, `VariableError`, `CommandError`, `GeneralError`
+- Internal/helper classes also PascalCase: `VariableWaitClass`, `PollQueueEntry`, `UpdateTracker`
+
+**Functions/Methods:**
+- Public methods use camelCase: `addListener()`, `getDisp()`, `setDisp()`, `genFrame()`, `writeBlocks()`
+- Private/internal methods use underscore prefix with camelCase: `_doUpdate()`, `_rootAttached()`, `_doTransaction()`
+- Module-level helper functions use camelCase: `logInit()`, `logException()`, `streamConnect()`, `waitCntrlC()`
+- Module-level utility functions use camelCase: `wordCount()`, `byteCount()`, `reverseBits()`
+- Some module-level functions use camelCase matching their class: `startTransaction()`, `checkTransaction()`, `writeBlocks()`
+
+**Variables:**
+- Instance variables use underscore prefix for private: `self._value`, `self._lock`, `self._count`
+- Public instance variables (rare) use camelCase without prefix: `self.path`, `self.name`
+- Module-level constants use PascalCase or UPPER_CASE: `FrameCount`, `FrameSize`, `MaxCycles`, `BENCH_COUNT`
+
+**Constructor Parameters:**
+- Use camelCase for keyword arguments: `bitSize`, `bitOffset`, `memBase`, `pollEn`, `initRead`, `maxFileSize`
+
+### C++
+
+**Files:**
+- PascalCase matching the class name: `Master.cpp`, `Slave.cpp`, `GeneralError.cpp`, `StreamWriter.cpp`
+- Headers use `.h`, sources use `.cpp`
+- Each module directory has a `module.cpp` for Python binding registration
+
+**Classes:**
+- PascalCase within nested namespaces: `rogue::interfaces::stream::Master`, `rogue::GeneralError`
+- Wrapper classes for Python bindings append `Wrap`: `SlaveWrap`
+
+**Functions/Methods:**
+- camelCase: `addSlave()`, `reqFrame()`, `sendFrame()`, `acceptFrame()`, `slaveCount()`
+- Static factory methods named `create()`: `Master::create()`, `Slave::create()`, `Logging::create()`
+- Python binding setup methods named `setup_python()` (snake_case exception)
+- Private members use trailing underscore: `slaves_`, `slaveMtx_`, `defSlave_`, `text_`, `level_`
+
+**Namespaces:**
+- Nested hierarchy matching directory structure: `rogue::interfaces::stream`, `rogue::utilities::fileio`
+- Namespace aliases at file scope: `namespace ris = rogue::interfaces::stream;`, `namespace bp = boost::python;`
+
+**Type Aliases:**
+- `typedef std::shared_ptr<ClassName> ClassNamePtr;` at end of namespace block
+- Example: `typedef std::shared_ptr<rogue::interfaces::stream::Master> MasterPtr;`
+
+## Code Style
+
+### Formatting
+
+**Python:**
+- Linter: flake8 (config: `.flake8`)
+- Many whitespace rules are intentionally ignored (E201, E202, E221, E241, E251, E501, etc.) to allow alignment-based formatting
+- No trailing whitespace (enforced in CI)
+- No tab characters (enforced in CI) -- use spaces only
+- Indentation: 4 spaces
+
+**C++:**
+- Linter: cpplint (config: `CPPLINT.cfg`), max line length 250
+- Formatter: clang-format (config: `.clang-format`) based on Google style
+- Column limit: 120
+- Indent width: 4 spaces
+- Pointer alignment: left (`int* ptr`)
+- No tab characters (enforced in CI)
+- No trailing whitespace (enforced in CI)
+
+### Linting
+
+**Python (`.flake8`):**
+- Excludes: `__init__.py`, `rogue_plugin.py`
+- Heavily relaxed whitespace rules to allow column-aligned parameter formatting
+- Line length (E501) is not enforced
+
+**C++ (`CPPLINT.cfg`):**
+- Disabled checks: `legal/copyright`, `build/c++11`, `build/include_order`, `build/header_guard`, `whitespace/indent`, `runtime/arrays`, `runtime/references`
+- Max line length: 250
+
+**CI enforcement (`scripts/run_linters.sh`):**
+- Compiles all Python files with `python -m compileall`
+- Runs `flake8 --count` on `python/` and `tests/`
+- Runs `cpplint` on all `.h` and `.cpp` files (excluding `build/`)
+- CI also checks for trailing whitespace and tab characters separately
+
+## Import Organization
+
+### Python
+
+**Order:**
+1. `from __future__ import annotations` (when used)
+2. Standard library imports (`sys`, `os`, `threading`, `time`, `logging`, `json`, `re`, etc.)
+3. Third-party imports (`numpy as np`)
+4. Package self-imports (`import pyrogue as pr`, `import rogue.interfaces.memory as rim`)
+5. Relative imports from `collections` (`from collections import OrderedDict as odict`)
+
+**Canonical aliases:**
+- `import pyrogue as pr`
+- `import rogue.interfaces.memory as rim`
+- `import rogue.interfaces.stream as ris`
+- `from collections import OrderedDict as odict`
+- `import numpy as np`
+
+**Star imports in `__init__.py`:**
+- `python/pyrogue/__init__.py` uses `from pyrogue._Module import *` pattern for all core modules
+
+### C++
+
+**Order (enforced by `.clang-format` `IncludeCategories`):**
+1. `"rogue/Directives.h"` (always first)
+2. Own header (e.g., `"rogue/interfaces/stream/Master.h"`)
+3. C headers (`<stdarg.h>`, `<stdint.h>`)
+4. C++ headers (`<memory>`, `<string>`, `<vector>`)
+5. Rogue headers (`"rogue/GeneralError.h"`, etc.)
+6. Boost/Python headers (conditionally included under `#ifndef NO_PYTHON`)
+
+**Path Aliases:**
+- No TypeScript-style path aliases; imports use quoted relative paths: `#include "rogue/interfaces/stream/Master.h"`
+
+## Error Handling
+
+### Python
+
+**Custom Exception Classes:**
+- Defined per module: `NodeError` in `_Node.py`, `VariableError` in `_Variable.py`, `CommandError` in `_Command.py`
+- All inherit from `Exception`
+- Pattern:
+```python
+class ModuleError(Exception):
+    """Raised when [specific condition] fails."""
+    pass
+```
+
+**Error Logging:**
+- Use `logException(log, e)` helper from `_Node.py` which distinguishes `MemoryError` from generic exceptions
+- Pattern: `MemoryError` logged with `log.error()`, others with `log.exception()`
+
+**Test Assertions:**
+- Older tests use `raise AssertionError(...)` pattern (note: this is a historical spelling used consistently throughout)
+- Newer tests use `assert` statements with messages
+- Some tests use `try/except` blocks to verify expected exceptions
+
+### C++
+
+**Exception Class:**
+- Single exception type: `rogue::GeneralError` inherits from `std::exception`
+- Factory method: `GeneralError::create(src, fmt, ...)` with printf-style formatting
+- Translated to Python exceptions via `setup_python()` and `translate()`
+- Fixed buffer size of 600 chars for error messages
+
+**GIL Management:**
+- `rogue::GilRelease noGil;` used at the top of C++ methods that may block, to release the Python GIL
+- `rogue::ScopedGil` for acquiring GIL when calling back into Python
+- Pattern:
+```cpp
+void SomeClass::blockingMethod() {
+    rogue::GilRelease noGil;
+    std::lock_guard<std::mutex> lock(mtx_);
+    // ... blocking work ...
+}
+```
+
+## Logging
+
+### Python
+
+**Framework:** Python `logging` module, initialized via `logInit()` helper in `_Node.py`
+
+**Logger Naming Convention:**
+- All loggers prefixed with `pyrogue`
+- Hierarchy: `pyrogue.{BaseClass}.{ClassName}.{path}` (e.g., `pyrogue.Variable.LocalVariable.root.myVar`)
+- Base class tags: `Command`, `Variable`, `Root`, `Device`
+
+**Initialization Pattern:**
+```python
+self._log = pr.logInit(cls=self, name=self.name, path=self.path)
+```
+
+### C++
+
+**Framework:** Custom `rogue::Logging` class in `include/rogue/Logging.h`
+
+**Levels:** `Critical=50`, `Error=40`, `Thread=35`, `Warning=30`, `Info=20`, `Debug=10`
+
+**Pattern:**
+```cpp
+std::shared_ptr<rogue::Logging> log_ = rogue::Logging::create("rogue.interfaces.stream.Master");
+log_->debug("Message: %s", data.c_str());
+```
+
+## Comments
+
+**Python Docstrings:**
+- Use NumPy-style docstrings with `Parameters`, `Returns`, `Raises` sections
+- Class docstrings describe purpose and constructor parameters
+- Method docstrings describe behavior and parameters
+- Pattern:
+```python
+def method(self, param: int) -> bool:
+    """Brief description.
+
+    Parameters
+    ----------
+    param : int
+        Description of param.
+
+    Returns
+    -------
+    bool
+        Description of return value.
+    """
+```
+
+**C++ Doxygen:**
+- Use `@brief`, `@details`, `@param`, `@return` tags
+- Pattern:
+```cpp
+/**
+ * @brief Brief description.
+ *
+ * @details
+ * Extended description of behavior.
+ *
+ * @param name Description.
+ * @return Description.
+ */
+```
+
+**Inline comments:**
+- C++ uses `//!` or `//` for inline/preceding comments
+- Python uses `#` with optional alignment for column formatting
+
+## Function Design
+
+**Python Constructors:**
+- Use keyword-only arguments (bare `*` in signature): `def __init__(self, *, name=None, description="", ...)`
+- Forward unknown kwargs with `**kwargs`
+- Call parent `__init__` explicitly: `pr.Device.__init__(self, **kwargs)` or `super().__init__(**kwargs)`
+
+**C++ Factory Pattern:**
+- Every class intended for shared ownership provides a `static create()` factory method
+- Returns `std::shared_ptr<ClassName>`
+- Constructors are public but documented as "low-level C++ allocation path"
+
+**Python Decorator:**
+- `@pr.expose` marks properties and methods for external interface (EPICS, ZMQ) visibility
+
+## Module Design
+
+**Python Exports:**
+- Core modules use star exports from `__init__.py`
+- Each module file (`_Node.py`, `_Variable.py`, etc.) defines public classes
+- No `__all__` lists observed; all top-level names are exported
+
+**C++ Module Registration:**
+- Each directory has a `module.cpp` that calls `setup_python()` on all classes in that namespace
+- Conditional compilation with `#ifndef NO_PYTHON` guards
+
+**Variable Definition Pattern (critical for hardware register definitions):**
+- Use column-aligned keyword arguments for readability:
+```python
+self.add(pr.RemoteVariable(
+    name         = "RegisterName",
+    offset       =  0x1c,
+    bitSize      =  16,
+    bitOffset    =  0x00,
+    base         = pr.UInt,
+    mode         = "RW",
+))
+```
+
+## Thread Safety
+
+**Python:**
+- Use `threading.Lock()` for instance-level locking: `self._lock = threading.Lock()`
+- Use `threading.Condition()` for wait/notify patterns: `self._cv = threading.Condition()`
+- Use `with` statement for lock acquisition
+
+**C++:**
+- Use `std::mutex` with `std::lock_guard<std::mutex>` for RAII locking
+- GIL release/acquire via `rogue::GilRelease` and `rogue::ScopedGil`
+
+## Operator Overloading
+
+**Stream connection operators:**
+- Python `>>` and `<<` operators connect stream masters to slaves
+- C++ equivalents: `operator>>` and `operator<<`
+- Usage: `prbsTx >> fifo >> prbsRx` or `sim << ms`
+- Defined in `Master` and `Slave` classes respectively
+
+---
+
+*Convention analysis: 2026-03-24*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,206 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-24
+
+## APIs & External Services
+
+**EPICS Control System (PVAccess / PV4):**
+- Purpose: Expose PyRogue variables as EPICS Process Variables for accelerator control system integration
+- SDK/Client: `p4p` (Python PVAccess library)
+- Implementation: `python/pyrogue/protocols/epicsV4.py`
+- Key classes: `EpicsPvServer`, `EpicsPvHolder`, `EpicsPvHandler`
+- Auth: None (EPICS CA/PVA network-level access)
+- Optional: imported with `try/except` - warns if `p4p` is not installed
+
+**Xilinx Virtual Cable (XVC):**
+- Purpose: Enables Vivado JTAG debugging over network via TCP XVC protocol
+- Implementation: C++ in `src/rogue/protocols/xilinx/`, headers in `include/rogue/protocols/xilinx/`
+- Key classes: `Xvc`, `XvcServer`, `XvcConnection`, `JtagDriver`
+- Protocol: TCP-based XVC for JTAG shift/query operations bridged to Rogue stream transport
+- Auth: None (TCP socket access)
+
+**GPIB Instrument Control:**
+- Purpose: Control SCPI-compatible instruments via GPIB bus
+- SDK/Client: `gpib_ctypes` (optional, `pip install gpib_ctypes`)
+- Implementation: `python/pyrogue/protocols/gpib.py`
+- Key class: `GpibController` (translates memory-mapped R/W to GPIB SCPI commands)
+- Auth: None (local GPIB bus)
+
+**GitHub (CI/Release):**
+- Purpose: Release generation, Docker image publishing
+- SDK/Client: `pygithub` (dev dependency), `gh` CLI via reusable workflows
+- Auth: `secrets.GH_TOKEN`
+- Workflows: `slaclab/ruckus/.github/workflows/gen_release.yml`, `docker_build.yml`
+
+**Anaconda/Conda-Forge:**
+- Purpose: Conda package distribution
+- Auth: `secrets.CONDA_UPLOAD_TOKEN_TAG`
+- Workflow: `slaclab/ruckus/.github/workflows/conda_build_lib.yml`
+- Channel: `tidair-tag` (SLAC channel on conda-forge)
+
+## Messaging & Transport
+
+**ZeroMQ (Core Messaging Layer):**
+- Purpose: Primary inter-process communication backbone
+- C++ implementation: `src/rogue/interfaces/ZmqServer.cpp`, `src/rogue/interfaces/ZmqClient.cpp`
+- Python wrappers: `python/pyrogue/interfaces/_ZmqServer.py`, `python/pyrogue/interfaces/_SimpleClient.py`
+- Transport: TCP sockets with pickle (binary) and JSON (string) serialization
+- Use cases:
+  - ZMQ Server/Client for remote tree access (get/set/exec operations)
+  - Variable update pub/sub via `_publish()` mechanism
+  - TCP stream bridge (`include/rogue/interfaces/stream/TcpCore.h`) uses ZMQ for stream data
+  - Simulation sideband (`python/pyrogue/interfaces/simulation.py`) uses ZMQ PUSH/PULL
+
+**UDP Transport:**
+- Purpose: Network data streaming with optional reliable delivery
+- C++ implementation: `src/rogue/protocols/udp/` (Client, Server, Core)
+- Headers: `include/rogue/protocols/udp/`
+- Supports jumbo frames (9000 MTU) and standard frames (1500 MTU)
+
+**RSSI (Reliable SSI):**
+- Purpose: Reliable stream transport over UDP
+- C++ implementation: `src/rogue/protocols/rssi/` (Client, Server, Controller)
+- Python wrapper: `python/pyrogue/protocols/_Network.py` (`UdpRssiPack` device)
+
+**SRP (SLAC Register Protocol):**
+- Purpose: Register read/write protocol for FPGA communication
+- C++ implementation: `src/rogue/protocols/srp/` (SrpV0, SrpV3, Cmd)
+- Versions: V0 and V3
+
+**Packetizer:**
+- Purpose: Frame packetization for multiplexed stream channels
+- C++ implementation: `src/rogue/protocols/packetizer/` (V1 and V2)
+
+**TCP Stream Bridge:**
+- Purpose: Bridge Rogue stream data over TCP connections
+- C++ implementation: `include/rogue/interfaces/stream/TcpCore.h`, `TcpClient.h`, `TcpServer.h`
+- Uses ZeroMQ internally for the TCP transport
+
+## Data Storage
+
+**Databases:**
+- SQL via SQLAlchemy (any SQLAlchemy-supported database)
+  - Connection: URL string passed to `SqlLogger`/`SqlReader` constructor
+  - Client: `sqlalchemy.create_engine(url)`
+  - Implementation: `python/pyrogue/interfaces/_SqlLogging.py`
+  - Tables: `variables` (path, enum, disp, value, valueDisp, severity, status) and `syslog` (name, message, exception, levelName, levelNumber)
+  - Pattern: Background worker thread with queue-based batched inserts
+
+**File Storage:**
+- Local filesystem only
+- Stream file I/O: `python/pyrogue/utilities/fileio/` (`StreamWriter`, `StreamReader`, `FileReader`)
+- C++ stream file I/O: `src/rogue/utilities/fileio/`, `include/rogue/utilities/fileio/`
+- Configuration save/load: YAML + ZIP archives via `_Root.py` (uses `zipfile`, `pyyaml`)
+- Compression: BZip2-based stream compression (`StreamZip`/`StreamUnZip` in `src/rogue/utilities/`)
+
+**Caching:**
+- None (no external cache service)
+
+## Hardware Interfaces
+
+**AXI Stream DMA (aes-stream-drivers):**
+- Purpose: Zero-copy DMA data streaming to/from FPGA hardware over PCIe or AXI
+- Implementation: `src/rogue/hardware/axi/AxiStreamDma.cpp`, `include/rogue/hardware/axi/AxiStreamDma.h`
+- Driver API: `include/rogue/hardware/drivers/DmaDriver.h`, `include/rogue/hardware/drivers/AxisDriver.h`
+- Device paths: e.g., `/dev/datadev_0`
+- External dependency: [aes-stream-drivers](https://github.com/slaclab/aes-stream-drivers) kernel module
+
+**AXI Memory Map:**
+- Purpose: Register read/write via AXI4 memory-mapped access through kernel driver
+- Implementation: `src/rogue/hardware/axi/AxiMemMap.cpp`, `include/rogue/hardware/axi/AxiMemMap.h`
+- Driver API: `dmaReadRegister`/`dmaWriteRegister` ioctl calls via DmaDriver.h
+
+**Serial/UART:**
+- Purpose: Register access over serial UART for embedded devices
+- SDK/Client: `pyserial` (`serial.Serial`)
+- Implementation: `python/pyrogue/protocols/_uart.py` (`UartMemory` class)
+
+## Authentication & Identity
+
+**Auth Provider:**
+- None - Rogue is infrastructure/DAQ software without user authentication
+- Network access control is at the transport level (ZMQ bind address, TCP ports)
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- Custom C++ exception hierarchy: `rogue::GeneralError` (`include/rogue/GeneralError.h`)
+- Python: `pyrogue.logException()` helper
+
+**Logging:**
+- Python `logging` module with custom `RogueLogHandler` in `python/pyrogue/_Root.py`
+- C++ `rogue::Logging` class (`include/rogue/Logging.h`)
+- SystemLog: Accumulated log entries stored as JSON in root `SystemLog` and `SystemLogLast` variables
+- SQL logging: Optional database sink via `SqlLogger` (`python/pyrogue/interfaces/_SqlLogging.py`)
+
+## CI/CD & Deployment
+
+**Hosting:**
+- GitHub: [slaclab/rogue](https://github.com/slaclab/rogue)
+- Docker: GitHub Container Registry (via `slaclab/ruckus` Docker build workflow)
+- Conda: `tidair-tag` channel
+
+**CI Pipeline:**
+- GitHub Actions (`.github/workflows/rogue_ci.yml`)
+- Jobs:
+  1. `full_build_test` - Ubuntu 24.04, Python 3.12, full build + lint + pytest + coverage + docs
+  2. `small_build_test` - Ubuntu 24.04, C++ only build (NO_PYTHON=1, STATIC_LIB=1)
+  3. `macos_arm64_build_test` - macOS 15 arm64 via Miniforge conda environment
+  4. `gen_release` - Reusable workflow from `slaclab/ruckus` (on tags)
+  5. `conda_build_lib` - Conda package build and upload (on tags)
+  6. `docker_build_rogue` - Docker image build and push (on tags)
+
+**Documentation Deployment:**
+- GitHub Pages via `peaceiris/actions-gh-pages@v3` (on tags)
+- Generated from Sphinx + Breathe + Doxygen
+
+## Environment Configuration
+
+**Required env vars (runtime):**
+- `PYTHONPATH` - Must include rogue `python/` directory (for local installs)
+- `LD_LIBRARY_PATH` - Must include rogue `lib/` directory (for local installs)
+- `ROGUE_DIR` - Rogue install root (for local/custom installs)
+
+**Optional env vars (runtime):**
+- `ROGUE_SERVERS` - Set by `pyrogue.pydm.runPyDM()` for GUI server list
+- `PYQTDESIGNERPATH` - Path to PyDM widget directory for Qt Designer
+- `PYDM_DATA_PLUGINS_PATH` - Path to `pyrogue/pydm/data_plugins` for Rogue data plugin auto-discovery
+- `PYDM_TOOLS_PATH` - Path to `pyrogue/pydm/tools` for custom PyDM tools
+
+**CI secrets:**
+- `GH_TOKEN` - GitHub token for releases and Docker push
+- `CONDA_UPLOAD_TOKEN_TAG` - Anaconda upload token for conda package publishing
+
+**Secrets location:**
+- GitHub Actions secrets (repository-level)
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None (no webhook endpoints)
+
+**Outgoing:**
+- None (no outbound webhooks)
+
+## Client/Remote Access Patterns
+
+**ZMQ Server (primary remote API):**
+- Default port: 9099 (configurable)
+- Protocol: pickle-serialized Python objects over ZMQ REQ/REP + PUB/SUB
+- String protocol: JSON request/response over ZMQ
+- CLI tool: `python -m pyrogue {gui|syslog|monitor|get|set|exec} --server='host:port'`
+- Implementation: `python/pyrogue/interfaces/_ZmqServer.py`, `python/pyrogue/interfaces/_SimpleClient.py`
+
+**Virtual Client:**
+- Purpose: Full tree-access client that mirrors remote Root structure locally
+- Implementation: `python/pyrogue/interfaces/_Virtual.py` (`VirtualClient`, `VirtualNode`)
+- Transport: ZMQ client connection to ZMQ server
+- Usage: `client = pyrogue.interfaces.VirtualClient(addr='localhost', port=9099)`
+
+**MATLAB Integration:**
+- `SimpleClient` designed for MATLAB interop via `pyzmq`
+- Documented in `python/pyrogue/interfaces/_SimpleClient.py`
+
+---
+
+*Integration audit: 2026-03-24*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,129 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-24
+
+## Languages
+
+**Primary:**
+- C++ (C++14 standard) - Core library (`src/rogue/`, `include/rogue/`), ~86 `.cpp` source files, ~95 `.h` header files
+- Python (>= 3.6, builds target 3.10-3.13) - High-level API, GUI, protocols (`python/pyrogue/`), ~74 `.py` files
+
+**Secondary:**
+- CMake - Build system (`CMakeLists.txt`)
+- Bash - Build/setup scripts (`scripts/`, `templates/*.sh.in`, `conda-recipe/build.sh`)
+
+## Runtime
+
+**Environment:**
+- Linux (primary target, Ubuntu 22.04/24.04 in CI and Docker)
+- macOS arm64 (supported via Miniforge/conda, no x86 macOS)
+- Python 3.10, 3.11, 3.12, 3.13 (conda variant builds in `conda-recipe/conda_build_config.yaml`)
+- C++14 runtime with Boost.Python bridge
+
+**Package Manager:**
+- Conda (conda-forge channel, primary distribution method)
+- pip (for development/CI dependencies)
+- Lockfile: Not present (no `conda-lock.yml` or `requirements.lock`)
+
+## Frameworks
+
+**Core:**
+- Boost.Python - C++/Python binding layer, discovered via CMake `find_package(Boost)` in `CMakeLists.txt`
+- ZeroMQ (libzmq) - Inter-process messaging, TCP stream bridging, ZMQ server/client in `src/rogue/interfaces/`
+- NumPy - Array data type support at the C++ binding layer and Python layer
+
+**GUI:**
+- PyDM (>= 1.18.0) - Qt-based display manager for Rogue GUIs (`python/pyrogue/pydm/`)
+- PyQt5 (>= 5.15) - Qt bindings required by PyDM
+
+**Testing:**
+- pytest (>= 3.6) - Python test runner, configured via `python -m pytest --cov`
+- pytest-cov - Coverage plugin
+- coverage + codecov - Coverage reporting in CI
+
+**Build/Dev:**
+- CMake (>= 3.15) - Primary C++ build system (`CMakeLists.txt`)
+- setuptools - Python package installation via generated `setup.py` from `templates/setup.py.in`
+- flake8 - Python linting (run via `scripts/run_linters.sh`)
+- cpplint - C++ linting with custom config (`CPPLINT.cfg`)
+- Sphinx + Breathe + RTD theme - Documentation generation (`docs/`)
+- Doxygen - C++ API doc generation (`docs/Doxyfile`)
+
+## Key Dependencies
+
+**Critical (Runtime):**
+- `boost` - C++/Python interop, threading; linked via `TARGET_LINK_LIBRARIES` in `CMakeLists.txt`
+- `zeromq` (libzmq) - Messaging backbone for ZMQ server/client, TCP stream bridge, simulation sideband
+- `numpy` (>= 2.0 for conda builds) - Array data types throughout variable system
+- `pyyaml` - Configuration file serialization/deserialization
+- `pyzmq` - Python ZeroMQ bindings for `SimpleClient`, `SideBandSim`
+- `bzip2` (libbz2) - Compression support in stream utilities (`StreamZip`/`StreamUnZip`)
+
+**Infrastructure (Runtime):**
+- `sqlalchemy` - SQL database logging (`python/pyrogue/interfaces/_SqlLogging.py`)
+- `p4p` - EPICS PVAccess (PV4) server for control system integration (`python/pyrogue/protocols/epicsV4.py`)
+- `pyserial` - Serial/UART communication (`python/pyrogue/protocols/_uart.py`)
+- `parse` - String parsing utility
+- `click` - CLI argument handling
+- `jsonpickle` - Object serialization
+- `matplotlib` - Plotting support
+- `pydm` (>= 1.18.0) - Qt display manager framework for GUI widgets
+
+**Development Only:**
+- `gitpython` - Git operations in scripts
+- `pygithub` - GitHub API access in CI/scripts
+- `hwcounter` - Hardware performance counters (Linux x86_64 only)
+- `ipython` - Interactive shell
+
+## Configuration
+
+**Environment:**
+- `ROGUE_DIR` - Root directory for local installs, set by `setup_rogue.sh`
+- `CONDA_PREFIX` - Auto-detected for conda installs; controls build type and paths in `CMakeLists.txt`
+- `PYTHONPATH` - Must include `python/` directory for local builds (set by generated `setup_rogue.sh`)
+- `LD_LIBRARY_PATH` - Must include `lib/` directory for local builds
+- `PYQTDESIGNERPATH` - Points to `pyrogue/pydm` for PyDM widget discovery
+- `PYDM_DATA_PLUGINS_PATH` - Points to `pyrogue/pydm/data_plugins` for Rogue data plugin
+- `PYDM_TOOLS_PATH` - Points to `pyrogue/pydm/tools` for custom PyDM tools
+- `ROGUE_SERVERS` - Set at runtime by `pyrogue.pydm.runPyDM()` for GUI server connection
+
+**Build:**
+- `CMakeLists.txt` - Main build configuration with options:
+  - `-DROGUE_INSTALL={local|conda|system|custom|target_arch}` - Install mode
+  - `-DROGUE_DIR=<path>` - Custom install path
+  - `-DNO_PYTHON=1` - Build without Python/Boost bindings
+  - `-DSTATIC_LIB=1` - Also build static library
+  - `-DROGUE_VERSION=<ver>` - Override version (defaults to `git describe`)
+- `CPPLINT.cfg` - C++ lint settings (linelength=250, filters for c++11 headers, include order, header guard, whitespace)
+- `templates/RogueConfig.h.in` - Generated version header
+- `templates/setup.py.in` - Generated Python package setup with PEP 440 version normalization
+- `conda-recipe/meta.yaml` - Conda package recipe
+- `conda-recipe/conda_build_config.yaml` - Python version variants (3.10-3.13)
+
+## Platform Requirements
+
+**Development:**
+- Linux (Ubuntu 22.04+) or macOS arm64
+- CMake >= 3.15
+- C/C++ compiler (gcc or clang with C++14 support)
+- Boost libraries with Python component
+- ZeroMQ (libzmq3-dev on Debian/Ubuntu)
+- BZip2 (libbz2-dev)
+- Python 3.10+ with development headers
+- NumPy with C headers
+- Git (required for version generation)
+
+**Production/Deployment:**
+- Conda package distributed via `tidair-tag` channel on conda-forge
+- Docker images: `docker/rogue/Dockerfile` (Ubuntu 22.04 base), `docker/rogue-anaconda/Dockerfile` (Miniforge base)
+- For hardware access: Linux with SLAC `aes-stream-drivers` kernel module (e.g., `datadev`, `axi_memory_map`)
+
+**CI/CD:**
+- GitHub Actions (`rogue_ci.yml`)
+- Runs on `ubuntu-24.04` and `macos-15` (arm64)
+- Reusable workflows from `slaclab/ruckus` for release generation, conda build, and Docker build
+- Secrets: `GH_TOKEN` (GitHub), `CONDA_UPLOAD_TOKEN_TAG` (Anaconda upload)
+
+---
+
+*Stack analysis: 2026-03-24*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,279 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-24
+
+## Directory Layout
+
+```
+rogue/
+├── CMakeLists.txt              # Top-level CMake build (builds librogue-core.so + rogue.so)
+├── include/                    # C++ public headers
+│   └── rogue/                  # All headers under rogue namespace
+│       ├── hardware/           # Hardware driver interfaces (AXI DMA, MemMap)
+│       │   ├── axi/            # AXI-specific drivers
+│       │   └── drivers/        # Low-level kernel driver headers
+│       ├── interfaces/         # Core stream/memory/ZMQ abstractions
+│       │   ├── api/            # BSP (Board Support Package) API
+│       │   ├── memory/         # Memory transaction interface (Master/Slave/Hub/Block/Variable)
+│       │   └── stream/         # Stream interface (Master/Slave/Frame/Buffer/Pool)
+│       ├── protocols/          # Network/transport protocol implementations
+│       │   ├── batcher/        # Frame batcher (V1/V2)
+│       │   ├── packetizer/     # Packetizer protocol (V1/V2)
+│       │   ├── rssi/           # Reliable SSI protocol (client/server)
+│       │   ├── srp/            # SLAC Register Protocol (V0/V3)
+│       │   ├── udp/            # UDP client/server
+│       │   └── xilinx/         # Xilinx XVC/JTAG
+│       └── utilities/          # Utility classes
+│           └── fileio/         # Stream file reader/writer
+├── src/                        # C++ source files
+│   ├── package.cpp             # BOOST_PYTHON_MODULE entry point (builds rogue.so)
+│   ├── CMakeLists.txt          # Globs .cpp for rogue.so target
+│   └── rogue/                  # Core library sources (mirrors include/rogue/ structure)
+│       ├── CMakeLists.txt      # Adds subdirs + core sources to rogue-core target
+│       ├── hardware/           # Hardware driver implementations
+│       ├── interfaces/         # Interface implementations
+│       ├── protocols/          # Protocol implementations
+│       └── utilities/          # Utility implementations
+├── python/                     # Python packages
+│   └── pyrogue/                # High-level Python device tree framework
+│       ├── __init__.py         # Package init - imports all core classes
+│       ├── __main__.py         # CLI entry point (python -m pyrogue)
+│       ├── _Node.py            # Base Node class (tree element)
+│       ├── _Device.py          # Device class (Node + memory Hub)
+│       ├── _Root.py            # Root class (top-level Device)
+│       ├── _Variable.py        # Variable classes (Remote/Local/Link)
+│       ├── _Command.py         # Command classes (Local/Remote)
+│       ├── _Block.py           # Block transaction helpers
+│       ├── _Model.py           # Data type conversion models
+│       ├── _PollQueue.py       # Variable polling scheduler
+│       ├── _Process.py         # Process management
+│       ├── _DataWriter.py      # Stream data writer device
+│       ├── _DataReceiver.py    # Stream data receiver device
+│       ├── _RunControl.py      # Run control device
+│       ├── _HelperFunctions.py # Utility functions (YAML, config)
+│       ├── examples/           # Example devices (AxiVersion, ExampleRoot)
+│       ├── hardware/           # Hardware-specific Python devices
+│       │   └── axi/            # AXI stream DMA monitor
+│       ├── interfaces/         # Client/server and simulation interfaces
+│       │   ├── _Virtual.py     # Virtual (remote) device tree client
+│       │   ├── _ZmqServer.py   # ZMQ server for remote access
+│       │   ├── _SimpleClient.py # Simple ZMQ client
+│       │   ├── _SqlLogging.py  # SQL-based logging
+│       │   ├── _OsCommandMemorySlave.py  # OS command memory slave
+│       │   ├── simulation.py   # Simulation support (sideband, stream sim)
+│       │   └── stream/         # Stream-level Python utilities (Fifo, Variable)
+│       ├── protocols/          # Python protocol wrappers
+│       │   ├── _Network.py     # Network protocol stack builder
+│       │   ├── _uart.py        # UART protocol
+│       │   ├── gpib.py         # GPIB instrument control
+│       │   └── epicsV4.py      # EPICS V4 PVA interface
+│       ├── pydm/               # PyDM GUI integration
+│       │   ├── __init__.py     # PyDM launcher
+│       │   ├── data_plugins/   # Rogue data plugin for PyDM
+│       │   ├── widgets/        # Custom PyDM widgets (tree, controls, plots)
+│       │   ├── tools/          # PyDM tools
+│       │   └── examples/       # PyDM example files
+│       └── utilities/          # Python utility modules
+│           ├── fileio/         # File I/O wrappers (FileReader, StreamReader/Writer)
+│           ├── hls/            # HLS register interface parser
+│           ├── prbs.py         # PRBS test device
+│           └── cpsw.py         # CPSW compatibility layer
+├── tests/                      # Test suite
+│   ├── test_*.py               # Python pytest test files
+│   ├── test_config_in.yml      # Test fixture YAML
+│   └── api_test/               # C++ API test
+│       └── src/api_test.cpp    # C++ test source
+├── templates/                  # Build system templates
+│   ├── RogueConfig.h.in        # Version header template
+│   ├── RogueConfig.cmake.in    # CMake config template
+│   ├── setup.py.in             # Python setup.py template
+│   └── setup_rogue.*.in        # Shell setup scripts (sh/csh/fish)
+├── conda-recipe/               # Conda build recipe
+├── docker/                     # Docker build files
+│   ├── rogue/Dockerfile        # Standard build image
+│   └── rogue-anaconda/Dockerfile  # Anaconda-based build image
+├── docs/                       # Documentation source (RST-based)
+├── scripts/                    # Development scripts
+│   ├── run_linters.sh          # Lint runner
+│   ├── updateDrivers.sh        # Driver update script
+│   └── generate_boostpython_api_docs.py  # API doc generator
+├── notebooks/                  # Jupyter notebooks
+│   └── ExampleRoot.ipynb       # Example root notebook
+├── .github/workflows/          # CI configuration
+│   └── rogue_ci.yml            # GitHub Actions CI workflow
+├── .clang-format               # C++ formatting config
+├── .flake8                     # Python linting config
+├── CPPLINT.cfg                 # C++ lint config
+├── .coveragerc                 # Python coverage config
+├── conda.yml                   # Conda environment spec
+├── pip_requirements.txt        # Python pip dependencies
+└── .gitignore                  # Git ignore rules
+```
+
+## Directory Purposes
+
+**`include/rogue/`:**
+- Purpose: Public C++ API headers for the rogue-core library
+- Contains: Header files organized by subsystem (interfaces, protocols, hardware, utilities)
+- Key files: `include/rogue/interfaces/stream/Master.h`, `include/rogue/interfaces/stream/Slave.h`, `include/rogue/interfaces/memory/Master.h`, `include/rogue/interfaces/memory/Slave.h`, `include/rogue/interfaces/memory/Hub.h`, `include/rogue/interfaces/memory/Block.h`, `include/rogue/interfaces/memory/Variable.h`
+
+**`src/rogue/`:**
+- Purpose: C++ implementation files for rogue-core, mirrors header structure
+- Contains: `.cpp` files organized identically to `include/rogue/`, each directory has its own `CMakeLists.txt`
+- Key files: `src/rogue/CMakeLists.txt` (adds subdirectories and core sources to `rogue-core` target)
+
+**`src/` (top-level):**
+- Purpose: Python extension module build source
+- Contains: `package.cpp` (BOOST_PYTHON_MODULE entry), `CMakeLists.txt` (globs .cpp for `rogue` target)
+- Key files: `src/package.cpp`
+
+**`python/pyrogue/`:**
+- Purpose: High-level Python framework for building device trees on top of C++ rogue
+- Contains: Core tree classes, interface implementations, protocol wrappers, GUI widgets
+- Key files: `python/pyrogue/_Root.py`, `python/pyrogue/_Device.py`, `python/pyrogue/_Variable.py`, `python/pyrogue/_Node.py`
+
+**`tests/`:**
+- Purpose: Test suite (Python pytest tests and one C++ API test)
+- Contains: `test_*.py` files covering memory, variables, commands, protocols, file I/O, EPICS
+- Key files: `tests/test_memory.py`, `tests/test_localvars.py`, `tests/test_hub.py`
+
+**`templates/`:**
+- Purpose: CMake configure_file templates for version headers, setup scripts, and Python setup.py
+- Contains: `.in` files processed during build
+- Key files: `templates/RogueConfig.h.in`, `templates/setup.py.in`
+
+## Key File Locations
+
+**Entry Points:**
+- `src/package.cpp`: BOOST_PYTHON_MODULE - creates the `rogue` Python extension
+- `python/pyrogue/__main__.py`: CLI entry point for `python -m pyrogue`
+- `python/pyrogue/__init__.py`: Package initialization, imports all core classes
+- `CMakeLists.txt`: Top-level build definition
+
+**Configuration:**
+- `CMakeLists.txt`: Build system, dependencies, install targets
+- `.clang-format`: C++ code formatting rules
+- `.flake8`: Python linting rules
+- `CPPLINT.cfg`: C++ linting rules
+- `.coveragerc`: Python test coverage config
+- `conda.yml`: Conda environment specification
+- `pip_requirements.txt`: Python pip dependencies
+- `.github/workflows/rogue_ci.yml`: CI pipeline definition
+
+**Core C++ Logic:**
+- `include/rogue/interfaces/stream/Master.h` / `src/rogue/interfaces/stream/Master.cpp`: Stream master
+- `include/rogue/interfaces/stream/Slave.h` / `src/rogue/interfaces/stream/Slave.cpp`: Stream slave
+- `include/rogue/interfaces/stream/Frame.h` / `src/rogue/interfaces/stream/Frame.cpp`: Frame container
+- `include/rogue/interfaces/stream/Pool.h` / `src/rogue/interfaces/stream/Pool.cpp`: Buffer pool
+- `include/rogue/interfaces/memory/Master.h` / `src/rogue/interfaces/memory/Master.cpp`: Memory master
+- `include/rogue/interfaces/memory/Slave.h` / `src/rogue/interfaces/memory/Slave.cpp`: Memory slave
+- `include/rogue/interfaces/memory/Hub.h` / `src/rogue/interfaces/memory/Hub.cpp`: Memory hub
+- `include/rogue/interfaces/memory/Block.h` / `src/rogue/interfaces/memory/Block.cpp`: Memory block
+- `include/rogue/interfaces/memory/Variable.h` / `src/rogue/interfaces/memory/Variable.cpp`: Memory variable
+- `include/rogue/interfaces/ZmqServer.h` / `src/rogue/interfaces/ZmqServer.cpp`: ZMQ server
+
+**Core Python Logic:**
+- `python/pyrogue/_Node.py`: Base tree node (1007 lines)
+- `python/pyrogue/_Variable.py`: Variable classes (2052 lines, largest file)
+- `python/pyrogue/_Root.py`: Root device tree node (1195 lines)
+- `python/pyrogue/_Device.py`: Device abstraction (942 lines)
+- `python/pyrogue/_Model.py`: Data type conversion (828 lines)
+- `python/pyrogue/_Command.py`: Command classes (599 lines)
+- `python/pyrogue/_Block.py`: Block transaction helpers (534 lines)
+- `python/pyrogue/_HelperFunctions.py`: YAML load/save, config utilities (544 lines)
+
+**Testing:**
+- `tests/test_*.py`: 18 Python test files
+- `tests/api_test/src/api_test.cpp`: C++ API test
+
+## Naming Conventions
+
+**Files:**
+- C++ headers: `PascalCase.h` (e.g., `Master.h`, `StreamWriter.h`, `AxiStreamDma.h`)
+- C++ sources: `PascalCase.cpp` matching header names
+- Python core modules: `_PascalCase.py` with leading underscore (e.g., `_Node.py`, `_Variable.py`, `_Root.py`)
+- Python non-core modules: `snake_case.py` (e.g., `simulation.py`, `epicsV4.py`)
+- Test files: `test_snake_case.py` (e.g., `test_memory.py`, `test_localvars.py`)
+
+**Directories:**
+- C++ namespaces map to directories: `rogue/interfaces/stream/` -> `rogue::interfaces::stream`
+- Python packages use lowercase: `pyrogue/`, `interfaces/`, `protocols/`, `utilities/`
+
+**C++ Classes:**
+- PascalCase class names: `Master`, `Slave`, `Hub`, `Frame`, `Buffer`, `Pool`
+- `*Wrap` suffix for Boost.Python wrapper classes: `SlaveWrap`, `HubWrap`
+- `*Ptr` typedef for shared pointers: `MasterPtr`, `SlavePtr`, `FramePtr`
+
+**Python Classes:**
+- PascalCase: `Node`, `Device`, `Root`, `BaseVariable`, `RemoteVariable`, `LocalCommand`
+- `setup_python()` static method on every C++-exposed class
+
+## Where to Add New Code
+
+**New Hardware Driver:**
+- C++ header: `include/rogue/hardware/<subsystem>/<DriverName>.h`
+- C++ source: `src/rogue/hardware/<subsystem>/<DriverName>.cpp`
+- Add `setup_python()` call in `src/rogue/hardware/<subsystem>/module.cpp`
+- Add `target_sources()` in `src/rogue/hardware/<subsystem>/CMakeLists.txt`
+- Python device wrapper (if needed): `python/pyrogue/hardware/<subsystem>/`
+
+**New Protocol:**
+- C++ header: `include/rogue/protocols/<protocol>/<ClassName>.h`
+- C++ source: `src/rogue/protocols/<protocol>/<ClassName>.cpp`
+- Add `setup_python()` call in `src/rogue/protocols/<protocol>/module.cpp`
+- Add `target_sources()` in `src/rogue/protocols/<protocol>/CMakeLists.txt`
+- Python wrapper (if needed): `python/pyrogue/protocols/`
+
+**New Stream Utility:**
+- C++ header: `include/rogue/utilities/<ClassName>.h`
+- C++ source: `src/rogue/utilities/<ClassName>.cpp`
+- Add `setup_python()` call in `src/rogue/utilities/module.cpp`
+- Add `target_sources()` in `src/rogue/utilities/CMakeLists.txt`
+
+**New PyRogue Device:**
+- Python file: `python/pyrogue/examples/<_DeviceName>.py` (for examples) or a separate downstream package
+- Pattern: Subclass `pyrogue.Device`, add `RemoteVariable`/`RemoteCommand`/`LocalVariable` nodes in `__init__`
+- Import: Add to `__init__.py` in the containing package
+
+**New PyRogue Interface:**
+- Python file: `python/pyrogue/interfaces/_InterfaceName.py`
+- Import: Add to `python/pyrogue/interfaces/__init__.py`
+
+**New Test:**
+- Python test: `tests/test_<feature>.py`
+- Follow existing pattern: import `pyrogue`, create `Root`, add devices, call `root.start()`/`root.stop()` in test setup/teardown
+
+**New PyDM Widget:**
+- Python file: `python/pyrogue/pydm/widgets/<widget_name>.py`
+- Import: Add to `python/pyrogue/pydm/widgets/__init__.py`
+
+## Special Directories
+
+**`templates/`:**
+- Purpose: CMake `configure_file()` input templates for build-time code generation
+- Generated: Templates are processed at build time to produce `RogueConfig.h`, `setup.py`, shell setup scripts
+- Committed: Yes (input templates are committed; generated outputs are not)
+
+**`docker/`:**
+- Purpose: Dockerfile definitions for containerized builds
+- Generated: No
+- Committed: Yes
+
+**`conda-recipe/`:**
+- Purpose: Conda package build recipe (meta.yaml, build.sh)
+- Generated: No
+- Committed: Yes
+
+**`notebooks/`:**
+- Purpose: Jupyter notebooks for interactive examples
+- Generated: No (but contains cell outputs)
+- Committed: Yes
+
+**`docs/`:**
+- Purpose: Documentation source files (RST format for Sphinx/similar)
+- Generated: Documentation is built from these sources
+- Committed: Yes (source only)
+
+---
+
+*Structure analysis: 2026-03-24*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,391 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-24
+
+## Test Framework
+
+**Runner:**
+- pytest >= 3.6
+- Config: No `pytest.ini` or `pyproject.toml` test config; pytest auto-discovers `tests/test_*.py`
+
+**Assertion Library:**
+- Built-in `assert` statements (newer tests)
+- `raise AssertionError(...)` pattern (older/majority of tests -- note the consistent historical spelling)
+
+**Coverage:**
+- coverage.py with config at `.coveragerc`
+- pytest-cov plugin for integrated coverage
+- codecov for reporting
+
+**Run Commands:**
+```bash
+source setup_rogue.sh             # Required: set up rogue environment
+python -m pytest --cov             # Run all tests with coverage
+python -m pytest tests/test_memory.py  # Run a single test file
+python -m pytest -v                # Verbose output
+coverage report -m                 # View coverage report after test run
+```
+
+## Test File Organization
+
+**Location:**
+- All Python tests in `tests/` directory at project root (NOT co-located with source)
+- One C++ API test in `tests/api_test/src/api_test.cpp` (built separately with its own CMake)
+
+**Naming:**
+- `test_<feature>.py` for Python test files
+- Test functions named `test_<description>()` for pytest auto-discovery
+
+**Structure:**
+```
+tests/
+    .gitignore              # Ignores generated *.yml files
+    test_block_overlap.py   # Block overlap/register tests
+    test_config_in.yml      # Test fixture YAML config
+    test_enum.py            # Enum variable tests
+    test_epics.py           # EPICS integration tests
+    test_fifo.py            # FIFO stream tests
+    test_file.py            # File I/O tests
+    test_hub.py             # Hub/virtual address space tests
+    test_int.py             # Signed integer variable tests
+    test_list_memory.py     # List/array variable tests
+    test_loadsave.py        # Config load/save tests
+    test_localcommand.py    # Local command tests
+    test_localvars.py       # Local variable tests
+    test_logging.py         # Logging feedback loop tests
+    test_memory.py          # Memory read/write tests
+    test_rate.py            # Performance benchmark tests
+    test_retry_memory.py    # Memory retry/error handling tests
+    test_root.py            # Root lifecycle tests
+    test_streamBridge.py    # TCP stream bridge tests
+    test_udpPacketizer.py   # UDP/packetizer/RSSI tests
+    api_test/               # C++ API test (separate build)
+        CMakeLists.txt
+        src/api_test.cpp
+```
+
+**No conftest.py:** There is no `conftest.py` file. Tests are self-contained.
+
+## Test Structure
+
+**Standard Test Pattern:**
+Each test file follows this structure:
+1. Define helper `Device` subclass(es) with register definitions
+2. Define a `DummyTree` (or similar) `Root` subclass that wires up memory emulation
+3. Define `test_<name>()` function(s) that use the root as a context manager
+
+```python
+#!/usr/bin/env python3
+# [license header]
+
+import pyrogue as pr
+import rogue.interfaces.memory
+
+class MyDev(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.add(pr.RemoteVariable(
+            name         = "RegA",
+            offset       =  0x00,
+            bitSize      =  32,
+            bitOffset    =  0x00,
+            base         = pr.UInt,
+            mode         = "RW",
+        ))
+
+class DummyTree(pr.Root):
+    def __init__(self):
+        pr.Root.__init__(self,
+                         name='dummyTree',
+                         description="Dummy tree for testing",
+                         timeout=2.0,
+                         pollEn=False)
+
+        sim = rogue.interfaces.memory.Emulate(4, 0x1000)
+        self.addInterface(sim)
+
+        self.add(MyDev(
+            offset     = 0x0,
+            memBase    = sim,
+        ))
+
+def test_my_feature():
+    with DummyTree() as root:
+        # Set values
+        root.MyDev.RegA.set(42)
+
+        # Read back and verify
+        result = root.MyDev.RegA.get()
+        if result != 42:
+            raise AssertionError(f'Expected 42, got {result}')
+
+if __name__ == "__main__":
+    test_my_feature()
+```
+
+**Key patterns:**
+- Use `with Root() as root:` context manager for setup/teardown
+- Memory emulation via `rogue.interfaces.memory.Emulate(minWidth, maxSize)`
+- TCP-based memory via `TcpServer`/`TcpClient` pair for more realistic tests
+- Each test file is independently runnable via `__main__`
+- `pollEn=False` in all test roots to disable background polling
+
+## Test Categories
+
+**Unit-level register tests:**
+- `test_memory.py`: RemoteVariable read/write with byte and bit-level access
+- `test_int.py`: Signed integer variable encoding
+- `test_enum.py`: Enum variable set/get/display
+- `test_list_memory.py`: Array/list variable types (UInt, Int, Float, Double, Bool) with numpy
+- `test_block_overlap.py`: Overlapping register block access
+- `test_localvars.py`: LocalVariable, LinkVariable, type checking, properties
+- `test_localcommand.py`: LocalCommand foreground execution timing
+
+**Integration tests:**
+- `test_root.py`: Root context manager lifecycle
+- `test_loadsave.py`: YAML config save/load round-trip
+- `test_hub.py`: Virtual address space hub with SPI-style indirect access
+- `test_retry_memory.py`: Memory transaction retry on error
+- `test_streamBridge.py`: TCP stream bridge with PRBS verification
+- `test_fifo.py`: FIFO stream path with PRBS verification
+- `test_udpPacketizer.py`: UDP/packetizer/RSSI protocol stack testing
+- `test_epics.py`: EPICS V4 (p4p) PV read/write integration
+- `test_file.py`: File writer/reader with compression
+
+**Performance tests:**
+- `test_rate.py`: Benchmark set/get operations with cycle-count or wall-clock thresholds
+
+**Logging tests:**
+- `test_logging.py`: SystemLog feedback loop prevention, RootLogHandler isolation
+
+## Mocking & Test Doubles
+
+**No mocking framework.** Tests use real rogue C++ objects with memory emulation.
+
+**Memory Emulation (primary test double):**
+```python
+sim = rogue.interfaces.memory.Emulate(4, 0x1000)  # (minWidth, maxSize)
+self.addInterface(sim)
+self.add(DeviceUnderTest(
+    offset  = 0x0,
+    memBase = sim,
+))
+```
+
+**Custom Memory Slaves:**
+For testing complex protocols (hub, retry), tests define custom `rogue.interfaces.memory.Slave` subclasses that emulate hardware behavior:
+
+```python
+class LocalEmulate(rogue.interfaces.memory.Slave):
+    def __init__(self, *, minWidth=4, maxSize=0xFFFFFFFF):
+        rogue.interfaces.memory.Slave.__init__(self, 4, 4)
+        self._data = {}
+
+    def _doTransaction(self, transaction):
+        address = transaction.address()
+        size    = transaction.size()
+        type    = transaction.type()
+
+        if type == rogue.interfaces.memory.Write:
+            ba = bytearray(size)
+            transaction.getData(ba, 0)
+            # store data...
+            transaction.done()
+        elif type == rogue.interfaces.memory.Read:
+            # retrieve data...
+            transaction.setData(ba, 0)
+            transaction.done()
+        else:
+            transaction.error("Unsupported transaction type")
+```
+
+**PRBS Verification (stream tests):**
+```python
+prbsTx = rogue.utilities.Prbs()
+prbsRx = rogue.utilities.Prbs()
+prbsTx >> bridge >> prbsRx
+prbsRx.checkPayload(True)
+
+for _ in range(FrameCount):
+    prbsTx.genFrame(FrameSize)
+
+# Poll for completion
+for i in range(300):
+    if prbsRx.getRxCount() == FrameCount:
+        break
+    time.sleep(.1)
+
+if prbsRx.getRxErrors() != 0:
+    raise AssertionError('PRBS Frame errors detected!')
+```
+
+**Fake/Stub objects (for unit isolation):**
+- `test_logging.py` defines `FakeSystemLogVariable` and `FakeLogRoot` classes to test the log handler in isolation without starting a full Root
+
+```python
+class FakeSystemLogVariable:
+    def __init__(self, name):
+        self._log = logging.getLogger(f'pyrogue.Variable.LocalVariable.root.{name}')
+        self._value = '[]' if name == 'SystemLog' else ''
+        self.calls = 0
+        self.overflow = False
+        self.lock = contextlib.nullcontext()
+        self.path = f'root.{name}'
+
+    def set(self, value):
+        self.calls += 1
+        if self.calls > 5:
+            self.overflow = True
+            return
+        self._value = value
+
+    def value(self):
+        return self._value
+```
+
+## Fixtures and Factories
+
+**Test Data:**
+- Inline constants at module level: `FrameCount = 10000`, `FrameSize = 10000`
+- Inline test values: `test_value=3.14`, `UInt32ListARaw = [int(random.random()*1000) for i in range(32)]`
+- YAML fixture file: `tests/test_config_in.yml`
+
+**No pytest fixtures or conftest.py.** Each test file is self-contained with its own device/tree classes.
+
+**Factory pattern:** Each test file defines its own `DummyTree` (or `LocalRoot`, `BlockRoot`) class as a test fixture factory.
+
+## Coverage
+
+**Configuration (`.coveragerc`):**
+```ini
+[run]
+branch = True
+source = pyrogue
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*
+```
+
+**Requirements:** No minimum coverage threshold enforced.
+
+**View Coverage:**
+```bash
+source setup_rogue.sh
+python -m pytest --cov
+coverage report -m
+codecov                            # Upload to codecov.io
+```
+
+**Coverage scope:** Only `pyrogue` Python package is measured. C++ code is not covered by Python coverage tools.
+
+## C++ API Test
+
+**Location:** `tests/api_test/`
+**Build:** Separate CMake project
+**Runner:** Standalone executable compiled against rogue C++ library
+
+```bash
+source setup_rogue.sh
+cd tests/api_test
+mkdir build; cd build
+cmake ..
+make
+../../bin/api_test
+```
+
+This test exercises the `rogue::interfaces::api::Bsp` C++ API for tree navigation, variable get/set, YAML config, and bulk read/write operations.
+
+## CI Integration
+
+**GitHub Actions:** `.github/workflows/rogue_ci.yml`
+
+**Test pipeline (full_build_test job):**
+1. Check for trailing whitespace and tabs in `*.cpp`, `*.h`, `*.py`
+2. Run Python/C++ linters (`scripts/run_linters.sh`)
+3. Build rogue with CMake
+4. Run `python -m pytest --cov`
+5. Build and run C++ API test
+6. Generate coverage report with codecov
+
+**Additional CI jobs:**
+- `small_build_test`: C++-only build without Python (`-DNO_PYTHON=1`)
+- `macos_arm64_build_test`: macOS arm64 conda build + pytest (no coverage)
+
+## Common Patterns
+
+**Async/Polling in Tests:**
+Stream tests use polling loops to wait for asynchronous frame delivery:
+```python
+for i in range(300):   # Wait up to 30 seconds
+    if prbsRx.getRxCount() == FrameCount:
+        break
+    time.sleep(.1)
+```
+
+**Error Testing:**
+Tests verify exceptions via try/except pattern:
+```python
+try:
+    self.add(pyrogue.LocalVariable(
+        name='var_without_value'))
+    raise AssertionError('Expected exception not raised')
+except Exception as e:
+    print(type(e))  # do something with "e" for flake8
+    pass
+```
+
+Newer tests use pytest-style assertion:
+```python
+try:
+    root.myDevice.var.set('wrong-type')
+    raise AssertionError('Changing a LocalVariable type did not raise an exception')
+except pyrogue.VariableError as exc:
+    assert 'typeCheck=False' in str(exc)
+    assert 'expected' in str(exc)
+```
+
+**pytest monkeypatch (newer tests):**
+```python
+def test_logging_feedback(monkeypatch):
+    with pr.Root(name='root', pollEn=False, maxLog=10) as root:
+        monkeypatch.setattr(root.SystemLog, 'set', wrap('SystemLog', root.SystemLog.set))
+        # ... test ...
+```
+
+**Performance Testing:**
+```python
+def _measure_operation(root, count, operation):
+    start_ns = time.perf_counter_ns()
+    _run_update_loop(root, count, operation)
+    elapsed_ns = time.perf_counter_ns() - start_ns
+    return {'avg_ns': float(elapsed_ns) / count}
+
+# Assert against threshold
+assert not failures, "Rate check failed:\n" + "\n".join(failures)
+```
+
+## Writing New Tests
+
+**To add a new test:**
+1. Create `tests/test_<feature>.py`
+2. Add the license header
+3. Define Device subclass(es) with register definitions
+4. Define a Root subclass using `rogue.interfaces.memory.Emulate(4, 0x1000)` for memory emulation
+5. Define `test_<name>()` functions using `with RootClass() as root:` context manager
+6. Add `if __name__ == "__main__": test_<name>()` for standalone execution
+7. Use `raise AssertionError(...)` or `assert` for verification
+8. Set `pollEn=False` and `timeout=2.0` in root constructor
+
+**No special registration needed** -- pytest auto-discovers `test_*.py` files in `tests/`.
+
+---
+
+*Testing analysis: 2026-03-24*

--- a/docs/src/built_in_modules/protocols/epicsV4/epicspvholder.rst
+++ b/docs/src/built_in_modules/protocols/epicsV4/epicspvholder.rst
@@ -37,6 +37,18 @@ PyRogue set and display paths. Commands are exposed through EPICS RPC behavior,
 with the holder forwarding the EPICS request payload into the bound PyRogue
 command and packaging the return value back into the EPICS response.
 
+RPC Dispatch
+------------
+
+When an EPICS client calls ``ctxt.rpc()`` on a command-backed PV, the
+``EpicsPvHandler.rpc()`` method extracts the query from the incoming request.
+If the query contains an ``arg`` field, the value is forwarded to the PyRogue
+command; otherwise the command is called with no argument. The return value is
+wrapped in a P4P ``Value`` and sent back to the client.
+
+For usage examples and client-side patterns, see
+:ref:`protocols_epicsv4_epicspvserver`.
+
 Lifecycle Role in the Server
 ============================
 

--- a/docs/src/built_in_modules/protocols/epicsV4/epicspvserver.rst
+++ b/docs/src/built_in_modules/protocols/epicsV4/epicspvserver.rst
@@ -79,6 +79,78 @@ The common setup follows this pattern:
 2. Construct ``EpicsPvServer(base=..., root=..., pvMap=...)``.
 3. Register it with ``root.addProtocol(...)``.
 4. Use a P4P client to put and get values and confirm round-trip behavior.
+5. Use ``ctxt.rpc()`` to invoke PyRogue Commands through EPICS.
+
+RPC for Commands
+================
+
+PyRogue Commands (``LocalCommand`` and ``RemoteCommand``) are automatically
+exposed through EPICS RPC when served by ``EpicsPvServer``. The server-side
+``EpicsPvHandler.rpc()`` method dispatches incoming RPC requests to the bound
+PyRogue Command.
+
+Commands appear in the PV namespace alongside variables and can be invoked from
+any P4P client using ``ctxt.rpc()``.
+
+Invoking a Command Without Arguments
+-------------------------------------
+
+Use an ``NTURI`` with an empty query to call a no-argument command:
+
+.. code-block:: python
+
+   from p4p.client.thread import Context
+   from p4p.nt import NTURI
+
+   ctxt = Context('pva')
+
+   pv_name = 'MyIoc:MyRoot:MyDevice:ResetCounter'
+   uri = NTURI([])
+   ctxt.rpc(pv_name, uri.wrap(pv_name))
+
+On the server side, the handler sees no ``arg`` field in the query and calls
+the command with no argument.
+
+Invoking a Command With an Argument
+------------------------------------
+
+To pass a value into a command, declare a query field named ``arg`` in the
+``NTURI``. The handler extracts ``val.arg`` from the query and forwards it
+to the PyRogue command:
+
+.. code-block:: python
+
+   from p4p.client.thread import Context
+   from p4p.nt import NTURI
+
+   ctxt = Context('pva')
+
+   pv_name = 'MyIoc:MyRoot:MyDevice:SetThreshold'
+   uri = NTURI([('arg', 'i')])   # 'i' = int32; use 'd' for float64, 's' for string
+   ctxt.rpc(pv_name, uri.wrap(pv_name, kws={'arg': 42}))
+
+The NTURI type code for the ``arg`` field should match the expected value type.
+Common type codes are ``'i'`` (int32), ``'l'`` (int64), ``'d'`` (float64), and
+``'s'`` (string).
+
+P4P Context Behavior After RPC
+-------------------------------
+
+.. note::
+
+   Calling ``ctxt.rpc()`` on a P4P ``Context`` may cause subsequent
+   ``ctxt.get()`` calls to return raw ``p4p.wrapper.Value`` structs instead of
+   auto-unwrapped scalars. If you need to continue using ``ctxt.get()`` after
+   an RPC call, use a separate ``Context`` for the RPC operation:
+
+   .. code-block:: python
+
+      rpc_ctxt = Context('pva')
+      rpc_ctxt.rpc(pv_name, uri.wrap(pv_name))
+      rpc_ctxt.close()
+
+      # The original context continues to return unwrapped scalars.
+      value = ctxt.get(other_pv)
 
 When To Use It
 ==============

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -47,6 +47,12 @@ class SimpleDev(pr.Device):
             description='Reset LocalRwInt to 0',
         ))
 
+        self.add(pr.LocalCommand(
+            name='SetLocalRwInt',
+            function=lambda dev, arg: dev.LocalRwInt.set(arg),
+            description='Set LocalRwInt to arg value',
+        ))
+
         self.add(pr.RemoteVariable(
             name      = "RemoteRwInt",
             offset    = 0x000,
@@ -107,6 +113,7 @@ class LocalRootWithEpics(LocalRoot):
                 'LocalRoot.SimpleDev.RemoteRwInt'  : epics_prefix+':LocalRoot:SimpleDev:RemoteRwInt',
                 'LocalRoot.SimpleDev.RemoteWoInt'    : epics_prefix+':LocalRoot:SimpleDev:RemoteWoInt',
                 'LocalRoot.SimpleDev.ResetLocalRwInt': epics_prefix+':LocalRoot:SimpleDev:ResetLocalRwInt',
+                'LocalRoot.SimpleDev.SetLocalRwInt'  : epics_prefix+':LocalRoot:SimpleDev:SetLocalRwInt',
             }
         else:
             pv_map=None
@@ -223,6 +230,20 @@ def test_local_root():
             test_result=ctxt.get(pv_name)
             if test_result != 0:
                 raise AssertionError('RPC reset failed: pv_name={}: expected=0; test_result={}'.format(pv_name, test_result))
+
+            # Test RPC with argument: call rpc with arg to set LocalRwInt to a specific value
+            pv_name=device_epics_prefix+':LocalRwInt'
+            rpc_pv=device_epics_prefix+':SetLocalRwInt'
+            test_value=99
+            rpc_ctxt = Context('pva')
+            uri = NTURI([('arg', 'i')])
+            result = rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv, kws={'arg': test_value}))
+            rpc_ctxt.close()
+
+            wait_pv_value(ctxt, pv_name, test_value)
+            test_result=ctxt.get(pv_name)
+            if test_result != test_value:
+                raise AssertionError('RPC set failed: pv_name={}: expected={}; test_result={}'.format(pv_name, test_value, test_result))
 
 if __name__ == "__main__":
     test_local_root()

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -42,15 +42,15 @@ class SimpleDev(pr.Device):
             mode  = 'RW'))
 
         self.add(pr.LocalCommand(
-            name='ResetLocalRwInt',
-            function=lambda dev: dev.LocalRwInt.set(0),
-            description='Reset LocalRwInt to 0',
+            name        = 'ResetLocalRwInt',
+            function    = lambda dev: dev.LocalRwInt.set(0),
+            description = 'Reset LocalRwInt to 0',
         ))
 
         self.add(pr.LocalCommand(
-            name='SetLocalRwInt',
-            function=lambda dev, arg: dev.LocalRwInt.set(arg),
-            description='Set LocalRwInt to arg value',
+            name        = 'SetLocalRwInt',
+            function    = lambda dev, arg: dev.LocalRwInt.set(arg),
+            description = 'Set LocalRwInt to arg value',
         ))
 
         self.add(pr.RemoteVariable(
@@ -107,13 +107,13 @@ class LocalRootWithEpics(LocalRoot):
         if use_map:
             # PV map
             pv_map = {
-                'LocalRoot.SimpleDev.LocalRwInt'   : epics_prefix+':LocalRoot:SimpleDev:LocalRwInt',
-                'LocalRoot.SimpleDev.LocalWoInt'   : epics_prefix+':LocalRoot:SimpleDev:LocalWoInt',
-                'LocalRoot.SimpleDev.LocalRwFloat' : epics_prefix+':LocalRoot:SimpleDev:LocalRwFloat',
-                'LocalRoot.SimpleDev.RemoteRwInt'  : epics_prefix+':LocalRoot:SimpleDev:RemoteRwInt',
-                'LocalRoot.SimpleDev.RemoteWoInt'    : epics_prefix+':LocalRoot:SimpleDev:RemoteWoInt',
-                'LocalRoot.SimpleDev.ResetLocalRwInt': epics_prefix+':LocalRoot:SimpleDev:ResetLocalRwInt',
-                'LocalRoot.SimpleDev.SetLocalRwInt'  : epics_prefix+':LocalRoot:SimpleDev:SetLocalRwInt',
+                'LocalRoot.SimpleDev.LocalRwInt'      : epics_prefix+':LocalRoot:SimpleDev:LocalRwInt',
+                'LocalRoot.SimpleDev.LocalWoInt'      : epics_prefix+':LocalRoot:SimpleDev:LocalWoInt',
+                'LocalRoot.SimpleDev.LocalRwFloat'    : epics_prefix+':LocalRoot:SimpleDev:LocalRwFloat',
+                'LocalRoot.SimpleDev.RemoteRwInt'     : epics_prefix+':LocalRoot:SimpleDev:RemoteRwInt',
+                'LocalRoot.SimpleDev.RemoteWoInt'     : epics_prefix+':LocalRoot:SimpleDev:RemoteWoInt',
+                'LocalRoot.SimpleDev.ResetLocalRwInt' : epics_prefix+':LocalRoot:SimpleDev:ResetLocalRwInt',
+                'LocalRoot.SimpleDev.SetLocalRwInt'   : epics_prefix+':LocalRoot:SimpleDev:SetLocalRwInt',
             }
         else:
             pv_map=None
@@ -223,7 +223,7 @@ def test_local_root():
             # context's NTScalar unwrapping for subsequent get() calls.
             rpc_ctxt = Context('pva')
             uri = NTURI([])
-            result = rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv))
+            rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv))
             rpc_ctxt.close()
 
             wait_pv_value(ctxt, pv_name, 0)
@@ -237,7 +237,7 @@ def test_local_root():
             test_value=99
             rpc_ctxt = Context('pva')
             uri = NTURI([('arg', 'i')])
-            result = rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv, kws={'arg': test_value}))
+            rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv, kws={'arg': test_value}))
             rpc_ctxt.close()
 
             wait_pv_value(ctxt, pv_name, test_value)

--- a/tests/test_epics.py
+++ b/tests/test_epics.py
@@ -15,6 +15,7 @@ import pyrogue.protocols.epicsV4
 import rogue.interfaces.memory
 
 from p4p.client.thread import Context
+from p4p.nt import NTURI
 
 epics_prefix='test_ioc'
 PropagateTimeout = 10.0
@@ -39,6 +40,12 @@ class SimpleDev(pr.Device):
             name  = 'LocalRwFloat',
             value = 0.0,
             mode  = 'RW'))
+
+        self.add(pr.LocalCommand(
+            name='ResetLocalRwInt',
+            function=lambda dev: dev.LocalRwInt.set(0),
+            description='Reset LocalRwInt to 0',
+        ))
 
         self.add(pr.RemoteVariable(
             name      = "RemoteRwInt",
@@ -98,7 +105,8 @@ class LocalRootWithEpics(LocalRoot):
                 'LocalRoot.SimpleDev.LocalWoInt'   : epics_prefix+':LocalRoot:SimpleDev:LocalWoInt',
                 'LocalRoot.SimpleDev.LocalRwFloat' : epics_prefix+':LocalRoot:SimpleDev:LocalRwFloat',
                 'LocalRoot.SimpleDev.RemoteRwInt'  : epics_prefix+':LocalRoot:SimpleDev:RemoteRwInt',
-                'LocalRoot.SimpleDev.RemoteWoInt'  : epics_prefix+':LocalRoot:SimpleDev:RemoteWoInt',
+                'LocalRoot.SimpleDev.RemoteWoInt'    : epics_prefix+':LocalRoot:SimpleDev:RemoteWoInt',
+                'LocalRoot.SimpleDev.ResetLocalRwInt': epics_prefix+':LocalRoot:SimpleDev:ResetLocalRwInt',
             }
         else:
             pv_map=None
@@ -196,6 +204,25 @@ def test_local_root():
             pv_name=device_epics_prefix+':RemoteWoInt'
             test_value=314
             ctxt.put(pv_name, test_value)
+
+            # Test RPC: set LocalRwInt to non-zero, call rpc to reset, verify it's zero
+            pv_name=device_epics_prefix+':LocalRwInt'
+            rpc_pv=device_epics_prefix+':ResetLocalRwInt'
+            test_value=42
+            ctxt.put(pv_name, test_value)
+            wait_pv_value(ctxt, pv_name, test_value)
+
+            # Use a separate context for rpc() to avoid tainting the main
+            # context's NTScalar unwrapping for subsequent get() calls.
+            rpc_ctxt = Context('pva')
+            uri = NTURI([])
+            result = rpc_ctxt.rpc(rpc_pv, uri.wrap(rpc_pv))
+            rpc_ctxt.close()
+
+            wait_pv_value(ctxt, pv_name, 0)
+            test_result=ctxt.get(pv_name)
+            if test_result != 0:
+                raise AssertionError('RPC reset failed: pv_name={}: expected=0; test_result={}'.format(pv_name, test_result))
 
 if __name__ == "__main__":
     test_local_root()


### PR DESCRIPTION
## Summary

Add test coverage and documentation for EPICS V4 RPC command invocation via `ctxt.rpc()`, which previously had no test or doc coverage.

### Test changes (`tests/test_epics.py`)
- Add `ResetLocalRwInt` command (no-arg): resets `LocalRwInt` to 0
- Add `SetLocalRwInt` command (with arg): sets `LocalRwInt` to the provided value
- Exercise both commands through `ctxt.rpc()` with NTURI, covering the `EpicsPvHandler.rpc()` dispatch path for both no-arg and arg-passing cases
- Use separate `Context` instances for RPC calls to avoid p4p unwrapping issues

### Documentation changes (`docs/src/built_in_modules/protocols/epicsV4/`)
- Add "RPC for Commands" section to `epicspvserver.rst` with usage examples for no-arg and arg-passing invocations, NTURI type codes, and a note on p4p Context behavior after RPC
- Add "RPC Dispatch" subsection to `epicspvholder.rst` describing how the handler routes requests to PyRogue commands

## Test plan
- [x] No-arg RPC: sets `LocalRwInt=42`, calls `ResetLocalRwInt` via rpc, confirms value is 0
- [x] Arg RPC: calls `SetLocalRwInt` via rpc with `arg=99`, confirms `LocalRwInt` is 99
- [x] Both `use_map=False` (auto) and `use_map=True` (explicit) PV mapping modes tested
