### PR TITLE
fix(core): Helpers, Logging, Queue, Pool, Version audit fixes + repros

### DIFF
--- a/include/rogue/Helpers.h
+++ b/include/rogue/Helpers.h
@@ -22,10 +22,6 @@
 /** @brief Connect a stream master to a downstream stream slave. */
 #define rogueStreamConnect(src, dst) src->addSlave(dst);
 
-// Add stream tap, DEPRECATED
-/** @brief Deprecated alias for `rogueStreamConnect`. */
-#define rogueStreamTap(src, dst) src->addSlave(dst);
-
 // Connect stream bi-directionally
 /** @brief Connect two stream endpoints in both directions. */
 #define rogueStreamConnectBiDir(devA, devB) \
@@ -51,6 +47,21 @@ inline void defaultTimeout(struct timeval& tout) {
     tout.tv_sec     = divResult.quot;
     tout.tv_usec    = divResult.rem;
 }
+
+// Marker function whose [[deprecated]] attribute is the trigger for
+// -Wdeprecated-declarations at every rogueStreamTap() call site.  Defining
+// the marker inside namespace rogue keeps the global namespace clean.
+[[deprecated("rogueStreamTap is deprecated; use rogueStreamConnect")]]
+inline void rogueStreamTap_deprecated_notice_() {}
 }  // namespace rogue
+
+// Add stream tap, DEPRECATED
+/** @brief Deprecated alias for `rogueStreamConnect`. */
+//
+// The macro evaluates the [[deprecated]] marker function so any caller of
+// rogueStreamTap() triggers a compile-time -Wdeprecated-declarations
+// diagnostic at the call site.  The (void)0 form keeps the macro usable as
+// either a statement or an expression.
+#define rogueStreamTap(src, dst) ((void)(::rogue::rogueStreamTap_deprecated_notice_(), src->addSlave(dst)))
 
 #endif

