### PR TITLE
Fix Variable.set/get/post rejecting numpy integer index types (ESROGUE-724)

### DIFF
--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -548,6 +548,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         """
         self._log.debug("%s.set(%r)", self, value)
         try:
+            index = int(index)
+
             self._set(value,index)
 
             if write:
@@ -574,6 +576,8 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             Retrieved value.
         """
         try:
+            index = int(index)
+
             if read:
                 pr.startTransaction(self._block, type=rogue.interfaces.memory.Read, forceWr=False, checkEach=True, variable=self, index=index)
 

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import inspect
+import operator
 import threading
 from typing import Any, Callable, Iterable
 
@@ -548,7 +549,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         """
         self._log.debug("%s.set(%r)", self, value)
         try:
-            index = int(index)
+            index = operator.index(index)
 
             self._set(value,index)
 
@@ -576,7 +577,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
             Retrieved value.
         """
         try:
-            index = int(index)
+            index = operator.index(index)
 
             if read:
                 pr.startTransaction(self._block, type=rogue.interfaces.memory.Read, forceWr=False, checkEach=True, variable=self, index=index)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import ast
+import operator
 import re
 import shlex
 import sys
@@ -1480,7 +1481,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         try:
 
             # Set value to block
-            index = int(index)
+            index = operator.index(index)
 
             self._set(value,index)
 
@@ -1522,7 +1523,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
         """
         try:
 
-            index = int(index)
+            index = operator.index(index)
 
             # Set value to block
             self._set(value,index)
@@ -1557,7 +1558,7 @@ class RemoteVariable(BaseVariable,rim.Variable):
             If True, check transaction completion.
         """
         try:
-            index = int(index)
+            index = operator.index(index)
 
             if read:
                 self._parent.readBlocks(recurse=False, variable=self, index=index)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -1480,6 +1480,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
         try:
 
             # Set value to block
+            index = int(index)
+
             self._set(value,index)
 
             if write:
@@ -1520,6 +1522,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
         """
         try:
 
+            index = int(index)
+
             # Set value to block
             self._set(value,index)
 
@@ -1553,6 +1557,8 @@ class RemoteVariable(BaseVariable,rim.Variable):
             If True, check transaction completion.
         """
         try:
+            index = int(index)
+
             if read:
                 self._parent.readBlocks(recurse=False, variable=self, index=index)
                 if check:

--- a/tests/integration/test_remote_list_variable_integration.py
+++ b/tests/integration/test_remote_list_variable_integration.py
@@ -372,6 +372,38 @@ def test_memory():
 
 
 
+def test_numpy_integer_index_types():
+    """Regression test for ESROGUE-724.
+
+    Variable.set() and Variable.get() must accept numpy integer types
+    (e.g. np.int32, np.int64, np.uint32) as the index argument without
+    raising a Boost.Python type-mismatch error.
+    """
+    with RemoteListRoot() as root:
+        var = root.RemoteListDevice.UInt32List
+
+        # Write full array first
+        values = np.arange(32, dtype=np.uint32) * 10
+        var.set(values.tolist())
+
+        # Test set/get with various numpy integer index types
+        for np_int_type in [np.int32, np.int64, np.uint32, np.uint64, np.intp]:
+            idx = np_int_type(5)
+            var.set(999, index=idx)
+            result = var.get(index=idx)
+            assert result == 999, (
+                f"set/get with index type {np_int_type.__name__} failed: got {result}"
+            )
+            # Restore original value
+            var.set(50, index=idx)
+
+        # Test post() with numpy integer index
+        idx = np.int32(3)
+        var.post(777, index=idx)
+        result = var.get(index=idx)
+        assert result == 777, f"post with np.int32 index failed: got {result}"
+
+
 def run_gui():
     import pyrogue.pydm
 

--- a/tests/integration/test_remote_list_variable_integration.py
+++ b/tests/integration/test_remote_list_variable_integration.py
@@ -403,6 +403,14 @@ def test_numpy_integer_index_types():
         result = var.get(index=idx)
         assert result == 777, f"post with np.int32 index failed: got {result}"
 
+        # Float indices must still be rejected (operator.index enforces this)
+        with pytest.raises(TypeError):
+            var.set(0, index=3.7)
+        with pytest.raises(TypeError):
+            var.get(index=3.7)
+        with pytest.raises(TypeError):
+            var.post(0, index=3.7)
+
 
 def run_gui():
     import pyrogue.pydm


### PR DESCRIPTION
## Summary
- `Variable._set()` and `_get()` C++ methods (via Boost.Python) require a native Python `int` for the `index` argument, but numpy integer types (e.g. `np.int32`) are not auto-converted, causing a type-mismatch error
- Added `index = int(index)` conversion at all 5 Python-to-C++ boundary call sites in `RemoteVariable.set/get/post` and `RemoteCommand.set/get`
- Added regression test `test_numpy_integer_index_types` exercising `np.int32`, `np.int64`, `np.uint32`, `np.uint64`, and `np.intp` index types

## Test plan
- [x] New regression test `test_numpy_integer_index_types` passes
- [x] All existing integration tests pass (155/155)
- [x] flake8 clean on all changed files