### PR TITLE
fix(pyrogue): core PyRogue (_*.py) and memory layer audit fixes + repros

### DIFF
--- a/docs/src/installing/build.rst
+++ b/docs/src/installing/build.rst
@@ -23,7 +23,7 @@ The following packages are required to build the Rogue library:
 
 * CMake >= 3.15
 * Boost >= 1.58
-* Python3 >= 3.9
+* Python3 >= 3.10
 * Bz2
 
 Package Manager Install
@@ -229,9 +229,12 @@ following toolchain file was used as an example:
    set(ZeroMQ_LIBRARY     /afs/slac/g/lcls/package/libzmq/zeromq-4.3.4/buildroot-2019.08-x86_64/lib/libzmq.a)
    set(ZeroMQ_INCLUDE_DIR /afs/slac/g/lcls/package/libzmq/zeromq-4.3.4/buildroot-2019.08-x86_64/include)
 
-   # Define the location of python3 (cross-compiled)
-   set(PYTHON_LIBRARY     /afs/slac/g/lcls/package/python/3.6.1/buildroot-2019.08-x86_64/lib/libpython3.6m.so)
-   set(PYTHON_INCLUDE_DIR /afs/slac/g/lcls/package/python/3.6.1/buildroot-2019.08-x86_64/include/python3.6m)
+   # Define the location of python3 (cross-compiled).
+   # Use a Python build that meets the >= 3.10 requirement above; the
+   # paths and ``python3.X`` suffix shown here are illustrative and must
+   # match the cross-compiled toolchain you actually have available.
+   set(PYTHON_LIBRARY     /afs/slac/g/lcls/package/python/3.12.0/buildroot-2024.02-x86_64/lib/libpython3.12.so)
+   set(PYTHON_INCLUDE_DIR /afs/slac/g/lcls/package/python/3.12.0/buildroot-2024.02-x86_64/include/python3.12)
 
    # Define the location of boost (cross-compiled)
    set(BOOST_ROOT /afs/slac/g/lcls/package/boost/1.64.0/buildroot-2019.08-x86_64)

--- a/python/pyrogue/_Block.py
+++ b/python/pyrogue/_Block.py
@@ -377,7 +377,7 @@ class LocalBlock(object):
             elif index >= 0:
                 changed = self._value[index] != value
             elif isinstance(value, np.ndarray):
-                changed = np.array_equal(self._value, value)
+                changed = not np.array_equal(self._value, value)
             else:
 
                 if (self._minimum is not None and value < self._minimum) or \

--- a/python/pyrogue/_DataReceiver.py
+++ b/python/pyrogue/_DataReceiver.py
@@ -41,10 +41,12 @@ class DataReceiver(pr.Device,ris.Slave):
     def __init__(self,
                  typeStr: str = 'UInt8[np]',
                  hideData: bool = True,
-                 value: Any = numpy.zeros(shape=1, dtype=numpy.uint8, order='C'),
+                 value: Any = None,
                  enableOnStart: bool = True,
                  **kwargs: Any) -> None:
         """Initialize the data receiver."""
+        if value is None:
+            value = numpy.zeros(shape=1, dtype=numpy.uint8, order='C')
 
         pr.Device.__init__(self, **kwargs)
         ris.Slave.__init__(self)

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -430,12 +430,12 @@ class Device(pr.Node,rim.Hub):
             Iterable of variable names or variables.
         """
         if variables is None:
-            variables=self.variables.values()
+            variables=list(self.variables.values())
 
         for v in variables:
             if isinstance(v, pr.BaseVariable):
                 v.hidden = hidden
-            elif isinstance(variables[0], str):
+            elif isinstance(v, str):
                 self.variables[v].hidden = hidden
 
     def initialize(self) -> None:

--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -70,10 +70,6 @@ def addLibraryPath(path: str | list[str]) -> None:
     else:
         base = os.path.dirname(sys.argv[0])
 
-    # If script was not started with ./       # If script was not started with ./
-    if base == '':
-        base = '.'
-
     # If script was not started with ./
     if base == '':
         base = '.'
@@ -226,7 +222,7 @@ def yamlToData(stream: str = '', fName: str | None = None) -> Any:
 
     log = pr.logInit(name='yamlToData')
 
-    class PyrogueLoader(yaml.Loader):
+    class PyrogueLoader(yaml.SafeLoader):
         pass
 
     def include_mapping(loader: yaml.Loader, node: Any) -> Any:
@@ -258,7 +254,14 @@ def yamlToData(stream: str = '', fName: str | None = None) -> Any:
 
     # Use passed string
     if fName is None:
-        return yaml.load(stream,Loader=PyrogueLoader)
+        try:
+            return yaml.load(stream, Loader=PyrogueLoader)
+        except yaml.constructor.ConstructorError as exc:
+            # Re-raise so callers (Root.loadYaml, yamlUpdate -> dictUpdate)
+            # see the security/parse failure instead of getting a None
+            # sentinel that crashes later with a confusing AttributeError.
+            log.error("YAML contained an unsafe or unrecognised tag: %s", exc)
+            raise
 
     # Main or sub-file is in a zip
     elif '.zip' in fName:
@@ -269,13 +272,21 @@ def yamlToData(stream: str = '', fName: str | None = None) -> Any:
 
         with zipfile.ZipFile(base, 'r', compression=zipfile.ZIP_LZMA) as myzip:
             with myzip.open(sub) as myfile:
-                return yaml.load(myfile.read(),Loader=PyrogueLoader)
+                try:
+                    return yaml.load(myfile.read(), Loader=PyrogueLoader)
+                except yaml.constructor.ConstructorError as exc:
+                    log.error("YAML contained an unsafe or unrecognised tag: %s", exc)
+                    raise
 
     # Non zip file
     else:
         log.debug("loading %s", fName)
-        with open(fName,'r') as f:
-            return yaml.load(f.read(),Loader=PyrogueLoader)
+        with open(fName, 'r') as f:
+            try:
+                return yaml.load(f.read(), Loader=PyrogueLoader)
+            except yaml.constructor.ConstructorError as exc:
+                log.error("YAML contained an unsafe or unrecognised tag: %s", exc)
+                raise
 
 
 def dataToYaml(data: Any) -> str:
@@ -448,24 +459,50 @@ def functionWrapper(
     """
 
     if function is None:
-        return eval("lambda " + ", ".join(['function'] + callArgs) + ": None")
+        def _noop(*_args, **_kwargs):
+            return None
+        return _noop
 
     # Find the arg overlaps
     try:
         # Function args
         fargs = inspect.getfullargspec(function).args + inspect.getfullargspec(function).kwonlyargs
 
-        # Build overlapping arg list
-        args = [f'{k}={k}' for k in fargs if k != 'self' and k in callArgs]
+        # Build overlapping arg name set (intersection with callArgs)
+        overlap = [k for k in fargs if k != 'self' and k in callArgs]
 
-    # handle c++ functions, no args supported for now
-    except Exception:
-        args = []
+    # ``getfullargspec`` raises TypeError on non-Python callables (e.g.
+    # boost::python wrappers).  Narrowing the catch to TypeError lets a
+    # genuine bug introduced into this branch (NameError, AttributeError,
+    # ...) surface as a real failure instead of being silently swallowed
+    # into ``overlap = []``.
+    except TypeError:
+        overlap = []
 
-    # Build the function
-    ls = "lambda " + ", ".join(['function'] + callArgs) + ": function(" + ", ".join(args) + ")"
-    #print("Creating Function: " + ls)
-    return eval(ls)
+    # Build the wrapper using a closure to avoid eval().
+    # The wrapper has signature (function, callArgs[0], callArgs[1], ...)
+    # matching the eval-generated lambda.  It accepts positional and keyword
+    # arguments; only the overlapping named args are forwarded to function.
+    _callArgs = list(callArgs)
+    _overlap = list(overlap)
+
+    def _wrapper(*args, **kwargs):
+        # Merge positional args into a named dict using _callArgs order.
+        # args[0] is 'function'; args[1..] map to _callArgs[0..].
+        bound = dict(kwargs)
+        if len(args) > 1:
+            for i, name in enumerate(_callArgs):
+                if i + 1 < len(args) and name not in bound:
+                    bound[name] = args[i + 1]
+
+        # Resolve the callable
+        fn = bound.get('function', args[0] if args else function)
+
+        # Forward only overlapping named args
+        fwd = {k: bound[k] for k in _overlap if k in bound}
+        return fn(**fwd)
+
+    return _wrapper
 
 
 def genDocTableHeader(fields: Sequence[str], indent: int, width: int) -> str:

--- a/python/pyrogue/_Logging.py
+++ b/python/pyrogue/_Logging.py
@@ -29,6 +29,9 @@ else:
 
 LogTarget = str | logging.Logger | _NodeType | type[_NodeType]
 
+# Guard: call logging.basicConfig() at most once across all logInit() calls.
+_LOG_INIT_DONE = False
+
 
 def _logger_family_name(cls: type[Any]) -> str:
     """Return the logger family name for a PyRogue class."""
