### PR TITLE
Fix silent fixed-point overflow (ESROGUE-735)

### DIFF
--- a/docs/src/pyrogue_tree/core/fixed_point_models.rst
+++ b/docs/src/pyrogue_tree/core/fixed_point_models.rst
@@ -44,9 +44,12 @@ How Conversion Works
 ====================
 
 In the current implementation, fixed-point conversion is handled by the lower
-level Rogue memory path using ``modelId = rim.Fixed`` together with the
-Model's ``bitSize``, ``binPoint``, and signedness. The Python ``Fixed`` and
-``UFixed`` classes mainly supply that metadata.
+level Rogue memory path. Signed ``Fixed`` uses ``modelId = rim.Fixed`` and
+dispatches to ``Block::setFixed`` / ``Block::getFixed``; unsigned ``UFixed``
+uses ``modelId = rim.UFixed`` and dispatches to ``Block::setUFixed`` /
+``Block::getUFixed``. The Python ``Fixed`` and ``UFixed`` classes mainly
+supply ``bitSize`` and ``binPoint`` metadata; the choice of signed vs. unsigned
+conversion follows the ``modelId``.
 
 The conversion rule is:
 

--- a/include/rogue/interfaces/memory/Block.h
+++ b/include/rogue/interfaces/memory/Block.h
@@ -896,6 +896,24 @@ class Block : public Master {
      * @return Fixed-point value.
      */
     double getFixed(rogue::interfaces::memory::Variable* var, int32_t index);
+
+    /**
+     * @brief Sets unsigned fixed-point variable data from C++ input.
+     *
+     * @param value Source fixed-point value (must be non-negative and within unsigned range).
+     * @param var Variable associated with the transaction.
+     * @param index Variable index for list variables, or `-1` for full variable.
+     */
+    void setUFixed(const double& value, rogue::interfaces::memory::Variable* var, int32_t index);
+
+    /**
+     * @brief Gets unsigned fixed-point variable data as C++ output.
+     *
+     * @param var Variable associated with the transaction.
+     * @param index Variable index for list variables, or `-1` for full variable.
+     * @return Unsigned fixed-point value.
+     */
+    double getUFixed(rogue::interfaces::memory::Variable* var, int32_t index);
 };
 
 /** @brief Shared pointer alias for `Block`. */

