### PR TITLE
Add EPICS V7 Python API docs pages

### DIFF
--- a/docs/src/api/python/pyrogue/protocols/epicsv7/epicspvholder.rst
+++ b/docs/src/api/python/pyrogue/protocols/epicsv7/epicspvholder.rst
@@ -1,0 +1,13 @@
+.. _api_python_protocols_epicsv7_epicspvholder:
+
+EpicsPvHolder
+=============
+
+For conceptual protocol usage, see:
+
+- :doc:`/built_in_modules/protocols/epicsV7/index`
+
+.. autoclass:: pyrogue.protocols.epicsV7.EpicsPvHolder
+   :members:
+   :member-order: bysource
+   :inherited-members:

--- a/docs/src/api/python/pyrogue/protocols/epicsv7/epicspvserver.rst
+++ b/docs/src/api/python/pyrogue/protocols/epicsv7/epicspvserver.rst
@@ -1,0 +1,13 @@
+.. _api_python_protocols_epicsv7_epicspvserver:
+
+EpicsPvServer
+=============
+
+For conceptual protocol usage, see:
+
+- :doc:`/built_in_modules/protocols/epicsV7/index`
+
+.. autoclass:: pyrogue.protocols.epicsV7.EpicsPvServer
+   :members:
+   :member-order: bysource
+   :inherited-members:

--- a/docs/src/api/python/pyrogue/protocols/epicsv7/index.rst
+++ b/docs/src/api/python/pyrogue/protocols/epicsv7/index.rst
@@ -1,0 +1,19 @@
+.. _api_python_pyrogue_protocols_epicsv7:
+
+==========================
+pyrogue.protocols.epicsv7
+==========================
+
+EPICS V7 protocol wrappers implemented directly in PyRogue.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   epicspvholder
+   epicspvserver
+
+
+.. rubric:: Related Topics
+
+- :doc:`/built_in_modules/protocols/epicsV7/index`

--- a/docs/src/api/python/pyrogue/protocols/index.rst
+++ b/docs/src/api/python/pyrogue/protocols/index.rst
@@ -15,10 +15,12 @@ Protocol wrappers implemented directly in PyRogue.
    gpibcontroller
    gpibdevice
    epicsv4/index
+   epicsv7/index
 
 
 .. rubric:: Related Topics
 
 - :doc:`/built_in_modules/protocols/index`
 - :doc:`/built_in_modules/protocols/epicsV4/index`
+- :doc:`/built_in_modules/protocols/epicsV7/index`
 - :doc:`/built_in_modules/protocols/gpib`

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -63,6 +63,8 @@ autodoc_mock_imports = [
     'matplotlib',
     'pyqtgraph',
     'sip',
+    'softioc',
+    'softioc.asyncio_dispatcher',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### Description
Add the missing Python API documentation pages for `pyrogue.protocols.epicsV7` so the recently added EPICS V7 protocol classes appear in the generated docs.

### Details
This change mirrors the existing `epicsv4` API doc structure by adding `epicsv7` namespace and class pages for `EpicsPvHolder` and `EpicsPvServer`, then links that namespace from the Python protocol API index.

It also adds `softioc` and `softioc.asyncio_dispatcher` to Sphinx `autodoc_mock_imports` so autodoc can import the EPICS V7 module in doc environments where pythonSoftIOC is not installed.

### Related
- PR: #1161 