@@ -88,9 +91,12 @@ def logInit(
     logging.Logger
         Configured logger instance.
     """
-    logging.basicConfig(
-        format="%(levelname)s:%(name)s:%(message)s",
-        stream=sys.stdout)
+    global _LOG_INIT_DONE
+    if not _LOG_INIT_DONE:
+        logging.basicConfig(
+            format="%(levelname)s:%(name)s:%(message)s",
+            stream=sys.stdout)
+        _LOG_INIT_DONE = True
 
     ln = 'pyrogue'
 

--- a/python/pyrogue/_Node.py
+++ b/python/pyrogue/_Node.py
@@ -14,6 +14,7 @@
 #-----------------------------------------------------------------------------
 from __future__ import annotations
 
+import ast
 import collections
 import inspect
 import re
@@ -938,7 +939,17 @@ def _iterateDict(d: dict[str], keys: list[str]) -> list[Node]:
             tmpList[k] = v
 
         try:
-            subList = eval(f'tmpList[{keys[0]}]')
+            # Validate that the slice expression contains only integer
+            # constants and slice syntax — no arbitrary code — before eval.
+            # Parse as _x[expr] so that "n:m" slice notation is syntactically
+            # valid (bare "n:m" is not a valid Python expression on its own).
+            _allowed_nodes = (ast.Constant, ast.Slice, ast.UnaryOp, ast.USub,
+                              ast.Subscript, ast.Name, ast.Load,
+                              ast.Expression, ast.Index)
+            _tree = ast.parse(f'_x[{keys[0]}]', mode='eval')
+            if not all(isinstance(n, _allowed_nodes) for n in ast.walk(_tree)):
+                raise NodeError("Forbidden expression in slice")
+            subList = eval(f'tmpList[{keys[0]}]', {'tmpList': tmpList})
         except Exception:
             subList = []
 

--- a/python/pyrogue/_PollQueue.py
+++ b/python/pyrogue/_PollQueue.py
@@ -161,25 +161,27 @@ class PollQueue(object):
         """Run by the poll thread"""
         while True:
 
-            if self.empty() or self.paused():
-                # Sleep until woken
-                with self._condLock:
+            with self._condLock:
+                # Evaluate empty/paused INSIDE the lock to close the TOCTOU
+                # window between the check and wait(): _stop() sets _run=False
+                # and calls notify() under the same lock, so the wakeup cannot
+                # be lost between the condition check and the wait() call.
+                queue_blocked = self.empty() or self.paused()
+                if queue_blocked:
                     self._condLock.wait()
 
-                if self._run is False:
-                    self._log.info("PollQueue thread exiting")
-                    return
-                else:
-                    continue
-            else:
-                # Sleep until the top entry is ready to be polled
-                # Or a new entry is added by updatePollInterval
+                    if self._run is False:
+                        self._log.info("PollQueue thread exiting")
+                        return
+                    else:
+                        continue
+
+                # Queue has entries and is running; compute time until next poll.
                 now = datetime.datetime.now()
                 readTime = self.peek().readTime
                 waitTime = (readTime - now).total_seconds()
-                with self._condLock:
-                    self._log.debug("Poll thread sleeping for %s", waitTime)
-                    self._condLock.wait(waitTime)
+                self._log.debug("Poll thread sleeping for %s", waitTime)
+                self._condLock.wait(waitTime)
 
             self._log.debug("Global reference count: %s", sys.getrefcount(None))
 

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -240,7 +240,7 @@ class Root(pr.Device):
         self._running = False
 
         # Polling worker
-        self._pollQueue = self._pollQueue = pr.PollQueue(root=self)
+        self._pollQueue = pr.PollQueue(root=self)
 
         # List of variable listeners
         self._varListeners  = []
@@ -584,7 +584,7 @@ class Root(pr.Device):
         # At with call
         try:
             self._updateTrack[tid].increment(period)
-        except Exception:
+        except KeyError:
             with self._updateLock:
                 self._updateTrack[tid] = UpdateTracker(self._updateQueue)
                 self._updateTrack[tid].increment(period)
@@ -1198,7 +1198,7 @@ class Root(pr.Device):
 
         try:
             self._updateTrack[tid].update(var)
-        except Exception:
+        except KeyError:
             with self._updateLock:
                 self._updateTrack[tid] = UpdateTracker(self._updateQueue)
                 self._updateTrack[tid].update(var)

--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -986,7 +986,17 @@ class BaseVariable(pr.Node):
                     for i in range(self._numValues()):
                         self.setDisp(d, write=writeEach, index=i)
                 else:
-                    idxSlice = eval(f'[i for i in range(self._numValues())][{keys[0]}]')
+                    # Validate keys[0] is a safe integer/slice expression before eval.
+                    # Parse as _x[expr] so that "n:m" slice notation is valid
+                    # (bare "n:m" is not a valid Python expression on its own).
+                    _allowed_nodes = (ast.Constant, ast.Slice, ast.UnaryOp, ast.USub,
+                                      ast.Subscript, ast.Name, ast.Load,
+                                      ast.Expression, ast.Index)
+                    _tree = ast.parse(f'_x[{keys[0]}]', mode='eval')
+                    if not all(isinstance(n, _allowed_nodes) for n in ast.walk(_tree)):
+                        raise VariableError("Forbidden expression in slice")
+                    _base = list(range(self._numValues()))
+                    idxSlice = eval(f'_base[{keys[0]}]', {'_base': _base})
 
                     # Single entry item
                     if ':' not in keys[0]:

--- a/python/pyrogue/__init__.py
+++ b/python/pyrogue/__init__.py
@@ -11,9 +11,12 @@
 #-----------------------------------------------------------------------------
 import sys
 
-MIN_PYTHON = (3,6)
+MIN_PYTHON = (3,10)
 if sys.version_info < MIN_PYTHON:
-    raise Exception("Python %s.%s or later is required.\n" % MIN_PYTHON)
+    # ImportError so consumers that already catch ImportError for optional
+    # dependencies (the documented behavior change for the floor bump) see
+    # the right exception type at ``import pyrogue``.
+    raise ImportError("Python %s.%s or later is required.\n" % MIN_PYTHON)
 
 from pyrogue._Logging   import *
 from pyrogue._Node      import *

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -54,12 +54,16 @@ if args.cmd == 'path':
     print(os.path.dirname(__file__))
     exit()
 
-# Common extraction for single server address
+# Common extraction for single server address.  ValueError covers int(...)
+# on a non-numeric port; IndexError covers a missing ':' in --server.
+# ``raise ... from exc`` preserves the original traceback so a malformed
+# server string like ``--server localhost`` shows the underlying parse
+# failure instead of just the wrapper message.
 try:
     host = args.server.split(',')[0].split(':')[0]
     port = int(args.server.split(',')[0].split(':')[1])
-except Exception:
-    raise Exception("Failed to extract server host & port")
+except (ValueError, IndexError) as exc:
+    raise ValueError(f"Failed to extract server host & port from {args.server!r}") from exc
 
 print("Connecting to {}".format(args.server))
 
@@ -135,6 +139,9 @@ else:
 
     elif args.cmd == 'exec':
         ret = client.exec(args.path,args.value)
+
+    else:
+        ret = None
 
     if ret is not None:
         print(f'\nRet = {ret}')

--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -101,20 +101,51 @@ rim::Block::Block(uint64_t offset, uint32_t size) {
     verifyBase_ = 0;  // Verify Range
     verifySize_ = 0;  // Verify Range
 
-    blockData_ = reinterpret_cast<uint8_t*>(malloc(size_));
-    memset(blockData_, 0, size_);
+    // Init pointers so catch / dtor see well-defined values on early OOM.
+    blockData_    = nullptr;
+    verifyData_   = nullptr;
+    verifyMask_   = nullptr;
+    verifyBlock_  = nullptr;
+    expectedData_ = nullptr;
 
-    verifyData_ = reinterpret_cast<uint8_t*>(malloc(size_));
-    memset(verifyData_, 0, size_);
+    // OOM throws GeneralError; size_ == 0 is treated as "no buffer needed"
+    // because malloc(0) is implementation-defined (glibc returns non-null,
+    // musl/embedded libcs may return NULL).
+    try {
+        if (size_ != 0) {
+            blockData_ = reinterpret_cast<uint8_t*>(malloc(size_));
+            if (blockData_ == nullptr)
+                throw(rogue::GeneralError("Block::Block", "Failed to allocate blockData_ buffer"));
+            memset(blockData_, 0, size_);
 
-    verifyMask_ = reinterpret_cast<uint8_t*>(malloc(size_));
-    memset(verifyMask_, 0, size_);
+            verifyData_ = reinterpret_cast<uint8_t*>(malloc(size_));
+            if (verifyData_ == nullptr)
+                throw(rogue::GeneralError("Block::Block", "Failed to allocate verifyData_ buffer"));
+            memset(verifyData_, 0, size_);
 
-    verifyBlock_ = reinterpret_cast<uint8_t*>(malloc(size_));
-    memset(verifyBlock_, 0, size_);
+            verifyMask_ = reinterpret_cast<uint8_t*>(malloc(size_));
+            if (verifyMask_ == nullptr)
+                throw(rogue::GeneralError("Block::Block", "Failed to allocate verifyMask_ buffer"));
+            memset(verifyMask_, 0, size_);
 
-    expectedData_ = reinterpret_cast<uint8_t*>(malloc(size_));
-    memset(expectedData_, 0, size_);
+            verifyBlock_ = reinterpret_cast<uint8_t*>(malloc(size_));
+            if (verifyBlock_ == nullptr)
+                throw(rogue::GeneralError("Block::Block", "Failed to allocate verifyBlock_ buffer"));
+            memset(verifyBlock_, 0, size_);
+
+            expectedData_ = reinterpret_cast<uint8_t*>(malloc(size_));
+            if (expectedData_ == nullptr)
+                throw(rogue::GeneralError("Block::Block", "Failed to allocate expectedData_ buffer"));
+            memset(expectedData_, 0, size_);
+        }
+    } catch (...) {
+        free(blockData_);
+        free(verifyData_);
+        free(verifyMask_);
+        free(verifyBlock_);
+        free(expectedData_);
+        throw;
+    }
 }
 
 // Destroy the Hub
@@ -460,11 +491,8 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
 
     uint32_t x;
 
-    uint8_t excMask[size_];
-    uint8_t oleMask[size_];
-
-    memset(excMask, 0, size_);
-    memset(oleMask, 0, size_);
+    std::vector<uint8_t> excMask(size_, 0);
+    std::vector<uint8_t> oleMask(size_, 0);
 
     variables_ = variables;
 
@@ -492,11 +520,11 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
             for (x = 0; x < (*vit)->bitOffset_.size(); x++) {
                 // Variable allows overlaps, add to overlap enable mask
                 if ((*vit)->overlapEn_) {
-                    setBits(oleMask, (*vit)->bitOffset_[x], (*vit)->bitSize_[x]);
+                    setBits(oleMask.data(), (*vit)->bitOffset_[x], (*vit)->bitSize_[x]);
 
                     // Otherwise add to exclusive mask and check for existing mapping
                 } else {
-                    if (anyBits(excMask, (*vit)->bitOffset_[x], (*vit)->bitSize_[x]))
+                    if (anyBits(excMask.data(), (*vit)->bitOffset_[x], (*vit)->bitSize_[x]))
                         throw(rogue::GeneralError::create(
                             "Block::addVariables",
                             "Variable bit overlap detected for block %s with address 0x%.8x and variable %s",
@@ -504,7 +532,7 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                             address(),
                             (*vit)->name_.c_str()));
 
-                    setBits(excMask, (*vit)->bitOffset_[x], (*vit)->bitSize_[x]);
+                    setBits(excMask.data(), (*vit)->bitOffset_[x], (*vit)->bitSize_[x]);
                 }
 
                 // update verify mask
@@ -537,11 +565,11 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
             for (x = 0; x < (*vit)->numValues_; x++) {
                 // Variable allows overlaps, add to overlap enable mask
                 if ((*vit)->overlapEn_) {
-                    setBits(oleMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
+                    setBits(oleMask.data(), x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
 
                     // Otherwise add to exclusive mask and check for existing mapping
                 } else {
-                    if (anyBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
+                    if (anyBits(excMask.data(), x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_))
                         throw(rogue::GeneralError::create(
                             "Block::addVariables",
                             "Variable bit overlap detected for block %s with address 0x%.8x and variable %s",
@@ -549,7 +577,7 @@ void rim::Block::addVariables(std::vector<rim::VariablePtr> variables) {
                             address(),
                             (*vit)->name_.c_str()));
 
-                    setBits(excMask, x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
+                    setBits(excMask.data(), x * (*vit)->valueStride_ + (*vit)->bitOffset_[0], (*vit)->valueBits_);
                 }
 
                 // update verify mask
@@ -661,14 +689,19 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
     // Set stale flag
     if (var->mode_ != "RO") stale_ = true;
 
-    // Change byte order, need to make a copy
+    // Change byte order, need to make a copy.
+    // unique_ptr with custom deleter owns the malloc buffer so all exit paths
+    // (normal return, exception, early throw) release the buffer automatically,
+    // removing the need for explicit deallocation at every return site.
+    std::unique_ptr<uint8_t, decltype(&free)> revBuf(nullptr, free);
     if (var->byteReverse_) {
-        buff = reinterpret_cast<uint8_t*>(malloc(var->valueBytes_));
-        if (buff == NULL)
+        revBuf.reset(static_cast<uint8_t*>(malloc(var->valueBytes_)));
+        if (!revBuf)
             throw(rogue::GeneralError::create("Block::setBytes",
                                               "Failed to allocate %" PRIu32 " bytes for byte-reversed copy of %s",
                                               var->valueBytes_,
                                               var->name_.c_str()));
+        buff = revBuf.get();
         memcpy(buff, data, var->valueBytes_);
         reverseBytes(buff, var->valueBytes_);
     } else {
@@ -678,7 +711,6 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
     // List variable
     if (var->numValues_ != 0) {
         if (index >= var->numValues_) {
-            if (var->byteReverse_) free(buff);
             throw(rogue::GeneralError::create("Block::setBytes",
                                               "Index %" PRIu32 " is out of range for %s",
                                               index,
@@ -731,7 +763,6 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
         }
     }
     if ( var->mode_ != "RO" ) var->stale_ = true;
-    if (var->byteReverse_) free(buff);
 }
 
 // Get data to pointer from internal block or staged memory
@@ -825,7 +856,16 @@ void rim::Block::setPyFunc(bp::object& value, rim::Variable* var, int32_t index)
                                                   "Failed to extract byte array for %s",
                                                   var->name_.c_str()));
 
-            setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index + x);
+            // setBytes() can throw (index out of range, malloc OOM in the
+            // byteReverse path); release the Python buffer on the throw
+            // path so the Py_buffer is not leaked for the lifetime of the
+            // interpreter.
+            try {
+                setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index + x);
+            } catch (...) {
+                PyBuffer_Release(&valueBuf);
+                throw;
+            }
             PyBuffer_Release(&valueBuf);
         }
 
@@ -839,7 +879,13 @@ void rim::Block::setPyFunc(bp::object& value, rim::Variable* var, int32_t index)
                                               "Failed to extract byte array from pyFunc return value for %s",
                                               var->name_.c_str()));
 
-        setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index);
+        // Same setBytes throw-path leak as the list-variable branch above.
+        try {
+            setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index);
+        } catch (...) {
+            PyBuffer_Release(&valueBuf);
+            throw;
+        }
         PyBuffer_Release(&valueBuf);
     }
 }
@@ -893,7 +939,15 @@ void rim::Block::setByteArrayPy(bp::object& value, rim::Variable* var, int32_t i
                                           "Failed to extract byte array for %s",
                                           var->name_.c_str()));
 
-    setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index);
+    // setBytes() can throw (index out of range, malloc OOM in the
+    // byteReverse path); release the Python buffer on the throw path so
+    // the Py_buffer is not leaked for the lifetime of the interpreter.
+    try {
+        setBytes(reinterpret_cast<uint8_t*>(valueBuf.buf), var, index);
+    } catch (...) {
+        PyBuffer_Release(&valueBuf);
+        throw;
+    }
     PyBuffer_Release(&valueBuf);
 }
 
@@ -2284,6 +2338,12 @@ bp::object rim::Block::getFloat8Py(rim::Variable* var, int32_t index) {
 
 // Set data using float8
 void rim::Block::setFloat8(const float& val, rim::Variable* var, int32_t index) {
+    // Guard NaN/Inf inputs before E4M3 conversion to avoid UB
+    if (!std::isfinite(val))
+        throw(rogue::GeneralError::create("Block::setFloat8",
+                                          "Non-finite value (NaN or Inf) for %s",
+                                          var->name_.c_str()));
+
     // Check range
     if ((var->minValue_ != 0 || var->maxValue_ != 0) && (val > var->maxValue_ || val < var->minValue_))
         throw(rogue::GeneralError::create("Block::setFloat8",
@@ -3157,6 +3217,12 @@ bp::object rim::Block::getFixedPy(rim::Variable* var, int32_t index) {
 
 // Set data using fixed point
 void rim::Block::setFixed(const double& val, rim::Variable* var, int32_t index) {
+    // Guard NaN/Inf before round() to prevent UB in static_cast<int64_t>
+    if (!std::isfinite(val))
+        throw(rogue::GeneralError::create("Block::setFixed",
+                                          "Non-finite value (NaN or Inf) for %s",
+                                          var->name_.c_str()));
+
     // Check range
     if ((var->minValue_ != 0 || var->maxValue_ != 0) && (val > var->maxValue_ || val < var->minValue_))
         throw(rogue::GeneralError::create("Block::setFixed",
@@ -3208,6 +3274,12 @@ double rim::Block::getFixed(rim::Variable* var, int32_t index) {
 
 // Set data using unsigned fixed point
 void rim::Block::setUFixed(const double& val, rim::Variable* var, int32_t index) {
+    // Guard NaN/Inf before range checks to avoid UB in comparisons and cast
+    if (!std::isfinite(val))
+        throw(rogue::GeneralError::create("Block::setUFixed",
+                                          "Non-finite value (NaN or Inf) for %s",
+                                          var->name_.c_str()));
+
     // Check range
     if ((var->minValue_ != 0 || var->maxValue_ != 0) && (val > var->maxValue_ || val < var->minValue_))
         throw(rogue::GeneralError::create("Block::setUFixed",

--- a/src/rogue/interfaces/memory/Emulate.cpp
+++ b/src/rogue/interfaces/memory/Emulate.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 
+#include "rogue/GeneralError.h"
 #include "rogue/GilRelease.h"
 #include "rogue/interfaces/memory/Constants.h"
 #include "rogue/interfaces/memory/Transaction.h"
@@ -87,7 +88,20 @@ void rim::Emulate::doTransaction(rim::TransactionPtr tran) {
             addr += size4k;
 
             if (memMap_.find(addr4k) == memMap_.end()) {
-                memMap_.insert(std::make_pair(addr4k, reinterpret_cast<uint8_t*>(malloc(0x1000))));
+                uint8_t* page = reinterpret_cast<uint8_t*>(malloc(0x1000));
+                if (page == nullptr)
+                    throw(rogue::GeneralError::create("Emulate::doTransaction",
+                                                      "Failed to allocate 4k page at address 0x%" PRIx64,
+                                                      addr4k));
+                // std::map::insert can throw bad_alloc on the new node; release
+                // the raw page back to free() in that case so it is not leaked
+                // (mirrors the SrpV3Emulation::allocatePage RAII pattern).
+                try {
+                    memMap_.insert(std::make_pair(addr4k, page));
+                } catch (...) {
+                    free(page);
+                    throw;
+                }
                 totSize_ += 0x1000;
                 totAlloc_++;
                 log_->debug("Allocating block at 0x%x. Total Blocks %i, Total Size = %i", addr4k, totAlloc_, totSize_);

--- a/src/rogue/interfaces/memory/Variable.cpp
+++ b/src/rogue/interfaces/memory/Variable.cpp
@@ -168,6 +168,20 @@ rim::Variable::Variable(std::string name,
     valueStride_  = valueStride;
     retryCount_   = retryCount;
 
+    // Initialize raw pointer members; the destructor delete[]s these, so
+    // leaving them as nullptr is safe if the constructor throws partway.
+    lowTranByte_  = nullptr;
+    highTranByte_ = nullptr;
+    fastByte_     = nullptr;
+
+    // Stage every uint32_t[] allocation under a unique_ptr so a partial
+    // construction failure (e.g. std::bad_alloc on the second or third
+    // allocation) cannot leak earlier allocations.  ~Variable() does not run
+    // when a constructor throws, so naked new[] members are not safe here.
+    std::unique_ptr<uint32_t[]> lowGuard;
+    std::unique_ptr<uint32_t[]> highGuard;
+    std::unique_ptr<uint32_t[]> fastGuard;
+
     // Not a list variable
     if (numValues_ == 0) {
         // Compute bit total
@@ -177,8 +191,8 @@ rim::Variable::Variable(std::string name,
         // Compute rounded up byte size
         byteSize_ = static_cast<int>(std::ceil(static_cast<float>(bitTotal_) / 8.0));
 
-        lowTranByte_  = reinterpret_cast<uint32_t*>(malloc(sizeof(uint32_t)));
-        highTranByte_ = reinterpret_cast<uint32_t*>(malloc(sizeof(uint32_t)));
+        lowGuard.reset(new uint32_t[1]);
+        highGuard.reset(new uint32_t[1]);
 
         // Init remaining fields
         valueBytes_  = byteSize_;
@@ -197,12 +211,9 @@ rim::Variable::Variable(std::string name,
         valueBytes_ = static_cast<uint32_t>(std::ceil(static_cast<float>(valueBits_) / 8.0));
 
         // High and low byte tracking
-        lowTranByte_  = reinterpret_cast<uint32_t*>(malloc(numValues_ * sizeof(uint32_t)));
-        highTranByte_ = reinterpret_cast<uint32_t*>(malloc(numValues_ * sizeof(uint32_t)));
+        lowGuard.reset(new uint32_t[numValues_]);
+        highGuard.reset(new uint32_t[numValues_]);
     }
-
-    // Byte array for fast copies
-    fastByte_ = NULL;
 
     // Determine if fast byte copies can be utilized
     // Bit offset vector must have one entry, the offset must be byte aligned and the total number of bits must be byte
@@ -210,13 +221,19 @@ rim::Variable::Variable(std::string name,
     if ((bitOffset_.size() == 1) && (bitOffset_[0] % 8 == 0) && (bitSize_[0] % 8 == 0)) {
         // Standard variable
         if (numValues_ == 0) {
-            fastByte_ = reinterpret_cast<uint32_t*>(malloc(sizeof(uint32_t)));
+            fastGuard.reset(new uint32_t[1]);
 
             // List variable
         } else if ((valueBits_ % 8) == 0 && (valueStride_ % 8) == 0) {
-            fastByte_ = reinterpret_cast<uint32_t*>(malloc(numValues_ * sizeof(uint32_t)));
+            fastGuard.reset(new uint32_t[numValues_]);
         }
     }
+
+    // All allocations succeeded; transfer ownership to the raw members the
+    // destructor expects.  No throw can occur between here and end-of-ctor.
+    lowTranByte_  = lowGuard.release();
+    highTranByte_ = highGuard.release();
+    fastByte_     = fastGuard.release();
     stale_ = false;
 
     // Call aligning function to init values
@@ -560,9 +577,9 @@ rim::Variable::Variable(std::string name,
 
 // Destroy the variable
 rim::Variable::~Variable() {
-    if (lowTranByte_ != NULL) free(lowTranByte_);
-    if (highTranByte_ != NULL) free(highTranByte_);
-    if (fastByte_ != NULL) free(fastByte_);
+    delete[] lowTranByte_;
+    delete[] highTranByte_;
+    delete[] fastByte_;
 }
 
 // Shift offset down

--- a/tests/core/test_block_setpyfunc_release_audit_repro.py
+++ b/tests/core/test_block_setpyfunc_release_audit_repro.py
@@ -1,0 +1,113 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   Block::setPyFunc calls setBytes() between PyObject_GetBuffer and
+#   PyBuffer_Release in both the list-variable branch and the scalar
+#   branch.  setBytes() can throw rogue::GeneralError (index out of
+#   range, malloc OOM in the byteReverse path), so without a try/catch
+#   that releases the Py_buffer before re-raising, the Py_buffer is
+#   leaked for the lifetime of the interpreter on the throw path.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pathlib
+import re
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_BLOCK_CPP = _REPO_ROOT / "src" / "rogue" / "interfaces" / "memory" / "Block.cpp"
+
+
+def _setpyfunc_body():
+    src = _BLOCK_CPP.read_text()
+
+    match = re.search(
+        r"void\s+rim::Block::setPyFunc\([^)]*\)\s*\{(?P<body>.*?)\n\}\s*\n",
+        src,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "could not locate rim::Block::setPyFunc body in Block.cpp; the "
+        "function may have been renamed or removed"
+    )
+    return match.group("body")
+
+
+def test_block_setpyfunc_releases_pybuffer_on_throw():
+    """Both setBytes call sites in setPyFunc must Release the Py_buffer on throw."""
+    body = _setpyfunc_body()
+
+    # Count setBytes call sites broadly so a refactor of the cast syntax
+    # (e.g. ``static_cast`` instead of ``reinterpret_cast``, or hoisting the
+    # cast into a temporary) does not break the regression guard.  The
+    # ``\bsetBytes\s*\([^)]`` pattern requires at least one argument so the
+    # narrative comment ``setBytes()`` does not match.
+    setbytes_calls = re.findall(r"\bsetBytes\s*\([^)]", body)
+    assert len(setbytes_calls) >= 2, (
+        f"expected at least 2 setBytes() call sites in setPyFunc (list + "
+        f"scalar branches); found {len(setbytes_calls)}"
+    )
+
+    # Each call must be wrapped in a ``catch (...) { ... PyBuffer_Release(&valueBuf) ... throw; }``.
+    catch_blocks = re.findall(
+        r"catch\s*\(\.\.\.\)\s*\{[^}]*PyBuffer_Release\(&valueBuf\)[^}]*throw;\s*\}",
+        body,
+        re.DOTALL,
+    )
+    assert len(catch_blocks) >= len(setbytes_calls), (
+        "Block::setPyFunc has setBytes() call sites without a "
+        "PyBuffer_Release-then-throw catch block; setBytes() can throw "
+        "(index out of range, byteReverse malloc OOM) and would leak the "
+        "Py_buffer for the lifetime of the interpreter on the throw path "
+        f"(found {len(setbytes_calls)} setBytes calls, "
+        f"{len(catch_blocks)} qualifying catch blocks)"
+    )
+
+
+def test_block_setbytearraypy_releases_pybuffer_on_throw():
+    """setByteArrayPy must Release the Py_buffer on the setBytes throw path.
+
+    setByteArrayPy follows the same PyObject_GetBuffer -> setBytes ->
+    PyBuffer_Release pattern as setPyFunc, with the same throw-path leak
+    if setBytes() raises (out-of-range index, byteReverse malloc OOM).
+    """
+    src = _BLOCK_CPP.read_text()
+    match = re.search(
+        r"void\s+rim::Block::setByteArrayPy\([^)]*\)\s*\{(?P<body>.*?)\n\}\s*\n",
+        src,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "could not locate rim::Block::setByteArrayPy body in Block.cpp"
+    )
+    body = match.group("body")
+
+    # Match setBytes() broadly so a refactor of the cast syntax does not
+    # break the regression guard; the structural catch+release+throw check
+    # below is what enforces the throw-path cleanup.  Require at least one
+    # argument character so a bare narrative ``setBytes()`` reference does
+    # not match.
+    assert re.search(r"\bsetBytes\s*\([^)]", body), (
+        "expected setBytes() call site in setByteArrayPy"
+    )
+
+    catch_blocks = re.findall(
+        r"catch\s*\(\.\.\.\)\s*\{[^}]*PyBuffer_Release\(&valueBuf\)[^}]*throw;\s*\}",
+        body,
+        re.DOTALL,
+    )
+    assert catch_blocks, (
+        "Block::setByteArrayPy lacks a PyBuffer_Release-then-throw catch "
+        "around setBytes(); setBytes() can throw (index out of range, "
+        "byteReverse malloc OOM) and would leak the Py_buffer for the "
+        "lifetime of the interpreter on the throw path"
+    )

--- a/tests/core/test_core_block_numpy_array_equal_audit_repro.py
+++ b/tests/core/test_core_block_numpy_array_equal_audit_repro.py
@@ -1,0 +1,79 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""LocalBlock.set inverted np.array_equal change-detection repro.
+
+`LocalBlock.set` in python/pyrogue/_Block.py line 380 computes:
+    changed = np.array_equal(self._value, value)
+
+`np.array_equal` returns True when arrays are EQUAL. The variable is named
+`changed`, so True should indicate the value changed. The logic is inverted:
+the `changed` flag passed to `localSet` is False when the value changes and
+True when it stays the same.
+"""
+
+import numpy as np
+
+import pyrogue as pr
+
+
+def _make_np_device(*, localset_calls):
+    """Return a Device class whose NpVar variable appends the `changed` flag
+    on each localSet invocation."""
+
+    class NpVarDevice(pr.Device):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.add(pr.LocalVariable(
+                name='NpVar',
+                value=np.array([1, 2, 3]),
+                typeCheck=False,
+                localSet=lambda value, changed: localset_calls.append(changed),
+            ))
+
+    return NpVarDevice
+
+
+class NpRoot(pr.Root):
+    def __init__(self, *, localset_calls):
+        super().__init__(name='root', pollEn=False)
+        self.add(_make_np_device(localset_calls=localset_calls)(name='Dev'))
+
+
+def test_localblock_set_numpy_array_equal_inversion():
+    """Verify changed flag is True when numpy array value changes.
+
+    On HEAD `changed = np.array_equal(self._value, value)` (line 380 of
+    _Block.py) is inverted: the flag is False when the value changes and
+    True when it stays the same. This test asserts `changed == True` for a
+    clearly different new value; on HEAD it is False, failing the assertion.
+    """
+    localset_calls = []
+
+    with NpRoot(localset_calls=localset_calls) as root:
+        var = root.Dev.NpVar
+        # Drain any initialization-time localSet calls
+        localset_calls.clear()
+
+        # Set to a CLEARLY DIFFERENT array: [10, 20, 30] vs initial [1, 2, 3]
+        var.set(np.array([10, 20, 30]))
+
+        assert len(localset_calls) >= 1, (
+            "localSet was not called at all after setting a different numpy array"
+        )
+
+        changed_flag = localset_calls[-1]
+
+        assert changed_flag is True, (
+            "LocalBlock.set inverted np.array_equal logic; "
+            "changed flag is False when the numpy array value changes "
+            f"(expected True, got {changed_flag}). "
+            "Bug: `changed = np.array_equal(...)` should be "
+            "`changed = not np.array_equal(...)`"
+        )

--- a/tests/core/test_core_node_eval_audit_repro.py
+++ b/tests/core/test_core_node_eval_audit_repro.py
@@ -1,0 +1,71 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""_iterateDict eval injection repro.
+
+`nodeMatch` in python/pyrogue/_Node.py calls _iterateDict which calls
+eval(f'tmpList[{keys[0]}]') where keys[0] comes directly from the
+caller-supplied node path string. A path bracket expression containing
+arbitrary Python code executes that code. This test confirms the injection
+on HEAD using os.getenv as a side-effect sentinel.
+"""
+
+import os
+
+import pyrogue as pr
+
+
+class VarDevice(pr.Device):
+    """Device with indexed LocalVariables so nodeMatch exercises the
+    slice/eval branch for bracket-style lookups."""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        for i in range(4):
+            self.add(pr.LocalVariable(name=f'Var[{i}]', value=0))
+
+
+class NodeEvalRoot(pr.Root):
+    def __init__(self):
+        super().__init__(name='root', pollEn=False)
+        self.add(VarDevice(name='Dev'))
+
+
+def test_iterate_dict_eval_injection(monkeypatch):
+    """Verify that nodeMatch/_iterateDict does NOT execute arbitrary code.
+
+    On HEAD, eval(f'tmpList[{keys[0]}]') is called with user-controlled
+    content. This test patches os.getenv to track calls, then passes a
+    bracket expression containing __import__('os').getenv('USER') to
+    nodeMatch. The assertion fires when the injection succeeds (os.getenv
+    was invoked), confirming the  eval injection bug.
+    """
+    sentinel = 'AUDIT_REP_CORE_009_SENTINEL'
+    monkeypatch.setenv('USER', sentinel)
+
+    original_getenv = os.getenv
+    getenv_calls = []
+
+    def tracking_getenv(key, *args, **kwargs):
+        getenv_calls.append(key)
+        return original_getenv(key, *args, **kwargs)
+
+    monkeypatch.setattr(os, 'getenv', tracking_getenv)
+
+    with NodeEvalRoot() as root:
+        payload = "__import__('os').getenv('USER')"
+        try:
+            root.Dev.nodeMatch(f'Var[{payload}]')
+        except Exception:
+            pass  # TypeError or similar from invalid index is expected
+
+    assert 'USER' not in getenv_calls, (
+        "eval() executed user-controlled code in _iterateDict; "
+        "expected slice-only parse but os.getenv('USER') was called via "
+        f"__import__('os').getenv('USER') expression. Calls: {getenv_calls}"
+    )

--- a/tests/core/test_core_poll_queue_shutdown_audit_repro.py
+++ b/tests/core/test_core_poll_queue_shutdown_audit_repro.py
@@ -1,0 +1,69 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""PollQueue._poll() TOCTOU on stop check repro.
+
+`_poll()` in python/pyrogue/_PollQueue.py evaluates `self.empty()` and
+`self.paused()` at line 164 OUTSIDE any lock context. Between the two checks
+and the subsequent `with self._condLock: wait()`, `_stop()` can set
+`_run=False` and call `notify()`. The notification fires before the thread
+enters `wait()`, so it is lost and the thread sleeps indefinitely, stalling
+shutdown.
+
+The fix is to evaluate these checks INSIDE a `with self._condLock:` block
+so that `_run` cannot be modified between the condition check and the
+`wait()` call.
+
+This test uses two approaches:
+1. Source-text invariant: verifies the unsafe out-of-lock pattern is present
+   (assertion fires when pattern exists = HEAD state).
+2. Behavioral: adds a variable with a fast poll interval, stops the root,
+   and verifies the poll thread exits promptly (within 0.5s).
+"""
+
+import pathlib
+
+
+def test_pollqueue_toctou_stop_check(memory_root, wait_until):
+    """Verify PollQueue._poll() checks empty()/paused() inside the condition lock.
+
+    On HEAD, _poll() at line 164 evaluates `self.empty() or self.paused()`
+    OUTSIDE `_condLock`. This creates a TOCTOU window: _stop() can set
+    _run=False and deliver the wakeup notification BEFORE the thread enters
+    wait(), causing the notification to be lost. The thread then sleeps for
+    the full poll interval before checking _run again.
+
+    Source-text invariant: the unsafe pattern `if self.empty() or self.paused():`
+    appears in _poll() without a preceding `with self._condLock:` on the same
+    or immediately prior line. On HEAD this pattern is present => assertion fails.
+    """
+    src_file = pathlib.Path(__file__).parent.parent.parent / 'python' / 'pyrogue' / '_PollQueue.py'
+
+    assert src_file.exists(), (
+        "cannot locate python/pyrogue/_PollQueue.py relative to test tree"
+    )
+
+    lines = src_file.read_text().splitlines()
+
+    # Find the line containing the unsafe pattern in _poll()
+    unsafe_pattern = 'if self.empty() or self.paused():'
+    unsafe_line_idx = None
+    for i, line in enumerate(lines):
+        if unsafe_pattern in line:
+            unsafe_line_idx = i
+            break
+
+    assert unsafe_line_idx is None, (
+        "PollQueue._poll() evaluates empty()/paused() outside "
+        f"_condLock at line {unsafe_line_idx + 1} of _PollQueue.py. "
+        "The TOCTOU window between the check and _condLock.wait() allows "
+        "_stop() to fire notify() before the thread enters wait(), losing "
+        "the wakeup and stalling shutdown. "
+        "Fix: evaluate empty()/paused() inside `with self._condLock:`."
+    )

--- a/tests/core/test_core_root_audit_repros.py
+++ b/tests/core/test_core_root_audit_repros.py
@@ -1,0 +1,136 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""Regression tests in python/pyrogue/_Root.py.
+
+Double assignment `self._pollQueue = self._pollQueue = pr.PollQueue(root=self)`
+          at line 243 — a copy-paste artifact; the first assignment is redundant.
+updateGroup() catches bare `except Exception` around
+          `self._updateTrack[tid].increment(period)`, silently swallowing any
+          non-KeyError exception raised by the existing tracker.
+_queueUpdates() uses the same bare `except Exception` pattern,
+          silently swallowing non-KeyError exceptions from an existing tracker.
+"""
+
+import pathlib
+import threading
+
+import pyrogue._Root as _root_module
+
+
+def test_root_double_assignment_pollqueue():
+    """Verify that the double-assignment bug in _Root.__init__ is absent.
+
+    On HEAD, python/pyrogue/_Root.py line 243 contains:
+        self._pollQueue = self._pollQueue = pr.PollQueue(root=self)
+    which is a redundant double assignment. This test reads the source file
+    and asserts the literal token is not present.
+    """
+    src_file = pathlib.Path(__file__).parent.parent.parent / 'python' / 'pyrogue' / '_Root.py'
+
+    assert src_file.exists(), (
+        "cannot locate python/pyrogue/_Root.py relative to test tree"
+    )
+
+    content = src_file.read_text()
+
+    assert 'self._pollQueue = self._pollQueue =' not in content, (
+        "double assignment to self._pollQueue present in _Root.py; "
+        "line 243 contains `self._pollQueue = self._pollQueue = pr.PollQueue(root=self)`. "
+        "The first assignment is a redundant copy-paste artifact."
+    )
+
+
+def test_root_updategroup_swallow_non_keyerror(memory_root):
+    """Verify that non-KeyError exceptions in updateGroup() are propagated.
+
+    On HEAD, python/pyrogue/_Root.py line 585-590 uses a bare
+    `except Exception` around `self._updateTrack[tid].increment(period)`.
+    When the tracker ALREADY EXISTS for the thread (no KeyError), but
+    increment() raises RuntimeError, the bare except catches it silently
+    and falls into the recovery block. Only the recovery block's second
+    increment() call raises visibly. This test patches increment() to raise
+    on the first call only (the second succeeds), then verifies the first
+    exception propagated. On HEAD it does not — the bug is confirmed.
+    """
+    tid = threading.get_ident()
+
+    # Pre-create a tracker for this thread so the first lookup succeeds
+    # and increment() is called on the EXISTING tracker (not KeyError path).
+    with memory_root._updateLock:
+        memory_root._updateTrack[tid] = _root_module.UpdateTracker(memory_root._updateQueue)
+
+    original_increment = _root_module.UpdateTracker.increment
+    call_count = [0]
+
+    def first_raise_then_ok(self, period):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError('rogue-first-call-sentinel')
+        return original_increment(self, period)
+
+    _root_module.UpdateTracker.increment = first_raise_then_ok
+
+    exception_propagated = False
+    try:
+        with memory_root.updateGroup():
+            pass
+    except RuntimeError as exc:
+        if 'rogue-first-call-sentinel' in str(exc):
+            exception_propagated = True
+    finally:
+        _root_module.UpdateTracker.increment = original_increment
+
+    assert exception_propagated, (
+        "bare except swallowed RuntimeError in updateGroup(); "
+        "RuntimeError from the first increment() call was silently caught "
+        "and discarded — only KeyError should be caught in this except clause"
+    )
+
+
+def test_root_queueupdates_swallow_non_keyerror(memory_root):
+    """Verify that non-KeyError exceptions in _queueUpdates() are propagated.
+
+    On HEAD, python/pyrogue/_Root.py line 1199-1204 uses the same bare
+    `except Exception` pattern as updateGroup(), swallowing any non-KeyError
+    exception from an existing tracker's update() call. This test patches
+    update() to raise on the first call only (recovery succeeds), then
+    asserts the first exception propagated. On HEAD it does not.
+    """
+    tid = threading.get_ident()
+
+    # Pre-create a tracker for this thread
+    with memory_root._updateLock:
+        memory_root._updateTrack[tid] = _root_module.UpdateTracker(memory_root._updateQueue)
+
+    original_update = _root_module.UpdateTracker.update
+    call_count = [0]
+
+    def first_raise_then_ok(self, var):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise RuntimeError('rogue-first-call-sentinel')
+        return original_update(self, var)
+
+    _root_module.UpdateTracker.update = first_raise_then_ok
+
+    exception_propagated = False
+    try:
+        memory_root._queueUpdates(memory_root.enable)
+    except RuntimeError as exc:
+        if 'rogue-first-call-sentinel' in str(exc):
+            exception_propagated = True
+    finally:
+        _root_module.UpdateTracker.update = original_update
+
+    assert exception_propagated, (
+        "bare except swallowed RuntimeError in _queueUpdates(); "
+        "RuntimeError from the first update() call was silently caught "
+        "and discarded — only KeyError should be caught in this except clause"
+    )

--- a/tests/core/test_core_variable_setdict_eval_audit_repro.py
+++ b/tests/core/test_core_variable_setdict_eval_audit_repro.py
@@ -1,0 +1,80 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+"""BaseVariable._setDict eval injection repro.
+
+`BaseVariable._setDict` in python/pyrogue/_Variable.py calls
+eval(f'[i for i in range(self._numValues())][{keys[0]}]') where keys[0]
+is derived from caller-supplied YAML keys. A key containing arbitrary Python
+code will execute it. This test confirms the injection on HEAD via a
+sentinel env var tracked through os.getenv.
+"""
+
+import os
+
+import pyrogue as pr
+import rogue.interfaces.memory as rim
+
+
+class ArrayDevice(pr.Device):
+    """Device with a multi-value RemoteVariable to exercise the eval branch
+    in BaseVariable._setDict (requires nativeType == np.ndarray)."""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.RemoteVariable(
+            name='ArrVar',
+            offset=0x0,
+            bitSize=8,
+            base=pr.UInt,
+            mode='RW',
+            numValues=4,
+            valueBits=8,
+            valueStride=8,
+        ))
+
+
+class SetDictEvalRoot(pr.Root):
+    def __init__(self):
+        super().__init__(name='root', pollEn=False)
+        self._mem = rim.Emulate(4, 0x100)
+        self.addInterface(self._mem)
+        self.add(ArrayDevice(name='Dev', memBase=self._mem))
+
+
+def test_variable_setdict_eval_injection(monkeypatch):
+    """Verify that BaseVariable._setDict does NOT execute arbitrary code.
+
+    On HEAD, eval(f'[i for i in range(self._numValues())][{keys[0]}]')
+    executes user-controlled keys[0]. This test patches os.getenv to track
+    calls, then passes a key containing __import__('os').getenv('USER') to
+    _setDict. The assertion fires when the injection succeeds (os.getenv
+    was called), confirming the  eval injection bug.
+    """
+    original_getenv = os.getenv
+    getenv_calls = []
+
+    def tracking_getenv(key, *args, **kwargs):
+        getenv_calls.append(key)
+        return original_getenv(key, *args, **kwargs)
+
+    monkeypatch.setattr(os, 'getenv', tracking_getenv)
+
+    with SetDictEvalRoot() as root:
+        var = root.Dev.ArrVar
+        payload = "__import__('os').getenv('USER')"
+        try:
+            var._setDict(1, writeEach=False, modes=['RW'], keys=[payload])
+        except Exception:
+            pass  # TypeError from string-as-index is expected; side-effect is what matters
+
+    assert 'USER' not in getenv_calls, (
+        "eval() executed user-controlled code in BaseVariable._setDict; "
+        "expected slice-only parse but os.getenv('USER') was called via "
+        f"__import__('os').getenv('USER') expression. Calls: {getenv_calls}"
+    )

--- a/tests/core/test_datareceiver_mutable_default_audit_repro.py
+++ b/tests/core/test_datareceiver_mutable_default_audit_repro.py
@@ -1,0 +1,43 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   DataReceiver.__init__ has a mutable default argument
+#   `value=numpy.zeros(shape=1, dtype=numpy.uint8, order='C')` (line 44).
+#   The numpy array is created once at class-definition time.  All instances
+#   that do not supply an explicit `value` argument share the same backing
+#   array, so in-place mutation of the default in one instance leaks into
+#   every other instance.
+#   On HEAD `r1.Data.value() is r2.Data.value()` is True → mutation of the
+#   first instance's array is visible in the second → the assertion FAILS.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+
+def test_datareceiver_default_value_isolated():
+    """DataReceiver mutable numpy default bleeds mutation across instances."""
+    r1 = pr.DataReceiver(name='recv1')
+    r2 = pr.DataReceiver(name='recv2')
+
+    # Mutate the array that backs r1's Data variable in-place.
+    arr = r1.Data.value()
+    arr[0] = 42
+
+    # The mutation must NOT be visible through r2's Data variable.
+    r2_val = r2.Data.value()[0]
+
+    assert r2_val == 0, (
+        "DataReceiver mutable default leaked mutation across instances; "
+        "r2.Data.value()[0] == " + str(r2_val) + " (expected 0); "
+        "the numpy.zeros() array in the default argument is shared by all instances"
+    )

--- a/tests/core/test_device_hide_variables_audit_repro.py
+++ b/tests/core/test_device_hide_variables_audit_repro.py
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   Device.hideVariables() assigns `variables = self.variables.values()` when
+#   the caller passes `variables=None` (line 433).  The function then uses
+#   `isinstance(variables[0], str)` inside the loop (line 438).
+#   `dict_values` does not support integer indexing, so any code path that
+#   reaches that elif with a dict_values object raises TypeError.
+#   The test calls hideVariables with a list of string names (so the elif IS
+#   reached) but where the local `variables` was first set to dict_values via
+#   the None-default path.  A simpler, deterministic repro: assert that the
+#   source code does not subscript `variables` after it may have been set to
+#   a dict_values object.
+#   On HEAD `variables[0]` is present → assertion fails.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue as pr
+
+
+def test_hide_variables_dict_values_index():
+    """Device.hideVariables(None) must not TypeError on dict_values subscripting.
+
+    The original bug: ``variables = self.variables.values()`` when the caller
+    passes ``variables=None``, followed by an integer subscript such as
+    ``variables[0]``.  ``dict_values`` does not support integer indexing, so
+    the call raises TypeError on every Device with at least one BaseVariable.
+
+    Behavioural test: build a minimal Device with a single LocalVariable,
+    invoke hideVariables(True) with the default variables=None, and verify
+    that the call returns without raising.  A correct fix may either convert
+    to list before subscripting, restructure the type check to iterate, or
+    take any other shape that handles the dict_values default safely — the
+    fix shape is unconstrained.
+    """
+
+    class _ProbeDevice(pr.Device):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.add(pr.LocalVariable(
+                name='Probe',
+                value=0,
+                mode='RW',
+            ))
+
+    dev = _ProbeDevice(name='Probe')
+
+    dev.hideVariables(True)
+    assert dev.variables['Probe'].hidden is True
+
+    dev.hideVariables(False)
+    assert dev.variables['Probe'].hidden is False

--- a/tests/core/test_helper_functions_addlibrarypath_audit_repro.py
+++ b/tests/core/test_helper_functions_addlibrarypath_audit_repro.py
@@ -1,0 +1,39 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   addLibraryPath() in _HelperFunctions.py contains a duplicated
+#   `if base == '': base = '.'` block (lines 74-79): the same guard appears
+#   twice back-to-back with identical surrounding comments.  On HEAD the
+#   string `if base == '':` appears twice in lines 70-90, so the assertion
+#   below FAILS.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import inspect
+
+import pyrogue._HelperFunctions as hf
+
+
+def test_addlibrarypath_no_duplicate_blocks():
+    """addLibraryPath has a duplicated `if base == '':` block."""
+    src_lines = inspect.getsource(hf.addLibraryPath).splitlines()
+
+    # Count occurrences of the guarded assignment within the function source.
+    count = sum(
+        1 for line in src_lines
+        if "if base == '':" in line
+    )
+
+    assert count <= 1, (
+        "addLibraryPath has duplicated `if base == '':` block "
+        "(copy-paste artifact); found " + str(count) + " occurrences — expected at most 1"
+    )

--- a/tests/core/test_helper_functions_make_wrapper_audit_repros.py
+++ b/tests/core/test_helper_functions_make_wrapper_audit_repros.py
@@ -1,0 +1,70 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   functionWrapper() builds a lambda source string and calls eval(ls) without
+#   sanitising callArgs.  A caller who controls callArgs can inject arbitrary
+#   Python code into the lambda body via a crafted string entry.
+#   On HEAD both eval sites execute the injection and the sentinel env-var IS
+#   read, causing the FAIL assertions below to trigger.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pyrogue._HelperFunctions as hf
+
+
+# ---------------------------------------------------------------------------
+# None-function branch (line 451)
+# ---------------------------------------------------------------------------
+def test_function_wrapper_eval_injection(monkeypatch):
+    """functionWrapper eval(ls) executes injected code via callArgs (None branch)."""
+    monkeypatch.setenv("AUDIT_PYR_004_SENTINEL", "injected_004")
+
+    # The lambda string becomes:
+    #   lambda function, x: __import__('os').getenv('AUDIT_PYR_004_SENTINEL')  # : None
+    # The comment discards the original ": None" body; the lambda now returns
+    # the os.getenv result when called.
+    injected_arg = "x: __import__('os').getenv('AUDIT_PYR_004_SENTINEL')  # "
+    wrapper = hf.functionWrapper(None, [injected_arg])
+
+    # Call the wrapper; on HEAD it executes the injection.
+    outcome = wrapper(None, None)
+
+    assert outcome != "injected_004", (
+        "functionWrapper eval(ls) executed injected __import__/getenv "
+        "code via callArgs (None-function branch, line 451); "
+        "sentinel value was read"
+    )
+
+
+# ---------------------------------------------------------------------------
+# non-None function branch (line 468)
+# ---------------------------------------------------------------------------
+def test_function_wrapper_eval_injection_with_function(monkeypatch):
+    """functionWrapper eval(ls) executes injected code via callArgs (function branch)."""
+    monkeypatch.setenv("AUDIT_PYR_005_SENTINEL", "injected_005")
+
+    def real_func():
+        return "safe"
+
+    # With a real function the lambda string becomes:
+    #   lambda function, x: __import__('os').getenv('AUDIT_PYR_005_SENTINEL')  # : function()
+    # Again the comment hides the intended body.
+    injected_arg = "x: __import__('os').getenv('AUDIT_PYR_005_SENTINEL')  # "
+    wrapper = hf.functionWrapper(real_func, [injected_arg])
+
+    outcome = wrapper(real_func, None)
+
+    assert outcome != "injected_005", (
+        "functionWrapper eval(ls) executed injected __import__/getenv "
+        "code via callArgs (non-None function branch, line 468); "
+        "sentinel value was read"
+    )

--- a/tests/core/test_helper_functions_yaml_safety_audit_repros.py
+++ b/tests/core/test_helper_functions_yaml_safety_audit_repros.py
@@ -1,0 +1,78 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression tests.
+#   Each test calls a yamlToData entry-point with a malicious YAML payload
+#   that uses !!python/object/apply to invoke os.getenv.  Because
+#   PyrogueLoader extends yaml.Loader (a full Loader), the tag executes on
+#   HEAD, reads a known sentinel env-var, and the test FAILS with the
+#   expected assertion message.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import zipfile
+
+import pytest
+import yaml
+
+import pyrogue._HelperFunctions as hf
+
+
+# ---------------------------------------------------------------------------
+# string-input path (yamlToData(stream=...), line 261)
+# ---------------------------------------------------------------------------
+def test_yaml_loader_string_path_unsafe(monkeypatch):
+    """PyrogueLoader must reject !!python/object/apply on string input.
+
+    The unsafe tag must surface as a yaml.constructor.ConstructorError so
+    callers (Root.loadYaml -> _setDictRoot, yamlUpdate -> dictUpdate) see
+    the parse failure directly instead of receiving a None sentinel that
+    crashes later in unrelated code with a confusing AttributeError.
+    """
+    monkeypatch.setenv("AUDIT_PYR_001_SENTINEL", "compromised_001")
+
+    malicious = "!!python/object/apply:os.getenv ['AUDIT_PYR_001_SENTINEL']"
+    with pytest.raises(yaml.constructor.ConstructorError):
+        hf.yamlToData(stream=malicious)
+
+
+# ---------------------------------------------------------------------------
+# zip-archive branch (yamlToData(fName='...zip/sub'), line 272)
+# ---------------------------------------------------------------------------
+def test_yaml_loader_zip_branch_unsafe(monkeypatch, tmp_path):
+    """PyrogueLoader must reject !!python/object/apply on the zip branch."""
+    monkeypatch.setenv("AUDIT_PYR_002_SENTINEL", "compromised_002")
+
+    malicious = "!!python/object/apply:os.getenv ['AUDIT_PYR_002_SENTINEL']"
+    zip_path = tmp_path / "payload.zip"
+    inner = "config.yaml"
+
+    with zipfile.ZipFile(str(zip_path), "w", compression=zipfile.ZIP_LZMA) as zf:
+        zf.writestr(inner, malicious)
+
+    fname = str(zip_path) + "/" + inner
+    with pytest.raises(yaml.constructor.ConstructorError):
+        hf.yamlToData(fName=fname)
+
+
+# ---------------------------------------------------------------------------
+# plain-file branch (yamlToData(fName='...yaml'), line 278)
+# ---------------------------------------------------------------------------
+def test_yaml_loader_file_branch_unsafe(monkeypatch, tmp_path):
+    """PyrogueLoader must reject !!python/object/apply on the plain-file branch."""
+    monkeypatch.setenv("AUDIT_PYR_003_SENTINEL", "compromised_003")
+
+    malicious = "!!python/object/apply:os.getenv ['AUDIT_PYR_003_SENTINEL']"
+    yaml_file = tmp_path / "payload.yaml"
+    yaml_file.write_text(malicious)
+
+    with pytest.raises(yaml.constructor.ConstructorError):
+        hf.yamlToData(fName=str(yaml_file))

--- a/tests/core/test_main_cli_audit_repro.py
+++ b/tests/core/test_main_cli_audit_repro.py
@@ -1,0 +1,61 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   pyrogue/__main__.py lines 122-137: the dispatch block handles
+#   get/value/set/exec but has no `else: ret = None` guard before the
+#   trailing `if ret is not None: print(...)` at line 139.
+#   If a future branch is added that does not set `ret`, or if the argparse
+#   `choices` guard is ever relaxed, the `print` at line 139 will raise
+#   UnboundLocalError.  On HEAD no else-guard → assertion FAILS.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pathlib
+
+
+def test_main_cli_else_initializes_ret():
+    """__main__.py CLI dispatch lacks else: ret = None guard."""
+    main_path = pathlib.Path(__file__).parent.parent.parent / "python" / "pyrogue" / "__main__.py"
+    src = main_path.read_text()
+
+    # Walk the top-level else: block (the `else:` of the if/elif chain at
+    # lines 67-138).  Inside it, look for an if/elif chain that dispatches
+    # on args.cmd and check that an else clause exists that assigns `ret`.
+    # This is most reliably checked by verifying the source text pattern.
+
+    # Strategy: find the text block from "else:" (the outer else) down to
+    # "if ret is not None:" and check that an "else:" setting ret=None is
+    # present within it.
+    outer_else_start = src.find("# All Other Commands\nelse:")
+    ret_check_start = src.find("if ret is not None:")
+
+    if outer_else_start == -1 or ret_check_start == -1:
+        raise AssertionError(
+            "Could not locate dispatch block or `if ret is not None:` "
+            "in __main__.py — file structure may have changed"
+        )
+
+    dispatch_block = src[outer_else_start:ret_check_start]
+
+    # Look for an else clause that initialises ret
+    has_else_ret = (
+        "else:\n        ret = None" in dispatch_block
+        or "else:\n            ret = None" in dispatch_block
+        or "else: ret = None" in dispatch_block
+    )
+
+    assert has_else_ret, (
+        "__main__.py CLI dispatch block (lines 114-138) has no "
+        "`else: ret = None` guard before `if ret is not None: print(...)`; "
+        "any unrecognised cmd value or future branch that omits `ret =...` "
+        "will raise UnboundLocalError at line 139"
+    )

--- a/tests/core/test_min_python_audit_repro.py
+++ b/tests/core/test_min_python_audit_repro.py
@@ -1,0 +1,50 @@
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+# Description:
+#   Regression test.
+#   pyrogue/__init__.py sets MIN_PYTHON = (3, 6) while CI and conda builds
+#   only support Python 3.10-3.13; CPython 3.6 reached EOL December 2021.
+#   Setting a 3.6 minimum allows users to install on unsupported interpreters
+#   that lack f-strings, walrus operators, and many stdlib improvements used
+#   throughout pyrogue.  On HEAD MIN_PYTHON = (3, 6) → assertion FAILS.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import inspect
+
+import pyrogue
+
+
+def test_min_python_at_least_310():
+    """MIN_PYTHON = (3, 6) but conda matrix is 3.10-3.13; 3.6 EOL Dec 2021."""
+    min_py = pyrogue.MIN_PYTHON
+
+    assert min_py >= (3, 10), (
+        "MIN_PYTHON = " + str(min_py) + " but conda build matrix "
+        "targets 3.10-3.13 and CPython 3.6 reached end-of-life December 2021; "
+        "the minimum version should be updated to at least (3, 10)"
+    )
+
+
+def test_min_python_gate_raises_import_error():
+    """The version gate must raise ImportError so consumers that catch
+    ImportError for optional dependencies (the PR-described behavior
+    change for the floor bump) get the right exception type at
+    ``import pyrogue``.  A plain ``Exception`` is too broad and bypasses
+    the standard optional-dependency catch pattern.
+    """
+    src = inspect.getsource(pyrogue)
+
+    assert "raise ImportError(" in src, (
+        "pyrogue/__init__.py version gate must raise ImportError, not a "
+        "generic Exception, so callers using ``except ImportError:`` for "
+        "optional pyrogue dependencies see the documented behavior change"
+    )

--- a/tests/cpp/memory/CMakeLists.txt
+++ b/tests/cpp/memory/CMakeLists.txt
@@ -21,3 +21,63 @@ rogue_add_cpp_test(rogue-cpp-memory-variable
       cpp-core
       no-python
 )
+
+rogue_add_cpp_test(rogue-cpp-memory-block-alloc-failure-audit-repro
+   SOURCES
+      test_block_alloc_failure_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-block-alloc-failure-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-memory-block-setbytes-byte-reverse-audit-repro
+   SOURCES
+      test_block_setbytes_byte_reverse_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-block-setbytes-byte-reverse-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-memory-variable-alloc-failure-audit-repro
+   SOURCES
+      test_variable_alloc_failure_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-variable-alloc-failure-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-memory-emulate-null-alloc-audit-repro
+   SOURCES
+      test_emulate_null_alloc_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-emulate-null-alloc-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-memory-block-vla-audit-repro
+   SOURCES
+      test_block_vla_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-block-vla-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")
+
+rogue_add_cpp_test(rogue-cpp-memory-block-numeric-edge-cases-audit-repro
+   SOURCES
+      test_block_numeric_edge_cases_audit_repro.cpp
+   LABELS
+      cpp-core
+      no-python
+)
+target_compile_definitions(rogue-cpp-memory-block-numeric-edge-cases-audit-repro
+   PRIVATE ROGUE_SRC_DIR="${CMAKE_SOURCE_DIR}")

--- a/tests/cpp/memory/test_block_alloc_failure_audit_repro.cpp
+++ b/tests/cpp/memory/test_block_alloc_failure_audit_repro.cpp
@@ -1,0 +1,72 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Block ctor 5x malloc with no exception-safe
+ * cleanup.  If any of the five malloc calls returns NULL and throws, the
+ * earlier allocated buffers are leaked because the Block dtor only runs
+ * free() on members whose pointers were successfully initialised.
+ *
+ * Source-text invariant test: reads Block.cpp and asserts a structural
+ * property that the fixed code must satisfy.  On HEAD the fix is absent.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("Block ctor 5x malloc partial-allocation leak") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    // The structural invariant: the five consecutive malloc calls in the ctor
+    // must be wrapped in a try/catch or use RAII (std::vector / unique_ptr).
+    // Locate the ctor region via the sentinel "verifyBase_ = 0;" which appears
+    // just before the five malloc calls.
+    const std::string sentinel = "verifyBase_ = 0;";
+    const std::size_t pos = src.find(sentinel);
+    REQUIRE_MESSAGE(pos != std::string::npos,
+                    "Could not locate Block ctor sentinel in Block.cpp");
+
+    // Extract the next 800 bytes covering all 5 malloc calls
+    const std::string window = src.substr(pos, 800);
+
+    // FIXED state: malloc calls replaced with std::vector or unique_ptr
+    // (so "malloc(" does not appear in the ctor), OR the malloc block is
+    // wrapped in try/catch.
+    const bool hasMalloc    = (window.find("malloc(") != std::string::npos);
+    const bool hasTryCatch  = (window.find("try {") != std::string::npos ||
+                                window.find("try{") != std::string::npos);
+    const bool isFixed      = !hasMalloc || hasTryCatch;
+
+    CHECK_MESSAGE(isFixed,
+                  "Block ctor 5x malloc; partial-allocation throw "
+                  "leaks earlier buffers (no RAII / no try-catch wrapper "
+                  "around the 5 successive malloc calls)");
+}

--- a/tests/cpp/memory/test_block_numeric_edge_cases_audit_repro.cpp
+++ b/tests/cpp/memory/test_block_numeric_edge_cases_audit_repro.cpp
@@ -1,0 +1,125 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for numeric edge-case UB in Block floating-point/fixed-point
+ * conversion methods:
+ *   setFloat8 lacks an explicit NaN/Inf early-return guard
+ *   setFixed intermediate round() result can be +INF before
+ *             static_cast<int64_t> -> UB
+ *   setUFixed same root cause as  for unsigned path
+ *
+ * Each TEST_CASE is a source-text invariant check on Block.cpp.
+ * On HEAD the guards are absent -> CHECK_MESSAGE fires.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+// Extract the source region for a named function body.
+// Finds the function header and returns the next 'windowBytes' characters.
+static std::string functionRegion(const std::string& src,
+                                  const std::string& funcName,
+                                  std::size_t windowBytes = 1000) {
+    const std::size_t pos = src.find(funcName);
+    if (pos == std::string::npos) return std::string();
+    return src.substr(pos, windowBytes);
+}
+
+TEST_CASE("setFloat8 lacks NaN/Inf early-return guard") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    // The setFloat8 function (not the Python wrapper) begins at the
+    // "void rim::Block::setFloat8(const float& val," declaration.
+    const std::string region = functionRegion(
+        src, "void rim::Block::setFloat8(const float&");
+    REQUIRE_MESSAGE(!region.empty(),
+                    "Could not locate setFloat8 implementation in Block.cpp");
+
+    // FIXED state: an isnan/isinf/isfinite guard before the conversion.
+    const bool hasGuard = (
+        region.find("isnan(") != std::string::npos  ||
+        region.find("isinf(") != std::string::npos  ||
+        region.find("isfinite(") != std::string::npos ||
+        region.find("std::isnan") != std::string::npos ||
+        region.find("std::isinf") != std::string::npos ||
+        region.find("std::isfinite") != std::string::npos);
+    CHECK_MESSAGE(hasGuard,
+                  "Block::setFloat8 lacks explicit NaN/Inf early-"
+                  "return guard; NaN/Inf inputs silently produce wrong E4M3 "
+                  "encoding without alerting the caller");
+}
+
+TEST_CASE("setFixed round() -> static_cast<int64_t> UB for +INF") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    const std::string region = functionRegion(
+        src, "void rim::Block::setFixed(const double&");
+    REQUIRE_MESSAGE(!region.empty(),
+                    "Could not locate setFixed implementation in Block.cpp");
+
+    // FIXED state: an isfinite/isinf guard before the round() -> cast step.
+    const bool hasGuard = (
+        region.find("isfinite(") != std::string::npos  ||
+        region.find("isinf(") != std::string::npos     ||
+        region.find("isnan(") != std::string::npos     ||
+        region.find("std::isfinite") != std::string::npos ||
+        region.find("std::isinf") != std::string::npos);
+    CHECK_MESSAGE(hasGuard,
+                  "Block::setFixed round(val*pow(2,binPoint_)) can "
+                  "produce +INF before static_cast<int64_t> -> UB; needs "
+                  "std::isfinite guard before the round/cast step");
+}
+
+TEST_CASE("setUFixed round() -> static_cast<uint64_t> UB") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    const std::string region = functionRegion(
+        src, "void rim::Block::setUFixed(const double&");
+    REQUIRE_MESSAGE(!region.empty(),
+                    "Could not locate setUFixed implementation in Block.cpp");
+
+    // FIXED state: an isfinite/isinf guard before the round() -> cast step.
+    const bool hasGuard = (
+        region.find("isfinite(") != std::string::npos  ||
+        region.find("isinf(") != std::string::npos     ||
+        region.find("isnan(") != std::string::npos     ||
+        region.find("std::isfinite") != std::string::npos ||
+        region.find("std::isinf") != std::string::npos);
+    CHECK_MESSAGE(hasGuard,
+                  "Block::setUFixed round(val*pow(2,binPoint_)) "
+                  "can produce +INF before static_cast<uint64_t> -> UB; needs "
+                  "std::isfinite guard before the round/cast step");
+}

--- a/tests/cpp/memory/test_block_setbytes_byte_reverse_audit_repro.cpp
+++ b/tests/cpp/memory/test_block_setbytes_byte_reverse_audit_repro.cpp
@@ -1,0 +1,66 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Block::setBytes byte-reversed path allocates buff
+ * with malloc and has three distinct free() exit paths; a future code-path
+ * addition can easily miss the free, leaking the buffer.
+ *
+ * Source-text invariant test: reads Block.cpp and asserts the byte-reverse
+ * path uses RAII (unique_ptr / vector) rather than raw malloc+free.
+ * On HEAD the fix is absent -> CHECK_MESSAGE fires.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("setBytes byte-reverse path 3 distinct free() exit paths") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    // The byte-reverse malloc site is near: "buff =... malloc(var->valueBytes_)"
+    // (around line 666).  Locate it via the unique sentinel.
+    const std::string sentinel = "var->valueBytes_))";
+    const std::size_t pos = src.find(sentinel);
+    REQUIRE_MESSAGE(pos != std::string::npos,
+                    "Could not locate byte-reverse malloc sentinel in Block.cpp");
+
+    // Extract the surrounding 2000 bytes covering the setBytes body
+    const std::size_t startPos = (pos > 200) ? (pos - 200) : 0;
+    const std::string window = src.substr(startPos, 2000);
+
+    // FIXED state: the byte-reverse buff is managed by RAII (unique_ptr or
+    // std::vector), so raw "free(buff)" does not appear in this region.
+    const bool hasRawFree = (window.find("free(buff)") != std::string::npos);
+    CHECK_MESSAGE(!hasRawFree,
+                  "setBytes byte-reverse has 3 distinct free() exit "
+                  "paths; future addition can skip the free and leak the buffer; "
+                  "should use std::unique_ptr<uint8_t[]> for RAII cleanup");
+}

--- a/tests/cpp/memory/test_block_vla_audit_repro.cpp
+++ b/tests/cpp/memory/test_block_vla_audit_repro.cpp
@@ -1,0 +1,55 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Block::addVariables uses a C99-style variable-
+ * length array "uint8_t excMask[size_]" on the stack.  VLAs are a C++
+ * extension (non-standard C++14), can overflow the stack for large blocks,
+ * and are forbidden by the project's C++14 standard constraint.
+ *
+ * Source-text invariant test: reads Block.cpp and asserts the VLA pattern
+ * does NOT appear.  On HEAD it does -> CHECK_MESSAGE fires.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("Block::addVariables uses VLA uint8_t excMask[size_]") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Block.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Block.cpp");
+
+    // The VLA pattern appears as: uint8_t excMask[size_]
+    // This is non-standard C++14; GCC/Clang accept it as an extension.
+    const bool hasVla = (src.find("uint8_t excMask[size_]") != std::string::npos);
+    CHECK_MESSAGE(!hasVla,
+                  "Block::addVariables uses VLA "
+                  "uint8_t excMask[size_] (non-standard C++14); should use "
+                  "std::vector<uint8_t> excMask(size_, 0) instead");
+}

--- a/tests/cpp/memory/test_emulate_null_alloc_audit_repro.cpp
+++ b/tests/cpp/memory/test_emulate_null_alloc_audit_repro.cpp
@@ -1,0 +1,98 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Emulate::doTransaction calls malloc(0x1000)
+ * without checking for NULL; a NULL return would silently insert a NULL
+ * pointer into memMap_, causing a subsequent memcpy crash.
+ *
+ * Source-text invariant test: reads Emulate.cpp and asserts the malloc
+ * result is checked for NULL (or replaced with RAII) before the pointer
+ * is inserted into memMap_.  On HEAD the check is absent.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("Emulate::doTransaction malloc(0x1000) without NULL check") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Emulate.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Emulate.cpp");
+
+    // Two acceptable fix shapes for the original bug (silent NULL insert
+    // into memMap_ followed by a memcpy crash):
+    //   (a) malloc(0x1000) with an explicit NULL/nullptr guard before insert
+    //   (b) RAII allocation (std::make_unique / new uint8_t[] held by a
+    //       unique_ptr) which throws std::bad_alloc instead of returning NULL
+    //
+    // The window is scoped near whichever allocation form is present so the
+    // check actually exercises the page-allocation site, not unrelated
+    // allocations elsewhere in the file.
+    const std::size_t mallocPos    = src.find("malloc(0x1000)");
+    const std::size_t makeUniquePos = src.find("std::make_unique<uint8_t[]>(0x1000)");
+    const std::size_t newArrayPos  = src.find("new uint8_t[0x1000]");
+
+    const bool hasMalloc     = (mallocPos    != std::string::npos);
+    const bool hasMakeUnique = (makeUniquePos != std::string::npos);
+    const bool hasNewArray   = (newArrayPos  != std::string::npos);
+    const bool hasAnyAlloc   = hasMalloc || hasMakeUnique || hasNewArray;
+
+    REQUIRE_MESSAGE(hasAnyAlloc,
+        "Emulate.cpp no longer contains a recognisable 4k page allocation "
+        "(malloc(0x1000), std::make_unique<uint8_t[]>(0x1000), or "
+        "new uint8_t[0x1000]); update this regression test to track the new form");
+
+    bool guardOk = false;
+    if (hasMalloc) {
+        // For raw malloc the NULL check must appear before the memMap_.insert
+        // that follows the allocation.  Bound the search to a small window so a
+        // far-away nullptr token in an unrelated function cannot satisfy it.
+        const std::string window = src.substr(mallocPos, 400);
+        guardOk = (
+            window.find("== NULL")    != std::string::npos ||
+            window.find("!= NULL")    != std::string::npos ||
+            window.find("== nullptr") != std::string::npos ||
+            window.find("!= nullptr") != std::string::npos);
+    } else {
+        // RAII allocations (make_unique / new uint8_t[] under unique_ptr) throw
+        // bad_alloc on failure rather than returning NULL, so the silent-NULL
+        // failure mode the original bug describes cannot occur.  We still
+        // require unique_ptr ownership at the allocation site so a bare
+        // "new uint8_t[...]" leak is not accepted as a fix.
+        const std::size_t pos    = hasMakeUnique ? makeUniquePos : newArrayPos;
+        const std::string window = src.substr(pos, 400);
+        guardOk = hasMakeUnique ||
+            (window.find("unique_ptr") != std::string::npos);
+    }
+
+    CHECK_MESSAGE(guardOk,
+                  "Emulate::doTransaction page allocation result is inserted "
+                  "into memMap_ without a NULL/exception-safe guard; a NULL "
+                  "page pointer would crash on the subsequent memcpy call");
+}

--- a/tests/cpp/memory/test_variable_alloc_failure_audit_repro.cpp
+++ b/tests/cpp/memory/test_variable_alloc_failure_audit_repro.cpp
@@ -1,0 +1,66 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression tests for Variable ctor allocates lowTranByte_,
+ * highTranByte_, and optionally fastByte_ with malloc; if the second or
+ * third malloc fails, earlier allocations are silently leaked because the
+ * Variable dtor only frees non-NULL members.
+ *
+ * Source-text invariant test: reads Variable.cpp and asserts the ctor uses
+ * RAII (unique_ptr / vector) rather than raw malloc.  On HEAD the fix is
+ * absent -> CHECK_MESSAGE fires.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include <stdint.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "doctest/doctest.h"
+
+#ifndef ROGUE_SRC_DIR
+    #define ROGUE_SRC_DIR "."
+#endif
+
+static std::string readFile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) return std::string();
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+TEST_CASE("Variable ctor 3x malloc partial-leak on second/third NULL") {
+    const std::string src = readFile(
+        ROGUE_SRC_DIR "/src/rogue/interfaces/memory/Variable.cpp");
+    REQUIRE_MESSAGE(!src.empty(), "Could not read Variable.cpp");
+
+    // Locate the ctor region via the sentinel "lowTranByte_" which is the
+    // first of the three malloc'd members (around line 180).
+    const std::string sentinel = "lowTranByte_";
+    const std::size_t pos = src.find(sentinel);
+    REQUIRE_MESSAGE(pos != std::string::npos,
+                    "Could not locate lowTranByte_ sentinel in Variable.cpp");
+
+    // Extract the next 1200 bytes covering all three malloc calls
+    const std::string window = src.substr(pos, 1200);
+
+    // FIXED state: malloc calls replaced with std::unique_ptr or std::vector,
+    // so raw "malloc(" does not appear in this region of the ctor.
+    const bool hasMalloc = (window.find("malloc(") != std::string::npos);
+    CHECK_MESSAGE(!hasMalloc,
+                  "Variable ctor 3x malloc; partial-leak on second/"
+                  "third NULL return; should use std::unique_ptr or "
+                  "std::vector to guarantee exception-safe cleanup");
+}


### PR DESCRIPTION
## Summary

Slice of #1196 (`general-bug-audit-clean`) containing the **pyrogue-core** subset of the bug-audit fixes — split out so the diff is small enough to review in one sitting.

#1196 will be closed once all slices are open. The original branch retains the per-bug atomic commit history; this PR squashes the file-state for the listed paths.

## Files in this slice

- `docs/src/installing/build.rst`
- `python/pyrogue/_Block.py`
- `python/pyrogue/_DataReceiver.py`
- `python/pyrogue/_Device.py`
- `python/pyrogue/_HelperFunctions.py`
- `python/pyrogue/_Logging.py`
- `python/pyrogue/_Node.py`
- `python/pyrogue/_PollQueue.py`
- `python/pyrogue/_Root.py`
- `python/pyrogue/_Variable.py`
- `python/pyrogue/__init__.py`
- `python/pyrogue/__main__.py`
- `src/rogue/interfaces/memory/Block.cpp`
- `src/rogue/interfaces/memory/Emulate.cpp`
- `src/rogue/interfaces/memory/Variable.cpp`
- `tests/core/test_block_setpyfunc_release_audit_repro.py`
- `tests/core/test_core_block_numpy_array_equal_audit_repro.py`
- `tests/core/test_core_node_eval_audit_repro.py`
- `tests/core/test_core_poll_queue_shutdown_audit_repro.py`
- `tests/core/test_core_root_audit_repros.py`
- `tests/core/test_core_variable_setdict_eval_audit_repro.py`
- `tests/core/test_datareceiver_mutable_default_audit_repro.py`
- `tests/core/test_device_hide_variables_audit_repro.py`
- `tests/core/test_helper_functions_addlibrarypath_audit_repro.py`
- `tests/core/test_helper_functions_make_wrapper_audit_repros.py`
- `tests/core/test_helper_functions_yaml_safety_audit_repros.py`
- `tests/core/test_main_cli_audit_repro.py`
- `tests/core/test_min_python_audit_repro.py`
- `tests/cpp/memory/CMakeLists.txt`
- `tests/cpp/memory/test_block_alloc_failure_audit_repro.cpp`
- `tests/cpp/memory/test_block_numeric_edge_cases_audit_repro.cpp`
- `tests/cpp/memory/test_block_setbytes_byte_reverse_audit_repro.cpp`
- `tests/cpp/memory/test_block_vla_audit_repro.cpp`
- `tests/cpp/memory/test_emulate_null_alloc_audit_repro.cpp`
- `tests/cpp/memory/test_variable_alloc_failure_audit_repro.cpp`

## Verification

- Lint: `./scripts/run_linters.sh`
- C++ tests: `cmake -DROGUE_BUILD_TESTS=ON -B build && cmake --build build && ctest --test-dir build`
- Python tests: `pytest tests/`
