### PR TITLE
Tweak list of releases in docs.

### DIFF
--- a/.github/workflows/docs_release.yml
+++ b/.github/workflows/docs_release.yml
@@ -94,6 +94,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "DOCS_MODE=release" >> "$GITHUB_ENV"
             echo "DOCS_VERSION=${{ inputs.version_label }}" >> "$GITHUB_ENV"
+            echo "DOCS_LATEST_TARGET_VERSION=${{ inputs.version_label }}" >> "$GITHUB_ENV"
             echo "DOCS_OUTPUT_ROOT=.tmp/gh-pages/${{ inputs.staging_prefix }}" >> "$GITHUB_ENV"
             echo "ROGUE_DOCS_SITE_ROOT=/${REPO_NAME}/${{ inputs.staging_prefix }}" >> "$GITHUB_ENV"
             echo "DOCS_WRITE_ROOT_REDIRECT=0" >> "$GITHUB_ENV"
@@ -104,6 +105,17 @@ jobs:
             echo "ROGUE_DOCS_SITE_ROOT=/${REPO_NAME}" >> "$GITHUB_ENV"
             echo "DOCS_WRITE_ROOT_REDIRECT=${{ vars.ROGUE_DOCS_WRITE_ROOT_REDIRECT || '0' }}" >> "$GITHUB_ENV"
           fi
+
+      - name: Determine latest release tag from main
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          git fetch origin main --tags
+          latest_tag="$(git tag --merged origin/main --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1)"
+          if [ -z "$latest_tag" ]; then
+            echo "Error: unable to determine latest release tag reachable from origin/main"
+            exit 1
+          fi
+          echo "DOCS_LATEST_TARGET_VERSION=$latest_tag" >> "$GITHUB_ENV"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -158,6 +170,7 @@ jobs:
             --site-root "${ROGUE_DOCS_SITE_ROOT}"
             --mode "${DOCS_MODE}"
             --version "${DOCS_VERSION}"
+            --latest-target-version "${DOCS_LATEST_TARGET_VERSION}"
           )
           if [ "${DOCS_WRITE_ROOT_REDIRECT}" = "1" ]; then
             publish_args+=(--write-root-redirect)

--- a/docs/src/_static/custom.js
+++ b/docs/src/_static/custom.js
@@ -109,23 +109,37 @@ function getVersionsUrl(siteRoot) {
   return siteRoot ? `${siteRoot}/versions.json` : '/versions.json';
 }
 
