### PR TITLE
fix(zmq): raise from VirtualClient bootstrap + liveness guard + ZmqClient::send errno (#1234)

### DIFF
--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -428,10 +428,14 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             If the bootstrap ``__ROOT__`` handshake fails within the window
             defined by ``ROGUE_VIRTUAL_CONNECT_TIMEOUT`` (default 5 s).
             Causes include the server process not running, an address/port
-            mismatch, or ports blocked by firewall. The underlying handshake
-            exception is preserved on the raised error's ``__cause__``.
-            Sockets and the ZMQ context are torn down before the raise, so
-            no partially-initialised instance is left in the singleton cache.
+            mismatch, or ports blocked by firewall. The handshake failure
+            is preserved via standard exception chaining: the immediate
+            ``__cause__`` is the wrapping ``Exception`` raised by
+            ``_remoteAttr``, and its own ``__cause__`` is the underlying
+            transport error (typically a ``rogue.GeneralError`` from
+            ``ZmqClient::send``). Sockets and the ZMQ context are torn
+            down before the raise, so no partially-initialised instance
+            is left in the singleton cache.
         """
         if getattr(self, "_vcInitialized", False):
             if linkTimeout is not None or requestStallTimeout is not None:
@@ -706,7 +710,11 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             self._requestDone(True)
         except Exception as e:
             self._requestDone(False)
-            raise Exception(f"ZMQ Interface Exception: {e}")
+            # Chain explicitly so the underlying transport error (e.g. the
+            # rogue.GeneralError from ZmqClient::send) is reachable via the
+            # standard __cause__ chain from any wrapping exception higher up
+            # the stack (notably the ConnectionError raised by __init__).
+            raise Exception(f"ZMQ Interface Exception: {e}") from e
 
         if isinstance(ret,Exception):
             raise ret

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -686,7 +686,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
                 mon(notify_link)
 
 
-    def _remoteAttr(self, path: str, attr: str, *args: Any, **kwargs: Any) -> Any:
+    def _remoteAttr(self, path: str, attr: str | None, *args: Any, **kwargs: Any) -> Any:
         """Invoke a remote attribute on the server."""
         # Liveness guard: fail fast on a dead instance (stop() was called or
         # a prior init failed). Without this guard the call slips through to

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -421,6 +421,17 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             treats it as stalled. ``None`` or non-positive values disable this
             policy. In practice this is usually left disabled unless a system
             has a known upper bound for valid request duration.
+
+        Raises
+        ------
+        ConnectionError
+            If the bootstrap ``__ROOT__`` handshake fails within the window
+            defined by ``ROGUE_VIRTUAL_CONNECT_TIMEOUT`` (default 5 s).
+            Causes include the server process not running, an address/port
+            mismatch, or ports blocked by firewall. The underlying handshake
+            exception is preserved on the raised error's ``__cause__``.
+            Sockets and the ZMQ context are torn down before the raise, so
+            no partially-initialised instance is left in the singleton cache.
         """
         if getattr(self, "_vcInitialized", False):
             if linkTimeout is not None or requestStallTimeout is not None:
@@ -464,19 +475,20 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
         try:
             self._root = self._waitForRoot()
-        except Exception:
+        except Exception as exc:
+            # Tear down sockets/context before raising so the caller cannot
+            # inadvertently use a half-initialised instance. Pre-fix this
+            # path printed the banner and returned normally, leaving the
+            # caller with a dead VirtualClient whose first _remoteAttr
+            # crashed in ZmqClient::send (issue #1234).
             self._cleanupFailedInit()
-            error_message = (
-                f"\n\nFailed to connect to {addr}:{port}!\n\n"
-                "Possible causes for the issue:\n"
-                "- ZeroMQ Server not included in the root class\n"
-                "- Root process not running\n"
-                "- Mismatch between Client address and Server address\n"
-                "- Mismatch between Client port and Server port\n"
-                "- Server ports being blocked\n"
-            )
-            print(error_message)
-            return
+            raise ConnectionError(
+                f"Failed to connect to {addr}:{port}. "
+                "Possible causes: ZeroMQ Server not included in the root "
+                "class; Root process not running; client/server address "
+                "mismatch; client/server port mismatch; server ports "
+                "blocked by firewall."
+            ) from exc
 
         print("Connected to {} at {}:{}".format(self._root.name,addr,port))
         self.setTimeout(1000,True)
@@ -676,6 +688,17 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
     def _remoteAttr(self, path: str, attr: str, *args: Any, **kwargs: Any) -> Any:
         """Invoke a remote attribute on the server."""
+        # Liveness guard: fail fast on a dead instance (stop() was called or
+        # a prior init failed). Without this guard the call slips through to
+        # ZmqClient::send on a torn-down socket and surfaces as the
+        # "zmq_sendmsg failed" crash reported in issue #1234.
+        if not getattr(self, "_vcInitialized", False):
+            raise RuntimeError(
+                "VirtualClient is not connected: __init__ failed or stop() "
+                "was called. Construct a new VirtualClient before issuing "
+                "remote attribute calls."
+            )
+
         self._requestStart()
 
         try:

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -328,8 +328,16 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
         // also prevents the recv loop below from blocking on a request that
         // was never put on the wire.
         if (zmq_sendmsg(this->zmqReq_, &txMsg, 0) < 0) {
+            // Capture errno before zmq_msg_close, which may overwrite it.
+            // ETERM here is the issue #1234 signature: VirtualClient.__init__
+            // tore down the context via _cleanupFailedInit() but returned
+            // without raising, so the caller is now sending on a dead socket.
+            int err = zmq_errno();
             zmq_msg_close(&txMsg);
-            throw rogue::GeneralError::create("ZmqClient::send", "zmq_sendmsg failed");
+            throw rogue::GeneralError::create("ZmqClient::send",
+                                              "zmq_sendmsg failed: errno=%d %s",
+                                              err,
+                                              zmq_strerror(err));
         }
 
         while (1) {

--- a/tests/interfaces/test_interfaces_virtual_client_connect.py
+++ b/tests/interfaces/test_interfaces_virtual_client_connect.py
@@ -12,6 +12,8 @@
 import os
 import time
 
+import pytest
+
 import pyrogue
 import pyrogue.interfaces
 
@@ -178,15 +180,24 @@ def test_virtual_client_reqlock_exists_before_zmq_base_init(monkeypatch):
 
 
 def test_virtual_client_does_not_cache_failed_bootstrap(monkeypatch):
+    """A failed bootstrap must raise and must not pollute ClientCache.
+
+    Issue #1234 fix: ``VirtualClient.__init__`` raises ``ConnectionError``
+    when ``_waitForRoot`` fails (previously it printed an error and
+    returned a dead instance). This test pins that contract and confirms
+    a subsequent successful ``VirtualClient(addr, port)`` against the
+    same target still works -- i.e. the failed construction did not pin
+    a stale entry in the singleton cache.
+    """
     port = _test_port(1)
     cache_key = hash(('127.0.0.1', port))
     _clear_virtual_client_cache()
     monkeypatch.setenv('ROGUE_VIRTUAL_CONNECT_TIMEOUT', '1.0')
 
     try:
-        failed = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+        with pytest.raises(ConnectionError):
+            pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
 
-        assert failed.root is None
         assert cache_key not in pyrogue.interfaces.VirtualClient.ClientCache
 
         with VirtualConnectRoot(name='RecoveredRoot', port=port):

--- a/tests/interfaces/test_zmq_client_dead_after_failed_init.py
+++ b/tests/interfaces/test_zmq_client_dead_after_failed_init.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : VirtualClient dead-instance regression (issue #1234)
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Regression for slaclab/rogue issue #1234:
+#   "ZMQ client crashed with rogue 6.12.0"
+#
+# Pre-fix behaviour (the bug):
+#   ``VirtualClient.__init__`` wrapped the bootstrap ``_waitForRoot``
+#   handshake in ``try/except Exception`` and on failure called
+#   ``_cleanupFailedInit()`` -- which tears down the ZMQ context via
+#   ``ZmqClient._stop(self)`` -- then *printed* a "Failed to connect" banner
+#   and *returned normally* from ``__init__``. The caller received a
+#   ``VirtualClient`` instance whose underlying ``ZmqClient`` had been
+#   destroyed, with no exception to signal the failure.
+#
+#   The first subsequent ``_remoteAttr`` / ``_send`` on the dead instance
+#   reached ``ZmqClient::send`` (src/rogue/interfaces/ZmqClient.cpp:330),
+#   where ``zmq_sendmsg`` on the torn-down socket returned -1 and the
+#   throw surfaced as the exact crash on the issue:
+#       rogue.GeneralError: ZmqClient::send: General Error: zmq_sendmsg failed
+#
+#   That throw was introduced in v6.12.0 (commit a5bff522c). Before then
+#   the same ``zmq_sendmsg`` failure was silently discarded and the recv
+#   loop subsequently timed out, surfacing as "Timeout waiting for response"
+#   -- so the bug is older than v6.12.0 but only became visible at v6.12.0.
+#
+# Post-fix behaviour pinned by this file:
+#   1. ``VirtualClient.__init__`` raises ``ConnectionError`` (chained from
+#      the underlying handshake exception) when ``_waitForRoot`` fails.
+#      No dead instance escapes the constructor.
+#   2. As defence-in-depth, ``_remoteAttr`` checks ``_vcInitialized`` and
+#      raises ``RuntimeError`` early on a dead instance (for example after
+#      ``stop()``), so even a path that constructed an instance and then
+#      tore it down fails fast with a clear message instead of slipping
+#      through to the C++ ``zmq_sendmsg failed`` throw.
+#   3. The C++ throw at ``ZmqClient::send`` now embeds ``zmq_errno`` and
+#      ``zmq_strerror`` in the message, so any residual path that does
+#      reach it produces a self-describing error.
+
+import pytest
+
+import pyrogue
+import pyrogue.interfaces
+
+
+pytestmark = pytest.mark.integration
+
+
+class _RemoteRoot(pyrogue.Root):
+    """Minimal Root with a ZmqServer suitable for VirtualClient bootstrap."""
+
+    def __init__(self, *, name: str, port: int):
+        super().__init__(name=name, pollEn=False)
+        self.add(pyrogue.LocalVariable(name='Value', value=0, mode='RO'))
+        self.zmqServer = pyrogue.interfaces.ZmqServer(
+            root=self, addr='127.0.0.1', port=port)
+        self.addInterface(self.zmqServer)
+
+
+def _clear_client_cache() -> None:
+    """Drain any cached VirtualClient instances between tests."""
+    cache = pyrogue.interfaces.VirtualClient.ClientCache
+    for client in list(cache.values()):
+        try:
+            client.stop()
+        except Exception:
+            pass
+    cache.clear()
+
+
+@pytest.fixture
+def fast_connect_timeout(monkeypatch):
+    """Shorten the _waitForRoot deadline so the unreachable cases finish fast."""
+    monkeypatch.setenv("ROGUE_VIRTUAL_CONNECT_TIMEOUT", "0.5")
+    _clear_client_cache()
+    yield
+    _clear_client_cache()
+
+
+def test_virtualclient_init_raises_connectionerror_on_unreachable_server(
+    fast_connect_timeout, free_zmq_port
+):
+    """``__init__`` must raise instead of returning a dead instance.
+
+    No server is bound on ``free_zmq_port``, so ``_waitForRoot`` exhausts
+    its bounded retry window and ``_cleanupFailedInit`` tears down the
+    underlying ZmqClient. Pre-fix, ``__init__`` printed an error and
+    returned -- this test pins the post-fix contract that the failure
+    surfaces as ``ConnectionError`` to the caller.
+    """
+    with pytest.raises(ConnectionError) as exc_info:
+        pyrogue.interfaces.VirtualClient(
+            addr='127.0.0.1', port=free_zmq_port)
+
+    msg = str(exc_info.value)
+    assert "127.0.0.1" in msg and str(free_zmq_port) in msg, (
+        f"ConnectionError must identify the unreachable target; got: {msg!r}"
+    )
+
+    # No instance must remain pinned in the singleton cache after init fails.
+    assert hash(('127.0.0.1', free_zmq_port)) not in (
+        pyrogue.interfaces.VirtualClient.ClientCache
+    ), "Failed-init instance must be removed from ClientCache by _cleanupFailedInit."
+
+
+def test_virtualclient_init_chains_underlying_handshake_exception(
+    fast_connect_timeout, free_zmq_port
+):
+    """The raised ConnectionError must chain the original handshake exception.
+
+    Preserving ``__cause__`` is what lets callers and tracebacks recover
+    the libzmq-level error (RCVTIMEO etc.) without grepping the message.
+    """
+    with pytest.raises(ConnectionError) as exc_info:
+        pyrogue.interfaces.VirtualClient(
+            addr='127.0.0.1', port=free_zmq_port)
+
+    assert exc_info.value.__cause__ is not None, (
+        "ConnectionError must chain the underlying _waitForRoot exception "
+        "via `raise ... from exc` so callers can inspect the root cause."
+    )
+
+
+def test_remoteattr_after_stop_raises_runtime_error(free_zmq_port):
+    """``_remoteAttr`` on a stopped VirtualClient must fail fast and clear.
+
+    Exercises the defence-in-depth liveness guard: construct a real,
+    working VirtualClient against a live Root, call ``stop()`` (which sets
+    ``_vcInitialized=False``), then call ``_remoteAttr``. Pre-fix this
+    slipped through to ``ZmqClient::send`` and crashed with the issue
+    #1234 traceback. Post-fix the guard catches it with a RuntimeError
+    that names what happened.
+    """
+    _clear_client_cache()
+    with _RemoteRoot(name='RemoteRoot', port=free_zmq_port):
+        client = pyrogue.interfaces.VirtualClient(
+            addr='127.0.0.1', port=free_zmq_port)
+        assert client.root is not None, "bootstrap handshake must succeed"
+
+        client.stop()
+        assert client._vcInitialized is False, (
+            "stop() must clear _vcInitialized (precondition for the guard)"
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            client._remoteAttr('__ROOT__', None)
+
+        msg = str(exc_info.value)
+        assert "not connected" in msg.lower(), (
+            f"RuntimeError must explain why the call is rejected; got: {msg!r}"
+        )
+        # Critically, the failure must NOT be the issue #1234 string -- if
+        # it is, the guard was bypassed and the call leaked to zmq_sendmsg.
+        assert "zmq_sendmsg failed" not in msg, (
+            "Liveness guard was bypassed: call reached ZmqClient::send "
+            "instead of failing in _remoteAttr."
+        )

--- a/tests/interfaces/test_zmq_client_efsm_recovery.py
+++ b/tests/interfaces/test_zmq_client_efsm_recovery.py
@@ -96,6 +96,16 @@ def test_zmq_client_second_send_after_recv_timeout_does_not_raise_sendmsg_failed
             assert "zmq_sendmsg failed" not in first_msg, (
                 f"First send raised zmq_sendmsg failed (unexpected): {first_msg}"
             )
+            # Positive assertion: the precondition for the EFSM-regression
+            # check on the second send is that the first send abandoned recv
+            # via RCVTIMEO. If the first send fails on a different error
+            # (early disconnect/ETERM/etc.), the second send isn't actually
+            # exercising the EFSM-recovery path and the test would pass
+            # vacuously.
+            assert "Timeout" in first_msg or "timeout" in first_msg.lower(), (
+                f"First send raised an unexpected error "
+                f"(not Timeout, not zmq_sendmsg): {first_msg}"
+            )
 
             # Second send immediately after the timeout: with ZMQ_REQ_RELAXED,
             # zmq_sendmsg must succeed (queue the message), and RCVTIMEO fires.

--- a/tests/interfaces/test_zmq_client_efsm_recovery.py
+++ b/tests/interfaces/test_zmq_client_efsm_recovery.py
@@ -41,8 +41,6 @@
 #   second _send either succeeds or raises "Timeout" (not "zmq_sendmsg failed")
 
 import pickle
-import threading
-import time
 
 import pytest
 import zmq
@@ -70,34 +68,6 @@ def _bind_silent_peer(port: int):
     rep = ctx.socket(zmq.REP)
     rep.bind(f"tcp://127.0.0.1:{port + 1}")
     return ctx, pub, rep
-
-
-def _bind_responding_peer(port: int):
-    """Bind PUB on port and a REP on port+1 that echoes requests back.
-
-    Used for the second-send phase: the REP peer recv+sends so the client
-    completes the request/reply cycle normally.
-    """
-    ctx = zmq.Context()
-    pub = ctx.socket(zmq.PUB)
-    pub.bind(f"tcp://127.0.0.1:{port}")
-    rep = ctx.socket(zmq.REP)
-    rep.bind(f"tcp://127.0.0.1:{port + 1}")
-
-    def _echo():
-        while True:
-            try:
-                rep.recv(flags=zmq.NOBLOCK)
-                rep.send(pickle.dumps(None))
-            except zmq.Again:
-                pass
-            except zmq.ZMQError:
-                break
-            time.sleep(0.01)
-
-    t = threading.Thread(target=_echo, daemon=True)
-    t.start()
-    return ctx, pub, rep, t
 
 
 def test_zmq_client_second_send_after_recv_timeout_does_not_raise_sendmsg_failed(free_zmq_port):
@@ -176,6 +146,14 @@ def test_zmq_client_multiple_sends_after_repeated_recv_timeouts(free_zmq_port):
                     f"Iteration {i}: send raised 'zmq_sendmsg failed' — "
                     f"REQ socket entered EFSM after {i} abandoned-recv cycles. "
                     f"ZMQ_REQ_RELAXED should prevent this. Full error: {msg}"
+                )
+                # Positive assertion: each iteration must surface the RCVTIMEO
+                # timeout, not some other ZMQ error (ETERM, ENOTSOCK, etc.).
+                # Without this check the test could pass on a different
+                # failure mode and silently lose coverage.
+                assert "Timeout" in msg or "timeout" in msg.lower(), (
+                    f"Iteration {i}: send raised an unexpected error "
+                    f"(not Timeout, not zmq_sendmsg failed): {msg}"
                 )
         finally:
             client._stop()

--- a/tests/interfaces/test_zmq_client_efsm_recovery.py
+++ b/tests/interfaces/test_zmq_client_efsm_recovery.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : ZmqClient REQ-socket EFSM / sendmsg-failure regression
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Regression for slaclab/rogue issue #1234:
+#   "ZMQ client crashed with rogue 6.12.0"
+#   pysmurf SmurfControl init raises rogue.GeneralError: zmq_sendmsg failed
+#   on the first _remoteAttr call after VirtualClient.__init__ prints
+#   "Connected to AMCc at localhost:9006".
+#
+# Root-cause hypothesis under investigation:
+#   H1: REQ socket in EFSM after a prior recv timeout (waitRetry_=False path).
+#       The _waitForRoot tight retry loop abandons recv and retries send;
+#       without ZMQ_REQ_RELAXED that would leave the socket in EFSM.
+#       ZMQ_REQ_RELAXED is already set in ZmqClient::ZmqClient — so EFSM
+#       should be suppressed. This test confirms the observable behaviour.
+#
+# Test structure:
+#   - A raw ZMQ REP peer is used (not pyrogue ZmqServer) to avoid the
+#     in-process GIL deadlock documented in test_zmq_client.py.
+#   - The peer binds a PUB on port and a REP on port+1 so the client
+#     constructor's zmq_connect calls succeed.
+#   - First _send: the REP peer does NOT recv/send, so the client
+#     hits RCVTIMEO and throws "Timeout waiting for response".
+#   - Second _send: with waitRetry_=False and ZMQ_REQ_RELAXED the client
+#     MUST be able to send again without zmq_sendmsg returning -1.
+#
+# The failing assertion (H1 confirmed) would be:
+#   second _send raises rogue.GeneralError matching "zmq_sendmsg failed"
+#
+# The passing assertion (H1 refuted / bug fixed) is:
+#   second _send either succeeds or raises "Timeout" (not "zmq_sendmsg failed")
+
+import pickle
+import threading
+import time
+
+import pytest
+import zmq
+
+import rogue
+import rogue.interfaces
+
+pytestmark = pytest.mark.integration
+
+
+def _bind_silent_peer(port: int):
+    """Bind PUB on port and a silent REP on port+1.
+
+    The REP socket binds but never calls recv, so every ZmqClient._send()
+    reaches RCVTIMEO and throws — exactly the timeout-then-throw recv path
+    that leaves a standard (non-RELAXED) REQ socket in EFSM.
+
+    Real binds are required so ZmqClient._stop() can close the context
+    cleanly during teardown.  free_zmq_port reserves a 3-port consecutive
+    block so port+1 is guaranteed free at allocation time.
+    """
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(f"tcp://127.0.0.1:{port}")
+    rep = ctx.socket(zmq.REP)
+    rep.bind(f"tcp://127.0.0.1:{port + 1}")
+    return ctx, pub, rep
+
+
+def _bind_responding_peer(port: int):
+    """Bind PUB on port and a REP on port+1 that echoes requests back.
+
+    Used for the second-send phase: the REP peer recv+sends so the client
+    completes the request/reply cycle normally.
+    """
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(f"tcp://127.0.0.1:{port}")
+    rep = ctx.socket(zmq.REP)
+    rep.bind(f"tcp://127.0.0.1:{port + 1}")
+
+    def _echo():
+        while True:
+            try:
+                rep.recv(flags=zmq.NOBLOCK)
+                rep.send(pickle.dumps(None))
+            except zmq.Again:
+                pass
+            except zmq.ZMQError:
+                break
+            time.sleep(0.01)
+
+    t = threading.Thread(target=_echo, daemon=True)
+    t.start()
+    return ctx, pub, rep, t
+
+
+def test_zmq_client_second_send_after_recv_timeout_does_not_raise_sendmsg_failed(free_zmq_port):
+    """Second _send after a recv-timeout must not raise 'zmq_sendmsg failed'.
+
+    This is the core H1 regression for issue #1234.  On a REQ socket with
+    ZMQ_REQ_RELAXED=1, abandoning the recv and calling send again is legal.
+    The send must succeed (return >= 0 from zmq_sendmsg), so the second
+    _send must raise "Timeout" (RCVTIMEO) not "zmq_sendmsg failed".
+
+    If this test fails with "zmq_sendmsg failed", H1 is confirmed and
+    ZMQ_REQ_RELAXED is either not being set or not effective.
+    """
+    port = free_zmq_port
+    ctx, pub, rep = _bind_silent_peer(port)
+    try:
+        client = rogue.interfaces.ZmqClient("127.0.0.1", port, False)
+        try:
+            client.setTimeout(200, False)  # 200 ms, no waitRetry
+            payload = pickle.dumps({"path": "__ROOT__", "attr": None, "args": (), "kwargs": {}})
+
+            # First send: server is silent, expect Timeout (not zmq_sendmsg failed)
+            with pytest.raises(Exception) as exc_info:
+                client._send(payload)
+            first_msg = str(exc_info.value)
+            assert "zmq_sendmsg failed" not in first_msg, (
+                f"First send raised zmq_sendmsg failed (unexpected): {first_msg}"
+            )
+
+            # Second send immediately after the timeout: with ZMQ_REQ_RELAXED,
+            # zmq_sendmsg must succeed (queue the message), and RCVTIMEO fires.
+            # If zmq_sendmsg fails (e.g. EFSM), we get "zmq_sendmsg failed" here.
+            with pytest.raises(Exception) as exc_info2:
+                client._send(payload)
+            second_msg = str(exc_info2.value)
+
+            assert "zmq_sendmsg failed" not in second_msg, (
+                f"H1 CONFIRMED: second send after recv-timeout raised "
+                f"'zmq_sendmsg failed' — REQ socket left in EFSM state. "
+                f"ZMQ_REQ_RELAXED is not suppressing EFSM for this send. "
+                f"Full error: {second_msg}"
+            )
+            # The second send must raise Timeout (not any other error)
+            assert "Timeout" in second_msg or "timeout" in second_msg.lower(), (
+                f"Second send raised unexpected error (not Timeout, not zmq_sendmsg): {second_msg}"
+            )
+        finally:
+            client._stop()
+    finally:
+        pub.close(linger=0)
+        rep.close(linger=0)
+        ctx.term()
+
+
+def test_zmq_client_multiple_sends_after_repeated_recv_timeouts(free_zmq_port):
+    """N consecutive sends each timing out must all reach the send phase.
+
+    Mirrors the _waitForRoot tight-retry loop: up to 5 calls with
+    waitRetry_=False, server silent.  Each must raise Timeout, not
+    zmq_sendmsg failed.  This proves the REQ socket does not degrade
+    after multiple abandoned-recv cycles.
+    """
+    port = free_zmq_port
+    ctx, pub, rep = _bind_silent_peer(port)
+    try:
+        client = rogue.interfaces.ZmqClient("127.0.0.1", port, False)
+        try:
+            client.setTimeout(100, False)  # 100 ms, no waitRetry
+            payload = pickle.dumps({"path": "__ROOT__", "attr": None, "args": (), "kwargs": {}})
+
+            for i in range(5):
+                with pytest.raises(Exception) as exc_info:
+                    client._send(payload)
+                msg = str(exc_info.value)
+                assert "zmq_sendmsg failed" not in msg, (
+                    f"Iteration {i}: send raised 'zmq_sendmsg failed' — "
+                    f"REQ socket entered EFSM after {i} abandoned-recv cycles. "
+                    f"ZMQ_REQ_RELAXED should prevent this. Full error: {msg}"
+                )
+        finally:
+            client._stop()
+    finally:
+        pub.close(linger=0)
+        rep.close(linger=0)
+        ctx.term()


### PR DESCRIPTION
<!--- Provide a one sentence summary of your changes in the Title above -->

### Description

Fixes #1234.

`VirtualClient.__init__` previously wrapped `_waitForRoot` in `try/except`, called `_cleanupFailedInit()` to tear down the ZMQ context, then printed a "Failed to connect" banner and *returned normally*. The caller received a `VirtualClient` whose underlying `ZmqClient` had been destroyed, with no exception to signal the failure. The first subsequent `_remoteAttr` reached `ZmqClient::send` on a torn-down socket and crashed with `rogue.GeneralError: ZmqClient::send: General Error: zmq_sendmsg failed` — the verbatim traceback in #1234.

The underlying bug predates v6.12.0; v6.11.0 silently discarded the `zmq_sendmsg` return value, so the failure used to surface as the more confusing "Timeout waiting for response after N Seconds". The v6.12.0 throw introduced by `a5bff522c` (`fix(ZmqClient): thread-safety, msg lifecycle, and ctor-throw cleanup`) made the dead-instance scenario crash visibly.

This PR:

1. **`VirtualClient.__init__` raises `ConnectionError`** chained from the underlying handshake exception when `_waitForRoot` fails, instead of `print + return`. No dead instance escapes the constructor. `_cleanupFailedInit()` still runs before the raise so sockets and the ZMQ context are released and the singleton cache stays clean.
2. **Liveness guard in `_remoteAttr`** as defence-in-depth: any path that produces a `VirtualClient` with `_vcInitialized=False` (post-`stop()`, partial init, or future regressions) now fails fast with `RuntimeError("VirtualClient is not connected: ...")` instead of slipping through to the C++ `zmq_sendmsg failed` throw.
3. **`ZmqClient::send` enriched throw**: when `zmq_sendmsg` returns -1 the throw now embeds `zmq_errno` and `zmq_strerror`, so any residual failure on this path is self-describing. The `"zmq_sendmsg failed"` substring is preserved so existing message-matching callers continue to work.

### Details

**Behavioural contract change.** `VirtualClient(addr, port)` against an unreachable target now raises `ConnectionError` instead of returning a dead instance. Callers that depended on the silent-return behaviour need to wrap the constructor in `try/except ConnectionError`. The exception message preserves the addr/port and the previous "Possible causes" list, and the underlying handshake exception is reachable via `__cause__`. The change is documented in the `VirtualClient.__init__` docstring (autodoc-exposed).

**Hypothesis triage.** Initial reading of the issue suggested H1: REQ socket in EFSM after a recv timeout. That hypothesis was eliminated empirically — `ZMQ_REQ_RELAXED` has been set in the `ZmqClient` constructor since `ca2c7cbca` (before v6.12.0), so the recv-timeout-then-retry path cannot wedge the REQ socket. The actual defect (H3) is the silent-return on `_waitForRoot` failure in `VirtualClient.__init__`. The H1 elimination tests are kept as a regression pin so the EFSM path doesn't regress if the constructor options are ever changed.

**Tests:**
- `tests/interfaces/test_zmq_client_efsm_recovery.py` *(new)* — H1 elimination. Two integration tests prove the REQ socket survives the recv-timeout-then-retry scenario without EFSM.
- `tests/interfaces/test_zmq_client_dead_after_failed_init.py` *(new)* — H3 contract. Three integration tests: `__init__` raises `ConnectionError` (with chained `__cause__`) on unreachable targets, and `_remoteAttr` on a stopped `VirtualClient` fails fast with `RuntimeError` rather than reaching `ZmqClient::send`.
- `tests/interfaces/test_interfaces_virtual_client_connect.py::test_virtual_client_does_not_cache_failed_bootstrap` *(updated)* — expects `ConnectionError` from the failed bootstrap and confirms the recovery scenario (subsequent successful construction against the same target) still works.

All three new H3 tests **fail on pristine `pre-release` HEAD** with the verbatim issue #1234 traceback, and pass with this fix applied — satisfying `tests/METHODOLOGY.md`'s "Add tests that fail for the old behavior when that is practical."

### Verification

```sh
# Build, install, source
cmake --build build -j$(nproc)
cmake --build build --target install
source build/setup_rogue.sh

# Lint (compileall + flake8 + cpplint)
bash scripts/run_linters.sh
# -> EXIT=0

# Targeted Python suite
python -m pytest tests/interfaces -q -m "not perf and not epics"
# -> 108 passed, 5 skipped, 1 deselected
#    (deselect = `test_rogue_connection_link_state_refreshes_static_name_channels`
#    in test_pydm_rogue_plugin.py, a pre-existing failure that reproduces on
#    pristine pre-release HEAD and is unrelated to this fix)

# Broader fast Python coverage of subsystems likely affected
python -m pytest tests/integration tests/core -q -m "not perf and not epics"
# -> 307 passed

# Native C++
ctest --test-dir build --output-on-failure -L cpp
# -> 13/14 passed
#    (1 failure: `rogue-cpp-memory-tcpserver-send-failure-recovery`, an
#    undefined-symbol linkage issue in a test mock that reproduces on
#    pristine pre-release HEAD and is unrelated to this fix)
```

### JIRA

N/A

### Related

- v6.12.0 introduced the visible throw at `ZmqClient::send` via `a5bff522c`. This PR addresses the root cause exposed by that change rather than reverting it.
- Server-side REP FSM recovery (`c8677e450`) is not touched here.
