### PR TITLE
fix(zmq): cap waitRetry recv loop in ZmqClient (#1236)

### DIFF
--- a/include/rogue/interfaces/ZmqClient.h
+++ b/include/rogue/interfaces/ZmqClient.h
@@ -61,6 +61,11 @@ class ZmqClient {
     // Continue retrying after timeout when true.
     bool waitRetry_;
 
+    // Maximum recv retries when waitRetry_ is true. 0 means unbounded (the
+    // default, preserving the pre-#1236 forever-retry contract that pysmurf
+    // and other downstream callers rely on).
+    uint32_t maxRetries_;
+
     //! \cond INTERNAL
   protected:
     std::thread* thread_ = nullptr;
@@ -117,10 +122,21 @@ class ZmqClient {
 
     /**
      * @brief Sets request timeout behavior.
+     *
+     * @details
+     * `maxRetries` caps the recv-then-retry loop in `send()` / `sendString()`
+     * when `waitRetry` is true. `0` (default) preserves the historic
+     * unbounded-retry contract; downstream callers (notably `pysmurf`) rely
+     * on it. A positive value throws `rogue::GeneralError` after that many
+     * RCVTIMEO trips, matching the throw on the `waitRetry == false` path.
+     * Ignored when `waitRetry` is false.
+     *
      * @param msecs Timeout in milliseconds.
      * @param waitRetry `true` to continue waiting/retrying after timeouts.
+     * @param maxRetries Optional retry cap when `waitRetry` is true. `0` means
+     *                   unbounded (default).
      */
-    void setTimeout(uint32_t msecs, bool waitRetry);
+    void setTimeout(uint32_t msecs, bool waitRetry, uint32_t maxRetries = 0);
 
     /**
      * @brief Sends a string-mode request.

--- a/src/rogue/interfaces/ZmqClient.cpp
+++ b/src/rogue/interfaces/ZmqClient.cpp
@@ -82,7 +82,9 @@ void rogue::interfaces::ZmqClient::setup_python() {
         bp::init<std::string, uint16_t, bool>())
         .def("_doUpdate", &rogue::interfaces::ZmqClient::doUpdate, &rogue::interfaces::ZmqClientWrap::defDoUpdate)
         .def("_send", &rogue::interfaces::ZmqClient::send)
-        .def("setTimeout", &rogue::interfaces::ZmqClient::setTimeout)
+        .def("setTimeout",
+             &rogue::interfaces::ZmqClient::setTimeout,
+             (bp::arg("msecs"), bp::arg("waitRetry"), bp::arg("maxRetries") = 0u))
         .def("getDisp", &rogue::interfaces::ZmqClient::getDisp)
         .def("setDisp", &rogue::interfaces::ZmqClient::setDisp)
         .def("exec", &rogue::interfaces::ZmqClient::exec)
@@ -141,8 +143,9 @@ rogue::interfaces::ZmqClient::ZmqClient(const std::string& addr, uint16_t port, 
         temp.append(":");
         temp.append(std::to_string(static_cast<int64_t>(reqPort)));
 
-        waitRetry_ = false;  // Don't keep waiting after timeout
-        timeout_   = 1000;   // 1 second
+        waitRetry_  = false;  // Don't keep waiting after timeout
+        timeout_    = 1000;   // 1 second
+        maxRetries_ = 0;      // unbounded retry budget when waitRetry_ becomes true
         if (zmq_setsockopt(this->zmqReq_, ZMQ_RCVTIMEO, &timeout_, sizeof(int32_t)) != 0)
             throw(rogue::GeneralError("ZmqClient::ZmqClient", "Failed to set socket timeout"));
 
@@ -211,16 +214,20 @@ void rogue::interfaces::ZmqClient::stop() {
     }
 }
 
-void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs, bool waitRetry) {
+void rogue::interfaces::ZmqClient::setTimeout(uint32_t msecs, bool waitRetry, uint32_t maxRetries) {
     // ZMQ sockets are not thread-safe; serialize zmqReq_ access.
     rogue::GilRelease noGil;
     std::lock_guard<std::mutex> lock(reqLock_);
 
-    waitRetry_ = waitRetry;
-    timeout_   = msecs;
+    waitRetry_  = waitRetry;
+    timeout_    = msecs;
+    maxRetries_ = maxRetries;
 
     // %d (not PRIu8): bool promotes to int through varargs.
-    log_->debug("Setting timeout to %" PRIu32 " msecs, waitRetry = %d", timeout_, waitRetry_);
+    log_->debug("Setting timeout to %" PRIu32 " msecs, waitRetry = %d, maxRetries = %" PRIu32,
+                timeout_,
+                waitRetry_,
+                maxRetries_);
 
     if (zmq_setsockopt(this->zmqReq_, ZMQ_RCVTIMEO, &timeout_, sizeof(int32_t)) != 0)
         throw(rogue::GeneralError("ZmqClient::setTimeout", "Failed to set socket timeout"));
@@ -247,11 +254,17 @@ std::string rogue::interfaces::ZmqClient::sendString(const std::string& path, co
     std::lock_guard<std::mutex> lock(reqLock_);
     zmq_send(this->zmqReq_, snd.c_str(), snd.size(), 0);
 
+    uint32_t retryCount = 0;
+
     while (1) {
         zmq_msg_init(&msg);
         if (zmq_recvmsg(this->zmqReq_, &msg, 0) <= 0) {
             seconds += static_cast<double>(timeout_) / 1000.0;
-            if (waitRetry_) {
+            // maxRetries_ == 0 preserves the historic unbounded-retry contract
+            // (issue #1236). Caps the loop only when the caller explicitly
+            // requested a finite retry budget via setTimeout(..., maxRetries).
+            const bool retryBudgetExhausted = (maxRetries_ != 0 && ++retryCount >= maxRetries_);
+            if (waitRetry_ && !retryBudgetExhausted) {
                 logWaitRetry(log_, seconds, lastLoggedSeconds);
                 zmq_msg_close(&msg);
             } else {
@@ -332,11 +345,17 @@ bp::object rogue::interfaces::ZmqClient::send(bp::object value) {
             throw rogue::GeneralError::create("ZmqClient::send", "zmq_sendmsg failed");
         }
 
+        uint32_t retryCount = 0;
+
         while (1) {
             zmq_msg_init(&rxMsg);
             if (zmq_recvmsg(this->zmqReq_, &rxMsg, 0) <= 0) {
                 seconds += static_cast<double>(timeout_) / 1000.0;
-                if (waitRetry_) {
+                // maxRetries_ == 0 preserves the historic unbounded-retry contract
+                // (issue #1236). Caps the loop only when the caller explicitly
+                // requested a finite retry budget via setTimeout(..., maxRetries).
+                const bool retryBudgetExhausted = (maxRetries_ != 0 && ++retryCount >= maxRetries_);
+                if (waitRetry_ && !retryBudgetExhausted) {
                     logWaitRetry(log_, seconds, lastLoggedSeconds);
                     zmq_msg_close(&rxMsg);
                 } else {

--- a/tests/interfaces/test_zmq_client_bounded_waitretry.py
+++ b/tests/interfaces/test_zmq_client_bounded_waitretry.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : ZmqClient bounded waitRetry regression (issue #1236)
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Pin the contract for issue #1236: ``ZmqClient::setTimeout(msecs, waitRetry,
+# maxRetries)`` must bound the recv-then-retry loop in ``ZmqClient::send()``
+# (binary mode) and ``ZmqClient::sendString()`` (string mode).
+#
+# Pre-fix recv loop (src/rogue/interfaces/ZmqClient.cpp, both call sites):
+#
+#     while (1) {
+#         zmq_msg_init(&rxMsg);
+#         if (zmq_recvmsg(zmqReq_, &rxMsg, 0) <= 0) {
+#             seconds += timeout_ / 1000.0;
+#             if (waitRetry_) {          // <-- unbounded; SO deployment hung 20+ min
+#                 logWaitRetry(...);
+#                 zmq_msg_close(&rxMsg);
+#             } else {
+#                 zmq_msg_close(&rxMsg);
+#                 throw rogue::GeneralError::create(...);
+#             }
+#         } else { break; }
+#     }
+#
+# Caller in the wild that triggered #1236 (pysmurf base_class.py:90):
+#
+#     self._client.setTimeout(10000, True)   # comment: "Retries forever anyway"
+#
+# The fix adds an optional ``maxRetries`` parameter (default ``0`` = unbounded
+# = pre-fix behaviour). When ``maxRetries > 0`` and ``waitRetry`` is true, the
+# recv loop throws the same ``rogue.GeneralError`` after that many timeouts as
+# the ``waitRetry=False`` path throws today.
+#
+# Test contracts pinned here:
+#   1. New 3-arg ``setTimeout(msecs, waitRetry=True, maxRetries=N)`` exists in
+#      the binding AND actually bounds the send-recv cycle.
+#   2. Existing 2-arg form is unchanged (still unbounded retry).
+
+import threading
+import time
+
+import pytest
+import rogue
+import rogue.interfaces
+import zmq
+
+
+def _silent_peer(port: int):
+    """Bind PUB on ``port`` and a never-recv'ing REP on ``port+1``.
+
+    Same pattern as ``test_zmq_client_send_timeout_leak``: real binds so
+    ``ZmqClient._stop()`` cleanly tears down sockets and the context.
+    ``free_zmq_port`` reserves a 3-port consecutive block.
+    """
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(f"tcp://127.0.0.1:{port}")
+    rep = ctx.socket(zmq.REP)
+    rep.bind(f"tcp://127.0.0.1:{port + 1}")
+    return ctx, pub, rep
+
+
+def test_setTimeout_three_arg_form_bounds_retries(free_zmq_port) -> None:
+    """``setTimeout(msecs, waitRetry=True, maxRetries=N)`` must throw after N timeouts.
+
+    Pre-fix this test fails because the binding only accepts 2 positional
+    args — boost::python raises ``ArgumentError``. With the fix, the recv
+    loop in ``ZmqClient::send()`` exits after ``maxRetries`` RCVTIMEO trips
+    and the call raises ``rogue.GeneralError`` with "Timeout" in the message.
+    """
+    port = free_zmq_port
+    ctx, pub, rep = _silent_peer(port)
+    try:
+        client = rogue.interfaces.ZmqClient("127.0.0.1", port, False)
+        try:
+            # 50 ms RCVTIMEO × 3 retries = ~150 ms total wait before throw.
+            client.setTimeout(50, True, 3)
+
+            t0 = time.monotonic()
+            with pytest.raises(rogue.GeneralError, match="Timeout"):
+                client._send(b"probe")
+            elapsed = time.monotonic() - t0
+
+            # Lower bound: must have actually waited the full retry budget,
+            # not short-circuited. Upper bound generous for CI jitter.
+            assert 0.10 < elapsed < 2.0, (
+                f"Bounded waitRetry: expected ~0.15 s, got {elapsed:.3f} s"
+            )
+        finally:
+            client._stop()
+    finally:
+        pub.close(linger=0)
+        rep.close(linger=0)
+        ctx.term()
+
+
+def test_setTimeout_two_arg_form_keeps_unbounded_retry(free_zmq_port) -> None:
+    """Backwards compat: 2-arg ``setTimeout(msecs, waitRetry=True)`` stays unbounded.
+
+    Issue #1236's pysmurf caller and ``_Virtual.py``'s post-bootstrap
+    ``self.setTimeout(1000, True)`` both rely on this. The fix adds the
+    ``maxRetries`` parameter as an opt-in default of ``0`` (unbounded). This
+    test runs ``_send`` in a daemon thread for 1 s of wall time: the call
+    must still be blocked when the wait expires.
+    """
+    port = free_zmq_port
+    ctx, pub, rep = _silent_peer(port)
+    client = None
+    try:
+        client = rogue.interfaces.ZmqClient("127.0.0.1", port, False)
+
+        # 50 ms RCVTIMEO; no maxRetries (default unbounded).
+        client.setTimeout(50, True)
+
+        state = {"raised": None, "returned": False, "done": False}
+
+        def _worker() -> None:
+            try:
+                client._send(b"probe")
+                state["returned"] = True
+            except BaseException as exc:
+                state["raised"] = exc
+            finally:
+                state["done"] = True
+
+        worker = threading.Thread(target=_worker, daemon=True)
+        worker.start()
+
+        # Wait well past several recv timeouts; the unbounded loop must still
+        # be retrying, not have thrown or returned.
+        worker.join(timeout=1.0)
+        assert worker.is_alive(), (
+            f"2-arg setTimeout unexpectedly exited send(): "
+            f"raised={state['raised']!r}, returned={state['returned']!r}"
+        )
+        assert state["raised"] is None
+        assert state["returned"] is False
+    finally:
+        # Closing the ZMQ context via _stop() unblocks the recv loop with
+        # ETERM (or the close zeroes the socket pointer) so the daemon thread
+        # exits before the process tears down.
+        if client is not None:
+            client._stop()
+        pub.close(linger=0)
+        rep.close(linger=0)
+        ctx.term()


### PR DESCRIPTION
### Description

Fixes #1236.

`ZmqClient::send()` and `ZmqClient::sendString()` retry the recv leg forever when `setTimeout(..., waitRetry=true)` is in effect. The configured `RCVTIMEO` expires, but the loop just logs `"Timeout waiting for response... server may be busy. Continuing to wait..."` and re-enters `zmq_recvmsg`, so any genuine timeout intent the caller passed is swallowed.

A SMuRF deployment running rogue at `1a04b1e1` hung 20+ minutes on a `RemoteVariable.get()`, only unwedging after the server docker was restarted. The 10 s timeout pysmurf configured did not fire because pysmurf intentionally uses `setTimeout(10000, True)` with the comment _"Retries forever anyway"_.

Survey of fix status before this PR:

- `1a04b1e1..v6.12.0`: three ZMQ commits (`a5bff522c`, `c8677e450`, `83d3e7d95`). They harden the server REP FSM and `_Virtual` locking but do **not** bound the client retry loop.
- `git log v6.12.0..pre-release -- ZmqClient.{h,cpp} ZmqServer.{h,cpp} _Virtual.py` is empty.
- Open ZMQ-related PRs (#1235, #1232, #1202, #1209) cover the bootstrap-failure crash, REP `_updateList` mutation, server-side hardening, and `SqlLogger`/`SideBandSim`. None touch the recv retry cap.

This PR adds a single, backwards-compatible opt-in:

```cpp
void setTimeout(uint32_t msecs, bool waitRetry, uint32_t maxRetries = 0);
```

- `maxRetries == 0` (default) preserves the historic forever-retry contract that pysmurf, `_Virtual.py:482`, and any other 2-arg caller relies on.
- `maxRetries > 0` caps both recv loops in `send()` / `sendString()`; after that many `RCVTIMEO` trips the loop throws the same `rogue::GeneralError("Timeout waiting for response after %d Seconds")` the `waitRetry == false` path throws today.

The Boost.Python binding switches to keyword-default form:

```cpp
.def("setTimeout", &ZmqClient::setTimeout,
     (bp::arg("msecs"), bp::arg("waitRetry"), bp::arg("maxRetries") = 0u))
```

so existing 2-arg call sites compile and behave unchanged.

### Details

**Scope.** This PR provides the *mechanism*. The SMuRF/SO deployment fully unwedges only once pysmurf adopts the cap:

```python
# pysmurf/client/base/base_class.py:90 (separate one-line follow-up)
self._client.setTimeout(10000, True, 60)   # cap at 60 × 10 s = 10 min
```

That adoption is intentionally out of scope here — flipping rogue's default to bound-by-default would silently break any deployment relying on the documented forever-retry contract. The two-PR rollout keeps the behavioural break opt-in. The follow-up is tracked in `docs/plans/zmq-waitretry-cap/HANDOFF.md`.

**Thread-safety.** `maxRetries_` lives next to `timeout_` and `waitRetry_` and is written / read under the existing `reqLock_` — the same discipline that already serialises every send/recv cycle. No new lock, no atomic.

**Tests.** `tests/interfaces/test_zmq_client_bounded_waitretry.py` (new):

- `test_setTimeout_three_arg_form_bounds_retries` — silent REP peer, `setTimeout(50, True, 3)`, `_send` must raise `rogue.GeneralError` with `"Timeout"` in ~150 ms. **Fails on pristine `pre-release` HEAD** with `Boost.Python.ArgumentError` (the 3-arg binding didn't exist), satisfying `tests/METHODOLOGY.md`'s _"Add tests that fail for the old behavior when that is practical."_
- `test_setTimeout_two_arg_form_keeps_unbounded_retry` — backwards-compat pin. Daemon thread running `_send` must still be alive after 1 s with the 2-arg `setTimeout(50, True)`.

### Related

- Server-side REP FSM recovery (`c8677e450`, already in v6.12.0) addresses the *server-side* stall that triggered #1236; this PR is the *client-side* defence in depth so a future server stall, network blip, or other downstream wedge cannot reproduce a 20-minute hang.
- PR #1235 fixes the bootstrap-failure crash (#1234), a different symptom on the same code path.