### PR TITLE
Add memBase validation for devices with remote variables (ESROGUE-732)

### DIFF
--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -656,7 +656,7 @@ class Device(pr.Node,rim.Hub):
             value._updateBlockEnable()
 
     def _validateMemBase(self, remVars: list) -> None:
-        """Raise DeviceError if this device has remote variables but no memBase in its ancestor chain.
+        """Raise DeviceError if this device has remote variables/commands but no memBase in its ancestor chain.
 
         A device added directly to Root without an explicit memBase will have Root
         as its memory slave (via _setSlave), but Root has no upstream memory path.
@@ -665,19 +665,19 @@ class Device(pr.Node,rim.Hub):
         Parameters
         ----------
         remVars : list
-            List of RemoteVariable nodes already collected in _buildBlocks.
+            List of RemoteVariable/RemoteCommand nodes already collected in _buildBlocks.
         """
         if not remVars:
             return
 
         # Walk up the parent chain looking for an ancestor with an explicit memBase.
         # If we reach Root without finding one, the device has no memory path.
+        # Root sets self._parent = self, so detect that self-cycle to avoid infinite loops.
         node = self
         while node is not None:
             if node._memBase is not None:
                 return  # Found a memBase — memory path is valid
-            # Detect Root by class name to avoid a circular import (_Root imports _Device)
-            if type(node).__name__ == 'Root':
+            if node._parent is node:
                 raise DeviceError(
                     f"Device '{self.path}' has RemoteVariables or RemoteCommands but no memBase. "
                     f"Pass memBase= when creating this device or when adding it to the tree."

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -655,6 +655,35 @@ class Device(pr.Node,rim.Hub):
         for key,value in self.devices.items():
             value._updateBlockEnable()
 
+    def _validateMemBase(self, remVars: list) -> None:
+        """Raise DeviceError if this device has remote variables but no memBase in its ancestor chain.
+
+        A device added directly to Root without an explicit memBase will have Root
+        as its memory slave (via _setSlave), but Root has no upstream memory path.
+        This produces silent timeouts; raise early instead.
+
+        Parameters
+        ----------
+        remVars : list
+            List of RemoteVariable nodes already collected in _buildBlocks.
+        """
+        if not remVars:
+            return
+
+        # Walk up the parent chain looking for an ancestor with an explicit memBase.
+        # If we reach Root without finding one, the device has no memory path.
+        node = self
+        while node is not None:
+            if node._memBase is not None:
+                return  # Found a memBase — memory path is valid
+            # Detect Root by class name to avoid a circular import (_Root imports _Device)
+            if type(node).__name__ == 'Root':
+                raise DeviceError(
+                    f"Device '{self.path}' has RemoteVariables or RemoteCommands but no memBase. "
+                    f"Pass memBase= when creating this device or when adding it to the tree."
+                )
+            node = node._parent
+
     def _buildBlocks(self) -> None:
         """Build and attach memory blocks for local/remote variables."""
         remVars = []
@@ -689,6 +718,8 @@ class Device(pr.Node,rim.Hub):
                     n.bitSize,
                     n.varBytes,
                 )
+
+        self._validateMemBase(remVars)
 
         # Sort var list by offset, size
         remVars.sort(key=lambda x: (x.offset, x.varBytes))

--- a/tests/core/test_core_validate_membase.py
+++ b/tests/core/test_core_validate_membase.py
@@ -1,0 +1,89 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+import pytest
+import rogue.interfaces.memory
+
+
+# ---------------------------------------------------------------------------
+# Helper device classes
+# ---------------------------------------------------------------------------
+
+class RemoteVarDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.RemoteVariable(
+            name='TestVar',
+            offset=0x0,
+            bitSize=32,
+            base=pr.UInt,
+            mode='RW',
+        ))
+
+
+class RemoteCmdDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.RemoteCommand(
+            name='TestCmd',
+            offset=0x10,
+            bitSize=32,
+            base=pr.UInt,
+            function=None,
+        ))
+
+
+class LocalOnlyDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.LocalVariable(name='LocalVar', value=0))
+        self.add(pr.LocalCommand(name='LocalCmd', value='', function=lambda arg: None))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_remote_variable_no_membase_raises():
+    """TEST-01: Device with RemoteVariable added to Root without memBase raises DeviceError."""
+    root = pr.Root(name='root', pollEn=False)
+    root.add(RemoteVarDevice(name='BadDev'))
+    # Root.start() raises before threads are created; do not call stop() afterward.
+    with pytest.raises(pr.DeviceError, match='has RemoteVariables or RemoteCommands but no memBase'):
+        root.__enter__()
+
+
+def test_remote_command_no_membase_raises():
+    """TEST-02: Device with RemoteCommand added to Root without memBase raises DeviceError."""
+    root = pr.Root(name='root', pollEn=False)
+    root.add(RemoteCmdDevice(name='BadCmdDev'))
+    # Root.start() raises before threads are created; do not call stop() afterward.
+    with pytest.raises(pr.DeviceError, match='has RemoteVariables or RemoteCommands but no memBase'):
+        root.__enter__()
+
+
+def test_local_only_device_no_membase_passes():
+    """TEST-03: Device with only LocalVariables/LocalCommands and no memBase starts without error."""
+    root = pr.Root(name='root', pollEn=False)
+    root.add(LocalOnlyDevice(name='SafeDev'))
+    with root:
+        assert root.SafeDev.LocalVar.value() == 0
+
+
+def test_sub_device_inherits_membase():
+    """TEST-04: Child device inherits memBase from parent; no error even without explicit memBase."""
+    mem = rogue.interfaces.memory.Emulate(4, 0x4000)
+    root = pr.Root(name='root', pollEn=False)
+    parent = pr.Device(name='Parent', memBase=mem)
+    parent.add(RemoteVarDevice(name='Child', offset=0x100))
+    root.add(parent)
+    with root:
+        pass  # No error means child inherited memBase from parent

--- a/tests/core/test_core_validate_membase.py
+++ b/tests/core/test_core_validate_membase.py
@@ -87,3 +87,16 @@ def test_sub_device_inherits_membase():
     root.add(parent)
     with root:
         pass  # No error means child inherited memBase from parent
+
+
+class CustomRoot(pr.Root):
+    """Root subclass to verify _validateMemBase handles Root subclasses."""
+    pass
+
+
+def test_root_subclass_no_membase_raises():
+    """TEST-05: Device with RemoteVariable under a Root subclass without memBase raises DeviceError."""
+    root = CustomRoot(name='root', pollEn=False)
+    root.add(RemoteVarDevice(name='BadDev'))
+    with pytest.raises(pr.DeviceError, match='has RemoteVariables or RemoteCommands but no memBase'):
+        root.__enter__()


### PR DESCRIPTION
## Summary

- Add `_validateMemBase()` to `Device` that raises `DeviceError` when a device with RemoteVariables or RemoteCommands is added to Root without a `memBase`, catching silent runtime timeouts at start time
- Walk the ancestor chain to allow sub-devices that inherit memBase from a parent to continue working
- Detect Root via the parent self-cycle (`node._parent is node`) that `Root._rootAttached()` creates, which safely handles Root subclasses without circular imports
- Add 5 unit tests covering all validation cases: RemoteVariable error, RemoteCommand error, local-only pass, inherited memBase pass, Root subclass error

Resolves ESROGUE-732

## Test plan

- [x] `test_remote_variable_no_membase_raises` — DeviceError raised for RemoteVariable device without memBase
- [x] `test_remote_command_no_membase_raises` — DeviceError raised for RemoteCommand device without memBase
- [x] `test_local_only_device_no_membase_passes` — Local-only device starts without error
- [x] `test_sub_device_inherits_membase` — Child device inherits memBase from parent
- [x] `test_root_subclass_no_membase_raises` — DeviceError raised for Root subclass without memBase (no infinite loop)
- [x] Full existing test suite passes with no regressions