### PR TITLE
Fix unpicklable Boost.Python exceptions crashing ZMQ server (ESROGUE-723)

### DIFF
--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -92,7 +92,9 @@ class ZmqServer(rogue.interfaces.ZmqServer):
             try:
                 return pickle.dumps(msg)
             except Exception:
-                return pickle.dumps(Exception(f"{type(msg).__module__}.{type(msg).__name__}: {msg}"))
+                exc_type = type(msg)
+                exc_name = getattr(exc_type, "__qualname__", exc_type.__name__)
+                return pickle.dumps(Exception(f"{exc_type.__module__}.{exc_name}: {msg}"))
 
     def _doString(self, data: str) -> str:
         """Handle a JSON-serialized request and return string response."""

--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -89,7 +89,10 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         try:
             return pickle.dumps(self._doOperation(pickle.loads(data)))
         except Exception as msg:
-            return pickle.dumps(msg)
+            try:
+                return pickle.dumps(msg)
+            except Exception:
+                return pickle.dumps(Exception(f"{type(msg).__module__}.{type(msg).__name__}: {msg}"))
 
     def _doString(self, data: str) -> str:
         """Handle a JSON-serialized request and return string response."""

--- a/tests/interfaces/test_interfaces_zmq_server.py
+++ b/tests/interfaces/test_interfaces_zmq_server.py
@@ -78,8 +78,9 @@ def test_zmq_server_operation_request_and_string_paths(monkeypatch, capsys):
     # Verify that unpicklable exceptions are converted to a standard Exception
     # instead of crashing the server (ESROGUE-723).
     class _UnpicklableError(Exception):
-        """An exception whose module cannot be resolved by pickle."""
-        pass
+        """An exception that is deterministically unpicklable."""
+        def __reduce__(self):
+            raise pickle.PicklingError("cannot pickle _UnpicklableError")
     _UnpicklableError.__module__ = "Boost.Python"
     _UnpicklableError.__qualname__ = "ArgumentError"
 

--- a/tests/interfaces/test_interfaces_zmq_server.py
+++ b/tests/interfaces/test_interfaces_zmq_server.py
@@ -89,8 +89,8 @@ def test_zmq_server_operation_request_and_string_paths(monkeypatch, capsys):
 
     unpicklable_request = pickle.dumps({"path": "root.Node", "attr": "trigger_unpicklable"})
     result = pickle.loads(server._doRequest(unpicklable_request))
-    assert isinstance(result, Exception)
-    assert "bad argument" in str(result)
+    assert type(result) is Exception
+    assert "Boost.Python.ArgumentError" in str(result)
 
     assert server._doString(json.dumps({"path": "root.Node", "attr": "value"})) == "node-value"
     assert server._doString(json.dumps({"path": "root.Node", "attr": "multiply", "args": [2], "kwargs": {"rhs": 4}})) == "8"

--- a/tests/interfaces/test_interfaces_zmq_server.py
+++ b/tests/interfaces/test_interfaces_zmq_server.py
@@ -75,6 +75,23 @@ def test_zmq_server_operation_request_and_string_paths(monkeypatch, capsys):
     bad_request = pickle.dumps({"path": "root.Node", "attr": "multiply", "args": (), "kwargs": {"rhs": 5}})
     assert isinstance(pickle.loads(server._doRequest(bad_request)), Exception)
 
+    # Verify that unpicklable exceptions are converted to a standard Exception
+    # instead of crashing the server (ESROGUE-723).
+    class _UnpicklableError(Exception):
+        """An exception whose module cannot be resolved by pickle."""
+        pass
+    _UnpicklableError.__module__ = "Boost.Python"
+    _UnpicklableError.__qualname__ = "ArgumentError"
+
+    def _raise_unpicklable(*args, **kwargs):
+        raise _UnpicklableError("bad argument")
+    node.trigger_unpicklable = _raise_unpicklable
+
+    unpicklable_request = pickle.dumps({"path": "root.Node", "attr": "trigger_unpicklable"})
+    result = pickle.loads(server._doRequest(unpicklable_request))
+    assert isinstance(result, Exception)
+    assert "bad argument" in str(result)
+
     assert server._doString(json.dumps({"path": "root.Node", "attr": "value"})) == "node-value"
     assert server._doString(json.dumps({"path": "root.Node", "attr": "multiply", "args": [2], "kwargs": {"rhs": 4}})) == "8"
     assert server._doString("{bad json") == "EXCEPTION: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)"

--- a/tests/interfaces/test_interfaces_zmq_server.py
+++ b/tests/interfaces/test_interfaces_zmq_server.py
@@ -91,6 +91,7 @@ def test_zmq_server_operation_request_and_string_paths(monkeypatch, capsys):
     result = pickle.loads(server._doRequest(unpicklable_request))
     assert type(result) is Exception
     assert "Boost.Python.ArgumentError" in str(result)
+    assert "bad argument" in str(result)
 
     assert server._doString(json.dumps({"path": "root.Node", "attr": "value"})) == "node-value"
     assert server._doString(json.dumps({"path": "root.Node", "attr": "multiply", "args": [2], "kwargs": {"rhs": 4}})) == "8"


### PR DESCRIPTION
## Summary

- When a `Boost.Python.ArgumentError` is raised during a ZMQ remote procedure call, `pickle.dumps()` fails because Boost.Python exceptions cannot be serialized, crashing the server
- Added a fallback in `ZmqServer._doRequest()` that converts unpicklable exceptions to a standard `Exception` preserving the full type name and message
- Added regression test simulating an unpicklable exception to prevent future regressions

## Test plan

- [x] New unit test verifies unpicklable exceptions are gracefully handled
- [x] Verified fix works with real `Boost.Python.ArgumentError` in local build
- [x] All existing tests pass (180/180)
- [x] flake8 linter clean

Resolves ESROGUE-723