### PR TITLE
fix(ESROGUE-740): make VirtualClient thread-safe and fix zmq_msg leaks

### DIFF
--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -19,6 +19,7 @@
 #include "rogue/Directives.h"
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -71,6 +72,9 @@ class ZmqClient {
 
     // True when operating in string request mode.
     bool doString_;
+
+    // Mutex serializing the ZMQ_REQ socket's send/recv cycle.
+    std::mutex reqLock_;
 
     void runThread();
 

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -140,6 +140,7 @@ class VirtualNode(pr.Node):
         self._root      = None
         self._client    = None
         self._functions = []
+        self._loadLock  = threading.Lock()
         self._loaded    = False
 
         # Setup logging
@@ -164,14 +165,18 @@ class VirtualNode(pr.Node):
     def __getattr__(self, name: str) -> Any:
         """Lazy-load children on first access, then resolve as a child attribute."""
         if not self._loaded:
-            self._loadNodes()
+            with self._loadLock:
+                if not self._loaded:
+                    self._loadNodes()
         return pr.Node.__getattr__(self,name)
 
     @property
     def nodes(self) -> dict[str, Any]:
         """Child nodes keyed by name."""
         if not self._loaded:
-            self._loadNodes()
+            with self._loadLock:
+                if not self._loaded:
+                    self._loadNodes()
         return self._nodes
 
     def node(self, name: str, load: bool = True) -> "VirtualNode | None":
@@ -190,7 +195,9 @@ class VirtualNode(pr.Node):
             Child node or None if not found.
         """
         if (not self._loaded) and load:
-            self._loadNodes()
+            with self._loadLock:
+                if not self._loaded:
+                    self._loadNodes()
 
         if name in self._nodes:
             return self._nodes[name]
@@ -217,8 +224,6 @@ class VirtualNode(pr.Node):
 
     def _loadNodes(self) -> None:
         """Populate child nodes from remote metadata."""
-        self._loaded = True
-
         for k,node in self._client._remoteAttr(self._path, 'nodes').items():
             if k in self._nodes:
                 node._parent = self
@@ -227,6 +232,8 @@ class VirtualNode(pr.Node):
 
                 self._nodes[k] = node
                 self._addArrayNode(node)
+
+        self._loaded = True
 
     def _getNode(self, path: str, load: bool = True) -> "VirtualNode | None":
         """Resolve a dotted path to a node.

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -219,6 +219,7 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
     snd += "}";
 
     rogue::GilRelease noGil;
+    std::lock_guard<std::mutex> lock(reqLock_);
     zmq_send(this->zmqReq_, snd.c_str(), snd.size(), 0);
 
     while (1) {
@@ -229,6 +230,7 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
                 logWaitRetry(log_, seconds, lastLoggedSeconds);
                 zmq_msg_close(&msg);
             } else {
+                zmq_msg_close(&msg);
                 throw rogue::GeneralError::create("ZmqClient::sendString",
                                                   "Timeout waiting for response after %d Seconds.",
                                                   static_cast<int>(seconds));
@@ -282,6 +284,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
 
     {
         rogue::GilRelease noGil;
+        std::lock_guard<std::mutex> lock(reqLock_);
         zmq_sendmsg(this->zmqReq_, &txMsg, 0);
 
         while (1) {
@@ -292,6 +295,7 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
                     logWaitRetry(log_, seconds, lastLoggedSeconds);
                     zmq_msg_close(&rxMsg);
                 } else {
+                    zmq_msg_close(&rxMsg);
                     throw rogue::GeneralError::create(
                         "ZmqClient::send",
                         "Timeout waiting for response after %d Seconds, server may be busy!",

--- a/tests/interfaces/test_zmq_client.py
+++ b/tests/interfaces/test_zmq_client.py
@@ -16,6 +16,8 @@
 # server is already covered by test_interfaces_zmq_server.py.
 
 import os
+import sys
+import threading
 import time
 
 import pyrogue as pr
@@ -110,6 +112,134 @@ def test_zmq_client_value_disp():
     finally:
         zmqSrv._stop()
         root.stop()
+
+
+def test_virtual_client_concurrent_threadsafety(free_zmq_port):
+    """Reproduce ESROGUE-740: concurrent threads on a cached VirtualClient
+    share a single ZMQ_REQ socket and violate its alternating send/recv
+    state machine.
+
+    On unpatched main this test is EXPECTED to fail (crash, timeout, or
+    ZMQ protocol error) within ~30 s. Phase 2 adds a std::mutex in C++
+    ZmqClient to serialize the REQ cycle; the same test must then pass.
+    """
+    N_COMMANDS = 500
+    WATCHDOG_SECONDS = 25.0
+    JOIN_TIMEOUT = 2.0
+
+    # Clear the process-wide cache so we observe a fresh cache miss + hit.
+    pyrogue.interfaces.VirtualClient.ClientCache.clear()
+
+    # Root name must NOT collide with the read-only VirtualClient.root @property
+    # (python/pyrogue/interfaces/_Virtual.py:698); _Virtual.py:477 does
+    # `setattr(self, self._root.name, self._root)`, so naming the Root 'root'
+    # raises AttributeError at VirtualClient construction, before the race can run.
+    root = pr.Root(name='Root', pollEn=False, timeout=2.0)
+    root.add(ZmqTestDevice(name='Dev'))
+    zmqSrv = pyrogue.interfaces.ZmqServer(
+        root=root, addr="127.0.0.1", port=free_zmq_port)
+    root.start()
+    try:
+        zmqSrv._start()
+        time.sleep(0.5)
+        port = zmqSrv.port()
+
+        # Two VirtualClients with the same (addr, port) MUST be the same
+        # Python object via ClientCache -- that is what forces them to
+        # share a single underlying ZMQ_REQ socket, which is the whole
+        # point of the reproduction.
+        client1 = pyrogue.interfaces.VirtualClient(addr="127.0.0.1", port=port)
+        client2 = pyrogue.interfaces.VirtualClient(addr="127.0.0.1", port=port)
+        assert client1 is client2, "VirtualClient cache miss: test would not reproduce ESROGUE-740"
+
+        stop_event = threading.Event()
+        errors = []
+        timeout_flag = {"fired": False}
+
+        def _poll_loop():
+            try:
+                while not stop_event.is_set():
+                    _ = client1.Root.Dev.TestVar.get()
+            except BaseException as exc:  # noqa: BLE001 - must capture any race-induced error
+                errors.append(exc)
+
+        def _watchdog():
+            # Fires iff the test process is still alive after WATCHDOG_SECONDS.
+            # On unpatched HEAD the corrupted ZMQ_REQ socket can deadlock
+            # teardown (srv._stop/root.stop), so setting stop_event alone
+            # is insufficient to satisfy REPRO-03 (< 30s).  Hard-exit is
+            # the only mechanism that bypasses a C++/GIL deadlock; a
+            # non-zero exit preserves the Phase 1 FAIL-on-unpatched signal.
+            timeout_flag["fired"] = True
+            stop_event.set()
+            sys.stderr.write(
+                "ESROGUE-740 watchdog fired at %.1fs: hard-exiting to "
+                "escape teardown deadlock\n" % WATCHDOG_SECONDS
+            )
+            sys.stderr.flush()
+            os._exit(77)
+
+        poll_thread = threading.Thread(
+            target=_poll_loop,
+            name="esrogue740-poller",
+            daemon=True,
+        )
+        watchdog = threading.Timer(WATCHDOG_SECONDS, _watchdog)
+        # Daemonize so a stray watchdog cannot keep the test process alive
+        # if cleanup is bypassed (e.g. exception between start() and the
+        # inner finally), avoiding a spurious os._exit(77) during teardown.
+        watchdog.daemon = True
+
+        poll_thread.start()
+        watchdog.start()
+        try:
+            for _ in range(N_COMMANDS):
+                client2.Root.Dev.TestCmd()
+        finally:
+            stop_event.set()
+            watchdog.cancel()
+            poll_thread.join(timeout=JOIN_TIMEOUT)
+
+        # REPRO-03 invariants: the polling thread MUST have exited, and
+        # the watchdog MUST NOT have fired (otherwise we blew the 30 s budget).
+        assert not poll_thread.is_alive(), "polling thread did not join within %.1fs" % JOIN_TIMEOUT
+        assert not timeout_flag["fired"], "watchdog fired: test exceeded %.1fs budget" % WATCHDOG_SECONDS
+
+        # Re-raise any error captured in the polling thread so a poller-only
+        # crash still fails the pytest run (D-12).
+        if errors:
+            raise AssertionError(
+                "concurrent RPC race: polling thread raised %d error(s); first: %r"
+                % (len(errors), errors[0])
+            ) from errors[0]
+    finally:
+        # Belt-and-braces: even on an exception path, make sure the
+        # polling thread, server, root, and cache are all cleaned up.
+        try:
+            stop_event.set()
+        except NameError:
+            pass
+        try:
+            watchdog.cancel()
+        except NameError:
+            pass
+        try:
+            poll_thread.join(timeout=JOIN_TIMEOUT)
+        except NameError:
+            pass
+        # VirtualClient._monWorker is a non-daemon thread (_Virtual.py:485).
+        # Without client.stop() it will keep the Python process alive after
+        # pytest returns, causing an apparent hang.  stop() sets
+        # _monEnable=False so the monitor exits on its next 1-second tick.
+        try:
+            client1.stop()
+            if getattr(client1, "_monThread", None) is not None:
+                client1._monThread.join(timeout=JOIN_TIMEOUT)
+        except NameError:
+            pass
+        zmqSrv._stop()
+        root.stop()
+        pyrogue.interfaces.VirtualClient.ClientCache.clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Fixes [ESROGUE-740](https://jira.slac.stanford.edu/browse/ESROGUE-740): `pyrogue.interfaces.VirtualClient` crashes when concurrent threads share a cached client, because the underlying `ZmqClient`'s `ZMQ_REQ` socket is not serialized and `VirtualNode._loadNodes` has a lazy-load race.

This PR serializes the full `zmq_send` → `zmq_recvmsg` cycle in `ZmqClient::sendString` / `ZmqClient::send` with a per-instance `std::mutex`, guards `VirtualNode._loadNodes` with a `threading.Lock` using double-checked locking, and fixes `zmq_msg_t` memory leaks on timeout-throw paths. Multi-threaded callers can now safely issue concurrent reads, writes, and commands on a shared `VirtualClient`. No public API change.

### Details

- **C++ mutex** (`include/rogue/interfaces/ZmqClient.h`, `src/rogue/interfaces/ZmqClient.cpp`): new private `std::mutex reqLock_` member with `#include <mutex>`; `std::lock_guard<std::mutex>` wraps the send/receive cycle in both `sendString` and `send`. The lock is acquired **after** the `rogue::GilRelease` scope opens, so a C++ worker can never block on the mutex while holding the GIL — matches the `Master.cpp` idiom (lock order: GIL-release → C++ mutex).
- **zmq_msg leak fix** (`src/rogue/interfaces/ZmqClient.cpp`): both `sendString` and `send` called `zmq_msg_init` before `zmq_recvmsg`, but the non-retry timeout-throw path did not call `zmq_msg_close`, leaking the message buffer. Added `zmq_msg_close` on both throw paths.
- **Python double-checked locking** (`python/pyrogue/interfaces/_Virtual.py`): `_loadLock = threading.Lock()` added to `VirtualNode.__init__`; `_loadNodes` uses double-checked locking and now sets `self._loaded = True` **after** populating children (was set before, creating a window where concurrent readers saw an empty node tree). Fixes the observed `ImportError` crash mode where two threads entered `_loadNodes` simultaneously during tree mirroring.
- **Concurrency test** (`tests/interfaces/test_zmq_client.py`): new `test_virtual_client_concurrent_threadsafety` races a polling `client1.Root.Dev.TestVar.get()` thread against 500 main-thread `client2.Root.Dev.TestCmd()` calls on a shared cached `VirtualClient` (`client1 is client2` assertion guards against silent cache regressions). Watchdog timer is daemonized with cleanup in the outer `finally`. Gated by `RUN_ZMQ_CLIENT_TESTS=1` matching the existing module-level `skipif`, so CI behavior is unchanged.
- Diff is surgical: 4 files, +150 / −5.

**Local test plan (all green):**

- [x] `rm -rf build && cmake -S . -B build -DROGUE_INSTALL=local -DROGUE_BUILD_TESTS=ON && cmake --build build -j$(nproc) && cmake --build build --target install` — clean build
- [x] `source build/setup_rogue.sh && python -c "import pyrogue"` — import works
- [x] `ctest --test-dir build --output-on-failure -L cpp` — 9/9 passed
- [x] `python -m pytest -n auto --dist loadfile -m "not perf"` — CI-literal pytest; `test_zmq_client.py` skipped at module level per existing skipif (CI parity)
- [x] `RUN_ZMQ_CLIENT_TESTS=1 python -m pytest tests/interfaces/test_zmq_client.py::test_virtual_client_concurrent_threadsafety --timeout=35` — 1 passed
- [x] `./scripts/run_linters.sh` — flake8 + cpplint clean

### JIRA

https://jira.slac.stanford.edu/browse/ESROGUE-740