### PR TITLE
fix(virtualclient): daemon monitor thread + stopMonitor() API (#1238)

### DIFF
--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -507,9 +507,12 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         self._link  = True
         self._ltime = self._root.Time.value()
 
-        # Create monitoring thread
+        # Create monitoring thread. daemon=True so the interpreter can exit
+        # cleanly even when ClientCache still pins this instance (issue #1238);
+        # without it, an ipython/host script that forgot to call stop() hangs
+        # on quit().
         self._monEnable = True
-        self._monThread = threading.Thread(target=self._monWorker)
+        self._monThread = threading.Thread(target=self._monWorker, daemon=True)
         self._monThread.start()
 
     def _removeFromCache(self) -> None:
@@ -746,13 +749,22 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             for func in self._varListeners:
                 func(k,val)
 
-    def stop(self) -> None:
-        """Stop the monitor thread and release the underlying ZMQ resources.
+    def stopMonitor(self) -> None:
+        """Stop the link-monitor thread without releasing ZMQ resources.
 
-        After ``stop()`` returns the C++ sockets and ZMQ context are released
-        and this instance is removed from ``ClientCache``; a subsequent
-        ``VirtualClient(addr, port)`` therefore constructs a fresh, fully
-        connected instance instead of returning the torn-down one.
+        Use this when a long-lived client must drop link-heartbeat polling
+        but the ZMQ transport must remain open. The intended caller is a
+        host script that hands a ``VirtualClient`` to an interactive
+        wrapper (for example ``pysmurf``) and wants to silence the monitor
+        on shutdown without losing the connection. ``stop()`` is the
+        wrong choice for that case because it also closes the C++
+        ``ZmqClient`` sockets and removes the instance from
+        ``ClientCache``.
+
+        After ``stopMonitor()`` returns the client still services
+        ``_remoteAttr`` calls and SUB publish updates; only the periodic
+        link-state heartbeat is disabled. Idempotent; safe to call from
+        any thread other than ``_monThread`` itself.
         """
         self._monEnable = False
         thr = self._monThread
@@ -765,6 +777,16 @@ class VirtualClient(rogue.interfaces.ZmqClient):
             thr.join(timeout=3.0)
             if thr.is_alive():
                 self._log.warning("Monitor thread did not stop within timeout")
+
+    def stop(self) -> None:
+        """Stop the monitor thread and release the underlying ZMQ resources.
+
+        After ``stop()`` returns the C++ sockets and ZMQ context are released
+        and this instance is removed from ``ClientCache``; a subsequent
+        ``VirtualClient(addr, port)`` therefore constructs a fresh, fully
+        connected instance instead of returning the torn-down one.
+        """
+        self.stopMonitor()
 
         # ClientCache pins this instance, so the C++ stop() must run explicitly
         # to release SUB/REQ sockets and the ZMQ context. _stop() is idempotent.

--- a/tests/interfaces/test_interfaces_virtual.py
+++ b/tests/interfaces/test_interfaces_virtual.py
@@ -16,8 +16,9 @@ import pyrogue.interfaces._Virtual as virtual_mod
 
 
 class FakeThread:
-    def __init__(self, target):
+    def __init__(self, target, daemon=None):
         self.target = target
+        self.daemon = daemon
         self.started = False
 
     def start(self):

--- a/tests/interfaces/test_virtual_client_monitor_daemon.py
+++ b/tests/interfaces/test_virtual_client_monitor_daemon.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : VirtualClient monitor-thread lifecycle regression tests
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Regression coverage for issue #1238:
+# "ZMQ client monitor thread is not exiting in interactive environment".
+#
+# ``VirtualClient.__init__`` spawned ``self._monThread`` via plain
+# ``threading.Thread(target=self._monWorker)`` -- without ``daemon=True``.
+# Because ``VirtualClient.ClientCache`` (a class-level dict) holds a strong
+# reference to every constructed instance, dropping the user-side reference
+# does not let the instance get garbage-collected. The non-daemon monitor
+# thread therefore keeps the interpreter alive on ``quit()`` / ``exit()``
+# in interactive sessions (the symptom reported by ``pysmurf``).
+#
+# Two contracts are pinned here:
+#
+# 1. ``_monThread.daemon is True`` so interpreter shutdown does not hang
+#    even when ``ClientCache`` still pins the instance. Reverting the
+#    ``daemon=True`` argument in ``_Virtual.py`` makes
+#    ``test_virtual_client_monitor_thread_is_daemon`` fail.
+#
+# 2. ``stopMonitor()`` disables the link-heartbeat polling thread without
+#    releasing the underlying ZMQ resources. The pre-issue-#1238 API only
+#    offered ``stop()``, which also closes the C++ ``ZmqClient`` sockets;
+#    this left ``pysmurf``-style callers (who want to silence the monitor
+#    while keeping the connection open) without a clean option. Removing
+#    ``stopMonitor()`` -- or making it tear down the ZMQ transport --
+#    makes ``test_stop_monitor_keeps_zmq_open`` fail.
+
+import threading
+
+import pytest
+
+import pyrogue
+import pyrogue.interfaces
+
+
+pytestmark = pytest.mark.integration
+
+
+def _clear_virtual_client_cache() -> None:
+    """Drain ``VirtualClient.ClientCache`` between tests.
+
+    The cache is a class-level dict pinned for the life of the process, so
+    test isolation depends on emptying it after each lifecycle test.
+    """
+    for client in list(pyrogue.interfaces.VirtualClient.ClientCache.values()):
+        try:
+            client.stop()
+            client._stop()
+        except Exception:
+            pass
+    pyrogue.interfaces.VirtualClient.ClientCache.clear()
+
+
+class _MonitorRoot(pyrogue.Root):
+    """Minimal Root + ZmqServer used to bring up a VirtualClient in tests."""
+
+    def __init__(self, *, name: str, port: int):
+        super().__init__(name=name, pollEn=False)
+        self.add(pyrogue.LocalVariable(name='Value', value=0, mode='RW'))
+        self.zmqServer = pyrogue.interfaces.ZmqServer(root=self, addr='127.0.0.1', port=port)
+        self.addInterface(self.zmqServer)
+
+
+def test_virtual_client_monitor_thread_is_daemon(free_zmq_port):
+    """``VirtualClient._monThread`` must be a daemon thread.
+
+    Pins the daemon flag so interpreter shutdown (``quit()`` in ipython,
+    process exit in a host script) does not hang when ``ClientCache`` is
+    still holding the only strong reference to the client.
+
+    Reverting the ``daemon=True`` argument in ``_Virtual.py`` makes this
+    assertion fail.
+    """
+    port = free_zmq_port
+    _clear_virtual_client_cache()
+
+    with _MonitorRoot(name='DaemonRoot', port=port):
+        client = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+        try:
+            assert client._monThread is not None, (
+                "VirtualClient.__init__ must spawn the link-monitor thread."
+            )
+            assert isinstance(client._monThread, threading.Thread)
+            assert client._monThread.daemon is True, (
+                "VirtualClient._monThread must be a daemon thread so the "
+                "interpreter can exit cleanly when ClientCache pins the "
+                "instance (issue #1238)."
+            )
+        finally:
+            client.stop()
+
+    _clear_virtual_client_cache()
+
+
+def test_stop_monitor_keeps_zmq_open(free_zmq_port):
+    """``stopMonitor()`` disables heartbeat polling but leaves ZMQ open.
+
+    The pre-fix API only offered ``stop()``, which also closes the C++
+    ``ZmqClient`` sockets. Callers that want to silence the monitor
+    thread but keep using the connection -- as ``pysmurf`` does -- need
+    a separate, narrower entry point.
+
+    Pins:
+      * ``stopMonitor()`` drains the Python monitor thread.
+      * ``_vcInitialized`` stays ``True`` so ``_remoteAttr`` keeps working.
+      * The instance remains in ``ClientCache`` (no implicit teardown).
+      * A real ZMQ round-trip (``Value.set``/``Value.get``) still
+        succeeds after ``stopMonitor()``.
+
+    Reverting ``stopMonitor()`` -- or making it call
+    ``rogue.interfaces.ZmqClient._stop`` -- makes this test fail.
+    """
+    port = free_zmq_port
+    _clear_virtual_client_cache()
+    cache_key = hash(('127.0.0.1', port))
+
+    with _MonitorRoot(name='MonOnlyRoot', port=port) as root:
+        client = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+        try:
+            mon_thread = client._monThread
+            assert mon_thread is not None and mon_thread.is_alive(), (
+                "VirtualClient must start the link-monitor thread before "
+                "stopMonitor() can be exercised."
+            )
+
+            client.stopMonitor()
+
+            # Thread reference may be cleared by stopMonitor; either way it
+            # must no longer be alive.
+            assert (client._monThread is None
+                    or not client._monThread.is_alive()), (
+                "stopMonitor() must drain the Python monitor thread."
+            )
+            assert not mon_thread.is_alive(), (
+                "Captured monitor-thread handle must report not-alive after "
+                "stopMonitor()."
+            )
+
+            # The ZMQ transport must still be functional -- this is the
+            # whole point of having a separate stopMonitor() entry point.
+            assert client._vcInitialized is True, (
+                "stopMonitor() must NOT clear _vcInitialized; the client "
+                "is still usable for remote attribute calls."
+            )
+            assert cache_key in pyrogue.interfaces.VirtualClient.ClientCache, (
+                "stopMonitor() must NOT remove the client from ClientCache."
+            )
+
+            # Real ZMQ round-trip after stopMonitor() to prove the transport
+            # is still alive.
+            client.root.Value.set(42)
+            assert root.Value.get() == 42, (
+                "Server-side write via VirtualClient must succeed after "
+                "stopMonitor(); the ZMQ transport must remain open."
+            )
+            assert client.root.Value.get() == 42, (
+                "Server-side read via VirtualClient must succeed after "
+                "stopMonitor(); the ZMQ transport must remain open."
+            )
+
+            # stopMonitor() is idempotent.
+            client.stopMonitor()
+        finally:
+            client.stop()
+
+    _clear_virtual_client_cache()
+
+
+def test_stop_monitor_then_stop_is_safe(free_zmq_port):
+    """``stop()`` after ``stopMonitor()`` still releases ZMQ resources.
+
+    Pins that calling the two methods in sequence does not leave the
+    instance pinned in ``ClientCache`` or double-join the (already-joined)
+    monitor thread. This protects callers that opportunistically call
+    ``stopMonitor()`` early and ``stop()`` later on the same instance.
+    """
+    port = free_zmq_port
+    _clear_virtual_client_cache()
+    cache_key = hash(('127.0.0.1', port))
+
+    with _MonitorRoot(name='SeqRoot', port=port):
+        client = pyrogue.interfaces.VirtualClient(addr='127.0.0.1', port=port)
+        try:
+            client.stopMonitor()
+        finally:
+            client.stop()
+
+        assert client._vcInitialized is False, (
+            "stop() must clear _vcInitialized after a prior stopMonitor()."
+        )
+        assert cache_key not in pyrogue.interfaces.VirtualClient.ClientCache, (
+            "stop() must remove the instance from ClientCache even when "
+            "stopMonitor() has already drained the monitor thread."
+        )
+
+    _clear_virtual_client_cache()


### PR DESCRIPTION
### Description

Fix VirtualClient monitor thread keeping the Python interpreter alive on shutdown in interactive sessions, and expose a new `stopMonitor()` API so callers can disable link-heartbeat polling without closing the ZMQ connection.

### Details

Issue #1238 reports that ipython/pysmurf sessions hang on `quit()` when a `VirtualClient` is still in scope. Root cause: `VirtualClient.__init__` spawned `self._monThread` via plain `threading.Thread(target=self._monWorker)` — without `daemon=True`. Because `VirtualClient.ClientCache` (a class-level dict) holds a strong reference to every instance, the user-side reference going out of scope does not let the instance get garbage-collected, and the non-daemon monitor thread therefore prevents interpreter shutdown.

Changes:

- `python/pyrogue/interfaces/_Virtual.py`
  - Pass `daemon=True` when constructing `_monThread`. Interpreter shutdown now proceeds cleanly even when `ClientCache` still pins the instance.
  - Factor out the monitor-thread join sequence into a new public `stopMonitor()` method. `stop()` now calls `stopMonitor()` before tearing down the C++ ZMQ sockets and removing the instance from `ClientCache`.
  - `stopMonitor()` is the recommended entry point for long-lived host scripts (e.g. pysmurf, cf. slaclab/pysmurf#991) that need to silence the heartbeat thread without losing their ZMQ connection. `stop()` keeps the existing tear-everything-down semantics.

- `tests/interfaces/test_virtual_client_monitor_daemon.py` (new, integration-marked)
  - `test_virtual_client_monitor_thread_is_daemon` — pins `_monThread.daemon is True`.
  - `test_stop_monitor_keeps_zmq_open` — exercises a real `Value.set`/`Value.get` round-trip after `stopMonitor()` to prove ZMQ is still alive; also pins that the instance stays in `ClientCache` and `_vcInitialized` stays `True`.
  - `test_stop_monitor_then_stop_is_safe` — pins that the `stopMonitor()` -> `stop()` sequence still releases ZMQ resources and clears the cache.

- `tests/interfaces/test_interfaces_virtual.py`
  - `FakeThread.__init__` now accepts the `daemon` kwarg that `VirtualClient.__init__` passes through.

All three new tests fail on the unpatched code (the daemon assertion fails directly; the `stopMonitor` tests fail with `AttributeError` because the method does not exist) and pass on the patched code. Wider verification: `tests/interfaces` + `tests/core` fast-marker selection (381 passed, 5 skipped) and `scripts/run_linters.sh` (clean).

### Related

- Fixes #1238
- Related: slaclab/pysmurf#991 (pysmurf-side workaround; with `stopMonitor()` available, that workaround can be retired or simplified)