### PR TITLE
Update UDP packetizer and RSSI loopback integration tests

### DIFF
--- a/tests/integration/test_rssi_loopback.py
+++ b/tests/integration/test_rssi_loopback.py
@@ -116,6 +116,17 @@ def test_rssi_retransmit_counter_zero_clean_path():
     rssiSrv = rogue.protocols.rssi.Server(1400)
     rssiCli = rogue.protocols.rssi.Client(1400)
 
+    # The default RSSI retransmit timeout is 20 ms (Controller.cpp's
+    # locRetranTout_ init with TimeoutUnit=3 => ms).  Under pytest-xdist
+    # (3 workers on macOS arm64 runners) the 20 ms window is tight enough
+    # that ACK delivery jitter routinely exceeds it and RSSI retransmits
+    # even though every frame arrived intact — observed as 14/50 spurious
+    # retransmits in CI.  Bump to 200 ms so the timer tolerates scheduler
+    # jitter on busy runners.  Both sides negotiate this in the SYN
+    # handshake, so setting it on both ends pins the on-the-wire value.
+    rssiSrv.setLocRetranTout(200)
+    rssiCli.setLocRetranTout(200)
+
     udpSrv == rssiSrv.transport()
     udpCli == rssiCli.transport()
 

--- a/tests/integration/test_udp_packetizer_integration.py
+++ b/tests/integration/test_udp_packetizer_integration.py
@@ -32,7 +32,15 @@ FRAME_SIZE = 2048
 # We only bail out if the counter stops advancing for STALL_WINDOW seconds,
 # which is a reliable indicator that the pipeline is genuinely stuck rather
 # than merely slow.
-STALL_WINDOW = 3.0
+#
+# 10s is generous on purpose: macOS arm64 GHA runners under pytest-xdist
+# (--dist loadfile, 3 workers) can have multi-second windows of zero
+# observed progress on the first parametrize variant — Python/conda
+# import warm-up plus contention on the C++ packetizer/RSSI worker
+# threads. Tightening this window only buys spurious failures, not
+# faster passing runs (the loop exits immediately once the counter
+# advances), so prefer a wide stall window.
+STALL_WINDOW = 10.0
 POLL_INTERVAL = 0.01
 
 # RSSI open is a one-shot handshake with no incremental progress, so it still
@@ -132,6 +140,21 @@ def run_udp_packetizer_path(version, jumbo):
 
     server_rssi = rogue.protocols.rssi.Server(server.maxPayload() - 8)
     client_rssi = rogue.protocols.rssi.Client(client.maxPayload() - 8)
+
+    # The default RSSI retransmit timeout is 20 ms (Controller.cpp's
+    # locRetranTout_ init with TimeoutUnit=3 => ms).  Under pytest-xdist
+    # on macOS arm64 (3 workers) ACK delivery jitter routinely exceeds
+    # that window, so spurious retransmits stack up on top of the
+    # intentional reordering this test injects.  With RSSI's 32-segment
+    # window and 15-retransmit ceiling, a sustained jitter storm can
+    # exhaust the retransmit budget and close the session, stranding
+    # the drain at 0 frames delivered.  Bump to 200 ms so the timer
+    # tolerates scheduler jitter; both sides negotiate this in the SYN
+    # handshake, so setting it on both ends pins the on-the-wire value.
+    # Same reasoning as tests/integration/test_rssi_loopback.py's
+    # test_rssi_retransmit_counter_zero_clean_path.
+    server_rssi.setLocRetranTout(200)
+    client_rssi.setLocRetranTout(200)
 
     server_pack, client_pack = build_packetizer_pair(version)
 


### PR DESCRIPTION
## Summary
- Cherry-pick updated integration tests from RoCEv2-dev branch
- Updates `test_udp_packetizer_integration.py` and `test_rssi_loopback.py`