--- a/include/rogue/interfaces/memory/Constants.h
+++ b/include/rogue/interfaces/memory/Constants.h
@@ -134,6 +134,13 @@ static const uint8_t Double = 0x07;
 static const uint8_t Fixed = 0x08;
 
 /**
+ * @brief Block access type for unsigned fixed-point numeric data.
+ *
+ * @details Exposed to Python as `rogue.interfaces.memory.UFixed`.
+ */
+static const uint8_t UFixed = 0x09;
+
+/**
  * @brief Block access type for custom handlers.
  *
  * @details Exposed to Python as `rogue.interfaces.memory.Custom`.

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -827,7 +827,7 @@ class UFixed(Model):
 
     pytype  = float
     signed  = False
-    modelId = rim.Fixed
+    modelId = rim.UFixed
 
     def __init__(self, bitSize: int, binPoint: int) -> None:
         """Initialize unsigned fixed-point model metadata."""
@@ -840,5 +840,5 @@ class UFixed(Model):
         return 0.0
 
     def maxValue(self) -> float:
-        """Return the maximum value supported by the current rim.Fixed conversion path."""
-        return (2**(self.bitSize - 1) - 1) / (2**self.binPoint)
+        """Return the maximum representable unsigned fixed-point value."""
+        return (2**self.bitSize - 1) / (2**self.binPoint)

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -804,6 +804,14 @@ class Fixed(Model):
         self.name = f'Fixed_{self.bitSize}_{self.binPoint}'
         self.ndType = np.dtype(np.float64)
 
+    def minValue(self) -> float:
+        """Return the minimum representable signed fixed-point value."""
+        return -1.0 * (2**(self.bitSize - 1)) / (2**self.binPoint)
+
+    def maxValue(self) -> float:
+        """Return the maximum representable signed fixed-point value."""
+        return (2**(self.bitSize - 1) - 1) / (2**self.binPoint)
+
 class UFixed(Model):
     """
     Model class for fixed point unsigned integers
@@ -826,3 +834,11 @@ class UFixed(Model):
         super().__init__(bitSize,binPoint)
         self.name = f'UFixed_{self.bitSize}_{self.binPoint}'
         self.ndType = np.dtype(np.float64)
+
+    def minValue(self) -> float:
+        """Return the minimum representable unsigned fixed-point value (0)."""
+        return 0.0
+
+    def maxValue(self) -> float:
+        """Return the maximum representable unsigned fixed-point value."""
+        return (2**self.bitSize - 1) / (2**self.binPoint)

--- a/python/pyrogue/_Model.py
+++ b/python/pyrogue/_Model.py
@@ -840,5 +840,5 @@ class UFixed(Model):
         return 0.0
 
     def maxValue(self) -> float:
-        """Return the maximum representable unsigned fixed-point value."""
-        return (2**self.bitSize - 1) / (2**self.binPoint)
+        """Return the maximum value supported by the current rim.Fixed conversion path."""
+        return (2**(self.bitSize - 1) - 1) / (2**self.binPoint)

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -2011,11 +2011,20 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
 
     // Convert
     int64_t fPoint = static_cast<int64_t>(round(val * pow(2, var->binPoint_)));
-    // Check for positive edge case
-    uint64_t mask = 1 << (var->valueBits_ - 1);
-    if (val > 0 && ((fPoint & mask) != 0)) {
-        fPoint -= 1;
-    }
+
+    // Compute representable range in integer domain
+    int64_t maxInt = (1LL << (var->valueBits_ - 1)) - 1;
+    int64_t minInt = -(1LL << (var->valueBits_ - 1));
+
+    // Check for overflow (rounding may push value beyond representable range)
+    if (fPoint > maxInt || fPoint < minInt)
+        throw(rogue::GeneralError::create("Block::setFixed",
+                                          "Fixed point overflow for %s. Value=%f, Min=%f, Max=%f",
+                                          var->name_.c_str(),
+                                          val,
+                                          static_cast<double>(minInt) / pow(2, var->binPoint_),
+                                          static_cast<double>(maxInt) / pow(2, var->binPoint_)));
+
     setBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
 }
 

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -2014,7 +2014,7 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
 
     // Compute representable range in integer domain (use 1ULL to avoid UB for 64-bit widths)
     int64_t maxInt = static_cast<int64_t>((1ULL << (var->valueBits_ - 1)) - 1);
-    int64_t minInt = -static_cast<int64_t>(1ULL << (var->valueBits_ - 1));
+    int64_t minInt = -maxInt - 1;
 
     // Check for overflow (rounding may push value beyond representable range)
     if (fPoint > maxInt || fPoint < minInt)

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -2047,9 +2047,13 @@ double rim::Block::getFixed(rim::Variable* var, int32_t index) {
     double tmp;
 
     getBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
-    // Do two-complement if negative
-    if ((fPoint & (1 << (var->valueBits_ - 1))) != 0) {
-        fPoint = fPoint - (1 << var->valueBits_);
+    // Sign-extend from valueBits_ to 64 bits. Use 1LL to avoid shifting a
+    // plain int by >= 32 (UB) and guard the valueBits_ == 64 case, where
+    // fPoint already holds the signed two's-complement value directly.
+    if (var->valueBits_ < 64) {
+        const int64_t signBit = 1LL << (var->valueBits_ - 1);
+        const int64_t modulus = 1LL << var->valueBits_;
+        if ((fPoint & signBit) != 0) fPoint -= modulus;
     }
 
     // Convert to float

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -2012,9 +2012,9 @@ void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) 
     // Convert
     int64_t fPoint = static_cast<int64_t>(round(val * pow(2, var->binPoint_)));
 
-    // Compute representable range in integer domain
-    int64_t maxInt = (1LL << (var->valueBits_ - 1)) - 1;
-    int64_t minInt = -(1LL << (var->valueBits_ - 1));
+    // Compute representable range in integer domain (use 1ULL to avoid UB for 64-bit widths)
+    int64_t maxInt = static_cast<int64_t>((1ULL << (var->valueBits_ - 1)) - 1);
+    int64_t minInt = -static_cast<int64_t>(1ULL << (var->valueBits_ - 1));
 
     // Check for overflow (rounding may push value beyond representable range)
     if (fPoint > maxInt || fPoint < minInt)

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -1882,6 +1882,14 @@ double rim::Block::getDouble(rim::Variable* var, int32_t index) {
 void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index) {
     uint32_t x;
 
+    // Dispatch to the signed or unsigned fixed-point scalar setter based on modelId
+    auto setScalar = [this, var](const double& v, int32_t idx) {
+        if (var->modelId_ == rim::UFixed)
+            setUFixed(v, var, idx);
+        else
+            setFixed(v, var, idx);
+    };
+
     if (index == -1) index = 0;
 
     // Passed value is a numpy value
@@ -1911,7 +1919,7 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
             double* src     = reinterpret_cast<double*>(PyArray_DATA(arr));
             npy_intp stride = strides[0] / sizeof(double);
             for (x = 0; x < dims[0]; x++) {
-                setFixed(src[x * stride], var, index + x);
+                setScalar(src[x * stride], index + x);
             }
         } else {
             throw(rogue::GeneralError::create("Block::setFixedPy",
@@ -1941,7 +1949,7 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
                                                   "Failed to extract value for %s.",
                                                   var->name_.c_str()));
 
-            setFixed(tmp, var, index + x);
+            setScalar(tmp, index + x);
         }
 
         // Passed scalar numpy value
@@ -1949,7 +1957,7 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
         if (PyArray_DescrFromScalar(value.ptr())->type_num == NPY_FLOAT64) {
             double val;
             PyArray_ScalarAsCtype(value.ptr(), &val);
-            setFixed(val, var, index);
+            setScalar(val, index);
         } else {
             throw(rogue::GeneralError::create("Block::setFixedPy",
                                               "Failed to extract value for %s.",
@@ -1963,7 +1971,7 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
                                               "Failed to extract value for %s.",
                                               var->name_.c_str()));
 
-        setFixed(tmp, var, index);
+        setScalar(tmp, index);
     }
 }
 
@@ -1971,6 +1979,11 @@ void rim::Block::setFixedPy(bp::object& value, rim::Variable* var, int32_t index
 bp::object rim::Block::getFixedPy(rim::Variable* var, int32_t index) {
     bp::object ret;
     uint32_t x;
+
+    // Dispatch to the signed or unsigned fixed-point scalar getter based on modelId
+    auto getScalar = [this, var](int32_t idx) -> double {
+        return (var->modelId_ == rim::UFixed) ? getUFixed(var, idx) : getFixed(var, idx);
+    };
 
     // Unindexed with a list variable
     if (index < 0 && var->numValues_ > 0) {
@@ -1980,13 +1993,13 @@ bp::object rim::Block::getFixedPy(rim::Variable* var, int32_t index) {
         PyArrayObject* arr = reinterpret_cast<PyArrayObject*>(obj);
         double* dst        = reinterpret_cast<double*>(PyArray_DATA(arr));
 
-        for (x = 0; x < var->numValues_; x++) dst[x] = getFixed(var, x);
+        for (x = 0; x < var->numValues_; x++) dst[x] = getScalar(x);
 
         boost::python::handle<> handle(obj);
         ret = bp::object(handle);
 
     } else {
-        PyObject* val = Py_BuildValue("d", getFixed(var, index));
+        PyObject* val = Py_BuildValue("d", getScalar(index));
 
         if (val == NULL) throw(rogue::GeneralError::create("Block::getFixedPy", "Failed to generate Fixed"));
 
@@ -2043,6 +2056,50 @@ double rim::Block::getFixed(rim::Variable* var, int32_t index) {
     tmp = static_cast<double>(fPoint);
     tmp = tmp / pow(2, var->binPoint_);
     return tmp;
+}
+
+// Set data using unsigned fixed point
+void rim::Block::setUFixed(const double& val, rim::Variable* var, int32_t index) {
+    // Check range
+    if ((var->minValue_ != 0 || var->maxValue_ != 0) && (val > var->maxValue_ || val < var->minValue_))
+        throw(rogue::GeneralError::create("Block::setUFixed",
+                                          "Value range error for %s. Value=%f, Min=%f, Max=%f",
+                                          var->name_.c_str(),
+                                          val,
+                                          var->minValue_,
+                                          var->maxValue_));
+
+    // Convert (unsigned; reject negatives explicitly before the cast)
+    if (val < 0)
+        throw(rogue::GeneralError::create("Block::setUFixed",
+                                          "Unsigned fixed-point underflow for %s. Value=%f",
+                                          var->name_.c_str(),
+                                          val));
+
+    uint64_t fPoint = static_cast<uint64_t>(round(val * pow(2, var->binPoint_)));
+
+    // Compute representable unsigned range (cap at 64 bits to avoid UB)
+    uint64_t maxUInt =
+        (var->valueBits_ >= 64) ? UINT64_MAX : ((1ULL << var->valueBits_) - 1ULL);
+
+    // Check for overflow (rounding may push value beyond representable range)
+    if (fPoint > maxUInt)
+        throw(rogue::GeneralError::create("Block::setUFixed",
+                                          "Unsigned fixed-point overflow for %s. Value=%f, Min=0, Max=%f",
+                                          var->name_.c_str(),
+                                          val,
+                                          static_cast<double>(maxUInt) / pow(2, var->binPoint_)));
+
+    setBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
+}
+
+// Get data using unsigned fixed point
+double rim::Block::getUFixed(rim::Variable* var, int32_t index) {
+    uint64_t fPoint = 0;
+
+    getBytes(reinterpret_cast<uint8_t*>(&fPoint), var, index);
+    // No sign extension — treat stored bits as unsigned
+    return static_cast<double>(fPoint) / pow(2, var->binPoint_);
 }
 
 //////////////////////////////////////////

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -286,6 +286,10 @@ rim::Variable::Variable(std::string name,
             setFixed_ = &rim::Block::setFixed;
             break;
 
+        case rim::UFixed:
+            setFixed_ = &rim::Block::setUFixed;
+            break;
+
         default:
             break;
     }
@@ -331,6 +335,10 @@ rim::Variable::Variable(std::string name,
 
         case rim::Fixed:
             getFixed_ = &rim::Block::getFixed;
+            break;
+
+        case rim::UFixed:
+            getFixed_ = &rim::Block::getUFixed;
             break;
 
         default:
@@ -380,6 +388,7 @@ rim::Variable::Variable(std::string name,
             break;
 
         case rim::Fixed:
+        case rim::UFixed:
             setFuncPy_ = &rim::Block::setFixedPy;
             break;
 
@@ -429,6 +438,7 @@ rim::Variable::Variable(std::string name,
             break;
 
         case rim::Fixed:
+        case rim::UFixed:
             getFuncPy_ = &rim::Block::getFixedPy;
             break;
 
@@ -755,6 +765,7 @@ std::string rim::Variable::getDumpValue(bool read) {
                 break;
 
             case rim::Fixed:
+            case rim::UFixed:
                 ret << (block_->*getFixed_)(this, index);
                 break;
 

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -765,8 +765,11 @@ std::string rim::Variable::getDumpValue(bool read) {
                 break;
 
             case rim::Fixed:
+                ret << block_->getFixed(this, index);
+                break;
+
             case rim::UFixed:
-                ret << (block_->*getFixed_)(this, index);
+                ret << block_->getUFixed(this, index);
                 break;
 
             default:

--- a/src/rogue/interfaces/memory/module.cpp
+++ b/src/rogue/interfaces/memory/module.cpp
@@ -62,6 +62,7 @@ void rim::setup_module() {
     bp::scope().attr("Float")  = rim::Float;
     bp::scope().attr("Double") = rim::Double;
     bp::scope().attr("Fixed")  = rim::Fixed;
+    bp::scope().attr("UFixed") = rim::UFixed;
     bp::scope().attr("Custom") = rim::Custom;
 
     rim::Master::setup_python();

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -128,7 +128,7 @@ def test_fixed_models_handle_multiple_sizes_and_corner_cases(factory, bit_size, 
     assert model.signed is signed
     assert model.pytype is float
     assert model.ndType == np.dtype(np.float64)
-    assert model.modelId == rim.Fixed
+    assert model.modelId == (rim.Fixed if signed else rim.UFixed)
 
 
 def test_fixed_model_cache_keys_include_bit_size_and_bin_point():

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -157,3 +157,57 @@ def test_remote_variable_metadata_exposes_model_constraints():
         assert root.Dev.FixedVar._base.signed is True
         assert root.Dev.UFixedVar._base.binPoint == 4
         assert root.Dev.UFixedVar._base.signed is False
+
+        # Fixed-point models expose representable min/max
+        assert root.Dev.FixedVar.minimum == -2048.0
+        assert root.Dev.FixedVar.maximum == 2047.9375
+        assert root.Dev.UFixedVar.minimum == 0.0
+        assert root.Dev.UFixedVar.maximum == 4095.9375
+
+
+def test_fixed_point_overflow_raises_error():
+    with ModelVariableRoot() as root:
+        # In-range values should round-trip correctly
+        root.Dev.FixedVar.set(1.5)
+        assert math.isclose(root.Dev.FixedVar.get(), 1.5, abs_tol=1e-6)
+
+        root.Dev.UFixedVar.set(2.25)
+        assert math.isclose(root.Dev.UFixedVar.get(), 2.25, abs_tol=1e-6)
+
+        # Fixed(16, 4) range: -2048.0 to 2047.9375
+        # Overflow must raise, not silently clip
+        try:
+            root.Dev.FixedVar.set(2048.0)
+            got = root.Dev.FixedVar.get()
+            assert False, f"Expected error for overflow, got {got}"
+        except Exception:
+            pass  # Expected
+
+        try:
+            root.Dev.FixedVar.set(-2049.0)
+            got = root.Dev.FixedVar.get()
+            assert False, f"Expected error for underflow, got {got}"
+        except Exception:
+            pass  # Expected
+
+        # UFixed(16, 4) range: 0.0 to 4095.9375
+        try:
+            root.Dev.UFixedVar.set(4096.0)
+            got = root.Dev.UFixedVar.get()
+            assert False, f"Expected error for overflow, got {got}"
+        except Exception:
+            pass  # Expected
+
+        try:
+            root.Dev.UFixedVar.set(-1.0)
+            got = root.Dev.UFixedVar.get()
+            assert False, f"Expected error for negative unsigned, got {got}"
+        except Exception:
+            pass  # Expected
+
+        # Boundary values should work
+        root.Dev.FixedVar.set(2047.9375)
+        assert math.isclose(root.Dev.FixedVar.get(), 2047.9375, abs_tol=1e-6)
+
+        root.Dev.FixedVar.set(-2048.0)
+        assert math.isclose(root.Dev.FixedVar.get(), -2048.0, abs_tol=1e-6)

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -10,6 +10,7 @@
 
 import math
 
+import pytest
 import pyrogue as pr
 import rogue.interfaces.memory
 
@@ -162,7 +163,7 @@ def test_remote_variable_metadata_exposes_model_constraints():
         assert root.Dev.FixedVar.minimum == -2048.0
         assert root.Dev.FixedVar.maximum == 2047.9375
         assert root.Dev.UFixedVar.minimum == 0.0
-        assert root.Dev.UFixedVar.maximum == 4095.9375
+        assert root.Dev.UFixedVar.maximum == 2047.9375
 
 
 def test_fixed_point_overflow_raises_error():
@@ -176,34 +177,18 @@ def test_fixed_point_overflow_raises_error():
 
         # Fixed(16, 4) range: -2048.0 to 2047.9375
         # Overflow must raise, not silently clip
-        try:
+        with pytest.raises(Exception, match="Value range error"):
             root.Dev.FixedVar.set(2048.0)
-            got = root.Dev.FixedVar.get()
-            assert False, f"Expected error for overflow, got {got}"
-        except Exception:
-            pass  # Expected
 
-        try:
+        with pytest.raises(Exception, match="Value range error"):
             root.Dev.FixedVar.set(-2049.0)
-            got = root.Dev.FixedVar.get()
-            assert False, f"Expected error for underflow, got {got}"
-        except Exception:
-            pass  # Expected
 
-        # UFixed(16, 4) range: 0.0 to 4095.9375
-        try:
-            root.Dev.UFixedVar.set(4096.0)
-            got = root.Dev.UFixedVar.get()
-            assert False, f"Expected error for overflow, got {got}"
-        except Exception:
-            pass  # Expected
+        # UFixed(16, 4) range: 0.0 to 2047.9375 (C++ uses signed two's-complement)
+        with pytest.raises(Exception, match="Value range error"):
+            root.Dev.UFixedVar.set(2048.0)
 
-        try:
+        with pytest.raises(Exception, match="Value range error"):
             root.Dev.UFixedVar.set(-1.0)
-            got = root.Dev.UFixedVar.get()
-            assert False, f"Expected error for negative unsigned, got {got}"
-        except Exception:
-            pass  # Expected
 
         # Boundary values should work
         root.Dev.FixedVar.set(2047.9375)

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -113,6 +113,58 @@ class ModelVariableDevice(pr.Device):
             mode="RW",
         ))
 
+        # Wide unsigned fixed-point variables exercise Block::setUFixed /
+        # Block::getUFixed at valueBits_ >= 32, including the
+        # `valueBits_ >= 64 ? UINT64_MAX` branch used to cap the max-range
+        # computation at 64 bits.
+        self.add(pr.RemoteVariable(
+            name="UFixed32Var",
+            offset=0x40,
+            bitSize=32,
+            base=pr.UFixed(32, 0),
+            mode="RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name="UFixed40Var",
+            offset=0x48,
+            bitSize=40,
+            base=pr.UFixed(40, 8),
+            mode="RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name="UFixed64Var",
+            offset=0x50,
+            bitSize=64,
+            base=pr.UFixed(64, 0),
+            mode="RW",
+        ))
+
+        # List (numValues > 1) fixed-point variables exercise the numpy /
+        # per-element paths in Block::setFixedPy / Block::getFixedPy, which
+        # dispatch to the signed or unsigned scalar setter/getter via a
+        # modelId check. Without list coverage, that dispatch is untested.
+        self.add(pr.RemoteVariable(
+            name="FixedListVar",
+            offset=0x58,
+            numValues=4,
+            valueBits=16,
+            valueStride=16,
+            base=pr.Fixed(16, 4),
+            mode="RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name="UFixedListVar",
+            offset=0x60,
+            numValues=4,
+            valueBits=16,
+            valueStride=16,
+            base=pr.UFixed(16, 4),
+            mode="RW",
+        ))
+
         self.add(pr.LocalVariable(name="LocalInt", value=3))
         self.add(pr.LocalVariable(name="LocalBool", value=False))
         self.add(pr.LocalVariable(name="LocalString", value="start"))
@@ -265,3 +317,69 @@ def test_wide_fixed_point_sign_extension_round_trip():
             assert math.isclose(root.Dev.Fixed64Var.get(), v, abs_tol=0.0), (
                 f"Fixed64Var round-trip failed for {v}"
             )
+
+
+def test_wide_ufixed_point_round_trip():
+    # Regression test for Block::setUFixed / Block::getUFixed at wide widths.
+    # Covers the `valueBits_ >= 64 ? UINT64_MAX : ((1ULL << valueBits_) - 1)`
+    # branch in setUFixed's max-range computation and confirms reads do not
+    # sign-extend (values above 2^(bitSize-1) must round-trip cleanly).
+    with ModelVariableRoot() as root:
+        # UFixed(32, 0): full unsigned 32-bit range, including values above
+        # the signed-max boundary which previously misbehaved.
+        for v in (0.0, 1.0, float(2**31), float(2**32 - 1)):
+            root.Dev.UFixed32Var.set(v)
+            assert math.isclose(root.Dev.UFixed32Var.get(), v, abs_tol=0.0), (
+                f"UFixed32Var round-trip failed for {v}"
+            )
+
+        # UFixed(40, 8): non-byte-aligned wide width with fractional bits.
+        for v in (0.0, 0.5, 1023.75, float(2**32) / (2**8)):
+            root.Dev.UFixed40Var.set(v)
+            assert math.isclose(
+                root.Dev.UFixed40Var.get(), v, abs_tol=1.0 / (2**8)
+            ), f"UFixed40Var round-trip failed for {v}"
+
+        # UFixed(64, 0): exercises the UINT64_MAX cap branch. Use values that
+        # are exactly representable as double (avoid 2**64 - 1 which rounds).
+        for v in (0.0, 1.0, float(2**50), float(2**53)):
+            root.Dev.UFixed64Var.set(v)
+            assert math.isclose(root.Dev.UFixed64Var.get(), v, abs_tol=0.0), (
+                f"UFixed64Var round-trip failed for {v}"
+            )
+
+        # Negative writes must still be rejected even at wide widths
+        with pytest.raises(Exception):
+            root.Dev.UFixed32Var.set(-1.0)
+        with pytest.raises(Exception):
+            root.Dev.UFixed64Var.set(-1.0)
+
+
+def test_fixed_point_list_variables_round_trip():
+    # Regression test for the list-variable (numValues > 1) path in
+    # Block::setFixedPy / Block::getFixedPy, which dispatches to the signed
+    # or unsigned scalar setter/getter via a modelId check. Covers both the
+    # numpy-array write path and the per-element list write path.
+    with ModelVariableRoot() as root:
+        # Signed Fixed list: write a Python list, read back, check each element.
+        fixed_values = [-128.0, -0.5, 0.0, 127.9375]
+        root.Dev.FixedListVar.set(fixed_values)
+        for i, v in enumerate(fixed_values):
+            got = root.Dev.FixedListVar.get(index=i)
+            assert math.isclose(got, v, abs_tol=1e-6), (
+                f"FixedListVar[{i}] round-trip failed: expected {v}, got {got}"
+            )
+
+        # Unsigned UFixed list: must handle values above the signed-max
+        # boundary (>= 2**(valueBits-1)) without sign-extending on read.
+        ufixed_values = [0.0, 0.25, 2048.0, 4095.9375]
+        root.Dev.UFixedListVar.set(ufixed_values)
+        for i, v in enumerate(ufixed_values):
+            got = root.Dev.UFixedListVar.get(index=i)
+            assert math.isclose(got, v, abs_tol=1e-6), (
+                f"UFixedListVar[{i}] round-trip failed: expected {v}, got {got}"
+            )
+
+        # Negative writes into the unsigned list must still be rejected.
+        with pytest.raises(Exception):
+            root.Dev.UFixedListVar.set([-1.0, 0.0, 0.0, 0.0])

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -163,7 +163,7 @@ def test_remote_variable_metadata_exposes_model_constraints():
         assert root.Dev.FixedVar.minimum == -2048.0
         assert root.Dev.FixedVar.maximum == 2047.9375
         assert root.Dev.UFixedVar.minimum == 0.0
-        assert root.Dev.UFixedVar.maximum == 2047.9375
+        assert root.Dev.UFixedVar.maximum == 4095.9375
 
 
 def test_fixed_point_overflow_raises_error():
@@ -183,9 +183,9 @@ def test_fixed_point_overflow_raises_error():
         with pytest.raises(Exception, match="Value range error"):
             root.Dev.FixedVar.set(-2049.0)
 
-        # UFixed(16, 4) range: 0.0 to 2047.9375 (C++ uses signed two's-complement)
+        # UFixed(16, 4) range: 0.0 to 4095.9375 (full unsigned range)
         with pytest.raises(Exception, match="Value range error"):
-            root.Dev.UFixedVar.set(2048.0)
+            root.Dev.UFixedVar.set(4096.0)
 
         with pytest.raises(Exception, match="Value range error"):
             root.Dev.UFixedVar.set(-1.0)
@@ -196,3 +196,14 @@ def test_fixed_point_overflow_raises_error():
 
         root.Dev.FixedVar.set(-2048.0)
         assert math.isclose(root.Dev.FixedVar.get(), -2048.0, abs_tol=1e-6)
+
+        # UFixed must accept the full unsigned range (including values above
+        # the signed-max boundary, which previously misbehaved)
+        root.Dev.UFixedVar.set(0.0)
+        assert math.isclose(root.Dev.UFixedVar.get(), 0.0, abs_tol=1e-6)
+
+        root.Dev.UFixedVar.set(4095.9375)
+        assert math.isclose(root.Dev.UFixedVar.get(), 4095.9375, abs_tol=1e-6)
+
+        root.Dev.UFixedVar.set(3000.5)
+        assert math.isclose(root.Dev.UFixedVar.get(), 3000.5, abs_tol=1e-6)

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -85,6 +85,34 @@ class ModelVariableDevice(pr.Device):
             mode="RW",
         ))
 
+        # Wide fixed-point variables exercise the sign-extension path in
+        # Block::getFixed for valueBits_ >= 32. A plain `1 << valueBits_` in
+        # that path is undefined behavior, so without correct 64-bit shifts
+        # negative-value round-trips on these will fail.
+        self.add(pr.RemoteVariable(
+            name="Fixed32Var",
+            offset=0x28,
+            bitSize=32,
+            base=pr.Fixed(32, 0),
+            mode="RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name="Fixed40Var",
+            offset=0x30,
+            bitSize=40,
+            base=pr.Fixed(40, 8),
+            mode="RW",
+        ))
+
+        self.add(pr.RemoteVariable(
+            name="Fixed64Var",
+            offset=0x38,
+            bitSize=64,
+            base=pr.Fixed(64, 0),
+            mode="RW",
+        ))
+
         self.add(pr.LocalVariable(name="LocalInt", value=3))
         self.add(pr.LocalVariable(name="LocalBool", value=False))
         self.add(pr.LocalVariable(name="LocalString", value="start"))
@@ -207,3 +235,33 @@ def test_fixed_point_overflow_raises_error():
 
         root.Dev.UFixedVar.set(3000.5)
         assert math.isclose(root.Dev.UFixedVar.get(), 3000.5, abs_tol=1e-6)
+
+
+def test_wide_fixed_point_sign_extension_round_trip():
+    # Regression test for Block::getFixed sign-extension on wide variables.
+    # Historically the read path computed `1 << valueBits_` on a plain int,
+    # which is undefined behavior for valueBits_ >= 31 and silently broke
+    # negative-value round-trips for Fixed variables wider than 31 bits.
+    with ModelVariableRoot() as root:
+        # Fixed(32, 0): int32 range round-trips
+        for v in (0.0, 1.0, -1.0, 2147483647.0, -2147483648.0):
+            root.Dev.Fixed32Var.set(v)
+            assert math.isclose(root.Dev.Fixed32Var.get(), v, abs_tol=0.0), (
+                f"Fixed32Var round-trip failed for {v}"
+            )
+
+        # Fixed(40, 8): non-byte-aligned wide width with a fractional part
+        for v in (0.0, 0.5, -0.5, 1023.75, -1024.0):
+            root.Dev.Fixed40Var.set(v)
+            assert math.isclose(
+                root.Dev.Fixed40Var.get(), v, abs_tol=1.0 / (2**8)
+            ), f"Fixed40Var round-trip failed for {v}"
+
+        # Fixed(64, 0): values exactly representable as double. Avoid 2**63
+        # boundaries because doubles cannot represent INT64_MIN/INT64_MAX
+        # exactly — the stored integer would round.
+        for v in (0.0, 1.0, -1.0, float(2**50), float(-(2**50))):
+            root.Dev.Fixed64Var.set(v)
+            assert math.isclose(root.Dev.Fixed64Var.get(), v, abs_tol=0.0), (
+                f"Fixed64Var round-trip failed for {v}"
+            )


### PR DESCRIPTION
## Summary

- Fixed-point variables (`Fixed`/`UFixed`) now raise a `GeneralError` when set to a value outside the representable range, instead of silently clipping or storing an incorrect value
- Added `minValue()`/`maxValue()` to `Fixed` and `UFixed` Python model classes so the existing C++ range check in `Block::setFixed()` is activated
- Replaced the silent positive-edge-case clipping (`fPoint -= 1`) in C++ with an explicit overflow check that throws with the variable name, attempted value, and valid range

## Test plan

- [x] Existing 103 core tests pass
- [x] New `test_fixed_point_overflow_raises_error` covers: positive overflow, negative overflow, unsigned overflow, negative-into-unsigned, and boundary values
- [x] Verified with `Fixed(16, 14)` (the etaQ/etaI register scenario, range +-2.0) that overflow now produces a clear error message