### PR TITLE
fix(zmq): guard ZmqServer._updateList against concurrent mutation (ESROGUE-711)

### DIFF
--- a/python/pyrogue/interfaces/_ZmqServer.py
+++ b/python/pyrogue/interfaces/_ZmqServer.py
@@ -16,6 +16,7 @@
 import rogue.interfaces
 import pickle
 import json
+import threading
 from typing import Any
 
 
@@ -48,8 +49,9 @@ class ZmqServer(rogue.interfaces.ZmqServer):
         rogue.interfaces.ZmqServer.__init__(self,addr,port)
         self._root = root
         self._addr = addr
-        self._root.addVarListener(func=self._varUpdate, done=self._varDone, incGroups=incGroups, excGroups=excGroups)
         self._updateList = {}
+        self._updateLock = threading.Lock()
+        self._root.addVarListener(func=self._varUpdate, done=self._varDone, incGroups=incGroups, excGroups=excGroups)
 
     @property
     def address(self) -> str:
@@ -106,13 +108,17 @@ class ZmqServer(rogue.interfaces.ZmqServer):
 
     def _varUpdate(self, path: str, value: Any) -> None:
         """Queue a variable update for batching."""
-        self._updateList[path] = value
+        with self._updateLock:
+            self._updateList[path] = value
 
     def _varDone(self) -> None:
         """Flush queued variable updates to subscribers."""
-        if len(self._updateList) > 0:
-            self._publish(pickle.dumps(self._updateList))
+        with self._updateLock:
+            if not self._updateList:
+                return
+            snapshot = self._updateList
             self._updateList = {}
+        self._publish(pickle.dumps(snapshot))
 
     def _start(self) -> None:
         """Start the ZMQ server and print connection info."""

--- a/tests/interfaces/test_zmq_server_update_race.py
+++ b/tests/interfaces/test_zmq_server_update_race.py
@@ -9,15 +9,32 @@
 #-----------------------------------------------------------------------------
 """Thread-safety tests for ZmqServer._updateList dictionary.
 
-_varUpdate() and _varDone() access _updateList without synchronization.
-If user code or multiple Root instances invoke these callbacks from
-different threads, concurrent access can corrupt the dictionary.
+_varUpdate() and _varDone() access _updateList without synchronization
+prior to the ESROGUE-711 fix. If user code or multiple Root instances
+invoke these callbacks from different threads, concurrent access can
+corrupt the dictionary or raise "dictionary changed size during
+iteration" during pickle.dumps.
 """
 import threading
 import time
 
 import pyrogue as pr
 import pyrogue.interfaces
+
+
+class _SlowPickleValue:
+    """Value whose pickle blocks in __reduce__, releasing the GIL.
+
+    Reproduces the matplotlib-transforms scenario from the original JIRA
+    report (ESROGUE-711): a value whose serialization is slow enough that
+    a concurrent _varUpdate() can mutate _updateList mid-pickle and raise
+    "RuntimeError: dictionary changed size during iteration".
+    """
+    delay_s = 0.2
+
+    def __reduce__(self):
+        time.sleep(self.delay_s)
+        return (self.__class__, ())
 
 
 class ZmqTestRoot(pr.Root):
@@ -103,3 +120,56 @@ def test_zmq_server_update_list_direct_race():
             assert not t.is_alive(), "update_caller thread hung"
 
     assert not errors, f"Errors: {errors}"
+
+
+def test_zmq_server_varDone_race_with_slow_pickle():
+    """Deterministic ESROGUE-711 reproducer.
+
+    Seed _updateList with a slow-pickling value and have a second thread
+    call _varUpdate() while _varDone() is mid-pickle. Without the
+    snapshot-and-swap fix this raises:
+        RuntimeError: dictionary changed size during iteration
+    """
+    errors = []
+
+    with ZmqTestRoot() as root:
+        zmq_server = pyrogue.interfaces.ZmqServer(root=root, addr='127.0.0.1', port=0)
+
+        # Seed extra entries so pickle iteration has time to start before
+        # hitting the slow value.
+        for i in range(10):
+            zmq_server._updateList[f'Root.Pre{i}'] = i
+        zmq_server._updateList['Root.Slow'] = _SlowPickleValue()
+
+        mutator_started = threading.Event()
+
+        def mutator():
+            mutator_started.wait(timeout=2)
+            try:
+                # Insert during _varDone's pickle iteration. The slow value
+                # holds pickle for ~0.2 s with the GIL released, giving this
+                # thread ample time to mutate _updateList.
+                for i in range(50):
+                    zmq_server._varUpdate(f'Root.Late{i}', i)
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(('mutator', e))
+
+        t = threading.Thread(target=mutator, daemon=True)
+        t.start()
+
+        mutator_started.set()
+        try:
+            zmq_server._varDone()
+        except Exception as e:
+            errors.append(('main', e))
+
+        t.join(timeout=10)
+        assert not t.is_alive(), "mutator thread hung"
+
+    runtime_errors = [e for tag, e in errors if isinstance(e, RuntimeError)]
+    assert not runtime_errors, (
+        f"ESROGUE-711 race triggered: {runtime_errors}. "
+        f"_varDone must snapshot _updateList under a lock before serializing."
+    )
+    assert not errors, f"Unexpected errors: {errors}"


### PR DESCRIPTION
## Summary

`ZmqServer._varDone()` iterated `_updateList` via `pickle.dumps` without synchronization. When a value's `__getstate__` released the GIL (matplotlib transforms during `SaveState`/`SaveConfig` was the reported case), `Root._updateWorker` could call `_varUpdate()` concurrently and mutate the dict mid-iteration, raising:

```
RuntimeError: dictionary changed size during iteration
  File "pyrogue/interfaces/_ZmqServer.py", line 114, in _varDone
    self._publish(pickle.dumps(self._updateList))
```

### Fix

- Wrap `_varUpdate` / `_varDone` in a `threading.Lock` and **snapshot-and-swap** the pending dict before `pickle.dumps`, so the slow serializer iterates a private reference no other thread can reach.
- The lock is released **before** `pickle.dumps` and `_publish` run. Holding it across `_publish` would risk deadlock — `ZmqServer::_publish` calls `rogue::GilRelease` and pickle of complex values can be arbitrarily slow.
- Initialize lock and dict **before** `addVarListener` so the worker thread cannot fire callbacks against uninitialized state (latent bug fixed in passing).

### Why `stream.Variable` is not changed

The same dict-mutate-during-serialize pattern exists in `pyrogue.interfaces.stream.Variable._varDone` (uses `pyrogue.dataToYaml` instead of `pickle.dumps`), but is **not exploitable**: PyYAML's `represent_mapping` calls `list(mapping.items())` before iterating, atomically snapshotting the dict. Left untouched per surgical-fix policy.

## Test coverage

The existing tests in `test_zmq_server_update_race.py` (added in #1191) used trivial integer values whose pickle is too fast to leave a meaningful race window — they passed 5/5 runs even on unpatched code.

This PR adds `test_zmq_server_varDone_race_with_slow_pickle`: a deterministic reproducer that uses a `_SlowPickleValue` whose `__reduce__` calls `time.sleep(0.2)`, mirroring the matplotlib-transforms scenario from the JIRA report.