### PR TITLE
test(prbs): stabilize test_prbs_tx_gen_frame_command under parallel CI load

### DIFF
--- a/tests/utilities/test_prbs_devices.py
+++ b/tests/utilities/test_prbs_devices.py
@@ -78,7 +78,7 @@ def test_prbs_tx_gen_frame_command():
 
     with root:
         root.Tx.genFrame.call(3)
-        assert wait_for(lambda: rx.getRxCount() == 3, timeout=5.0)
+        assert wait_for(lambda: rx.getRxCount() >= 3, timeout=10.0)
         assert rx.getRxErrors() == 0
 
 


### PR DESCRIPTION
## Summary
- `test_prbs_tx_gen_frame_command` failed intermittently in CI ([run 25236265246](https://github.com/slaclab/rogue/actions/runs/25236265246/job/74003019814#step:9:137)) with a 5s timeout waiting for `rx.getRxCount() == 3` after `genFrame.call(3)`.
- Under `pytest -n auto` (4 xdist workers) on shared GitHub runners, the Fifo worker thread can be scheduled late enough that the third frame isn't delivered before the deadline.
- Aligned the predicate with the sibling `test_prbs_pair_loopback` (`>= 3` + `timeout=10.0`). Three `genFrame` calls cannot produce more than three accepted frames — errored frames increment `rxErrCount_`, not `rxCount_` — so `>=` is equivalent to `==` for correctness, and the `getRxErrors() == 0` check below still catches header/payload corruption.

## Test plan
- [x] `python -m pytest tests/utilities/test_prbs_devices.py` — 50/50 sequential runs pass
- [x] `python -m pytest -n auto --dist loadfile -m "not perf"` — full suite passes (the unrelated `test_pydm_rogue_plugin` flake is pre-existing and out of scope)
- [x] flake8 clean on the touched lines