### PR TITLE
Add path to support Qt6 in the future via qtpy abstraction layer (ESROGUE-688)

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -32,3 +32,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pyqt>=5.15
+  - qtpy>=2.0
+  - pyqtgraph>=0.13

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -25,5 +25,6 @@ cpplint
 gitpython
 pygithub
 pydm
+qtpy
 matplotlib
 hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/python/pyrogue/pydm/data_plugins/rogue_plugin.py
+++ b/python/pyrogue/pydm/data_plugins/rogue_plugin.py
@@ -18,8 +18,8 @@ import os
 # import time
 
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
-from PyQt5.QtCore import pyqtSlot, Qt
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import Slot, Qt
+from qtpy.QtWidgets import QApplication
 from pydm import utilities
 from pydm.widgets.channel import PyDMChannel
 
@@ -207,10 +207,10 @@ class RogueConnection(PyDMConnection):
         self.new_severity_signal.emit(AlarmToInt[varValue.severity])
 
 
-    @pyqtSlot(int)
-    @pyqtSlot(float)
-    @pyqtSlot(str)
-    @pyqtSlot(np.ndarray)
+    @Slot(int)
+    @Slot(float)
+    @Slot(str)
+    @Slot(np.ndarray)
     def put_value(self, new_value: int | float | str | np.ndarray | None) -> None:
         """Handle write requests from PyDM widgets.
 

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -32,8 +32,7 @@ from qtpy.QtWidgets import (
 
 from pyqtgraph import ViewBox
 
-from PyQt5.QtWidgets import QSplitter
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QSplitter
 
 import random
 
@@ -571,7 +570,7 @@ class TimePlotter(PyDMFrame):
         selection_box = QGroupBox()
         selection_box.setLayout(selection_layout)
 
-        selection_splitter = QSplitter(Qt.Vertical)
+        selection_splitter = QSplitter(QtCore.Qt.Vertical)
         selection_splitter.addWidget(self.selection_tree)
         selection_splitter.addWidget(self.scroll_area)
 
@@ -581,7 +580,7 @@ class TimePlotter(PyDMFrame):
         graphs_box = QGroupBox()
         graphs_box.setLayout(graphs_layout)
 
-        main_splitter = QSplitter(Qt.Horizontal)
+        main_splitter = QSplitter(QtCore.Qt.Horizontal)
 
         main_splitter.addWidget(selection_splitter)
         main_splitter.addWidget(graphs_box)

--- a/python/pyrogue/pydm/widgets/time_plotter.py
+++ b/python/pyrogue/pydm/widgets/time_plotter.py
@@ -254,7 +254,7 @@ class DebugHolder(QTreeWidgetItem):
         w.alarmSensitiveBorder  = True
 
         fm = QFontMetrics(w.font())
-        width = int(fm.width(self._path.split('.')[-1]) * 1.1)
+        width = int(fm.horizontalAdvance(self._path.split('.')[-1]) * 1.1)
 
         rightEdge = width + (self._top._tree.indentation() * self._depth)
 
@@ -301,7 +301,7 @@ class DebugHolder(QTreeWidgetItem):
 
 
         self._top._tree.setItemWidget(self,2,w)
-        width = fm.width('0xAAAAAAAA    ')
+        width = fm.horizontalAdvance('0xAAAAAAAA    ')
 
         if width > self._top._colWidths[1]:
             self._top._colWidths[1] = width


### PR DESCRIPTION
## Summary

- Replace direct PyQt5 imports with qtpy in `rogue_plugin.py` and `time_plotter.py`, matching PyDM's own Qt backend abstraction
- Replace deprecated `QFontMetrics.width()` with `horizontalAdvance()` for Qt6 compatibility
- Add `qtpy>=2.0` and `pyqtgraph>=0.13` to `conda.yml`; add `qtpy` to `pip_requirements.txt`

Users can now choose their Qt backend (PyQt5 or PySide6) via the `QT_API` environment variable. Existing PyQt5 users see zero behavior change since qtpy defaults to PyQt5 when `QT_API` is not set.

Currently, PyDM has limited support for PyQt5 and PySide6, and does not yet support PyQt6. This will allow users to easily migrate to PyQt6 once PyDM adds support for it.

## Test plan

- [x] CI passes on ESROGUE-688 branch (all 4 jobs green)
- [x] `grep -rn "PyQt5\|pyqtSlot" python/ tests/ --include="*.py"` returns zero matches
- [x] flake8 clean on `python/` and `tests/`
- [x] Full test suite passes under PyQt5 backend
- [x] Full test suite passes under PySide6 backend

JIRA: ESROGUE-688