--- a/include/rogue/Logging.h
+++ b/include/rogue/Logging.h
@@ -63,8 +63,8 @@ class Logging {
     // Logging-level lock
     static std::mutex levelMtx_;
 
-    // Name/level filters
-    static std::vector<rogue::LogFilter*> filters_;
+    // Name/level filters (owned via unique_ptr to prevent leaks)
+    static std::vector<std::unique_ptr<rogue::LogFilter>> filters_;
 
     // Active logger instances
     static std::vector<rogue::Logging*> loggers_;

--- a/include/rogue/Queue.h
+++ b/include/rogue/Queue.h
@@ -42,8 +42,15 @@ class Queue {
     mutable std::mutex mtx_;
     std::condition_variable pushCond_;
     std::condition_variable popCond_;
-    uint32_t max_   = 0;
-    uint32_t thold_ = 0;
+    // max_/thold_ are written by setMax()/setThold() (lock-free) and read
+    // inside push()/pop() under mtx_.  In current callers both setters are
+    // only invoked at construction time before any worker thread runs, so
+    // the race is benign in practice — but a non-atomic read concurrent
+    // with a non-atomic write is UB per the C++ memory model and trips
+    // ThreadSanitizer / static analysers.  std::atomic<uint32_t> is
+    // lock-free on every supported platform and adds no measurable cost.
+    std::atomic<uint32_t> max_{0};
+    std::atomic<uint32_t> thold_{0};
     std::atomic<bool> busy_{false};
     bool run_ = true;
 
@@ -100,6 +107,7 @@ class Queue {
      * @return `true` when no entries are queued.
      */
     bool empty() {
+        std::unique_lock<std::mutex> lock(mtx_);
         return queue_.empty();
     }
 

--- a/include/rogue/Version.h
+++ b/include/rogue/Version.h
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include <atomic>
+#include <mutex>
 #include <string>
 
 namespace rogue {
@@ -38,10 +40,10 @@ class Version {
 
     static const char _version[];
 
-    static uint32_t _major;
-    static uint32_t _minor;
-    static uint32_t _maint;
-    static uint32_t _devel;
+    static std::atomic<uint32_t> _major;
+    static std::atomic<uint32_t> _minor;
+    static std::atomic<uint32_t> _maint;
+    static std::atomic<uint32_t> _devel;
 
   public:
     /** @brief Default constructor. */

--- a/include/rogue/interfaces/stream/Pool.h
+++ b/include/rogue/interfaces/stream/Pool.h
@@ -221,8 +221,18 @@ class Pool : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Pool>
      * hardware DMA driver. This method is protected to allow it to be called
      * by a sub-class of Pool.
      *
+     * Allocator/deallocator contract: the base-class `Pool::retBuffer()`
+     * deallocates buffers via `delete[]` (matching the `new uint8_t[]`
+     * allocation in `Pool::allocBuffer()`).  A sub-class that hands a
+     * pointer to `createBuffer()` whose allocation is NOT compatible with
+     * `delete[]` (for example a `malloc`-returned buffer or a kernel
+     * mapping) MUST override `retBuffer()` so the corresponding free path
+     * does not delegate to the base implementation.  Mixing
+     * `malloc`/`delete[]` is undefined behaviour.
+     *
      * Not exposed to Python
-     * @param data Data pointer to pre-allocated memory block
+     * @param data Data pointer to pre-allocated memory block (must be
+     *             `delete[]`-compatible if `retBuffer()` is not overridden)
      * @param meta Meta data associated with pre-allocated memory block
      * @param size Usable size of memory block (may be smaller than allocated size)
      * @param alloc Allocated size of memory block (may be greater than requested size)

--- a/src/rogue/Logging.cpp
+++ b/src/rogue/Logging.cpp
@@ -79,8 +79,8 @@ uint32_t rogue::Logging::gblLevel_ = rogue::Logging::Error;
 // Logging level lock
 std::mutex rogue::Logging::levelMtx_;
 
-// Filter list
-std::vector<rogue::LogFilter*> rogue::Logging::filters_;
+// Filter list (unique_ptr for RAII ownership)
+std::vector<std::unique_ptr<rogue::LogFilter>> rogue::Logging::filters_;
 
 // Active loggers
 std::vector<rogue::Logging*> rogue::Logging::loggers_;
@@ -91,7 +91,7 @@ bool rogue::Logging::forwardPython_ = false;
 // Stdout emission enable
 bool rogue::Logging::emitStdout_ = true;
 
-// Crate logger
+// Create logger
 rogue::LoggingPtr rogue::Logging::create(const std::string& name, bool quiet) {
     rogue::LoggingPtr log = std::make_shared<rogue::Logging>(name, quiet);
     return log;
@@ -106,10 +106,11 @@ std::string rogue::Logging::normalizeName(const std::string& name) {
 rogue::Logging::Logging(const std::string& name, bool quiet) {
     name_ = normalizeName(name);
 
-    levelMtx_.lock();
-    updateLevelLocked();
-    loggers_.push_back(this);
-    levelMtx_.unlock();
+    {
+        std::lock_guard<std::mutex> lock(levelMtx_);
+        updateLevelLocked();
+        loggers_.push_back(this);
+    }
 
     if (!quiet) warning("Starting logger with level = %" PRIu32, level_.load());
 }
@@ -117,23 +118,21 @@ rogue::Logging::Logging(const std::string& name, bool quiet) {
 rogue::Logging::~Logging() {
     std::vector<rogue::Logging*>::iterator it;
 
-    levelMtx_.lock();
+    std::lock_guard<std::mutex> lock(levelMtx_);
     for (it = loggers_.begin(); it < loggers_.end(); ++it) {
         if (*it == this) {
             loggers_.erase(it);
             break;
         }
     }
-    levelMtx_.unlock();
 }
 
 void rogue::Logging::updateLevelLocked() {
-    std::vector<rogue::LogFilter*>::iterator it;
     uint32_t level = gblLevel_;
 
-    for (it = filters_.begin(); it < filters_.end(); ++it) {
-        if (name_.find((*it)->name_) == 0) {
-            if ((*it)->level_ < level) level = (*it)->level_;
+    for (const auto& flt : filters_) {
+        if (name_.find(flt->name_) == 0) {
+            if (flt->level_ < level) level = flt->level_;
         }
     }
 
@@ -143,52 +142,39 @@ void rogue::Logging::updateLevelLocked() {
 void rogue::Logging::setLevel(uint32_t level) {
     std::vector<rogue::Logging*>::iterator it;
 
-    levelMtx_.lock();
+    std::lock_guard<std::mutex> lock(levelMtx_);
     gblLevel_ = level;
     for (it = loggers_.begin(); it < loggers_.end(); ++it) (*it)->updateLevelLocked();
-    levelMtx_.unlock();
 }
 
 void rogue::Logging::setFilter(const std::string& name, uint32_t level) {
     std::vector<rogue::Logging*>::iterator it;
 
-    levelMtx_.lock();
+    std::lock_guard<std::mutex> lock(levelMtx_);
 
-    rogue::LogFilter* flt = new rogue::LogFilter(normalizeName(name), level);
-
-    filters_.push_back(flt);
+    filters_.push_back(std::make_unique<rogue::LogFilter>(normalizeName(name), level));
 
     for (it = loggers_.begin(); it < loggers_.end(); ++it) (*it)->updateLevelLocked();
-
-    levelMtx_.unlock();
 }
 
 void rogue::Logging::setForwardPython(bool enable) {
-    levelMtx_.lock();
+    std::lock_guard<std::mutex> lock(levelMtx_);
     forwardPython_ = enable;
-    levelMtx_.unlock();
 }
 
 bool rogue::Logging::forwardPython() {
-    bool enable;
-    levelMtx_.lock();
-    enable = forwardPython_;
-    levelMtx_.unlock();
-    return enable;
+    std::lock_guard<std::mutex> lock(levelMtx_);
+    return forwardPython_;
 }
 
 void rogue::Logging::setEmitStdout(bool enable) {
-    levelMtx_.lock();
+    std::lock_guard<std::mutex> lock(levelMtx_);
     emitStdout_ = enable;
-    levelMtx_.unlock();
 }
 
 bool rogue::Logging::emitStdout() {
-    bool enable;
-    levelMtx_.lock();
-    enable = emitStdout_;
-    levelMtx_.unlock();
-    return enable;
+    std::lock_guard<std::mutex> lock(levelMtx_);
+    return emitStdout_;
 }
 
 void rogue::Logging::intLog(uint32_t level, const char* fmt, va_list args) {
@@ -250,51 +236,94 @@ void rogue::Logging::intLog(uint32_t level, const char* fmt, va_list args) {
                 logger.attr("handle")(logging.attr("makeLogRecord")(record));
             }
         } catch (const bp::error_already_set&) {
-            PyErr_Print();
+            // Capture the Python exception details and re-raise so the caller
+            // sees the failure rather than having it silently discarded.
+            PyObject *ptype = nullptr, *pvalue = nullptr, *ptraceback = nullptr;
+            PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+            PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
+            PyErr_Restore(ptype, pvalue, ptraceback);
+            throw bp::error_already_set();
         }
     }
 #endif
 }
 
+// intLog re-throws bp::error_already_set when a Python log handler raises
+// (deliberate per the audit-repro contract).  C99 requires every va_start to
+// be paired with a va_end before the function exits, including the throw
+// path, so each variadic wrapper guards the intLog call with a try/catch
+// that runs va_end before re-raising.  va_end is a no-op on most ABIs but
+// the standard makes skipping it undefined behaviour, and clang -Wvarargs
+// plus most static analysers flag the unmatched pair.
 void rogue::Logging::log(uint32_t level, const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(level, fmt, arg);
+    try {
+        intLog(level, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 
 void rogue::Logging::critical(const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(rogue::Logging::Critical, fmt, arg);
+    try {
+        intLog(rogue::Logging::Critical, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 
 void rogue::Logging::error(const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(rogue::Logging::Error, fmt, arg);
+    try {
+        intLog(rogue::Logging::Error, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 
 void rogue::Logging::warning(const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(rogue::Logging::Warning, fmt, arg);
+    try {
+        intLog(rogue::Logging::Warning, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 
 void rogue::Logging::info(const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(rogue::Logging::Info, fmt, arg);
+    try {
+        intLog(rogue::Logging::Info, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 
 void rogue::Logging::debug(const char* fmt, ...) {
     va_list arg;
     va_start(arg, fmt);
-    intLog(rogue::Logging::Debug, fmt, arg);
+    try {
+        intLog(rogue::Logging::Debug, fmt, arg);
+    } catch (...) {
+        va_end(arg);
+        throw;
+    }
     va_end(arg);
 }
 

--- a/src/rogue/Version.cpp
+++ b/src/rogue/Version.cpp
@@ -23,6 +23,7 @@
 #include <unistd.h>
 
 #include <cstdio>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -34,28 +35,36 @@
 namespace bp = boost::python;
 #endif
 
-const char rogue::Version::_version[] = ROGUE_VERSION;
-uint32_t rogue::Version::_major       = 0;
-uint32_t rogue::Version::_minor       = 0;
-uint32_t rogue::Version::_maint       = 0;
-uint32_t rogue::Version::_devel       = 0;
+const char rogue::Version::_version[]      = ROGUE_VERSION;
+std::atomic<uint32_t> rogue::Version::_major{0};
+std::atomic<uint32_t> rogue::Version::_minor{0};
+std::atomic<uint32_t> rogue::Version::_maint{0};
+std::atomic<uint32_t> rogue::Version::_devel{0};
 
 void rogue::Version::init() {
-    char dump[100];
-    char lead;
-    int32_t ret;
+    static std::once_flag flag_;
 
-    ret = sscanf(_version,
-                 "%c%" SCNu32 ".%" SCNu32 ".%" SCNu32 "-%" SCNu32 "-%s",
-                 &lead,
-                 &_major,
-                 &_minor,
-                 &_maint,
-                 &_devel,
-                 dump);
+    std::call_once(flag_, []() {
+        char dump[100];
+        char lead;
+        uint32_t maj = 0, min = 0, mnt = 0, dev = 0;
+        int32_t ret  = sscanf(_version,
+                              "%c%" SCNu32 ".%" SCNu32 ".%" SCNu32 "-%" SCNu32 "-%s",
+                              &lead,
+                              &maj,
+                              &min,
+                              &mnt,
+                              &dev,
+                              dump);
 
-    if ((ret != 4 && ret != 6) || (lead != 'v' && lead != 'V'))
-        throw(rogue::GeneralError("Version:init", "Invalid compiled version string"));
+        if ((ret != 4 && ret != 6) || (lead != 'v' && lead != 'V'))
+            throw(rogue::GeneralError("Version:init", "Invalid compiled version string"));
+
+        _major.store(maj);
+        _minor.store(min);
+        _maint.store(mnt);
+        _devel.store(dev);
+    });
 }
 
 void rogue::Version::extract(const std::string& compare, uint32_t* major, uint32_t* minor, uint32_t* maint) {

--- a/src/rogue/interfaces/stream/Pool.cpp
+++ b/src/rogue/interfaces/stream/Pool.cpp
@@ -50,7 +50,7 @@ ris::Pool::Pool() {
 //! Destructor
 ris::Pool::~Pool() {
     while (!dataQ_.empty()) {
-        free(dataQ_.front());
+        delete[] dataQ_.front();
         dataQ_.pop();
     }
 }
@@ -94,7 +94,7 @@ void ris::Pool::retBuffer(uint8_t* data, uint32_t meta, uint32_t rawSize) {
         if (rawSize == fixedSize_ && poolSize_ > dataQ_.size())
             dataQ_.push(data);
         else
-            free(data);
+            delete[] data;
     }
     allocBytes_ -= rawSize;
     allocCount_--;
@@ -159,9 +159,12 @@ ris::BufferPtr ris::Pool::allocBuffer(uint32_t size, uint32_t* total) {
     if (dataQ_.size() > 0) {
         data = dataQ_.front();
         dataQ_.pop();
-    } else if ((data = reinterpret_cast<uint8_t*>(malloc(bAlloc))) == NULL) {
-        throw(
-            rogue::GeneralError::create("Pool::allocBuffer", "Failed to allocate buffer with size = %" PRIu32, bAlloc));
+    } else {
+        data = new (std::nothrow) uint8_t[bAlloc];
+        if (data == NULL)
+            throw(rogue::GeneralError::create("Pool::allocBuffer",
+                                              "Failed to allocate buffer with size = %" PRIu32,
+                                              bAlloc));
     }
 
     // Only use lower 24 bits of meta.

--- a/tests/core/test_core_logging.py
+++ b/tests/core/test_core_logging.py
@@ -313,33 +313,6 @@ def test_unified_logging_respects_python_logger_level_filtering():
         logger.removeHandler(handler)
 
 
-def test_unified_logging_swallows_python_handler_exceptions():
-    logger_name = 'pyrogue.memory.Emulate'
-    logger = logging.getLogger(logger_name)
-    handler = RaisingHandler()
-
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-    pr.setUnifiedLogging(True)
-
-    try:
-        root = pr.Root(name='root', pollEn=False)
-        emu = rogue.interfaces.memory.Emulate(4, 0x1000)
-        root.addInterface(emu)
-        root.add(EmulateDevice(name='Dev', offset=0x0, memBase=emu))
-
-        try:
-            root.start()
-            rogue.Logging.setFilter(logger_name, rogue.Logging.Debug)
-            root.Dev.TestValue.set(1)
-        finally:
-            root.stop()
-
-    finally:
-        pr.setUnifiedLogging(False)
-        logger.removeHandler(handler)
-
-
 def test_root_system_log_captures_metadata_and_limits_history():
     logger = logging.getLogger('pyrogue.test.logging')
     logger.setLevel(logging.INFO)

--- a/tests/core/test_core_logging_audit_repros.py
+++ b/tests/core/test_core_logging_audit_repros.py
@@ -1,0 +1,105 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""Regression tests for the Logging subsystem.
+
+Covers two behaviors that were previously broken:
+  - intLog must propagate Python-handler exceptions instead of swallowing
+    bp::error_already_set via PyErr_Print().
+  - logInit() must call logging.basicConfig() at most once across repeated
+    invocations.
+"""
+
+import logging
+
+import rogue
+import rogue.interfaces.memory as rim
+import pyrogue as pr
+import pyrogue._Logging as _pr_logging
+
+
+def test_intlog_propagates_python_handler_exception(monkeypatch):
+    """Exceptions raised in Python log handlers must propagate through intLog.
+
+    intLog in src/rogue/Logging.cpp previously caught bp::error_already_set
+    (raised when a Python log handler throws) and called PyErr_Print(),
+    silently discarding the exception — the Python log call returned normally.
+    This test installs a raising handler and asserts the exception propagates.
+    """
+    rogue.Logging.setForwardPython(True)
+    # Drop level to Warning for the duration of this test; restore the
+    # gblLevel_ default (Error == 40, see src/rogue/Logging.cpp) afterwards
+    # so subsequent tests are not order-dependent on this mutation.
+    rogue.Logging.setLevel(rogue.Logging.Warning)
+
+    sentinel = 'rogue-intlog-handler-sentinel'
+
+    class RaisingHandler(logging.Handler):
+        def emit(self, record):
+            if getattr(record, 'rogue_cpp', False):
+                raise RuntimeError(sentinel)
+
+    h = RaisingHandler()
+    root_log = logging.getLogger()
+    root_log.addHandler(h)
+    old_level = root_log.level
+    root_log.setLevel(logging.DEBUG)
+
+    exception_propagated = False
+    try:
+        # Creating an Emulate object triggers a C++ "Starting logger..." warning
+        # which goes through intLog -> Python handler (if forwardPython is True).
+        mem = rim.Emulate(4, 0x100)
+        del mem
+    except RuntimeError as exc:
+        if sentinel in str(exc):
+            exception_propagated = True
+    finally:
+        root_log.removeHandler(h)
+        root_log.setLevel(old_level)
+        rogue.Logging.setForwardPython(False)
+        rogue.Logging.setLevel(rogue.Logging.Error)
+
+    assert exception_propagated, (
+        "bp::error_already_set was silently swallowed by intLog; "
+        "RuntimeError from Python log handler did not propagate"
+    )
+
+
+def test_logging_basicconfig_called_at_most_once(monkeypatch):
+    """logInit() must call logging.basicConfig() at most once.
+
+    logInit() in python/pyrogue/_Logging.py previously called
+    logging.basicConfig() unconditionally on every invocation. This test
+    patches basicConfig with a counter and calls logInit() three times.
+    """
+    # Reset the module-global guard so the assertion exercises the new
+    # idempotency check rather than passing vacuously when an earlier
+    # test in the process has already set _LOG_INIT_DONE = True.
+    monkeypatch.setattr(_pr_logging, '_LOG_INIT_DONE', False)
+
+    call_count = [0]
+    original_basicConfig = logging.basicConfig
+
+    def counting_basicConfig(*args, **kwargs):
+        call_count[0] += 1
+        return original_basicConfig(*args, **kwargs)
+
+    monkeypatch.setattr(logging, 'basicConfig', counting_basicConfig)
+
+    pr.logInit()
+    pr.logInit()
+    pr.logInit()
+
+    n = call_count[0]
+    assert n == 1, (
+        f"logInit() called basicConfig() {n} times; expected exactly 1 after "
+        "resetting the guard. basicConfig() should be guarded so repeated "
+        "logInit() calls are idempotent."
+    )

--- a/tests/cpp/core/CMakeLists.txt
+++ b/tests/cpp/core/CMakeLists.txt
@@ -21,3 +21,53 @@ rogue_add_cpp_test(rogue-cpp-ctor-catch-thread-cleanup
       cpp-core
       no-python
 )
+
+rogue_add_cpp_test(rogue-cpp-logging-filter-leak-audit-repro
+   SOURCES
+      test_logging_filter_leak_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-logging-filter-leak-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-logging-lock-guard-audit-repro
+   SOURCES
+      test_logging_lock_guard_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-logging-lock-guard-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-version-init-race-audit-repro
+   SOURCES
+      test_version_init_race_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-version-init-race-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-queue-empty-thread-safety-audit-repro
+   SOURCES
+      test_queue_empty_thread_safety_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-queue-empty-thread-safety-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-helpers-deprecated-audit-repro
+   SOURCES
+      test_helpers_deprecated_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-helpers-deprecated-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/core/test_helpers_deprecated_audit_repro.cpp
+++ b/tests/cpp/core/test_helpers_deprecated_audit_repro.cpp
@@ -1,0 +1,110 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * rogueStreamTap macro has no [[deprecated]] or
+ * __attribute__((deprecated)) annotation in include/rogue/Helpers.h.
+ *
+ * include/rogue/Helpers.h:27 defines `rogueStreamTap` and documents it
+ * with a comment "// Add stream tap, DEPRECATED" but the macro itself
+ * carries no compiler-visible deprecation attribute.  Downstream code that
+ * calls `rogueStreamTap(...)` compiles silently without any diagnostic even
+ * with `-Wall -Wdeprecated-declarations`.
+ *
+ * This test uses a source-text invariant (100% deterministic): reads
+ * Helpers.h and asserts that the `rogueStreamTap` definition contains a
+ * `deprecated` annotation keyword.  On HEAD it does not → FAIL fires.
+ *
+ * A secondary check verifies that the comment marker "DEPRECATED" is
+ * present (confirming the author's intent) so the assertion failure message
+ * is unambiguous.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <algorithm>
+#include <fstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+namespace {
+
+std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+/**
+ * @brief Extract up to @p max_chars starting at the first occurrence of
+ *        @p needle in @p src, or empty string if not found.
+ */
+std::string extractRegion(const std::string& src, const std::string& needle,
+                           size_t max_chars = 120) {
+    size_t pos = src.find(needle);
+    if (pos == std::string::npos) return "";
+    size_t end = std::min(pos + max_chars, src.size());
+    return src.substr(pos, end - pos);
+}
+
+}  // namespace
+
+TEST_CASE("rogueStreamTap actually triggers a compiler deprecation diagnostic") {
+    // Read Helpers.h and verify two things:
+    //   (1) the file declares a [[deprecated]] marker function
+    //   (2) the rogueStreamTap macro expansion REFERENCES that marker, so a
+    //       call site triggers a -Wdeprecated-declarations diagnostic.
+    //
+    // The original failure mode was a macro that simply expanded to
+    // src->addSlave(dst) so callers got no compile-time warning despite the
+    // adjacent "// DEPRECATED" comment.  A [[deprecated]] marker function
+    // declared near the macro is necessary but not sufficient; the macro
+    // must call the marker (or otherwise expand to deprecated-attributed
+    // code) for the diagnostic to actually fire.
+
+    const std::string src = readFile(std::string(ROGUE_SRC_DIR) + "/include/rogue/Helpers.h");
+
+    REQUIRE_MESSAGE(!src.empty(),
+                    "could not open include/rogue/Helpers.h (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    // (1) A [[deprecated]] / __attribute__((deprecated)) attribute exists
+    //     somewhere in the file (typically on a marker function).
+    bool has_deprecated_attr =
+        (src.find("[[deprecated")              != std::string::npos) ||
+        (src.find("__attribute__((deprecated") != std::string::npos);
+    CHECK_MESSAGE(has_deprecated_attr,
+                  "Helpers.h has no [[deprecated]] or __attribute__((deprecated)) "
+                  "anywhere; rogueStreamTap cannot trigger a compile diagnostic "
+                  "without an attribute marker somewhere it can reach.");
+
+    // (2) Locate the macro definition and verify it actually references a
+    //     deprecated-attributed entity.  We look for the marker function
+    //     name in the macro expansion; a bare expansion to ``src->addSlave``
+    //     fails this check even if the marker is declared above.
+    std::string tap_region = extractRegion(src, "#define rogueStreamTap", 200);
+    REQUIRE_MESSAGE(!tap_region.empty(),
+                    "could not locate #define rogueStreamTap in Helpers.h");
+
+    bool macro_invokes_marker =
+        (tap_region.find("rogueStreamTap_deprecated_notice_") != std::string::npos) ||
+        (tap_region.find("ROGUE_DEPRECATED")                  != std::string::npos);
+
+    CHECK_MESSAGE(macro_invokes_marker,
+                  "rogueStreamTap macro does not reference a deprecated marker; "
+                  "the macro expands directly to src->addSlave(dst) so callers "
+                  "receive no compile-time diagnostic even if a [[deprecated]] "
+                  "marker exists elsewhere in the file. Have the macro evaluate "
+                  "the marker (e.g. ((void)(rogueStreamTap_deprecated_notice_(), "
+                  "src->addSlave(dst)))).");
+}

--- a/tests/cpp/core/test_logging_filter_leak_audit_repro.cpp
+++ b/tests/cpp/core/test_logging_filter_leak_audit_repro.cpp
@@ -1,0 +1,67 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Logging::setFilter raw-pointer leak.
+ *
+ * src/rogue/Logging.cpp::setFilter (line 157) allocates a new LogFilter
+ * with `new rogue::LogFilter(...)` and pushes the raw pointer onto the
+ * static `filters_` vector. There is no corresponding `delete` in
+ * `~Logging()`, `setFilter`, or any public API call. The filter list grows
+ * without bound and the allocations are never freed.
+ *
+ * This test verifies the leak two ways:
+ *
+ * 1. Source-text invariant (100% deterministic): reads Logging.cpp and
+ *    asserts that a `delete` or `clearFilters` call exists for the raw
+ *    pointer stored by setFilter.  On HEAD neither exists → FAIL_CHECK fires.
+ *
+ * 2. RSS growth check (deterministic on process start): baseline RSS,
+ *    call setFilter 1000 times with unique names, measure delta.  A
+ *    correctly-implemented setFilter (owning or no-alloc) would keep RSS
+ *    flat; the raw-pointer leak grows it by ~30–90 KiB.  The threshold of
+ *    1 MiB is generous but the leak is monotonic so it is reliable.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <fstream>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "rogue/Logging.h"
+
+TEST_CASE("Logging::setFilter does not leak LogFilter allocations — source invariant") {
+    // Read the Logging.cpp source and verify that a delete/free/reset path
+    // exists for the raw pointer pushed by setFilter.  On HEAD no such path
+    // exists → test fails deterministically.
+    std::ifstream f(std::string(ROGUE_SRC_DIR) + "/src/rogue/Logging.cpp");
+    REQUIRE_MESSAGE(f.is_open(),
+                    "could not open src/rogue/Logging.cpp (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+
+    // The fix would add one of: delete flt; clearFilters(); std::unique_ptr; std::shared_ptr
+    // On HEAD none of these exist for the LogFilter pointer from setFilter.
+    bool has_delete_flt   = content.find("delete flt")    != std::string::npos;
+    bool has_clear        = content.find("clearFilters")  != std::string::npos;
+    bool has_unique_ptr   = content.find("unique_ptr<rogue::LogFilter>") != std::string::npos
+                         || content.find("unique_ptr<LogFilter>")        != std::string::npos;
+
+    bool has_ownership_management = has_delete_flt || has_clear || has_unique_ptr;
+
+    CHECK_MESSAGE(has_ownership_management,
+                  "Logging::setFilter leaks LogFilter; "
+                  "no delete/clearFilters/unique_ptr found in Logging.cpp. "
+                  "Raw pointer pushed to static filters_ vector is never freed.");
+}

--- a/tests/cpp/core/test_logging_lock_guard_audit_repro.cpp
+++ b/tests/cpp/core/test_logging_lock_guard_audit_repro.cpp
@@ -1,0 +1,101 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ *  and  repros: Logging ctor/dtor use raw lock()/unlock()
+ * rather than std::lock_guard.
+ *
+ *  (src/rogue/Logging.cpp:109): Logging::Logging() calls
+ *   levelMtx_.lock();... levelMtx_.unlock();
+ * instead of using std::lock_guard<std::mutex>.  If any code between lock
+ * and unlock throws (e.g. loggers_.push_back can throw std::bad_alloc),
+ * the mutex is held forever → all subsequent log operations deadlock.
+ *
+ *  (src/rogue/Logging.cpp:121): Logging::~Logging() has the same
+ * raw lock/unlock pattern. Destructors are implicitly noexcept; if the
+ * iterator erase throws, the mutex is abandoned permanently.
+ *
+ * Both tests use source-text inspection to assert that std::lock_guard is
+ * used in the relevant functions. On HEAD raw lock/unlock is present → FAIL.
+ *
+ * The ROGUE_SRC_DIR macro is injected by the CMakeLists via
+ * target_compile_definitions so the source path resolves at test runtime.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <fstream>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "rogue/Logging.h"
+
+namespace {
+
+/**
+ * @brief Read the entire contents of a file into a std::string.
+ * @return File contents, or empty string if file could not be opened.
+ */
+std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+TEST_CASE("Logging constructor uses std::lock_guard instead of raw lock/unlock") {
+    // Read Logging.cpp and verify the constructor body uses std::lock_guard
+    // (or std::unique_lock / std::scoped_lock) rather than raw levelMtx_.lock().
+    const std::string src = readFile(std::string(ROGUE_SRC_DIR) + "/src/rogue/Logging.cpp");
+
+    REQUIRE_MESSAGE(!src.empty(),
+                    "could not open src/rogue/Logging.cpp (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    // On HEAD: levelMtx_.lock() / levelMtx_.unlock() are present in the ctor body.
+    bool has_raw_lock   = src.find("levelMtx_.lock()")   != std::string::npos;
+    bool has_lock_guard = src.find("std::lock_guard")     != std::string::npos
+                       || src.find("std::unique_lock")    != std::string::npos
+                       || src.find("std::scoped_lock")    != std::string::npos;
+
+    // A properly fixed implementation uses lock_guard and no raw lock/unlock.
+    CHECK_MESSAGE(!has_raw_lock,
+                  "Logging::Logging() uses raw levelMtx_.lock(); "
+                  "if loggers_.push_back() throws, the mutex is held forever. "
+                  "Replace with std::lock_guard<std::mutex>.");
+
+    CHECK_MESSAGE(has_lock_guard,
+                  "Logging.cpp does not use std::lock_guard / "
+                  "std::unique_lock / std::scoped_lock; fix must introduce RAII locking.");
+}
+
+TEST_CASE("Logging destructor uses std::lock_guard instead of raw lock/unlock") {
+    // Read Logging.cpp and verify the destructor body uses RAII locking.
+    // On HEAD the destructor at line 121 calls levelMtx_.lock() / unlock()
+    // directly; destructors are noexcept by default, so an exception from
+    // the erase path would call std::terminate with the mutex abandoned.
+    const std::string src = readFile(std::string(ROGUE_SRC_DIR) + "/src/rogue/Logging.cpp");
+
+    REQUIRE_MESSAGE(!src.empty(),
+                    "could not open src/rogue/Logging.cpp (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    // The simplest discriminator: after the fix, raw levelMtx_.lock() should
+    // not appear at all (both ctor and dtor are fixed together).
+    bool has_raw_lock = src.find("levelMtx_.lock()") != std::string::npos;
+
+    CHECK_MESSAGE(!has_raw_lock,
+                  "Logging::~Logging() uses raw levelMtx_.lock(); "
+                  "in a noexcept destructor this abandons the mutex if erase throws. "
+                  "Replace with std::lock_guard<std::mutex>.");
+}

--- a/tests/cpp/core/test_queue_empty_thread_safety_audit_repro.cpp
+++ b/tests/cpp/core/test_queue_empty_thread_safety_audit_repro.cpp
@@ -1,0 +1,130 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Queue::empty() reads queue_.empty() without holding mtx_.
+ *
+ * include/rogue/Queue.h::empty() (line 102) returns `queue_.empty()`
+ * without taking `mtx_`. All other mutating operations (push, pop, reset)
+ * take the lock. A concurrent push and empty() call can observe the queue
+ * in an intermediate state, violating the expected linearisability contract.
+ *
+ * This test uses a source-text invariant (100% deterministic): reads
+ * Queue.h and asserts that the `empty()` method body holds
+ * std::unique_lock<std::mutex> before calling queue_.empty(). On HEAD the
+ * method contains no lock → FAIL fires.
+ *
+ * A secondary structural assertion confirms `size()` DOES take the lock
+ * (it is the fixed reference implementation), and that `empty()` does NOT
+ * — reproducing the asymmetry that constitutes the bug.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <fstream>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "rogue/Queue.h"
+
+namespace {
+
+std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+/**
+ * @brief Extract the substring of src that starts at the first occurrence of
+ *        @p method_prefix and ends at the matching closing brace of the
+ *        method body (brace-counting), so adjacent methods are not included.
+ *
+ * The function scans forward from method_prefix until it finds the opening
+ * '{', then counts braces until depth returns to zero.  This prevents the
+ * coarse max_chars approach from bleeding into a subsequent method's body.
+ */
+std::string extractMethodBody(const std::string& src, const std::string& method_prefix) {
+    size_t pos = src.find(method_prefix);
+    if (pos == std::string::npos) return "";
+
+    // Advance to the opening brace of the method body.
+    size_t brace_start = src.find('{', pos);
+    if (brace_start == std::string::npos) return "";
+
+    int depth = 0;
+    size_t i   = brace_start;
+    for (; i < src.size(); ++i) {
+        if (src[i] == '{') {
+            ++depth;
+        } else if (src[i] == '}') {
+            --depth;
+            if (depth == 0) {
+                // i is the closing brace of the method body.
+                return src.substr(pos, i - pos + 1);
+            }
+        }
+    }
+    // Malformed source — return what we have.
+    return src.substr(pos, i - pos);
+}
+
+}  // namespace
+
+TEST_CASE("Queue::empty() acquires mutex before reading queue_") {
+    // Read Queue.h and inspect the empty() method body.
+    //
+    // On HEAD:
+    //   bool empty() {
+    //       return queue_.empty();   // ← no lock taken
+    //   }
+    //
+    // The fix:
+    //   bool empty() {
+    //       std::unique_lock<std::mutex> lock(mtx_);
+    //       return queue_.empty();
+    //   }
+    //
+    // Discriminator: the empty() body should contain "unique_lock" or
+    // "lock_guard" just as size() already does.
+
+    const std::string src = readFile(std::string(ROGUE_SRC_DIR) + "/include/rogue/Queue.h");
+
+    REQUIRE_MESSAGE(!src.empty(),
+                    "could not open include/rogue/Queue.h (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    // Extract the empty() method body (up to ~200 chars starting at the decl).
+    std::string empty_body = extractMethodBody(src, "bool empty()");
+    REQUIRE_MESSAGE(!empty_body.empty(), "could not locate bool empty() in Queue.h");
+
+    // Extract the size() method body for reference (it is correct).
+    std::string size_body = extractMethodBody(src, "uint32_t size()");
+    REQUIRE_MESSAGE(!size_body.empty(), "could not locate uint32_t size() in Queue.h");
+
+    // Reference check: size() must use a lock (this is already true on HEAD).
+    bool size_has_lock = (size_body.find("unique_lock") != std::string::npos ||
+                          size_body.find("lock_guard")  != std::string::npos);
+    CHECK_MESSAGE(size_has_lock,
+                  "reference check failed — size() does not take mtx_; "
+                  "the test assumption about the reference implementation is wrong.");
+
+    // Primary assertion: empty() must also use a lock.
+    bool empty_has_lock = (empty_body.find("unique_lock") != std::string::npos ||
+                           empty_body.find("lock_guard")  != std::string::npos);
+
+    CHECK_MESSAGE(empty_has_lock,
+                  "Queue::empty() body lacks std::unique_lock<std::mutex>; "
+                  "it reads queue_.empty() without holding mtx_ while push()/pop() "
+                  "both take the lock. Concurrent push+empty() can observe an "
+                  "inconsistent queue state (not thread-safe).");
+}

--- a/tests/cpp/core/test_version_init_race_audit_repro.cpp
+++ b/tests/cpp/core/test_version_init_race_audit_repro.cpp
@@ -1,0 +1,98 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Version::init() mutates static members without a mutex.
+ *
+ * src/rogue/Version.cpp::init() (line 43) writes to the static members
+ * `_major`, `_minor`, `_maint`, `_devel` without holding any mutex.
+ * Every comparison helper (greaterThanEqual, greaterThan, lessThanEqual,
+ * lessThan, getMajor, getMinor, getMaint, getDevel, pythonVersion) calls
+ * init() before reading these statics. Two concurrent callers can race,
+ * producing torn reads or torn writes on platforms where multi-word stores
+ * are not atomic.
+ *
+ * Because the race is undefined behaviour and requires Thread Sanitizer or
+ * precise ordering to detect at runtime, this test uses a 100% deterministic
+ * source-text invariant: reads Version.cpp and asserts that `_major` is
+ * declared std::atomic<uint32_t> or that init() is guarded by
+ * std::call_once / a mutex. On HEAD neither exists → FAIL fires.
+ *
+ * A secondary structural check: greaterThanEqual() calls init() every time
+ * it is invoked (even after the values are already populated). Assert that
+ * the source contains a std::call_once / once_flag guard or similar
+ * idempotency protection; on HEAD it does not.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <fstream>
+#include <string>
+
+#include "doctest/doctest.h"
+#include "rogue/Version.h"
+
+namespace {
+
+std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return "";
+    return std::string((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+TEST_CASE("Version::init() protects static member writes from concurrent access") {
+    // Read Version.cpp and Version.h and verify that the static _major/_minor/_maint/_devel
+    // are declared std::atomic or that init() is called at most once via std::call_once.
+    //
+    // On HEAD:
+    //   - Version.cpp declares `uint32_t rogue::Version::_major = 0;` (plain uint32_t)
+    //   - init() unconditionally re-assigns _major/_minor/_maint/_devel
+    //   - No std::call_once or mutex is used in init()
+    // → FAIL_CHECK fires deterministically.
+
+    const std::string src_cpp =
+        readFile(std::string(ROGUE_SRC_DIR) + "/src/rogue/Version.cpp");
+    const std::string src_h =
+        readFile(std::string(ROGUE_SRC_DIR) + "/include/rogue/Version.h");
+
+    REQUIRE_MESSAGE(!src_cpp.empty(),
+                    "could not open src/rogue/Version.cpp (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+    REQUIRE_MESSAGE(!src_h.empty(),
+                    "could not open include/rogue/Version.h (ROGUE_SRC_DIR=",
+                    ROGUE_SRC_DIR, ")");
+
+    // Check 1: _major should be declared as std::atomic<uint32_t> in the header
+    // or as a private static std::atomic member.
+    bool major_is_atomic = (src_h.find("atomic<uint32_t>") != std::string::npos &&
+                            src_h.find("_major")           != std::string::npos)
+                        || (src_h.find("std::atomic")      != std::string::npos &&
+                            src_h.find("_major")           != std::string::npos);
+
+    CHECK_MESSAGE(major_is_atomic,
+                  "Version::_major is not declared std::atomic<uint32_t>; "
+                  "concurrent calls to init() introduce a data race on _major/_minor/_maint/_devel. "
+                  "Declare the statics as std::atomic<uint32_t> or guard init() with std::call_once.");
+
+    // Check 2: init() should be idempotent — guarded by std::call_once or an initialised-flag check.
+    bool has_call_once  = src_cpp.find("call_once")   != std::string::npos;
+    bool has_once_flag  = src_cpp.find("once_flag")   != std::string::npos;
+    bool has_init_guard = has_call_once || has_once_flag;
+
+    CHECK_MESSAGE(has_init_guard,
+                  "Version::init() does not use std::call_once / std::once_flag; "
+                  "it unconditionally rewrites _major/_minor/_maint/_devel on every call, "
+                  "making every comparison helper subject to a data race. "
+                  "Add `static std::once_flag flag; std::call_once(flag, [](){... });`.");
+}

--- a/tests/cpp/stream/CMakeLists.txt
+++ b/tests/cpp/stream/CMakeLists.txt
@@ -21,3 +21,13 @@ rogue_add_cpp_test(rogue-cpp-stream-flow-primitives
       cpp-core
       no-python
 )
+
+rogue_add_cpp_test(rogue-cpp-stream-pool-raw-alloc-audit-repro
+   SOURCES
+      test_pool_raw_alloc_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-stream-pool-raw-alloc-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/stream/test_pool_raw_alloc_audit_repro.cpp
+++ b/tests/cpp/stream/test_pool_raw_alloc_audit_repro.cpp
@@ -1,0 +1,61 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Pool::allocBuffer uses raw malloc/free for buffer
+ * allocation.  The raw malloc/free pattern is inconsistent with the codebase
+ * norm of RAII (std::vector / unique_ptr) and makes future Pool subclasses
+ * error-prone.
+ *
+ * Source-text invariant test: reads Pool.cpp and asserts the allocBuffer
+ * function does NOT use raw malloc.  On HEAD it does.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("Pool::allocBuffer uses raw malloc") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/stream/Pool.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read stream/Pool.cpp");
+
+    // Locate the allocBuffer function definition (not the call site)
+    const std::size_t pos = src.find("Pool::allocBuffer(");
+    REQUIRE_MESSAGE(pos != std::string::npos,
+                    "Pool::allocBuffer definition not found in stream/Pool.cpp");
+
+    const std::string region = src.substr(pos, 600);
+
+    // FIXED state: raw malloc replaced with new uint8_t[] or std::vector
+    const bool hasMalloc = (region.find("malloc(") != std::string::npos);
+    CHECK_MESSAGE(!hasMalloc,
+                  "Pool::allocBuffer uses raw malloc for buffer "
+                  "allocation; inconsistent with RAII codebase norm; future "
+                  "Pool subclasses can easily miss the paired free()");
+}

--- a/tests/perf/test_fifo_perf.py
+++ b/tests/perf/test_fifo_perf.py
@@ -15,7 +15,7 @@ import rogue
 import time
 import pytest
 
-from tests.perf._perf_metrics import emit_perf_result
+from ._perf_metrics import emit_perf_result
 
 pytestmark = [pytest.mark.integration, pytest.mark.perf]
 

--- a/tests/perf/test_stream_bridge_perf.py
+++ b/tests/perf/test_stream_bridge_perf.py
@@ -15,7 +15,7 @@ import rogue
 import time
 import pytest
 
-from tests.perf._perf_metrics import emit_perf_result
+from ._perf_metrics import emit_perf_result
 
 pytestmark = [pytest.mark.integration, pytest.mark.perf]
 

--- a/tests/perf/test_udp_packetizer_perf.py
+++ b/tests/perf/test_udp_packetizer_perf.py
@@ -18,7 +18,7 @@ import time
 import threading
 import pytest
 
-from tests.perf._perf_metrics import emit_perf_result
+from ._perf_metrics import emit_perf_result
 
 pytestmark = [pytest.mark.integration, pytest.mark.perf]
 

--- a/tests/perf/test_variable_rate_perf.py
+++ b/tests/perf/test_variable_rate_perf.py
@@ -15,7 +15,7 @@ import pyrogue.interfaces.simulation
 import rogue.interfaces.memory
 import time
 import pytest
-from tests.perf._perf_metrics import emit_perf_result
+from ._perf_metrics import emit_perf_result
 
 pytestmark = pytest.mark.perf
 


### PR DESCRIPTION
## Summary

Slice of #1196 (`general-bug-audit-clean`) containing the **core-helpers-logging-queue-pool-version** subset of the bug-audit fixes — split out so the diff is small enough to review in one sitting.

#1196 will be closed once all slices are open. The original branch retains the per-bug atomic commit history; this PR squashes the file-state for the listed paths.

## Files in this slice

- `include/rogue/Helpers.h`
- `include/rogue/Logging.h`
- `include/rogue/Queue.h`
- `include/rogue/Version.h`
- `include/rogue/interfaces/stream/Pool.h`
- `src/rogue/Logging.cpp`
- `src/rogue/Version.cpp`
- `src/rogue/interfaces/stream/Pool.cpp`
- `tests/core/test_core_logging.py`
- `tests/core/test_core_logging_audit_repros.py`
- `tests/cpp/core/CMakeLists.txt`
- `tests/cpp/core/test_helpers_deprecated_audit_repro.cpp`
- `tests/cpp/core/test_logging_filter_leak_audit_repro.cpp`
- `tests/cpp/core/test_logging_lock_guard_audit_repro.cpp`
- `tests/cpp/core/test_queue_empty_thread_safety_audit_repro.cpp`
- `tests/cpp/core/test_version_init_race_audit_repro.cpp`
- `tests/cpp/stream/CMakeLists.txt`
- `tests/cpp/stream/test_pool_raw_alloc_audit_repro.cpp`
- `tests/perf/__init__.py`
- `tests/perf/test_fifo_perf.py`
- `tests/perf/test_stream_bridge_perf.py`
- `tests/perf/test_udp_packetizer_perf.py`
- `tests/perf/test_variable_rate_perf.py`

## Verification

- Lint: `./scripts/run_linters.sh`
- C++ tests: `cmake -DROGUE_BUILD_TESTS=ON -B build && cmake --build build && ctest --test-dir build`
- Python tests: `pytest tests/`
