### PR TITLE
test: harden UDP packetizer integration test against flakiness

### DIFF
--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -49,15 +49,15 @@ def wait_for_progress(get_value, target, label):
     stops advancing for STALL_WINDOW seconds.
     """
     last_value = get_value()
-    last_change = time.time()
+    last_change = time.monotonic()
     while True:
         current = get_value()
         if current >= target:
             return current
         if current != last_value:
             last_value = current
-            last_change = time.time()
-        elif (time.time() - last_change) > STALL_WINDOW:
+            last_change = time.monotonic()
+        elif (time.monotonic() - last_change) > STALL_WINDOW:
             raise AssertionError(
                 f"{label} stalled at {current}/{target} "
                 f"after {STALL_WINDOW:.1f}s with no progress"
@@ -158,9 +158,9 @@ def run_udp_packetizer_path(version, jumbo):
 
         # RSSI handshake is binary (open / not open) with no incremental
         # progress, so a plain bound is appropriate here.
-        open_deadline = time.time() + CONNECTION_TIMEOUT
+        open_deadline = time.monotonic() + CONNECTION_TIMEOUT
         while not client_rssi.getOpen():
-            if time.time() > open_deadline:
+            if time.monotonic() > open_deadline:
                 raise AssertionError(f"RSSI timeout error. Ver={version} Jumbo={jumbo}")
             time.sleep(0.1)
 

--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -137,6 +137,21 @@ def run_udp_packetizer_path(version, jumbo):
     prbs_rx = rogue.utilities.Prbs()
     out_of_order = RssiOutOfOrder(period=0)
 
+    # out_of_order sits on the RSSI transport path, so its counter advances
+    # once per RSSI segment — not once per PRBS application frame. A 2048-byte
+    # frame fits in a single jumbo segment but is split into multiple segments
+    # on a standard-MTU link, so we compute the exact expected segment count
+    # from the UDP max payload and the per-packet packetizer overhead. Without
+    # this, `out_of_order.cnt >= FRAME_COUNT` can become true in the non-jumbo
+    # case long before all generated frames have actually been observed,
+    # reintroducing the reorder-drain race the wait is meant to close.
+    rssi_hdr_size = 8
+    pack_hdr_size = 8
+    pack_tail_size = 8 if version == 2 else 1
+    segment_payload = client.maxPayload() - rssi_hdr_size - pack_hdr_size - pack_tail_size
+    segments_per_frame = max(1, (FRAME_SIZE + segment_payload - 1) // segment_payload)
+    expected_segments = FRAME_COUNT * segments_per_frame
+
     prbs_tx >> client_pack.application(0)
     client_rssi.application() == client_pack.transport()
     client_rssi.transport() >> out_of_order >> client >> client_rssi.transport()
@@ -168,12 +183,14 @@ def run_udp_packetizer_path(version, jumbo):
         for _ in range(FRAME_COUNT):
             prbs_tx.genFrame(FRAME_SIZE)
 
-        # Wait until the reordering stage has actually observed every frame
-        # before flushing its cache. Otherwise a frame that lands in the cache
-        # after the flush ran gets stuck there and starves the drain loop.
+        # Wait until the reordering stage has actually observed every segment
+        # for every generated frame before flushing its cache. Otherwise a
+        # frame that lands in the cache after the flush ran gets stuck there
+        # and starves the drain loop. The target is in RSSI segments — see
+        # the `expected_segments` derivation above.
         wait_for_progress(
             lambda: out_of_order.cnt,
-            FRAME_COUNT,
+            expected_segments,
             label=f"reorder settle Ver={version} Jumbo={jumbo}",
         )
 

--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -145,13 +145,16 @@ def run_udp_packetizer_path(version, jumbo):
     server_rssi.application() == server_pack.transport()
     server_pack.application(0) >> prbs_rx
 
-    rssi_started = False
+    server_started = False
+    client_started = False
     try:
         # Start with orderly transport first so the RSSI session comes up cleanly
-        # before periodic reordering is introduced.
+        # before periodic reordering is introduced. Track each endpoint
+        # separately so a failure mid-start still gets cleaned up in finally.
         server_rssi._start()
+        server_started = True
         client_rssi._start()
-        rssi_started = True
+        client_started = True
 
         # RSSI handshake is binary (open / not open) with no incremental
         # progress, so a plain bound is appropriate here.
@@ -182,6 +185,9 @@ def run_udp_packetizer_path(version, jumbo):
             label=f"frame drain Ver={version} Jumbo={jumbo}",
         )
 
+        # Enforce exact equality — wait_for_progress returns on >=, so this
+        # catches any duplicated or replayed frames that would otherwise pass.
+        assert prbs_rx.getRxCount() == FRAME_COUNT
         assert prbs_rx.getRxErrors() == 0
 
     finally:
@@ -193,11 +199,12 @@ def run_udp_packetizer_path(version, jumbo):
             out_of_order.period = 0
         except Exception:
             pass
-        if rssi_started:
+        if client_started:
             try:
                 client_rssi._stop()
             except Exception:
                 pass
+        if server_started:
             try:
                 server_rssi._stop()
             except Exception:

--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -138,13 +138,16 @@ def run_udp_packetizer_path(version, jumbo):
     out_of_order = RssiOutOfOrder(period=0)
 
     # out_of_order sits on the RSSI transport path, so its counter advances
-    # once per RSSI segment — not once per PRBS application frame. A 2048-byte
+    # once per RSSI segment — not once per PRBS application frame, and it also
+    # ticks for non-data control traffic (SYN/ACK/NULL keepalives). A 2048-byte
     # frame fits in a single jumbo segment but is split into multiple segments
-    # on a standard-MTU link, so we compute the exact expected segment count
-    # from the UDP max payload and the per-packet packetizer overhead. Without
-    # this, `out_of_order.cnt >= FRAME_COUNT` can become true in the non-jumbo
-    # case long before all generated frames have actually been observed,
-    # reintroducing the reorder-drain race the wait is meant to close.
+    # on a standard-MTU link, so we compute the exact expected data-segment
+    # count from the UDP max payload and the per-packet packetizer overhead.
+    # The wait below baselines `cnt` immediately before generating frames so
+    # handshake/keepalive segments don't let it return early. Without these
+    # two pieces, `out_of_order.cnt >= FRAME_COUNT` can become true long before
+    # all generated frames have actually been observed, reintroducing the
+    # reorder-drain race the wait is meant to close.
     rssi_hdr_size = 8
     pack_hdr_size = 8
     pack_tail_size = 8 if version == 2 else 1
@@ -180,17 +183,25 @@ def run_udp_packetizer_path(version, jumbo):
             time.sleep(0.1)
 
         out_of_order.period = 10
+
+        # Baseline the segment counter AFTER the RSSI handshake (which itself
+        # bumps cnt via SYN/ACK control frames) and immediately before we
+        # start generating data frames. The wait below uses an absolute
+        # target, so without this baseline the handshake/keepalive traffic
+        # would let the wait return early and reintroduce the flush race.
+        baseline_segments = out_of_order.cnt
+
         for _ in range(FRAME_COUNT):
             prbs_tx.genFrame(FRAME_SIZE)
 
         # Wait until the reordering stage has actually observed every segment
         # for every generated frame before flushing its cache. Otherwise a
         # frame that lands in the cache after the flush ran gets stuck there
-        # and starves the drain loop. The target is in RSSI segments — see
-        # the `expected_segments` derivation above.
+        # and starves the drain loop. The target is baseline + the expected
+        # data-segment count — see the derivations above.
         wait_for_progress(
             lambda: out_of_order.cnt,
-            expected_segments,
+            baseline_segments + expected_segments,
             label=f"reorder settle Ver={version} Jumbo={jumbo}",
         )
 

--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -25,8 +25,45 @@ pytestmark = pytest.mark.integration
 # the path without turning the test into a stress benchmark.
 FRAME_COUNT = 200
 FRAME_SIZE = 2048
-DRAIN_TIMEOUT = 10.0
-CONNECTION_TIMEOUT = 10
+
+# Rather than an arbitrary wall-clock timeout (which fails on slow machines),
+# the drain and reorder-settle loops use progress-based waiting: as long as
+# the monitored counter keeps advancing we keep waiting, no matter how slow.
+# We only bail out if the counter stops advancing for STALL_WINDOW seconds,
+# which is a reliable indicator that the pipeline is genuinely stuck rather
+# than merely slow.
+STALL_WINDOW = 5.0
+POLL_INTERVAL = 0.01
+
+# RSSI open is a one-shot handshake with no incremental progress, so it still
+# uses a plain bound. This has never been the flake source, but 30s gives
+# plenty of headroom on loaded runners.
+CONNECTION_TIMEOUT = 30.0
+
+
+def wait_for_progress(get_value, target, label):
+    """Block until get_value() reaches target.
+
+    Progress-based: resets the stall clock every time the value advances,
+    so arbitrarily slow machines still pass. Only raises if the counter
+    stops advancing for STALL_WINDOW seconds.
+    """
+    last_value = get_value()
+    last_change = time.time()
+    while True:
+        current = get_value()
+        if current >= target:
+            return current
+        if current != last_value:
+            last_value = current
+            last_change = time.time()
+        elif (time.time() - last_change) > STALL_WINDOW:
+            raise AssertionError(
+                f"{label} stalled at {current}/{target} "
+                f"after {STALL_WINDOW:.1f}s with no progress"
+            )
+        time.sleep(POLL_INTERVAL)
+
 
 class RssiOutOfOrder(rogue.interfaces.stream.Slave, rogue.interfaces.stream.Master):
 
@@ -52,6 +89,11 @@ class RssiOutOfOrder(rogue.interfaces.stream.Slave, rogue.interfaces.stream.Mast
             if self._period == 0 and self._last is not None:
                 self._sendFrame(self._last)
                 self._last = None
+
+    @property
+    def cnt(self):
+        with self._lock:
+            return self._cnt
 
     def _acceptFrame(self, frame: rogue.interfaces.stream.Frame) -> None:
 
@@ -103,41 +145,74 @@ def run_udp_packetizer_path(version, jumbo):
     server_rssi.application() == server_pack.transport()
     server_pack.application(0) >> prbs_rx
 
-    # Start with orderly transport first so the RSSI session comes up cleanly
-    # before periodic reordering is introduced.
-    server_rssi._start()
-    client_rssi._start()
+    rssi_started = False
+    try:
+        # Start with orderly transport first so the RSSI session comes up cleanly
+        # before periodic reordering is introduced.
+        server_rssi._start()
+        client_rssi._start()
+        rssi_started = True
 
-    waited = 0
-    while not client_rssi.getOpen():
-        time.sleep(1)
-        waited += 1
-        if waited == CONNECTION_TIMEOUT:
-            client_rssi._stop()
-            server_rssi._stop()
-            raise AssertionError(f"RSSI timeout error. Ver={version} Jumbo={jumbo}")
+        # RSSI handshake is binary (open / not open) with no incremental
+        # progress, so a plain bound is appropriate here.
+        open_deadline = time.time() + CONNECTION_TIMEOUT
+        while not client_rssi.getOpen():
+            if time.time() > open_deadline:
+                raise AssertionError(f"RSSI timeout error. Ver={version} Jumbo={jumbo}")
+            time.sleep(0.1)
 
-    out_of_order.period = 10
-    for _ in range(FRAME_COUNT):
-        prbs_tx.genFrame(FRAME_SIZE)
+        out_of_order.period = 10
+        for _ in range(FRAME_COUNT):
+            prbs_tx.genFrame(FRAME_SIZE)
 
-    out_of_order.period = 0
+        # Wait until the reordering stage has actually observed every frame
+        # before flushing its cache. Otherwise a frame that lands in the cache
+        # after the flush ran gets stuck there and starves the drain loop.
+        wait_for_progress(
+            lambda: out_of_order.cnt,
+            FRAME_COUNT,
+            label=f"reorder settle Ver={version} Jumbo={jumbo}",
+        )
 
-    start = time.time()
-    while prbs_rx.getRxCount() != FRAME_COUNT:
+        out_of_order.period = 0
+
+        wait_for_progress(
+            lambda: prbs_rx.getRxCount(),
+            FRAME_COUNT,
+            label=f"frame drain Ver={version} Jumbo={jumbo}",
+        )
+
+        assert prbs_rx.getRxErrors() == 0
+
+    finally:
+        # Deterministic teardown: quiesce the reordering stage, stop RSSI
+        # sessions, give in-flight C++ callbacks a moment to unwind, then
+        # drop references in reverse link order so upstream stages never
+        # outlive the downstream slaves they still hold pointers to.
+        try:
+            out_of_order.period = 0
+        except Exception:
+            pass
+        if rssi_started:
+            try:
+                client_rssi._stop()
+            except Exception:
+                pass
+            try:
+                server_rssi._stop()
+            except Exception:
+                pass
         time.sleep(0.1)
-        if (time.time() - start) > DRAIN_TIMEOUT:
-            client_rssi._stop()
-            server_rssi._stop()
-            raise AssertionError(
-                f"Frame drain timeout. Ver={version} Jumbo={jumbo} "
-                f"Got = {prbs_rx.getRxCount()} expected = {FRAME_COUNT}"
-            )
 
-    client_rssi._stop()
-    server_rssi._stop()
-
-    assert prbs_rx.getRxErrors() == 0
+        prbs_tx = None
+        prbs_rx = None
+        client_pack = None
+        server_pack = None
+        client_rssi = None
+        server_rssi = None
+        out_of_order = None
+        client = None
+        server = None
 
 
 @pytest.mark.parametrize("version,jumbo", [(1, True), (2, True), (1, False), (2, False)])


### PR DESCRIPTION
## Summary
- Replace wall-clock `DRAIN_TIMEOUT` / reorder-settle timeouts in `tests/integration/test_udp_packetizer_integration.py` with progress-based polling (`wait_for_progress`). As long as the monitored counter keeps advancing, the test keeps waiting — so slow CI runners no longer produce spurious failures. It only bails if the counter stops advancing for `STALL_WINDOW = 5.0s`.
- Wrap the body in `try/finally` with deterministic, ordered teardown: flush the reordering stage, stop client then server RSSI, brief unwind sleep, then drop references in reverse link order. This avoids the worker-crash signature observed in https://github.com/slaclab/rogue/actions/runs/24151542407 (C++ use-after-free during Python teardown when upstream stages outlive downstream slaves).
- Close the reorder-drain race: wait until every generated frame has been observed by the reordering stage (`out_of_order.cnt >= FRAME_COUNT`) before setting `period = 0`, so the flush in the setter cannot miss a frame that gets cached a moment later.
- Add a small public `cnt` property on `RssiOutOfOrder` to expose the observation counter safely.
- Bump `CONNECTION_TIMEOUT` to 30s (RSSI open is a binary handshake with no incremental progress to poll).

## Test plan
- [x] Looped `test_data_path` locally 30x — 30 passed / 0 failed.
- [x] Full non-perf test suite (`python -m pytest -n auto --dist loadfile -m "not perf"`) run locally — all 4 `test_data_path` parametrizations pass. (Unrelated pre-existing env failures on softioc/pydm/zmq-port were reproduced on unmodified `pre-release` and are not from this change.)
- [x] `./scripts/run_linters.sh` — clean.
- [x] GitHub Actions "Full Build Test / Rogue Tests" green on this PR.