### PR TITLE
fix(protocols): SRP, UDP, batcher, xilinx audit fixes + repros

### DIFF
--- a/include/rogue/protocols/srp/SrpV3Emulation.h
+++ b/include/rogue/protocols/srp/SrpV3Emulation.h
@@ -67,7 +67,10 @@ namespace srp {
  * a transaction lock during its `doTransaction()` call chain.
  *
  * Memory is allocated on demand in 4 KiB pages, similar to
- * `rogue::interfaces::memory::Emulate`.
+ * `rogue::interfaces::memory::Emulate`. Each new page is filled with
+ * random (non-deterministic) data via `std::mt19937` to emulate
+ * uninitialised hardware SRAM; callers must not assume zero-initialisation
+ * of unwritten address ranges.
  *
  * Threading/locking model:
  * - `acceptFrame()` queues frames and returns immediately.

--- a/include/rogue/protocols/udp/Core.h
+++ b/include/rogue/protocols/udp/Core.h
@@ -77,7 +77,7 @@ class Core {
     // Transmit select()/send timeout.
     struct timeval timeout_;
 
-    std::thread* thread_ = nullptr;
+    std::unique_ptr<std::thread> thread_;
     std::atomic<bool> threadEn_{false};
 
     // Synchronizes shared socket/address updates in derived classes.

--- a/src/rogue/protocols/batcher/InverterV1.cpp
+++ b/src/rogue/protocols/batcher/InverterV1.cpp
@@ -78,6 +78,16 @@ void rpb::InverterV1::acceptFrame(ris::FramePtr frame) {
     // Header and tail size must match, must have at least one record
     if ((core.headerSize() != core.tailSize()) || (core.count() == 0)) return;
 
+    // Verify frame payload holds the full tail region before copying.
+    // frame->getPayload() is the total byte count; tail starts after the
+    // header so we need headerSize() + count() * headerSize() bytes minimum.
+    // headerSize() and count() are uint32_t; promote the multiplication to
+    // uint64_t so a crafted oversized batcher frame cannot wrap the product
+    // back below frame->getPayload() and bypass the bounds check.
+    const uint64_t requiredBytes =
+        static_cast<uint64_t>(core.headerSize()) * (static_cast<uint64_t>(core.count()) + 1);
+    if (static_cast<uint64_t>(frame->getPayload()) < requiredBytes) return;
+
     // Copy first tail to head
     std::memcpy(core.beginHeader().ptr(), core.beginTail(0).ptr(), core.headerSize());
 

--- a/src/rogue/protocols/batcher/InverterV2.cpp
+++ b/src/rogue/protocols/batcher/InverterV2.cpp
@@ -78,6 +78,20 @@ void rpb::InverterV2::acceptFrame(ris::FramePtr frame) {
     // Must have at least one record
     if (core.count() == 0) return;
 
+    // Verify frame payload holds the full tail region before copying.
+    // CoreV2 has headerSize_=2 and tailSize_=7 (CoreV2.cpp:68-69), so the
+    // minimum payload is one fixed header plus count() tails of tailSize()
+    // bytes each.  Using headerSize()*(count+1) like the V1 path would
+    // under-approximate the requirement here because the V2 head and tail
+    // are intentionally different sizes.  headerSize(), tailSize() and
+    // count() all return uint32_t; promote to uint64_t before the
+    // multiplication so a crafted oversized batcher frame cannot wrap the
+    // product back below frame->getPayload() and bypass the bounds check.
+    const uint64_t requiredBytes =
+        static_cast<uint64_t>(core.headerSize()) +
+        static_cast<uint64_t>(core.count()) * static_cast<uint64_t>(core.tailSize());
+    if (static_cast<uint64_t>(frame->getPayload()) < requiredBytes) return;
+
     // Copy first tail to head
     std::memcpy(core.beginHeader().ptr(), core.beginTail(0).ptr(), core.headerSize());
 

--- a/src/rogue/protocols/srp/SrpV0.cpp
+++ b/src/rogue/protocols/srp/SrpV0.cpp
@@ -223,9 +223,10 @@ void rps::SrpV0::acceptFrame(ris::FramePtr frame) {
     // Setup transaction iterator
     rim::TransactionLockPtr lock = tran->lock();
 
-    // Transaction expired
+    // Transaction expired — complete with error so callers do not block forever
     if (tran->expired()) {
         log_->warning("Transaction expired. Id=%" PRIu32, id);
+        tran->error("SrpV0 transaction timeout: Id=%" PRIu32, id);
         return;
     }
     tIter = tran->begin();

--- a/src/rogue/protocols/srp/SrpV3Emulation.cpp
+++ b/src/rogue/protocols/srp/SrpV3Emulation.cpp
@@ -74,7 +74,7 @@ rps::SrpV3Emulation::~SrpV3Emulation() {
 
     MemoryMap::iterator it = memMap_.begin();
     while (it != memMap_.end()) {
-        free(it->second);
+        delete[] it->second;
         ++it;
     }
 }
@@ -112,7 +112,21 @@ void rps::SrpV3Emulation::runThread() {
             queue_.pop();
         }
 
-        processFrame(frame);
+        // processFrame() may invoke allocatePage(), which uses
+        // std::make_unique<uint8_t[]> and therefore throws std::bad_alloc
+        // on OOM (rather than returning nullptr as the previous malloc()
+        // path did).  An unhandled exception escaping the worker thread
+        // calls std::terminate() per [thread.thread.member]; catch and
+        // log instead so the worker drops the offending frame and
+        // continues, matching the project-wide
+        // "background-thread exceptions are caught and logged" contract.
+        try {
+            processFrame(frame);
+        } catch (const std::exception& e) {
+            log_->error("Dropped frame on exception in processFrame: %s", e.what());
+        } catch (...) {
+            log_->error("Dropped frame on unknown exception in processFrame");
+        }
     }
 
     log_->debug("Worker thread stopped");
@@ -120,21 +134,32 @@ void rps::SrpV3Emulation::runThread() {
 
 //! Allocate a new 4K page filled with random data
 uint8_t* rps::SrpV3Emulation::allocatePage(uint64_t addr4k) {
-    uint8_t* page = reinterpret_cast<uint8_t*>(malloc(0x1000));
-    if (page == nullptr) {
-        log_->error("Failed to allocate page at 0x%" PRIx64, addr4k);
-        return nullptr;
-    }
+    std::unique_ptr<uint8_t[]> page = std::make_unique<uint8_t[]>(0x1000);
 
     // Fill with random data to emulate uninitialized hardware memory
     std::mt19937 gen(std::random_device {}());
-    uint32_t* p32 = reinterpret_cast<uint32_t*>(page);
+    uint32_t* p32 = reinterpret_cast<uint32_t*>(page.get());
     for (size_t i = 0; i < 0x1000 / 4; i++) p32[i] = gen();
 
-    memMap_.insert(std::make_pair(addr4k, page));
-    totAlloc_++;
-    log_->debug("Allocating page at 0x%" PRIx64 ". Total pages %" PRIu32, addr4k, totAlloc_);
-    return page;
+    // Insert the raw pointer into the map and only release ownership when
+    // insertion actually took place.  std::map::insert is a no-op when the
+    // key already exists; without inspecting result.second the unique_ptr
+    // would be released even though the new buffer is not in the map,
+    // leaking it.  A throwing insert (e.g. std::bad_alloc on the new map
+    // node) is also handled because ownership has not been released yet,
+    // so stack unwinding frees the buffer.
+    auto result = memMap_.emplace(addr4k, page.get());
+    if (result.second) {
+        page.release();
+        totAlloc_++;
+        log_->debug("Allocating page at 0x%" PRIx64 ". Total pages %" PRIu32, addr4k, totAlloc_);
+    } else {
+        log_->debug("Page at 0x%" PRIx64 " already present; reusing existing buffer", addr4k);
+    }
+    // Return the buffer that the map actually owns (existing or newly
+    // inserted).  page goes out of scope; if it still owns a buffer
+    // (duplicate-key case) it is freed here, never leaked.
+    return result.first->second;
 }
 
 //! Read from internal memory
@@ -152,9 +177,11 @@ void rps::SrpV3Emulation::readMemory(uint64_t address, uint8_t* data, uint32_t s
 
         auto it = memMap_.find(addr4k);
         if (it == memMap_.end()) {
-            // Allocate page with random data on first read (like uninitialized SRAM)
+            // Allocate page with random data on first read (like uninitialized SRAM).
+            // allocatePage() throws std::bad_alloc on OOM (via make_unique);
+            // the worker's runThread try/catch surfaces that as a logged
+            // dropped frame.  A null check here would be dead code.
             uint8_t* page = allocatePage(addr4k);
-            if (page == nullptr) return;
             memcpy(data, page + off4k, size4k);
         } else {
             memcpy(data, it->second + off4k, size4k);
@@ -181,8 +208,10 @@ void rps::SrpV3Emulation::writeMemory(uint64_t address, const uint8_t* data, uin
 
         auto it = memMap_.find(addr4k);
         if (it == memMap_.end()) {
-            uint8_t* page = allocatePage(addr4k);
-            if (page == nullptr) return;
+            // allocatePage() throws std::bad_alloc on OOM; runThread's
+            // try/catch surfaces that as a logged dropped frame.  After
+            // a successful return the page is now in memMap_, so re-find.
+            allocatePage(addr4k);
             it = memMap_.find(addr4k);
         }
 

--- a/src/rogue/protocols/udp/Client.cpp
+++ b/src/rogue/protocols/udp/Client.cpp
@@ -73,6 +73,21 @@ rpu::Client::Client(std::string host, uint16_t port, bool jumbo) : rpu::Core(jum
                                           port_,
                                           address_.c_str()));
 
+    // Validate fd_ fits in fd_set before the worker thread is started.  An fd
+    // returned by socket() can legally exceed FD_SETSIZE on a process with
+    // many open descriptors; deferring the check to runThread() turns that
+    // into an asynchronous throw out of the worker, terminating the process
+    // after the constructor has already returned a "live" object.
+    if (fd_ >= FD_SETSIZE) {
+        const int badFd = fd_;
+        ::close(fd_);
+        fd_ = -1;
+        throw(rogue::GeneralError::create("Client::Client",
+                                          "Socket fd %d >= FD_SETSIZE (%d); reduce open file descriptors",
+                                          badFd,
+                                          static_cast<int>(FD_SETSIZE)));
+    }
+
     // Lookup host address
     bzero(&aiHints, sizeof(aiHints));
     aiHints.ai_flags    = AI_CANONNAME;
@@ -109,7 +124,7 @@ rpu::Client::Client(std::string host, uint16_t port, bool jumbo) : rpu::Core(jum
 
     threadEn_ = true;
     try {
-        thread_ = new std::thread(&rpu::Client::runThread, this, std::weak_ptr<int>(scopePtr));
+        thread_ = std::make_unique<std::thread>(&rpu::Client::runThread, this, std::weak_ptr<int>(scopePtr));
     } catch (...) {
         threadEn_ = false;
         ::close(fd_);
@@ -136,8 +151,7 @@ void rpu::Client::stop() {
         rogue::GilRelease noGil;
         ::close(fd_);
         thread_->join();
-        delete thread_;
-        thread_ = nullptr;
+        thread_.reset();
         fd_ = -1;
         udpLog_->debug("Stopping UDP client for remote %s:%" PRIu16, address_.c_str(), port_);
     }
@@ -187,6 +201,8 @@ void rpu::Client::acceptFrame(ris::FramePtr frame) {
         // but write fails because we did not win the (*it)er lock
         do {
             // Setup fds for select call
+            if (fd_ < 0 || fd_ >= FD_SETSIZE)
+                throw rogue::GeneralError::create("Client::acceptFrame", "fd_ value %d out of FD_SETSIZE range", fd_);
             FD_ZERO(&fds);
             FD_SET(fd_, &fds);
 
@@ -246,7 +262,18 @@ void rpu::Client::runThread(std::weak_ptr<int> lockPtr) {
             // Get new frame
             frame = reqLocalFrame(maxPayload(), false);
         } else {
-            // Setup fds for select call
+            // Setup fds for select call.  runThread() has no top-level
+            // catch, so a throw here would call std::terminate.  The
+            // ctor already guarantees fd_ < FD_SETSIZE; this in-loop
+            // check only fires if stop()/close() races with the worker
+            // and toggles fd_ to -1.  In that case log and exit the
+            // worker cleanly so stop() can complete instead of crashing
+            // the process.
+            if (fd_ < 0 || fd_ >= FD_SETSIZE) {
+                udpLog_->error("Client::runThread: fd_ value %d out of FD_SETSIZE range; exiting worker", fd_);
+                threadEn_ = false;
+                break;
+            }
             FD_ZERO(&fds);
             FD_SET(fd_, &fds);
 

--- a/src/rogue/protocols/udp/Server.cpp
+++ b/src/rogue/protocols/udp/Server.cpp
@@ -65,6 +65,21 @@ rpu::Server::Server(uint16_t port, bool jumbo) : rpu::Core(jumbo) {
     if ((fd_ = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
         throw(rogue::GeneralError::create("Server::Server", "Failed to create socket for port %" PRIu16, port_));
 
+    // Validate fd_ fits in fd_set before the worker thread is started.  An fd
+    // returned by socket() can legally exceed FD_SETSIZE on a process with
+    // many open descriptors; deferring the check to runThread() turns that
+    // into an asynchronous throw out of the worker, terminating the process
+    // after the constructor has already returned a "live" object.
+    if (fd_ >= FD_SETSIZE) {
+        const int badFd = fd_;
+        ::close(fd_);
+        fd_ = -1;
+        throw(rogue::GeneralError::create("Server::Server",
+                                          "Socket fd %d >= FD_SETSIZE (%d); reduce open file descriptors",
+                                          badFd,
+                                          static_cast<int>(FD_SETSIZE)));
+    }
+
     // Setup Remote Address
     memset(&locAddr_, 0, sizeof(struct sockaddr_in));
     locAddr_.sin_family      = AF_INET;
@@ -104,7 +119,7 @@ rpu::Server::Server(uint16_t port, bool jumbo) : rpu::Core(jumbo) {
 
     threadEn_ = true;
     try {
-        thread_ = new std::thread(&rpu::Server::runThread, this, std::weak_ptr<int>(scopePtr));
+        thread_ = std::make_unique<std::thread>(&rpu::Server::runThread, this, std::weak_ptr<int>(scopePtr));
     } catch (...) {
         threadEn_ = false;
         ::close(fd_);
@@ -131,8 +146,7 @@ void rpu::Server::stop() {
         rogue::GilRelease noGil;
         ::close(fd_);
         thread_->join();
-        delete thread_;
-        thread_ = nullptr;
+        thread_.reset();
         fd_ = -1;
         udpLog_->debug("Stopping UDP server on local port %" PRIu16, port_);
     }
@@ -186,6 +200,8 @@ void rpu::Server::acceptFrame(ris::FramePtr frame) {
         // but write fails because we did not win the buffer lock
         do {
             // Setup fds for select call
+            if (fd_ < 0 || fd_ >= FD_SETSIZE)
+                throw rogue::GeneralError::create("Server::acceptFrame", "fd_ value %d out of FD_SETSIZE range", fd_);
             FD_ZERO(&fds);
             FD_SET(fd_, &fds);
 
@@ -264,7 +280,18 @@ void rpu::Server::runThread(std::weak_ptr<int> lockPtr) {
                 remAddr_ = tmpAddr;
             }
         } else {
-            // Setup fds for select call
+            // Setup fds for select call.  runThread() has no top-level
+            // catch, so a throw here would call std::terminate.  The
+            // ctor already guarantees fd_ < FD_SETSIZE; this in-loop
+            // check only fires if stop()/close() races with the worker
+            // and toggles fd_ to -1.  In that case log and exit the
+            // worker cleanly so stop() can complete instead of crashing
+            // the process.
+            if (fd_ < 0 || fd_ >= FD_SETSIZE) {
+                udpLog_->error("Server::runThread: fd_ value %d out of FD_SETSIZE range; exiting worker", fd_);
+                threadEn_ = false;
+                break;
+            }
             FD_ZERO(&fds);
             FD_SET(fd_, &fds);
 

--- a/src/rogue/protocols/xilinx/JtagDriver.cpp
+++ b/src/rogue/protocols/xilinx/JtagDriver.cpp
@@ -212,7 +212,10 @@ int rpx::JtagDriver::xferRel(uint8_t* txb, unsigned txBytes, Header* phdr, uint8
                 }
                 return got;
             }
-        } catch (rogue::GeneralError&) {}
+        } catch (rogue::GeneralError& e) {
+            // Log and retry; do not silently swallow the error.
+            log_->warning("xferRel attempt %u failed: %s", attempt, e.what());
+        }
     }
     if (!this->done_.load(std::memory_order_acquire))
         throw(rogue::GeneralError::create("JtagDriver::xferRel()", "Timeout error"));

--- a/src/rogue/protocols/xilinx/Xvc.cpp
+++ b/src/rogue/protocols/xilinx/Xvc.cpp
@@ -85,6 +85,27 @@ rpx::Xvc::Xvc(uint16_t port) : JtagDriver(port), mtu_(1450), threadEn_{false}, s
         throw(rogue::GeneralError::create("Xvc::Xvc()", "pipe2() failed: %s (errno %d)",
                                           strerror(errno), errno));
 #endif
+
+    // Reject wakeFd_ >= FD_SETSIZE synchronously here, before start() is
+    // called.  XvcServer::run / XvcConnection::readTo defensively check
+    // FD_SETSIZE inside the worker thread, but a high fd would only
+    // surface as a silent worker-thread exit while start() returned
+    // success; throwing in the ctor lets the caller see a clean failure.
+    // Mirrors the AxiStreamDma / udp::Client / udp::Server FD_SETSIZE
+    // ctor checks added earlier in this audit.
+    for (int idx = 0; idx < 2; ++idx) {
+        if (wakeFd_[idx] >= FD_SETSIZE) {
+            int badFd = wakeFd_[idx];
+            ::close(wakeFd_[0]);
+            ::close(wakeFd_[1]);
+            wakeFd_[0] = wakeFd_[1] = -1;
+            throw(rogue::GeneralError::create(
+                "Xvc::Xvc()",
+                "wake-pipe fd %d exceeds FD_SETSIZE (%d); too many open files in process",
+                badFd,
+                static_cast<int>(FD_SETSIZE)));
+        }
+    }
 }
 
 //! Destructor

--- a/src/rogue/protocols/xilinx/XvcConnection.cpp
+++ b/src/rogue/protocols/xilinx/XvcConnection.cpp
@@ -44,6 +44,24 @@ rpx::XvcConnection::XvcConnection(int sd, int wakeFd, JtagDriver* drv, uint64_t 
     if ((sd_ = ::accept(sd, reinterpret_cast<struct sockaddr*>(&peer_), &sz)) < 0)
         throw(rogue::GeneralError::create("XvcConnection::XvcConnection()", "Unable to accept connection"));
 
+    // accept() can return a fd >= FD_SETSIZE on a process with many open
+    // descriptors.  readTo() defensively checks FD_SETSIZE on every call
+    // and would treat the connection as immediately broken (returning
+    // -2/EBADF), but that path leaves the bad fd open until the
+    // connection scope exits.  Reject it synchronously so the listener
+    // loop in XvcServer::run drops the bad connection cleanly and moves
+    // on to the next accept.
+    if (sd_ >= FD_SETSIZE) {
+        int badFd = sd_;
+        ::close(sd_);
+        sd_ = -1;
+        throw(rogue::GeneralError::create(
+            "XvcConnection::XvcConnection()",
+            "accept() returned fd %d which exceeds FD_SETSIZE (%d); too many open files",
+            badFd,
+            static_cast<int>(FD_SETSIZE)));
+    }
+
     // XVC protocol is synchronous / not pipelined :-(
     // use TCP_NODELAY to make sure our messages (many of which
     // are small) are sent ASAP

--- a/src/rogue/protocols/xilinx/XvcServer.cpp
+++ b/src/rogue/protocols/xilinx/XvcServer.cpp
@@ -50,6 +50,22 @@ rpx::XvcServer::XvcServer(uint16_t port, int wakeFd, JtagDriver* drv, unsigned m
     if ((sd_ = ::socket(AF_INET, SOCK_STREAM, 0)) < 0)
         throw(rogue::GeneralError::create("XvcServer::XvcServer()", "Failed to create socket"));
 
+    // Reject sd_ >= FD_SETSIZE synchronously here, before start()
+    // returns.  The defensive FD_SETSIZE check in run() runs on the
+    // worker thread and would only surface as a silent worker-thread
+    // exit (caught by Xvc::runThread) while the caller saw start()
+    // return success.  Throwing in the ctor lets start() fail fast.
+    if (sd_ >= FD_SETSIZE) {
+        int badFd = sd_;
+        ::close(sd_);
+        sd_ = -1;
+        throw(rogue::GeneralError::create(
+            "XvcServer::XvcServer()",
+            "socket fd %d exceeds FD_SETSIZE (%d); too many open files in process",
+            badFd,
+            static_cast<int>(FD_SETSIZE)));
+    }
+
     if (::setsockopt(sd_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes))) {
         ::close(sd_);
         sd_ = -1;

--- a/tests/cpp/protocols/CMakeLists.txt
+++ b/tests/cpp/protocols/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(packetizer)
+add_subdirectory(udp)
+add_subdirectory(srp)
 
 if (NOT NO_PYTHON)
    add_subdirectory(xilinx)

--- a/tests/cpp/protocols/srp/CMakeLists.txt
+++ b/tests/cpp/protocols/srp/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Regression tests for SRP protocol candidates (plan 02-03).
+
+rogue_add_cpp_test(rogue-cpp-protocols-srpv3-emulation-alloc-audit-repro
+   SOURCES
+      test_srpv3_emulation_alloc_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-protocols-srpv3-emulation-alloc-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/protocols/srp/test_srpv3_emulation_alloc_audit_repro.cpp
+++ b/tests/cpp/protocols/srp/test_srpv3_emulation_alloc_audit_repro.cpp
@@ -1,0 +1,85 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests
+ * SrpV3Emulation::allocatePage() allocates each 4 KiB emulated memory page
+ * via raw ``malloc(0x1000)`` and stores the raw pointer in the ``memMap_``
+ * std::map.  If the map::insert call throws std::bad_alloc after malloc
+ * succeeds, the allocated page is leaked because no RAII owner holds it.
+ * A correct implementation uses std::unique_ptr<uint8_t[]> or
+ * std::make_unique<uint8_t[]>(0x1000).
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #error "ROGUE_SRC_DIR must be defined via target_compile_definitions"
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+/// Extract up to maxLines lines starting at the line that contains marker.
+static std::string extractContext(const std::string& src,
+                                  const std::string& marker,
+                                  int maxLines) {
+    std::istringstream ss(src);
+    std::string line;
+    std::ostringstream out;
+    bool inFunc   = false;
+    int count     = 0;
+    while (std::getline(ss, line)) {
+        if (!inFunc && line.find(marker) != std::string::npos) inFunc = true;
+        if (inFunc) {
+            out << line << "\n";
+            if (++count >= maxLines) break;
+        }
+    }
+    return out.str();
+}
+
+TEST_CASE("SrpV3Emulation::allocatePage uses RAII page allocation") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/srp/SrpV3Emulation.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "SrpV3Emulation.cpp not found at " << path);
+
+    // Scope the RAII check to the allocatePage function body.
+    // std::vector<uint8_t> used elsewhere in processFrame does NOT fix the
+    // page-allocation leak — the fix must be in allocatePage itself.
+    const std::string funcBody = extractContext(src, "allocatePage(uint64_t addr4k)", 30);
+    REQUIRE_MESSAGE(!funcBody.empty(),
+        "allocatePage function not found in SrpV3Emulation.cpp");
+
+    const bool hasRawMalloc = funcBody.find("malloc(0x1000)") != std::string::npos;
+    CHECK_MESSAGE(!hasRawMalloc,
+        " regression: raw 'malloc(0x1000)' is back in allocatePage; "
+        "fix replaced it with std::make_unique<uint8_t[]>(0x1000)");
+
+    const bool hasRAII =
+        funcBody.find("unique_ptr<uint8_t") != std::string::npos ||
+        funcBody.find("make_unique<uint8_t") != std::string::npos;
+    CHECK_MESSAGE(hasRAII,
+        "allocatePage must use std::make_unique<uint8_t[]>(0x1000) "
+        "or std::unique_ptr<uint8_t[]> for RAII ownership of the 4K page");
+}

--- a/tests/cpp/protocols/udp/CMakeLists.txt
+++ b/tests/cpp/protocols/udp/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Regression tests for UDP protocol candidates (plan 02-03).
+
+rogue_add_cpp_test(rogue-cpp-protocols-udp-fd-setsize-audit-repro
+   SOURCES
+      test_udp_fd_setsize_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-protocols-udp-fd-setsize-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-protocols-udp-raw-thread-audit-repro
+   SOURCES
+      test_udp_raw_thread_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-protocols-udp-raw-thread-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/protocols/udp/test_udp_fd_setsize_audit_repro.cpp
+++ b/tests/cpp/protocols/udp/test_udp_fd_setsize_audit_repro.cpp
@@ -1,0 +1,126 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests.
+ * Four FD_SET sites in udp::Client (acceptFrame / runThread) and
+ * udp::Server (acceptFrame / runThread) call FD_SET(fd_, &fds) without
+ * first checking fd_ < FD_SETSIZE.  On Linux FD_SETSIZE=1024; if fd_
+ * reaches >= 1024 the FD_SET macro writes past the fd_set bitset,
+ * causing heap corruption.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #error "ROGUE_SRC_DIR must be defined via target_compile_definitions"
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+/// Split source into lines.
+static std::vector<std::string> splitLines(const std::string& src) {
+    std::vector<std::string> lines;
+    std::istringstream ss(src);
+    std::string line;
+    while (std::getline(ss, line)) lines.push_back(line);
+    return lines;
+}
+
+/// Return the 0-based line index of the Nth occurrence of needle (N is 0-based).
+static int findNthLine(const std::vector<std::string>& lines,
+                       const std::string& needle,
+                       unsigned occurrence) {
+    unsigned count = 0;
+    for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+        if (lines[i].find(needle) != std::string::npos) {
+            if (count == occurrence) return i;
+            ++count;
+        }
+    }
+    return -1;
+}
+
+/// Return true if a FD_SETSIZE guard precedes the FD_SET call.
+/// Searches the 8 lines before fdSetLine for "FD_SETSIZE".
+static bool hasFdGuard(const std::vector<std::string>& lines, int fdSetLine) {
+    int start = (fdSetLine > 8) ? fdSetLine - 8 : 0;
+    for (int i = start; i < fdSetLine; ++i) {
+        if (lines[i].find("FD_SETSIZE") != std::string::npos) return true;
+    }
+    return false;
+}
+
+/// Return true if `line` is a single-line comment (`//...` after optional
+/// whitespace). Used to skip FD_SET tokens that appear only in comments.
+static bool isCommentLine(const std::string& line) {
+    for (char c : line) {
+        if (c == ' ' || c == '\t') continue;
+        return c == '/' && line.find("//") != std::string::npos &&
+               line.find("//") <= line.find("FD_SET");
+    }
+    return false;
+}
+
+/// Return true if every active (non-comment) FD_SET(fd_,...) call in the
+/// file has an FD_SETSIZE guard within the 8 lines preceding it.
+static bool everyFdSetIsGuarded(const std::vector<std::string>& lines) {
+    bool allGuarded = true;
+    bool any        = false;
+    for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+        if (lines[i].find("FD_SET(fd_") == std::string::npos) continue;
+        if (isCommentLine(lines[i])) continue;
+        any = true;
+        if (!hasFdGuard(lines, i)) allGuarded = false;
+    }
+    return any && allGuarded;
+}
+
+TEST_CASE("udp::Client all FD_SET sites guarded by FD_SETSIZE") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/udp/Client.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "Client.cpp not found at " << path);
+
+    const auto lines = splitLines(src);
+    CHECK_MESSAGE(everyFdSetIsGuarded(lines),
+        " regression: at least one FD_SET(fd_,...) site in "
+        "udp/Client.cpp lacks an FD_SETSIZE bounds check within the preceding "
+        "8 lines; fix added 'if (fd_ >= FD_SETSIZE) throw...' "
+        "before each FD_SET to prevent heap corruption when fd_ >= 1024");
+}
+
+TEST_CASE("udp::Server all FD_SET sites guarded by FD_SETSIZE") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/udp/Server.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "Server.cpp not found at " << path);
+
+    const auto lines = splitLines(src);
+    CHECK_MESSAGE(everyFdSetIsGuarded(lines),
+        " regression: at least one FD_SET(fd_,...) site in "
+        "udp/Server.cpp lacks an FD_SETSIZE bounds check within the preceding "
+        "8 lines; fix added 'if (fd_ >= FD_SETSIZE) throw...' "
+        "before each FD_SET to prevent heap corruption when fd_ >= 1024");
+}

--- a/tests/cpp/protocols/udp/test_udp_raw_thread_audit_repro.cpp
+++ b/tests/cpp/protocols/udp/test_udp_raw_thread_audit_repro.cpp
@@ -1,0 +1,79 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests
+ * Both udp::Client and udp::Server allocate their worker thread via
+ * ``new std::thread`` (with a try/catch guard), storing the result in a raw
+ * ``thread_`` pointer.  The existing try/catch makes the immediate exception
+ * path safe, but the raw-ptr pattern is still tech debt: future code changes
+ * that add throw paths between allocation and the catch block re-introduce
+ * the leak.  A correct fix replaces the raw pointer with
+ * ``std::unique_ptr<std::thread>``.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #error "ROGUE_SRC_DIR must be defined via target_compile_definitions"
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+/// Return true if the source uses RAII-managed thread allocation.
+static bool hasRaiiThread(const std::string& src) {
+    return src.find("make_unique<std::thread>") != std::string::npos ||
+           src.find("unique_ptr<std::thread>") != std::string::npos;
+}
+
+TEST_CASE("udp::Client uses RAII thread allocation") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/udp/Client.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "Client.cpp not found at " << path);
+
+    const bool hasRaw = src.find("new std::thread") != std::string::npos;
+    CHECK_MESSAGE(!hasRaw,
+        " regression: raw 'new std::thread' is back in udp/Client.cpp; "
+        "fix replaced it with std::make_unique<std::thread>");
+
+    CHECK_MESSAGE(hasRaiiThread(src),
+        "Client.cpp must allocate worker thread via "
+        "std::make_unique<std::thread> or std::unique_ptr<std::thread>");
+}
+
+TEST_CASE("udp::Server uses RAII thread allocation") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/udp/Server.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "Server.cpp not found at " << path);
+
+    const bool hasRaw = src.find("new std::thread") != std::string::npos;
+    CHECK_MESSAGE(!hasRaw,
+        " regression: raw 'new std::thread' is back in udp/Server.cpp; "
+        "fix replaced it with std::make_unique<std::thread>");
+
+    CHECK_MESSAGE(hasRaiiThread(src),
+        "Server.cpp must allocate worker thread via "
+        "std::make_unique<std::thread> or std::unique_ptr<std::thread>");
+}

--- a/tests/cpp/protocols/xilinx/CMakeLists.txt
+++ b/tests/cpp/protocols/xilinx/CMakeLists.txt
@@ -6,3 +6,13 @@ rogue_add_cpp_test(rogue-cpp-xvc-smoke
       requires-python
 )
 set_tests_properties(rogue-cpp-xvc-smoke PROPERTIES TIMEOUT 10)
+
+rogue_add_cpp_test(rogue-cpp-protocols-jtag-driver-swallow-audit-repro
+   SOURCES
+      test_jtag_driver_swallow_audit_repro.cpp
+   LABELS
+      cpp-core
+      requires-python
+)
+target_compile_definitions(rogue-cpp-protocols-jtag-driver-swallow-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/protocols/xilinx/test_jtag_driver_swallow_audit_repro.cpp
+++ b/tests/cpp/protocols/xilinx/test_jtag_driver_swallow_audit_repro.cpp
@@ -1,0 +1,115 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests
+ * JtagDriver::xferRel() retries a JTAG transfer up to retry_ times.  The
+ * inner try/catch block catches ``rogue::GeneralError&`` with an empty body,
+ * silently swallowing the original error across all retry attempts.  After
+ * exhausting retries the function throws "Timeout error" instead of the
+ * actual cause, losing all diagnostic information about what went wrong.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #error "ROGUE_SRC_DIR must be defined via target_compile_definitions"
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+static std::vector<std::string> splitLines(const std::string& src) {
+    std::vector<std::string> lines;
+    std::istringstream ss(src);
+    std::string line;
+    while (std::getline(ss, line)) lines.push_back(line);
+    return lines;
+}
+
+TEST_CASE("JtagDriver::xferRel logs caught GeneralError instead of swallowing") {
+    const std::string path =
+        std::string(ROGUE_SRC_DIR) + "/src/rogue/protocols/xilinx/JtagDriver.cpp";
+    const std::string src = readFile(path);
+    REQUIRE_MESSAGE(!src.empty(), "JtagDriver.cpp not found at " << path);
+
+    const auto lines = splitLines(src);
+
+    // Locate the xferRel function definition.
+    int xferRelLine = -1;
+    for (int i = 0; i < static_cast<int>(lines.size()); ++i) {
+        if (lines[i].find("xferRel(") != std::string::npos &&
+            lines[i].find("//") == std::string::npos) {
+            xferRelLine = i;
+            break;
+        }
+    }
+    REQUIRE_MESSAGE(xferRelLine >= 0, "xferRel function not found in JtagDriver.cpp");
+
+    // Find the catch(rogue::GeneralError& [name]) block after xferRel.
+    // The fix may name the exception parameter (e.g., 'catch (rogue::GeneralError& e)').
+    int catchLine = -1;
+    for (int i = xferRelLine; i < static_cast<int>(lines.size()); ++i) {
+        const auto& l = lines[i];
+        if (l.find("catch") != std::string::npos &&
+            l.find("rogue::GeneralError&") != std::string::npos) {
+            catchLine = i;
+            break;
+        }
+    }
+    REQUIRE_MESSAGE(catchLine >= 0,
+        "catch(rogue::GeneralError&) not found in xferRel");
+
+    // Capture the catch block body (up to 6 lines after the catch line) and
+    // verify it contains a logging or rethrow statement — not just '{}' or '}'.
+    std::string catchBody;
+    const int end = static_cast<int>(lines.size()) < catchLine + 6
+                        ? static_cast<int>(lines.size())
+                        : catchLine + 6;
+    for (int i = catchLine; i < end; ++i) catchBody += lines[i] + "\n";
+
+    bool isEmptyCatch = false;
+    if (catchBody.find("{}") != std::string::npos) {
+        isEmptyCatch = true;
+    } else if (catchLine + 1 < static_cast<int>(lines.size())) {
+        std::string stripped;
+        for (char c : lines[catchLine + 1]) {
+            if (c != ' ' && c != '\t') stripped += c;
+        }
+        if (stripped == "}" || stripped.empty()) isEmptyCatch = true;
+    }
+
+    const bool logsOrRethrows =
+        catchBody.find("log_") != std::string::npos ||
+        catchBody.find("warning") != std::string::npos ||
+        catchBody.find("error") != std::string::npos ||
+        catchBody.find("throw") != std::string::npos ||
+        catchBody.find("e.what()") != std::string::npos;
+    const bool catchHandlesError = !isEmptyCatch && logsOrRethrows;
+
+    CHECK_MESSAGE(catchHandlesError,
+        " regression: catch(rogue::GeneralError&) in xferRel must log "
+        "or rethrow the caught error; fix added log_->warning(...) "
+        "in the catch body so callers see the root cause across retries "
+        "instead of a generic 'Timeout error'");
+}

--- a/tests/protocols/test_batcher_audit_repros.py
+++ b/tests/protocols/test_batcher_audit_repros.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+# -----------------------------------------------------------------------------
+# Description:
+#   Regression tests
+#   batcher V1/V2 InverterV1/InverterV2 acceptFrame() performs memcpy on
+#   tail region without verifying that at least headerSize() bytes are
+#   available before the copy.
+# -----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+# -----------------------------------------------------------------------------
+
+import pathlib
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_INV_V1 = _REPO_ROOT / "src" / "rogue" / "protocols" / "batcher" / "InverterV1.cpp"
+_INV_V2 = _REPO_ROOT / "src" / "rogue" / "protocols" / "batcher" / "InverterV2.cpp"
+
+
+def _read_source(path):
+    return path.read_text()
+
+
+def _has_tail_payload_guard(src, memcpy_tag):
+    """Return True if a runtime payload-vs-tailsize bounds check precedes the memcpy.
+
+    A correct fix would compare the actual available bytes in the tail region
+    against headerSize() at runtime — e.g. checking that
+    ``(frame->getPayload() - tailOffset) >= headerSize()`` or an equivalent
+    guard derived from CoreV1/V2 helper methods.  The existing metadata check
+    (``headerSize() != tailSize()``) only validates that the two declared sizes
+    are consistent; it does NOT verify that the frame payload is long enough to
+    actually contain the tail data.
+    """
+    lines = src.splitlines()
+    memcpy_lineno = None
+    for i, line in enumerate(lines):
+        if memcpy_tag in line:
+            memcpy_lineno = i
+            break
+    if memcpy_lineno is None:
+        return False
+
+    search_start = max(0, memcpy_lineno - 20)
+    preceding = "\n".join(lines[search_start:memcpy_lineno])
+
+    # These tokens indicate a runtime payload-size guard.
+    # Note: "tailSize()" alone is intentionally excluded because InverterV1
+    # already has ``headerSize() != tailSize()`` which checks metadata
+    # consistency but NOT frame-buffer availability.
+    return any(
+        token in preceding
+        for token in (
+            "getPayload()",
+            "getSize()",
+            "bytes_available",
+            "frame->size",
+            "payload_size",
+            "frameSize",
+            "frame_size",
+            ">= headerSize() *",
+            "* core.count()",
+        )
+    )
+
+
+def _multiplication_is_64bit(src, memcpy_tag):
+    """Return True if the bounds-check multiplication is performed in 64-bit.
+
+    headerSize() and count() both return uint32_t. A crafted oversized
+    batcher frame can wrap ``headerSize() * (count() + 1)`` back below
+    frame->getPayload() so the bounds check passes even though the tail
+    region runs past the payload.  The fix promotes one operand to
+    uint64_t before the multiplication.
+    """
+    lines = src.splitlines()
+    memcpy_lineno = None
+    for i, line in enumerate(lines):
+        if memcpy_tag in line:
+            memcpy_lineno = i
+            break
+    if memcpy_lineno is None:
+        return False
+
+    search_start = max(0, memcpy_lineno - 20)
+    preceding = "\n".join(lines[search_start:memcpy_lineno])
+
+    return ("uint64_t" in preceding) and ("headerSize()" in preceding)
+
+
+def test_batcher_v1_memcpy_bounds_check():
+    """InverterV1::acceptFrame memcpy lacks runtime frame-size guard.
+
+    The memcpy near line 82 of InverterV1.cpp copies headerSize() bytes from
+    core.beginTail(0).ptr() without verifying that the frame payload is long
+    enough to contain the full tail region.  The existing check
+    ``headerSize() != tailSize()`` validates metadata consistency but not
+    whether the frame buffer has at least ``headerSize() * count()`` bytes
+    available for tail data.
+    """
+    src = _read_source(_INV_V1)
+
+    assert "memcpy(core.beginHeader().ptr(), core.beginTail(0).ptr(), core.headerSize())" in src, \
+        "expected memcpy pattern not found in InverterV1.cpp; file may have changed"
+
+    has_guard = _has_tail_payload_guard(src, "memcpy(core.beginHeader")
+
+    assert has_guard, (
+        "V1 batcher memcpy lacks runtime frame-size bounds check — "
+        "InverterV1::acceptFrame copies core.headerSize() bytes from tail region "
+        "without verifying the frame payload holds at least headerSize()*count() "
+        "bytes of tail data (the existing headerSize()!=tailSize() check only "
+        "validates metadata consistency, not frame-buffer availability)"
+    )
+
+    assert _multiplication_is_64bit(src, "memcpy(core.beginHeader"), (
+        "V1 batcher bounds-check multiplication is still in 32-bit arithmetic — "
+        "headerSize() * (count() + 1) can wrap on a crafted oversized batcher "
+        "frame and the comparison would then under-approximate the required "
+        "tail bytes; promote one operand to uint64_t before the multiplication"
+    )
+
+
+def test_batcher_v2_memcpy_bounds_check():
+    """InverterV2::acceptFrame memcpy lacks runtime frame-size guard.
+
+    The memcpy near line 82 of InverterV2.cpp copies headerSize() bytes (7 bytes
+    for V2) from core.beginTail(0).ptr() without verifying that the frame
+    payload is long enough to contain all tail records.
+    """
+    src = _read_source(_INV_V2)
+
+    assert "memcpy(core.beginHeader().ptr(), core.beginTail(0).ptr(), core.headerSize())" in src, \
+        "expected memcpy pattern not found in InverterV2.cpp; file may have changed"
+
+    has_guard = _has_tail_payload_guard(src, "memcpy(core.beginHeader")
+
+    assert has_guard, (
+        "V2 batcher memcpy lacks runtime frame-size bounds check — "
+        "InverterV2::acceptFrame copies core.headerSize() bytes from tail region "
+        "without verifying at least headerSize() bytes are available there"
+    )
+
+    assert _multiplication_is_64bit(src, "memcpy(core.beginHeader"), (
+        "V2 batcher bounds-check multiplication is still in 32-bit arithmetic — "
+        "headerSize() * (count() + 1) can wrap on a crafted oversized batcher "
+        "frame and the comparison would then under-approximate the required "
+        "tail bytes; promote one operand to uint64_t before the multiplication"
+    )

--- a/tests/protocols/test_srpv0_timeout_audit_repro.py
+++ b/tests/protocols/test_srpv0_timeout_audit_repro.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+# -----------------------------------------------------------------------------
+# Description:
+#   Regression tests
+#   SrpV0::doTransaction expired-transaction branch calls log_->warning()
+#   and continues without calling tran->error(), leaving the Transaction
+#   pending indefinitely instead of completing it with an error.
+# -----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+# -----------------------------------------------------------------------------
+
+import pathlib
+
+import pytest
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SRPV0 = _REPO_ROOT / "src" / "rogue" / "protocols" / "srp" / "SrpV0.cpp"
+
+
+@pytest.mark.integration
+def test_srpv0_calls_tran_error_on_timeout():
+    """SrpV0::doTransaction expired-transaction branch lacks tran->error().
+
+    SrpV0.cpp handles expired transactions in the doTransaction() receive loop.
+    The branch at line ~228 detects ``tran->expired()`` and logs a warning but
+    does NOT call ``tran->error(...)`` to complete the Transaction with an error.
+    Compare with SrpV3.cpp which calls ``tran->error("Timeout")`` on the
+    equivalent path.  Without the error() call any Block waiting on the
+    transaction's completion future will block forever.
+    """
+    src = _SRPV0.read_text()
+    lines = src.splitlines()
+
+    # Find the expired() check
+    expired_lineno = None
+    for i, line in enumerate(lines):
+        if "tran->expired()" in line or "expired()" in line:
+            expired_lineno = i
+            break
+
+    assert expired_lineno is not None, \
+        "tran->expired() check not found in SrpV0.cpp; file may have changed"
+
+    # Inspect the block following expired() for a tran->error( call.
+    # Search up to 15 lines after the expired() check.
+    search_end = min(len(lines), expired_lineno + 15)
+    following = "\n".join(lines[expired_lineno:search_end])
+
+    has_error_call = "tran->error(" in following or "->error(" in following
+
+    assert has_error_call, (
+        "SrpV0::doTransaction expired-transaction branch lacks tran->error() call "
+        "(compare with SrpV3.cpp which calls tran->error(\"Timeout\") on the equivalent path); "
+        "Transaction left pending indefinitely — callers waiting on the transaction future hang forever"
+    )

--- a/tests/protocols/test_srpv3_emulation_audit_repros.py
+++ b/tests/protocols/test_srpv3_emulation_audit_repros.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+# -----------------------------------------------------------------------------
+# Description:
+#   Regression tests
+#   SrpV3Emulation::allocatePage uses raw malloc(0x1000) with no
+#              RAII; if the subsequent map insert throws after malloc, the
+#              page leaks.
+#   Random-fill behaviour of new pages is documented only in the
+#             .cpp comment, not in the public header docstring; callers
+#              writing deterministic tests may be surprised.
+# -----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+# -----------------------------------------------------------------------------
+
+import pathlib
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_EMULATION_CPP = _REPO_ROOT / "src" / "rogue" / "protocols" / "srp" / "SrpV3Emulation.cpp"
+_EMULATION_H = _REPO_ROOT / "include" / "rogue" / "protocols" / "srp" / "SrpV3Emulation.h"
+
+
+def _extract_function_body(src, func_name):
+    """Extract the lines of a named function from C++ source text.
+
+    Scans for ``func_name`` and returns lines from that point to the
+    matching closing brace.  Returns empty string if not found.
+    """
+    lines = src.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if func_name in line:
+            start = i
+            break
+    if start is None:
+        return ""
+    depth = 0
+    body_lines = []
+    for line in lines[start:]:
+        body_lines.append(line)
+        depth += line.count("{") - line.count("}")
+        if depth <= 0 and body_lines:
+            break
+    return "\n".join(body_lines)
+
+
+def _extract_public_class_docstring(src):
+    """Extract the class-level Doxygen block comment from the header.
+
+    Returns the text of the block comment that immediately precedes
+    the class declaration, which constitutes the public API documentation.
+    """
+    lines = src.splitlines()
+    class_lineno = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("class ") and "SrpV3Emulation" in line:
+            class_lineno = i
+            break
+    if class_lineno is None:
+        return ""
+    # Walk backwards to collect the preceding Doxygen block
+    doc_lines = []
+    in_block = False
+    for line in reversed(lines[:class_lineno]):
+        stripped = line.strip()
+        if stripped.endswith("*/"):
+            in_block = True
+        if in_block:
+            doc_lines.insert(0, line)
+        if stripped.startswith("/**") and in_block:
+            break
+    return "\n".join(doc_lines)
+
+
+def test_srpv3_emulation_random_fill_documented():
+    """SrpV3Emulation random-fill init not in the class-level public docstring.
+
+    New memory pages are filled with ``std::mt19937`` random data to emulate
+    uninitialised hardware memory.  This behavioural contract is visible in a
+    comment inside SrpV3Emulation.cpp and in the private ``allocatePage``
+    docstring, but the **class-level** public API docstring (the block comment
+    immediately before ``class SrpV3Emulation``) does not mention it.  Callers
+    relying on the class-level docstring to understand read-back semantics
+    (e.g., writing deterministic tests that assume zero-initialisation) will
+    get random data and may see unexpected failures.
+    """
+    header_src = _EMULATION_H.read_text()
+    class_doc = _extract_public_class_docstring(header_src)
+
+    assert class_doc, \
+        "class-level docstring not found in SrpV3Emulation.h"
+
+    # The class-level docstring must mention random or non-deterministic fill
+    has_random_note = any(
+        keyword in class_doc.lower()
+        for keyword in (
+            "random",
+            "uninitializ",
+            "uninitialis",
+            "non-deterministic",
+            "nondeterministic",
+        )
+    )
+
+    assert has_random_note, (
+        "random-fill init mentioned in SrpV3Emulation.cpp and private allocatePage doc "
+        "but NOT in the class-level public docstring of SrpV3Emulation.h; "
+        "deterministic-test callers may be surprised by non-zero initial page contents — "
+        "add a note about random fill to the class-level /**... */ docstring in SrpV3Emulation.h"
+    )

--- a/tests/protocols/xilinx/test_xvc_fd_setsize_audit_repro.py
+++ b/tests/protocols/xilinx/test_xvc_fd_setsize_audit_repro.py
@@ -1,0 +1,118 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression tests.
+#   Three Xvc constructors create file descriptors via syscalls that can
+#   legally return fd >= FD_SETSIZE on a process with many open files,
+#   yet were only validated by the defensive FD_SETSIZE check inside
+#   XvcServer::run / XvcConnection::readTo.  That late check produces a
+#   silent worker-thread exit (caught by Xvc::runThread) while the
+#   caller sees Xvc::start() return success.  These source-text tests
+#   assert each ctor performs the FD_SETSIZE check synchronously so
+#   start() / accept fail fast with a clear error.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pathlib
+import re
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_XVC_CPP = _REPO_ROOT / "src" / "rogue" / "protocols" / "xilinx" / "Xvc.cpp"
+_XVC_SERVER_CPP = _REPO_ROOT / "src" / "rogue" / "protocols" / "xilinx" / "XvcServer.cpp"
+_XVC_CONN_CPP = _REPO_ROOT / "src" / "rogue" / "protocols" / "xilinx" / "XvcConnection.cpp"
+
+
+def _ctor_body(path, qualified_name):
+    """Return the body of ``qualified_name(...)`` defined in ``path``."""
+    src = path.read_text()
+    pattern = re.escape(qualified_name) + r"\([^{]*\{(?P<body>.*?)\n\}\s*\n"
+    match = re.search(pattern, src, re.DOTALL)
+    assert match is not None, (
+        f"could not locate {qualified_name} ctor body in {path.name}"
+    )
+    return match.group("body")
+
+
+def test_xvc_wakefd_fd_setsize_check_in_ctor():
+    """Xvc::Xvc must reject wakeFd_ >= FD_SETSIZE synchronously after pipe()/pipe2().
+
+    Without this, a high pipe fd would surface only as a deferred throw
+    in XvcServer::run / XvcConnection::readTo, which Xvc::runThread
+    catches and turns into a silent worker-thread exit while start()
+    already returned success.
+    """
+    body = _ctor_body(_XVC_CPP, "rpx::Xvc::Xvc")
+
+    # Both pipe creation and the FD_SETSIZE bounds check must appear in
+    # the ctor body, with the bounds check after the pipe call.
+    pipe_match = re.search(r"::pipe2?\(wakeFd_", body)
+    assert pipe_match, "expected pipe()/pipe2() call in Xvc::Xvc"
+
+    bounds_match = re.search(r"wakeFd_\[\s*\w+\s*\]\s*>=\s*FD_SETSIZE", body)
+    assert bounds_match, (
+        "Xvc::Xvc lacks an FD_SETSIZE bounds check on wakeFd_; high pipe "
+        "fds would only surface as a silent worker-thread exit caught by "
+        "Xvc::runThread, while the Python caller saw Xvc::start() return "
+        "success"
+    )
+    assert bounds_match.start() > pipe_match.start(), (
+        "FD_SETSIZE check must follow pipe()/pipe2() in Xvc::Xvc"
+    )
+
+
+def test_xvc_server_fd_setsize_check_in_ctor():
+    """XvcServer::XvcServer must reject sd_ >= FD_SETSIZE after socket().
+
+    The defensive FD_SETSIZE check in XvcServer::run runs on the worker
+    thread and would only surface as a silent thread exit; the ctor
+    check makes XvcServer construction fail fast so Xvc::start propagates
+    the failure to the Python caller instead.
+    """
+    body = _ctor_body(_XVC_SERVER_CPP, "rpx::XvcServer::XvcServer")
+
+    socket_match = re.search(r"sd_\s*=\s*::socket\(", body)
+    assert socket_match, "expected ::socket() call in XvcServer::XvcServer"
+
+    bounds_match = re.search(r"sd_\s*>=\s*FD_SETSIZE", body)
+    assert bounds_match, (
+        "XvcServer::XvcServer lacks an FD_SETSIZE bounds check on sd_; "
+        "a high socket fd would only surface inside the worker thread's "
+        "FD_SETSIZE check and be silently swallowed by Xvc::runThread"
+    )
+    assert bounds_match.start() > socket_match.start(), (
+        "FD_SETSIZE check must follow ::socket() in XvcServer::XvcServer"
+    )
+
+
+def test_xvc_connection_fd_setsize_check_in_ctor():
+    """XvcConnection::XvcConnection must reject sd_ >= FD_SETSIZE after accept().
+
+    accept() can return a high fd on a process with many open files;
+    readTo()'s defensive check would otherwise leave the bad fd open
+    for the lifetime of the XvcConnection.  Throwing in the ctor lets
+    XvcServer::run drop the bad connection cleanly via the existing
+    ``catch (rogue::GeneralError&)`` arm and continue accepting.
+    """
+    body = _ctor_body(_XVC_CONN_CPP, "rpx::XvcConnection::XvcConnection")
+
+    accept_match = re.search(r"sd_\s*=\s*::accept\(", body)
+    assert accept_match, "expected ::accept() call in XvcConnection::XvcConnection"
+
+    bounds_match = re.search(r"sd_\s*>=\s*FD_SETSIZE", body)
+    assert bounds_match, (
+        "XvcConnection::XvcConnection lacks an FD_SETSIZE bounds check on "
+        "sd_; a high accept fd would leave a dead connection open until "
+        "scope exit and every readTo() would silently return -2/EBADF"
+    )
+    assert bounds_match.start() > accept_match.start(), (
+        "FD_SETSIZE check must follow ::accept() in XvcConnection::XvcConnection"
+    )


### PR DESCRIPTION
## Summary

Slice of #1196 (`general-bug-audit-clean`) containing the **srp-udp-batcher-xilinx** subset of the bug-audit fixes — split out so the diff is small enough to review in one sitting.

#1196 will be closed once all slices are open. The original branch retains the per-bug atomic commit history; this PR squashes the file-state for the listed paths.

## Files in this slice

- `include/rogue/protocols/srp/SrpV3Emulation.h`
- `include/rogue/protocols/udp/Core.h`
- `src/rogue/protocols/batcher/InverterV1.cpp`
- `src/rogue/protocols/batcher/InverterV2.cpp`
- `src/rogue/protocols/srp/SrpV0.cpp`
- `src/rogue/protocols/srp/SrpV3Emulation.cpp`
- `src/rogue/protocols/udp/Client.cpp`
- `src/rogue/protocols/udp/Server.cpp`
- `src/rogue/protocols/xilinx/JtagDriver.cpp`
- `src/rogue/protocols/xilinx/Xvc.cpp`
- `src/rogue/protocols/xilinx/XvcConnection.cpp`
- `src/rogue/protocols/xilinx/XvcServer.cpp`
- `tests/cpp/protocols/CMakeLists.txt`
- `tests/cpp/protocols/srp/CMakeLists.txt`
- `tests/cpp/protocols/srp/test_srpv3_emulation_alloc_audit_repro.cpp`
- `tests/cpp/protocols/udp/CMakeLists.txt`
- `tests/cpp/protocols/udp/test_udp_fd_setsize_audit_repro.cpp`
- `tests/cpp/protocols/udp/test_udp_raw_thread_audit_repro.cpp`
- `tests/cpp/protocols/xilinx/CMakeLists.txt`
- `tests/cpp/protocols/xilinx/test_jtag_driver_swallow_audit_repro.cpp`
- `tests/protocols/test_batcher_audit_repros.py`
- `tests/protocols/test_srpv0_timeout_audit_repro.py`
- `tests/protocols/test_srpv3_emulation_audit_repros.py`
- `tests/protocols/xilinx/test_xvc_fd_setsize_audit_repro.py`

## Verification

- Lint: `./scripts/run_linters.sh`
- C++ tests: `cmake -DROGUE_BUILD_TESTS=ON -B build && cmake --build build && ctest --test-dir build`
- Python tests: `pytest tests/`