-function detectCurrentVersion(pathname, siteRoot, versions) {
+function latestTargetSlug(metadata) {
+  return entryForSlug(metadata, 'latest')?.target_slug || null;
+}
+
+function detectCurrentVersionInfo(pathname, siteRoot, metadata) {
+  const versions = metadata.versions || [];
   const entries = new Set(versions.map((entry) => entry.slug));
   const parts = splitRelativePath(pathname, siteRoot);
   if (!parts.length) {
-    return null;
+    return { selectedSlug: null, pathVersion: null };
   }
 
-  return entries.has(parts[0]) ? parts[0] : null;
+  const pathVersion = parts[0];
+  if (entries.has(pathVersion)) {
+    return { selectedSlug: pathVersion, pathVersion };
+  }
+
+  if (pathVersion === latestTargetSlug(metadata)) {
+    return { selectedSlug: 'latest', pathVersion };
+  }
+
+  return { selectedSlug: null, pathVersion };
 }
 
-function relativePagePath(pathname, siteRoot, currentVersion) {
-  if (!currentVersion) {
+function relativePagePath(pathname, siteRoot, pathVersion) {
+  if (!pathVersion) {
     return '';
   }
 
   const parts = splitRelativePath(pathname, siteRoot);
-  if (!parts.length || parts[0] !== currentVersion) {
+  if (!parts.length || parts[0] !== pathVersion) {
     return '';
   }
 
@@ -161,11 +175,12 @@ function createBanner(text, href, linkText) {
 }
 
 function renderBanner(metadata, currentVersion, siteRoot) {
-  if (!currentVersion) {
+  const currentPathVersion = currentVersion?.pathVersion || null;
+  if (!currentPathVersion) {
     return;
   }
 
-  if (currentVersion === 'pre-release') {
+  if (currentPathVersion === 'pre-release') {
     const latestEntry = latestReleaseEntry(metadata);
     if (latestEntry) {
       createBanner(
@@ -179,20 +194,24 @@ function renderBanner(metadata, currentVersion, siteRoot) {
     return;
   }
 
-  const currentEntry = entryForSlug(metadata, currentVersion);
+  if (currentPathVersion === latestTargetSlug(metadata)) {
+    return;
+  }
+
+  const currentEntry = entryForSlug(metadata, currentPathVersion);
   if (!currentEntry || currentEntry.kind !== 'release') {
     return;
   }
 
-  const newestRelease = metadata.versions.find((entry) => entry.kind === 'release');
-  if (newestRelease && newestRelease.slug === currentVersion) {
+  const newestReleaseSlug = latestTargetSlug(metadata) || metadata.versions.find((entry) => entry.kind === 'release')?.slug;
+  if (newestReleaseSlug && newestReleaseSlug === currentPathVersion) {
     return;
   }
 
   const latestEntry = latestReleaseEntry(metadata);
   createBanner(
-    `You are viewing archived documentation for ${currentVersion}.`,
-    latestEntry?.url || joinUrl(siteRoot, currentVersion),
+    `You are viewing archived documentation for ${currentPathVersion}.`,
+    latestEntry?.url || joinUrl(siteRoot, currentPathVersion),
     latestEntry ? 'Open latest release.' : null,
   );
 }
@@ -228,11 +247,11 @@ function renderVersionSelector(metadata, currentVersion, siteRoot) {
     const option = document.createElement('option');
     option.value = entry.slug;
     option.textContent = entry.title;
-    option.selected = entry.slug === currentVersion;
+    option.selected = entry.slug === currentVersion?.selectedSlug;
     select.appendChild(option);
   }
 
-  if (!currentVersion && metadata.versions.length > 0) {
+  if (!currentVersion?.selectedSlug && metadata.versions.length > 0) {
     select.selectedIndex = 0;
   }
 
@@ -249,7 +268,7 @@ async function handleVersionChange(event, metadata, currentVersion, siteRoot) {
     return;
   }
 
-  const relativePath = relativePagePath(window.location.pathname, siteRoot, currentVersion);
+  const relativePath = relativePagePath(window.location.pathname, siteRoot, currentVersion?.pathVersion);
   let targetUrl = targetEntry.url;
 
   if (relativePath) {
@@ -280,7 +299,7 @@ async function initVersionUi() {
       return;
     }
 
-    const currentVersion = detectCurrentVersion(window.location.pathname, siteRoot, metadata.versions);
+    const currentVersion = detectCurrentVersionInfo(window.location.pathname, siteRoot, metadata);
     renderBanner(metadata, currentVersion, siteRoot);
 
     const select = renderVersionSelector(metadata, currentVersion, siteRoot);

--- a/scripts/docs_publish.py
+++ b/scripts/docs_publish.py
@@ -102,7 +102,11 @@ def read_versions_metadata(path: Path) -> VersionsMetadata | None:
     if not path.is_file():
         return None
 
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
     if not isinstance(data, dict):
         return None
     versions = data.get("versions")
@@ -394,7 +398,8 @@ def main() -> int:
             raise ValueError("--version is required in release mode")
         version_slug = validate_safe_slug(args.version, "--version")
         sync_tree(site_dir, output_root / version_slug)
-        sync_tree(site_dir, output_root / "latest")
+        if latest_target_slug is None or latest_target_slug == version_slug:
+            sync_tree(site_dir, output_root / "latest")
     else:
         sync_tree(site_dir, output_root / "pre-release")
 

--- a/scripts/docs_publish.py
+++ b/scripts/docs_publish.py
@@ -140,13 +140,28 @@ def choose_default_slug(versions: list[dict[str, str]]) -> str | None:
 def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
     versions: list[dict[str, str]] = []
 
+    release_slugs = sorted(
+        (
+            path.name
+            for path in output_root.iterdir()
+            if path.is_dir() and RELEASE_DIR_RE.match(path.name)
+        ),
+        key=release_sort_key,
+        reverse=True,
+    )
+    newest_release_slug = release_slugs[0] if release_slugs else None
+
     if (output_root / "latest").is_dir():
+        latest_title = "Latest Release"
+        if newest_release_slug is not None:
+            latest_title = f"{newest_release_slug} - Latest Release"
         versions.append(
             {
                 "slug": "latest",
-                "title": "Latest Release",
+                "title": latest_title,
                 "kind": "alias",
                 "url": url_join(site_root, "latest"),
+                "target_slug": newest_release_slug,
             }
         )
 
@@ -160,17 +175,9 @@ def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
             }
         )
 
-    release_slugs = sorted(
-        (
-            path.name
-            for path in output_root.iterdir()
-            if path.is_dir() and RELEASE_DIR_RE.match(path.name)
-        ),
-        key=release_sort_key,
-        reverse=True,
-    )
-
     for slug in release_slugs:
+        if slug == newest_release_slug and any(entry["slug"] == "latest" for entry in versions):
+            continue
         versions.append(
             {
                 "slug": slug,

--- a/scripts/docs_publish.py
+++ b/scripts/docs_publish.py
@@ -19,10 +19,24 @@ import json
 import re
 import shutil
 from pathlib import Path
+from typing import Literal, NotRequired, TypedDict
 
 
 RELEASE_DIR_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 SAFE_SLUG_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+class VersionEntry(TypedDict):
+    slug: str
+    title: str
+    kind: Literal["alias", "branch", "release"]
+    url: str
+    target_slug: NotRequired[str | None]
+
+
+class VersionsMetadata(TypedDict):
+    default: str | None
+    versions: list[VersionEntry]
 
 
 def parse_args() -> argparse.Namespace:
@@ -45,6 +59,10 @@ def parse_args() -> argparse.Namespace:
         "--write-root-redirect",
         action="store_true",
         help="Write index.html at the output root redirecting to latest/",
+    )
+    parser.add_argument(
+        "--latest-target-version",
+        help="Release slug that should be labeled as the latest release in metadata",
     )
     return parser.parse_args()
 
@@ -78,6 +96,27 @@ def ensure_parent(path: Path) -> None:
 def write_text(path: Path, content: str) -> None:
     ensure_parent(path)
     path.write_text(content, encoding="utf-8")
+
+
+def read_versions_metadata(path: Path) -> VersionsMetadata | None:
+    if not path.is_file():
+        return None
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        return None
+    versions = data.get("versions")
+    if not isinstance(versions, list):
+        return None
+
+    default_slug = data.get("default")
+    if default_slug is not None and not isinstance(default_slug, str):
+        default_slug = None
+
+    return {
+        "default": default_slug,
+        "versions": [entry for entry in versions if isinstance(entry, dict)],
+    }
 
 
 def release_sort_key(slug: str) -> tuple[int, int, int]:
@@ -125,7 +164,7 @@ def validate_output_root(path: Path) -> Path:
     return resolved
 
 
-def choose_default_slug(versions: list[dict[str, str]]) -> str | None:
+def choose_default_slug(versions: list[VersionEntry]) -> str | None:
     for preferred_slug in ("latest", "pre-release"):
         if any(entry["slug"] == preferred_slug for entry in versions):
             return preferred_slug
@@ -137,8 +176,25 @@ def choose_default_slug(versions: list[dict[str, str]]) -> str | None:
     return versions[0]["slug"] if versions else None
 
 
-def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
-    versions: list[dict[str, str]] = []
+def existing_latest_target_slug(output_root: Path) -> str | None:
+    metadata = read_versions_metadata(output_root / "versions.json")
+    if metadata is None:
+        return None
+
+    latest_entry = next((entry for entry in metadata["versions"] if entry.get("slug") == "latest"), None)
+    if latest_entry is None:
+        return None
+
+    target_slug = latest_entry.get("target_slug")
+    if isinstance(target_slug, str) and RELEASE_DIR_RE.match(target_slug):
+        return target_slug
+    return None
+
+
+def collect_versions(
+    output_root: Path, site_root: str, latest_target_slug: str | None = None
+) -> VersionsMetadata:
+    versions: list[VersionEntry] = []
 
     release_slugs = sorted(
         (
@@ -149,19 +205,22 @@ def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
         key=release_sort_key,
         reverse=True,
     )
-    newest_release_slug = release_slugs[0] if release_slugs else None
+    if latest_target_slug is None:
+        latest_target_slug = existing_latest_target_slug(output_root)
+    if latest_target_slug is None and release_slugs:
+        latest_target_slug = release_slugs[0]
 
     if (output_root / "latest").is_dir():
         latest_title = "Latest Release"
-        if newest_release_slug is not None:
-            latest_title = f"{newest_release_slug} - Latest Release"
+        if latest_target_slug is not None:
+            latest_title = f"{latest_target_slug} - Latest Release"
         versions.append(
             {
                 "slug": "latest",
                 "title": latest_title,
                 "kind": "alias",
                 "url": url_join(site_root, "latest"),
-                "target_slug": newest_release_slug,
+                "target_slug": latest_target_slug,
             }
         )
 
@@ -176,7 +235,7 @@ def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
         )
 
     for slug in release_slugs:
-        if slug == newest_release_slug and any(entry["slug"] == "latest" for entry in versions):
+        if slug == latest_target_slug and any(entry["slug"] == "latest" for entry in versions):
             continue
         versions.append(
             {
@@ -190,7 +249,7 @@ def collect_versions(output_root: Path, site_root: str) -> dict[str, object]:
     return {"default": choose_default_slug(versions), "versions": versions}
 
 
-def render_versions_page(metadata: dict[str, object]) -> str:
+def render_versions_page(metadata: VersionsMetadata) -> str:
     versions = metadata["versions"]
     default_slug = metadata["default"]
     latest = next((entry for entry in versions if entry["slug"] == "latest"), None)
@@ -198,7 +257,7 @@ def render_versions_page(metadata: dict[str, object]) -> str:
     releases = [entry for entry in versions if entry["kind"] == "release"]
     default_entry = next((entry for entry in versions if entry["slug"] == default_slug), None)
 
-    def render_entry(entry: dict[str, str]) -> str:
+    def render_entry(entry: VersionEntry) -> str:
         return f'<li><a href="{entry["url"]}">{entry["title"]}</a></li>'
 
     latest_html = render_entry(latest) if latest else "<li>Not published yet.</li>"
@@ -319,6 +378,11 @@ def main() -> int:
     site_dir = Path(args.site_dir).resolve()
     output_root = validate_output_root(Path(args.output_root))
     site_root = normalize_site_root(args.site_root)
+    latest_target_slug = (
+        validate_safe_slug(args.latest_target_version, "--latest-target-version")
+        if args.latest_target_version
+        else None
+    )
 
     if not site_dir.is_dir():
         raise FileNotFoundError(f"Built site directory not found: {site_dir}")
@@ -334,7 +398,7 @@ def main() -> int:
     else:
         sync_tree(site_dir, output_root / "pre-release")
 
-    metadata = collect_versions(output_root, site_root)
+    metadata = collect_versions(output_root, site_root, latest_target_slug=latest_target_slug)
     write_text(output_root / "versions.json", json.dumps(metadata, indent=2, sort_keys=False) + "\n")
     write_text(output_root / "versions" / "index.html", render_versions_page(metadata))
 


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

The publisher now treats `latest` as the display entry for the newest release tag:
- `latest` is labeled `vX.Y.Z - Latest Release`
- the newest concrete `vX.Y.Z` release is omitted from the selector/history list
- older releases still appear newest-first after `Pre-release`

The frontend was updated so direct URLs under the newest concrete tag, like `/v6.10.1/...`, still behave as `latest` in the selector and don’t get an “archived” banner.
