### PR TITLE
feat: opt-in nonBlocking Command for long-running ZMQ operations (#1243)

### DIFF
--- a/docs/src/pyrogue_tree/builtin_devices/index.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/index.rst
@@ -34,6 +34,8 @@ The built-in devices fall into a few natural groups:
 
 * Start with :doc:`run_control` and :doc:`process` if you are organizing
   software actions, acquisition loops, or operator-visible procedures.
+* When you need ad-hoc fire-and-poll dispatch without progress or step UI, see
+  :doc:`long_running_operations` for the comparison and recipes.
 * Use :doc:`data_writer` and :doc:`data_receiver` for tree-facing stream write
   and receive patterns.
 * Use :doc:`/built_in_modules/index` for lower-level utilities and wrappers
@@ -57,6 +59,7 @@ Related Topics
 * Data receive/read path: :doc:`data_receiver`
 * Lower-level modules and wrappers: :doc:`/built_in_modules/index`
 * External process integration: :doc:`process`
+* Long-running operations: comparing pr.Process vs Command(nonBlocking=True): :doc:`long_running_operations`
 
 .. toctree::
    :maxdepth: 1
@@ -66,3 +69,4 @@ Related Topics
    data_writer
    data_receiver
    process
+   long_running_operations

--- a/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
@@ -1,0 +1,188 @@
+.. _pyrogue_tree_builtin_devices_long_running_ops:
+
+=======================
+Long-running Operations
+=======================
+
+.. versionadded:: 6.14.0
+
+Overview
+========
+
+If your :py:class:`~pyrogue.LocalCommand` runs longer than a few seconds, a
+synchronous ``exec`` call ties the ZMQ client thread up until the function
+returns.  For :py:class:`~pyrogue.interfaces.SimpleClient` the calling thread
+blocks on ``recv`` for the entire duration.  For
+:py:class:`~pyrogue.interfaces.VirtualClient` the ``linkTimeout`` is an *idle*
+timeout: ``_checkLinkState`` tolerates a single in-flight request and only
+declares the link stalled if the optional ``requestStallTimeout`` is set and
+exceeded.  Either way the right answer is not to enlarge a timeout — it is to
+choose the right dispatch pattern so the long work runs on the server while
+the client thread stays responsive.  PyRogue offers two canonical approaches:
+:py:class:`~pyrogue.Process` for stateful procedures that benefit from
+GUI-visible progress, and ``LocalCommand(nonBlocking=True)`` for ad-hoc
+fire-and-poll dispatch where a simple pass/fail result is enough.
+
+Both patterns run the work on a background thread and return immediately to the
+caller.  The difference is in what the tree exposes while the work is running.
+Choose :py:class:`~pyrogue.Process` when the operation is multi-step and you
+want built-in ``Running`` / ``Progress`` / ``Message`` status Variables that
+GUI clients and scripts can poll.  Choose ``Command(nonBlocking=True)`` when
+you need the simplest possible mechanism: fire the command, get ``None`` back
+immediately, and poll a ``Running`` flag until the work finishes.
+
+Comparison
+==========
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 38 38
+
+   * - Attribute
+     - ``pr.Process``
+     - ``Command(nonBlocking=True)``
+   * - Use case
+     - Stateful multi-step procedure with GUI-visible progress and status text
+     - Ad-hoc one-shot command; caller polls for completion via sibling Variables
+   * - State held across calls
+     - Yes — ``Progress``, ``Step``, ``TotalSteps``, ``Message`` persist on the
+       ``Device`` between invocations
+     - Minimal — only the auto-injected ``{name}Running``, ``{name}Result``, and
+       ``{name}Error`` siblings persist on the ``Device``.  Each call sets
+       ``{name}Running`` ``True`` at dispatch and ``False`` on exit and clears
+       ``{name}Error`` at dispatch; ``{name}Result`` is updated only on
+       successful return so the previous value remains visible while a new
+       call is in flight
+   * - Progress / step UI
+     - Built in: ``Progress`` (fraction), ``Step`` / ``TotalSteps`` (count-based),
+       ``Message`` (free text); GUI widgets consume these automatically
+     - Not built in; progress must flow through separate tree Variables if needed
+   * - Cancel primitive
+     - Built-in ``Stop`` command; procedure checks ``self._runEn``
+     - None in v1 — no ``Stop`` equivalent for non-blocking Commands (deferred)
+   * - Status variables exposed
+     - ``Running``, ``Progress``, ``Step``, ``TotalSteps``, ``Message``; optional
+       ``argVariable`` and ``returnVariable``
+     - ``{name}Running`` (bool), ``{name}Result`` (last return value),
+       ``{name}Error`` (last exception string, empty on success)
+   * - Best when
+     - The operation is long-running, multi-step, needs operator-visible status,
+       or must be cancellable via ``Stop``
+     - The operation may outlast ``linkTimeout`` and only a pass/fail result or
+       simple return value is needed; existing function requires no refactoring
+
+Pattern 1: pr.Process
+=====================
+
+Use :py:class:`~pyrogue.Process` when the procedure is naturally stateful —
+calibration runs, capture workflows, multi-step initialization — and you want
+``Running``, ``Progress``, and ``Message`` automatically exposed in the device
+tree.  A minimal sketch:
+
+.. code-block:: python
+
+   import pyrogue as pr
+
+   class ApplyCalibration(pr.Process):
+       def __init__(self, **kwargs):
+           super().__init__(description='Run calibration', **kwargs)
+
+       def _process(self):
+           self.setTotalSteps(3)
+           for i, step in enumerate(['reset', 'load', 'verify'], 1):
+               self.Message.setDisp(f'Step: {step}')
+               # ... real work here ...
+               self.setStep(i)
+
+For the full ``CaptureProcess`` example with operator-facing input and result
+Variables, see :doc:`process`.
+
+Pattern 2: Command(nonBlocking=True)
+=====================================
+
+Add ``nonBlocking=True`` to any :py:class:`~pyrogue.LocalCommand` to enable
+fire-and-poll dispatch.  PyRogue automatically injects three sibling
+``LocalVariable``\s — ``{name}Running``, ``{name}Result``, and
+``{name}Error`` — onto the parent ``Device``.  The server-side definition is
+unchanged from a normal ``LocalCommand`` except for the one kwarg:
+
+.. code-block:: python
+
+   import pyrogue as pr
+   import time
+
+   def _apply_config(cmd):
+       steps = [('reset_defaults', 0.3), ('load_cal_table', 0.3), ('verify', 0.3)]
+       for step, duration in steps:
+           cmd._log.info('Config step: %s', step)
+           time.sleep(duration)
+       return 'configured'
+
+   class ConfigDevice(pr.Device):
+       def __init__(self, **kwargs):
+           super().__init__(**kwargs)
+           self.add(pr.LocalCommand(
+               name='ApplyConfig',
+               description='Apply full device configuration.  Returns immediately.',
+               function=_apply_config,
+               nonBlocking=True,
+               retValue='',
+           ))
+
+Calling ``client.exec('Top.Dev.ApplyConfig')`` over ZMQ returns ``None``
+immediately because the server dispatches a worker thread and replies before
+the function finishes.  Poll ``ApplyConfigRunning`` on the client side to
+detect completion — see the next section.
+
+Client-Side Polling Pattern
+============================
+
+After ``exec`` returns, poll the auto-injected ``{name}Running`` sibling
+Variable until it transitions to ``False``, then read ``{name}Result`` and
+``{name}Error``.  This mirrors the :py:class:`~pyrogue.Process` pattern
+(``Running`` / ``Progress`` / ``Message``) but uses the lighter-weight triplet
+(``Running`` / ``Result`` / ``Error``) that requires no ``Process`` subclass.
+
+The example below is the canonical reference shape for the hand-rolled loop:
+
+.. literalinclude:: ../../../../python/pyrogue/examples/_NonBlockingCommandExample.py
+   :language: python
+   :pyobject: main
+   :caption: SimpleClient hand-rolled polling loop
+
+For :py:class:`~pyrogue.VirtualClient` users, the equivalent approach is a
+per-variable listener or ``VariableWait`` rather than an explicit loop — see
+:doc:`/pyrogue_tree/client_interfaces/virtual` for those APIs.
+
+Interaction with linkTimeout and requestStallTimeout
+=====================================================
+
+A non-blocking ``exec`` RPC returns immediately once the server has dispatched
+the worker thread — before the function body runs.  Because the reply travels
+over the wire before any long-running work begins, neither ``linkTimeout`` nor
+``requestStallTimeout`` fires for the dispatch call itself.
+
+The only RPCs that race a timeout after dispatch are the subsequent
+``client.get(...)`` polls of ``{name}Running``, ``{name}Result``, and
+``{name}Error``.  Those are lightweight reads of in-memory ``LocalVariable``
+values and complete in well under a millisecond on any non-pathological
+connection, so they are not a practical timeout concern.
+
+``requestStallTimeout`` defaults to ``None`` (disabled), meaning there is no
+global stall deadline on in-flight requests today.  A future release may add
+awareness of non-blocking polls to this timeout; until then, the hand-rolled
+loop in the previous section is the supported approach.
+
+Related Topics
+==============
+
+* Process-based long-running operations with progress UI: :doc:`process`
+* Command behavior and dispatch semantics: :doc:`/pyrogue_tree/core/command`
+* Python-defined commands with ``nonBlocking`` support: :doc:`/pyrogue_tree/core/local_command`
+* Mirrored-tree remote client with ``linkTimeout`` and ``requestStallTimeout``: :doc:`/pyrogue_tree/client_interfaces/virtual`
+* Lightweight string-path client (``SimpleClient``): :doc:`/pyrogue_tree/client_interfaces/simple`
+
+API Reference
+=============
+
+See :doc:`/api/python/pyrogue/basecommand` for generated API details.

--- a/docs/src/pyrogue_tree/builtin_devices/process.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/process.rst
@@ -197,6 +197,7 @@ Related Topics
 * Command behavior: :doc:`/pyrogue_tree/core/command`
 * Device composition and lifecycle: :doc:`/pyrogue_tree/core/device`
 * Lower-level transport, protocol, and utility families: :doc:`/built_in_modules/index`
+* Long-running operations comparison: :doc:`long_running_operations`
 
 API Reference
 =============

--- a/docs/src/pyrogue_tree/client_interfaces/simple.rst
+++ b/docs/src/pyrogue_tree/client_interfaces/simple.rst
@@ -81,6 +81,7 @@ Related Topics
 - Server-side transport setup: :doc:`/pyrogue_tree/client_interfaces/zmq_server`
 - Mirrored-tree access model: :doc:`/pyrogue_tree/client_interfaces/virtual`
 - CLI operations for quick checks: :doc:`/pyrogue_tree/client_interfaces/commandline`
+- Long-running operations: :doc:`/pyrogue_tree/builtin_devices/long_running_operations`
 
 API Reference
 =============

--- a/docs/src/pyrogue_tree/client_interfaces/virtual.rst
+++ b/docs/src/pyrogue_tree/client_interfaces/virtual.rst
@@ -112,6 +112,12 @@ It is only useful when the deployment has a known upper bound for legitimate
 request duration and wants the client to declare a request hung after that
 threshold.
 
+.. note::
+   For Commands whose work duration legitimately exceeds ``linkTimeout``,
+   prefer the non-blocking dispatch pattern documented in
+   :doc:`/pyrogue_tree/builtin_devices/long_running_operations`
+   over enlarging the timeout.
+
 .. code-block:: python
 
    from pyrogue.interfaces import VirtualClient
@@ -150,6 +156,7 @@ Related Topics
 - Server endpoint and port behavior: :doc:`/pyrogue_tree/client_interfaces/zmq_server`
 - Minimal string-path client usage: :doc:`/pyrogue_tree/client_interfaces/simple`
 - CLI and GUI workflows: :doc:`/pyrogue_tree/client_interfaces/commandline`
+- Long-running operations: :doc:`/pyrogue_tree/builtin_devices/long_running_operations`
 
 API Reference
 =============

--- a/docs/src/pyrogue_tree/core/command.rst
+++ b/docs/src/pyrogue_tree/core/command.rst
@@ -102,6 +102,7 @@ What To Explore Next
 * Hardware-backed actions: :doc:`/pyrogue_tree/core/remote_command`
 * Device placement and operational hooks: :doc:`/pyrogue_tree/core/device`
 * Root-level system actions: :doc:`/pyrogue_tree/core/root`
+* Long-running operations: :doc:`/pyrogue_tree/builtin_devices/long_running_operations`
 
 API Reference
 =============

--- a/docs/src/pyrogue_tree/core/local_command.rst
+++ b/docs/src/pyrogue_tree/core/local_command.rst
@@ -220,6 +220,7 @@ real implementation is attached.
 What To Explore Next
 ====================
 
+* Long-running operations: :doc:`/pyrogue_tree/builtin_devices/long_running_operations`
 * Hardware-backed commands: :doc:`/pyrogue_tree/core/remote_command`
 * Shared command behavior: :doc:`/pyrogue_tree/core/command`
 * Tree-level placement and decorators: :doc:`/pyrogue_tree/core/device`

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -57,7 +57,22 @@ class BaseCommand(pr.BaseVariable):
         callback may accept any subset of these names.
         Default to no-op for command if None.
     background : bool, optional (default = False)
-        Reserved for background execution.
+        Reserved for future use; not implemented. Use ``nonBlocking=True``
+        to dispatch the function on a worker thread.
+    nonBlocking : bool, optional (default = False)
+        When ``True``, ``call()`` dispatches the function on a non-daemon
+        worker thread and returns ``None`` immediately.  Three sibling
+        ``LocalVariable``\\s are auto-added to the parent ``Device``:
+        ``{name}Running`` (bool), ``{name}Result`` (last return value),
+        and ``{name}Error`` (last exception string, empty when none).
+        Re-entrant calls while the worker is running are logged as a
+        warning and ignored.  The worker is joined on ``Root.stop()``.
+        Mirrors the ``pr.Process`` worker-thread lifecycle.
+
+        See :ref:`pyrogue_tree_builtin_devices_long_running_ops` for the
+        polling pattern and timeout interactions.
+
+        .. versionadded:: 6.14.0
     guiGroup : str, optional
         GUI grouping label.
     **kwargs : Any
@@ -78,6 +93,7 @@ class BaseCommand(pr.BaseVariable):
         maximum: Any | None = None,
         function: Callable[..., Any] | None = None,
         background: bool = False,
+        nonBlocking: bool = False,
         guiGroup: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -101,8 +117,15 @@ class BaseCommand(pr.BaseVariable):
         self._functionWrap = pr.functionWrapper(function=self._function, callArgs=['root', 'dev', 'cmd', 'arg'])
 
         self._thread = None
-        self._lock = threading.Lock()
+        self._lock   = threading.Lock()
+        self._runEn  = False
         self._retDisp = "{}"
+
+        self._nonBlocking = nonBlocking
+        self._nonBlockingVarsAdded = False
+        self._varRunning = None
+        self._varResult  = None
+        self._varError   = None
 
         if retValue is None:
             self._retTypeStr = None
@@ -131,6 +154,75 @@ class BaseCommand(pr.BaseVariable):
         """Return the display string for the return type."""
         return self._retTypeStr
 
+    def _rootAttached(self, parent: Any, root: Any) -> None:
+        """Attach this command into the rooted tree; inject sibling status vars."""
+        pr.BaseVariable._rootAttached(self, parent, root)
+
+        if not self._nonBlocking or self._nonBlockingVarsAdded:
+            return
+        if not isinstance(parent, pr.Device):
+            return
+
+        # Inject three sibling LocalVariables onto the parent Device.
+        # parent.add() cannot be used here because parent._root is already set
+        # (Device._rootAttached sets it before iterating children).  Instead we
+        # place the vars directly into parent._nodes and call _rootAttached on
+        # each so they receive their path, logger, and block setup.
+        lv_running = pr.LocalVariable(
+            name=f'{self.name}Running',
+            mode='RO',
+            value=False,
+            pollInterval=1.0,
+            description=f'Running status for {self.path}.',
+        )
+        lv_result = pr.LocalVariable(
+            name=f'{self.name}Result',
+            mode='RO',
+            value='',
+            pollInterval=1.0,
+            typeCheck=False,
+            description=f'Last successful return value of {self.path}.',
+        )
+        lv_error = pr.LocalVariable(
+            name=f'{self.name}Error',
+            mode='RO',
+            value='',
+            pollInterval=1.0,
+            description=f'Last error from {self.path}. Empty string when none.',
+        )
+
+        # Check for name collisions BEFORE any parent._nodes mutation so a
+        # collision on the second or third sibling does not leave a
+        # half-injected state.  Mirrors Node.add()'s duplicate guard, which is
+        # bypassed here because parent.add() raises when the tree is already
+        # started.
+        for lv in (lv_running, lv_result, lv_error):
+            if lv.name in parent._nodes:
+                raise pr.NodeError(
+                    'Error adding node with name %s to %s. Name collision.' % (lv.name, parent.name))
+
+        for lv in (lv_running, lv_result, lv_error):
+            parent._nodes[lv.name] = lv
+            lv._rootAttached(parent, root)
+
+        self._varRunning = lv_running
+        self._varResult  = lv_result
+        self._varError   = lv_error
+        self._nonBlockingVarsAdded = True
+
+    def _resolveArg(self, arg: Any) -> Any:
+        """Parse raw call argument into the canonical command value.
+
+        Parameters
+        ----------
+        arg : object
+            Raw argument as received by ``__call__``; ``None`` selects the
+            default value.
+        """
+        if arg is None:
+            return self._default
+        return self.parseDisp(arg)
+
     def __call__(self, arg: Any = None) -> Any:
         """Invoke the command.
 
@@ -139,7 +231,36 @@ class BaseCommand(pr.BaseVariable):
         arg : object, optional
             Command argument. If ``None``, uses the default value.
         """
-        return self._doFunc(arg)
+        if not self._nonBlocking:
+            return self._doFunc(arg)
+
+        # Non-blocking path: dispatch worker thread and return immediately.
+        if self.parent.enable.value() is not True:
+            return None
+
+        resolvedArg = self._resolveArg(arg)
+
+        with self._lock:
+            if self._thread is None or not self._thread.is_alive():
+                # Mirror the _doFunc sync path: when the callback accepts an
+                # arg and this is a LocalCommand, cache the resolved argument
+                # so cmd.get() reflects the last invocation.
+                if self._arg and not isinstance(self, RemoteCommand):
+                    self._default = resolvedArg
+                    self._queueUpdate()
+
+                self._runEn  = True
+                self._thread = threading.Thread(
+                    target=self._runWorker,
+                    args=(resolvedArg,),
+                    daemon=False,
+                    name=f'{self.path}.worker',
+                )
+                self._thread.start()
+            else:
+                self._log.warning("Command already running!")
+
+        return None
 
     def _doFunc(self, arg: Any) -> Any:
         """Execute command callback.
@@ -195,7 +316,80 @@ class BaseCommand(pr.BaseVariable):
         arg : object, optional
             Command argument.
         """
+        if self._nonBlocking:
+            self.__call__(arg)
+            return ""
         return self.genDisp(self.__call__(arg),useDisp=self._retDisp)
+
+    def _runWorker(self, arg: Any) -> None:
+        """Execute the command function on a worker thread.
+
+        Mirrors ``pr.Process._run``.  State transitions are batched via
+        ``Root.updateGroup()`` so clients receive one coherent snapshot per
+        phase.  Exceptions are logged server-side; only ``str(exc)`` is
+        surfaced to clients via the ``{name}Error`` sibling variable.
+        """
+        # Start transition: clear previous error, advertise running.
+        with self.root.updateGroup():
+            self._varError.set('')
+            self._varRunning.set(True)
+
+        ret = None
+        err = None
+        try:
+            with self.root.updateGroup(period=1.0):
+                ret = self._functionWrap(
+                    function=self._function,
+                    root=self.root,
+                    dev=self.parent,
+                    cmd=self,
+                    arg=arg,
+                )
+        except Exception as e:
+            pr.logException(self._log, e)
+            err = str(e)
+
+        # End transition: publish result or error, clear running.
+        if err is not None:
+            with self.root.updateGroup():
+                self._varError.set(err)
+                self._varRunning.set(False)
+        else:
+            with self.root.updateGroup():
+                self._varResult.set(ret)
+                self._varRunning.set(False)
+
+        # Release the run-enable flag last so re-entry detection is accurate
+        # throughout the variable-update phase above.
+        with self._lock:
+            self._runEn  = False
+            self._thread = None
+
+    def _stopWorker(self) -> None:
+        """Signal the worker to stop and wait for it to exit.
+
+        Mirrors ``pr.Process._stopProcess`` including the self-thread guard
+        that prevents deadlock when the user function triggers ``Root.stop()``.
+        """
+        with self._lock:
+            self._runEn = False
+            thr = self._thread
+
+        # Self-thread guard: prevents deadlock if the user function calls
+        # Root.stop() from within the worker (mirrors _Process._stopProcess).
+        if (thr is not None
+                and hasattr(thr, 'is_alive') and thr.is_alive()
+                and hasattr(thr, 'join')
+                and threading.current_thread() is not thr):
+            thr.join()
+
+    def _stop(self) -> None:
+        """Join the in-flight worker thread if nonBlocking.
+
+        Called by ``Device._stop`` during ``Root.stop()``.
+        """
+        if self._nonBlocking:
+            self._stopWorker()
 
     @staticmethod
     def nothing() -> None:
@@ -466,6 +660,10 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         keyword arguments ``root``, ``dev``, ``cmd``, and ``arg``; the
         callback may accept any subset of these names.
         Default to no-op for command if None.
+    nonBlocking : bool, optional (default = False)
+        When ``True``, ``call()`` dispatches the function on a non-daemon
+        worker thread and returns ``None`` immediately.  Forwarded only to
+        ``BaseCommand.__init__``; not passed to ``RemoteVariable.__init__``.
     base : object, optional (default = ``pr.UInt``)
         Base data type for the underlying remote variable.
     offset : int, optional
@@ -495,6 +693,7 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         minimum: Any | None = None,
         maximum: Any | None = None,
         function: Callable[..., Any] | None = None,
+        nonBlocking: bool = False,
         base: Any = pr.UInt,
         offset: int | None = None,
         bitSize: int = 32,
@@ -505,12 +704,15 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
     ) -> None:
         """Initialize a remote command."""
 
-        # RemoteVariable constructor will handle assignment of most params
+        # nonBlocking is explicit here so it is NOT in **kwargs and therefore
+        # does not reach pr.RemoteVariable.__init__ (which does not accept it).
+        # Forward it only to BaseCommand.__init__.
         BaseCommand.__init__(
             self,
             name=name,
             retValue=retValue,
             function=function,
+            nonBlocking=nonBlocking,
             guiGroup=guiGroup,
             **kwargs)
 

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -320,6 +320,13 @@ class Device(pr.Node,rim.Hub):
 
     def _stop(self) -> None:
         """Called recursively from Root.stop when exiting"""
+        # Join non-blocking command workers BEFORE stopping interfaces — the
+        # worker function may still touch managed interfaces/memory during
+        # teardown.  Mirrors Process._stop calling _stopProcess() before
+        # Device._stop().
+        for c in self.commands.values():
+            if hasattr(c, '_stop'):
+                c._stop()
         for intf in self._ifAndProto:
             if hasattr(intf,"_stop"):
                 self._log.debug("Stopping managed interface/protocol %s", intf)
@@ -1103,7 +1110,11 @@ class Device(pr.Node,rim.Hub):
         """Attach this device into the rooted tree and build variable blocks."""
         pr.Node._rootAttached(self, parent, root)
 
-        for key,value in self._nodes.items():
+        # Snapshot _nodes before iterating: nonBlocking BaseCommand._rootAttached
+        # may inject sibling LocalVariables into _nodes during the loop; a live
+        # dict view would raise RuntimeError.  Newly added siblings are processed
+        # by _buildBlocks below since they are in _nodes by the time it runs.
+        for key,value in list(self._nodes.items()):
             value._rootAttached(self,root)
 
         self._buildBlocks()

--- a/python/pyrogue/examples/_NonBlockingCommandExample.py
+++ b/python/pyrogue/examples/_NonBlockingCommandExample.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       Cookbook: non-blocking Command with client-side polling loop.
+#       Demonstrates a setDefaults-shaped configuration-apply Command using
+#       nonBlocking=True and the matching hand-rolled polling loop driven by
+#       SimpleClient.  Run directly:
+#           python -m pyrogue.examples._NonBlockingCommandExample
+#       Import and call main() from a smoke test for CI coverage.
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+import time
+import pyrogue as pr
+import pyrogue.interfaces as pr_interfaces
+
+
+def _apply_config(cmd):
+    """Simulate a multi-step configuration apply (the long-running work).
+
+    Models a setDefaults-style operation: iterate over named steps, each
+    with a short delay to simulate real register/DMA traffic, then return
+    a status string that populates the ApplyConfigResult sibling variable.
+    """
+    steps = [
+        ('reset_defaults',   0.3),
+        ('load_cal_table',   0.3),
+        ('verify_checksums', 0.3),
+    ]
+    for step, duration in steps:
+        cmd._log.info('Config step: %s', step)
+        time.sleep(duration)
+    return 'configured'
+
+
+class ConfigDevice(pr.Device):
+    """Device that exposes a single long-running ApplyConfig command.
+
+    The command is marked nonBlocking=True so that ZMQ clients (e.g.
+    SimpleClient, VirtualClient) receive None immediately and can poll
+    the ApplyConfigRunning / ApplyConfigResult / ApplyConfigError sibling
+    variables for completion status.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.LocalCommand(
+            name='ApplyConfig',
+            description=(
+                'Apply full device configuration (setDefaults-style). '
+                'Returns immediately; poll ApplyConfigRunning for completion. '
+                'Result is available in ApplyConfigResult once Running is False.'
+            ),
+            function=_apply_config,
+            nonBlocking=True,
+            retValue='',
+        ))
+
+
+class NonBlockingCommandRoot(pr.Root):
+    """Minimal Root wiring up ConfigDevice and a ZmqServer.
+
+    Parameters
+    ----------
+    port : int
+        Base ZMQ port.  0 (default) lets the server auto-assign from 9099
+        upward.  Pass an explicit port when the caller must control binding
+        (e.g. in a smoke test that supplies a free port).
+    """
+
+    def __init__(self, *, port=0):
+        super().__init__(name='Top', pollEn=False)
+        self.add(ConfigDevice(name='Dev'))
+        self.zmqServer = pr_interfaces.ZmqServer(root=self, addr='127.0.0.1', port=port)
+        self.addInterface(self.zmqServer)
+
+
+def main(port=0, poll_interval=0.1, timeout=30.0):
+    """Run the non-blocking Command example and return the Result string.
+
+    This function is the canonical reference shape for the hand-rolled
+    client-side polling loop that pairs with a nonBlocking=True Command:
+
+    1. Fire the command via SimpleClient.exec — returns None immediately.
+    2. Poll ApplyConfigRunning until it becomes False (bounded by timeout).
+    3. Read ApplyConfigError; raise RuntimeError if non-empty.
+    4. Return ApplyConfigResult.
+
+    Parameters
+    ----------
+    port : int
+        ZMQ base port passed to NonBlockingCommandRoot.  0 = auto-assign.
+    poll_interval : float
+        Seconds between ApplyConfigRunning polls.
+    timeout : float
+        Maximum seconds to wait for the command to finish before raising.
+
+    Returns
+    -------
+    str
+        The value stored in ApplyConfigResult on successful completion.
+    """
+    with NonBlockingCommandRoot(port=port) as root:
+        actual_port = root.zmqServer.port()
+        with pr_interfaces.SimpleClient(addr='127.0.0.1', port=actual_port) as client:
+
+            # Fire the long-running command — returns None immediately because
+            # the server dispatches a worker thread and replies before it finishes.
+            client.exec('Top.Dev.ApplyConfig')
+
+            # Hand-rolled polling loop: the canonical pattern for nonBlocking Commands.
+            # Poll the auto-injected ApplyConfigRunning sibling variable until it
+            # transitions to False, indicating the worker thread has completed.
+            deadline  = time.monotonic() + timeout
+            completed = False
+            while time.monotonic() < deadline:
+                if not client.get('Top.Dev.ApplyConfigRunning'):
+                    completed = True
+                    break
+                time.sleep(poll_interval)
+
+            if not completed:
+                raise TimeoutError(
+                    f'ApplyConfig did not complete within {timeout:.1f}s')
+
+            error  = client.get('Top.Dev.ApplyConfigError')
+            result = client.get('Top.Dev.ApplyConfigResult')
+
+            if error:
+                raise RuntimeError(f'ApplyConfig failed: {error}')
+
+            return result
+
+
+if __name__ == '__main__':
+    result = main()
+    print(f'ApplyConfig completed: {result}')

--- a/python/pyrogue/examples/__init__.py
+++ b/python/pyrogue/examples/__init__.py
@@ -13,5 +13,6 @@
 from pyrogue.examples._AxiVersion  import *
 from pyrogue.examples._ExampleRoot import *
 from pyrogue.examples._LargeDevice import *
+from pyrogue.examples._NonBlockingCommandExample import *
 from pyrogue.examples._OsMemMaster import *
 from pyrogue.examples._OsMemSlave  import *

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -340,11 +340,18 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         primary operational timeout knob for both hardware and simulation
         applications.
 
+        For Commands whose work duration legitimately exceeds this timeout,
+        see :ref:`pyrogue_tree_builtin_devices_long_running_ops` for the
+        non-blocking dispatch pattern.
+
     requestStallTimeout : float | None, optional
         Optional policy timeout for how long a single in-flight request may
         remain outstanding before the client declares the connection stalled.
         This is disabled by default and is typically only useful when a
         deployment has a well-defined upper bound for legitimate request time.
+
+        See :ref:`pyrogue_tree_builtin_devices_long_running_ops` for how
+        this interacts with non-blocking Command polling.
 
     Attributes
     ----------

--- a/tests/core/test_core_command_nonblocking_construction.py
+++ b/tests/core/test_core_command_nonblocking_construction.py
@@ -1,0 +1,203 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import pytest
+import pyrogue as pr
+from conftest import MemoryRoot
+
+
+# ---------------------------------------------------------------------------
+# Helpers — plain functions (not lambdas) so the arg introspection in
+# BaseCommand.__init__ succeeds without raising on C-extension paths.
+# ---------------------------------------------------------------------------
+
+def _noop_fn(root=None, dev=None, cmd=None, arg=None):
+    """No-op command function for construction tests."""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Device / Root definitions — RemoteCommand cases (need memory backing)
+# ---------------------------------------------------------------------------
+
+class _AsyncRegDevice(pr.Device):
+    """Device that adds a RemoteCommand with nonBlocking=True."""
+
+    def __init__(self, mem_base, **kwargs):
+        super().__init__(memBase=mem_base, **kwargs)
+        # The explicit `nonBlocking` kwarg on RemoteCommand.__init__ routes
+        # nonBlocking only to BaseCommand.__init__ and keeps it out of the
+        # **kwargs handed to pr.RemoteVariable.__init__.  pr.RemoteVariable
+        # accepts **kwargs and silently absorbs unknown keywords, so this
+        # routing is documentation rather than a crash fix.
+        self.add(pr.RemoteCommand(
+            name='AsyncReg',
+            offset=0x00,
+            bitSize=8,
+            base=pr.UInt,
+            value=0,
+            function=_noop_fn,
+            nonBlocking=True,
+            description='Non-blocking remote command — construction guard.',
+        ))
+
+
+class _AsyncRegRoot(MemoryRoot):
+    def __init__(self):
+        super().__init__(name='AsyncRegRoot')
+        self.add(_AsyncRegDevice(name='Dev', mem_base=self._mem))
+
+
+# ---------------------------------------------------------------------------
+# Device / Root definitions — default RemoteCommand (backward-compat)
+# ---------------------------------------------------------------------------
+
+class _SyncRegDevice(pr.Device):
+    """Device that adds a default (no nonBlocking kwarg) RemoteCommand."""
+
+    def __init__(self, mem_base, **kwargs):
+        super().__init__(memBase=mem_base, **kwargs)
+        self.add(pr.RemoteCommand(
+            name='SyncReg',
+            offset=0x00,
+            bitSize=8,
+            base=pr.UInt,
+            value=0,
+            function=_noop_fn,
+            description='Default (sync) remote command — backward-compat guard.',
+        ))
+
+
+class _SyncRegRoot(MemoryRoot):
+    def __init__(self):
+        super().__init__(name='SyncRegRoot')
+        self.add(_SyncRegDevice(name='Dev', mem_base=self._mem))
+
+
+# ---------------------------------------------------------------------------
+# Device / Root definitions — sibling-name collision (LocalCommand path)
+# ---------------------------------------------------------------------------
+
+class _CollisionDevice(pr.Device):
+    """Device with a pre-existing 'FooRunning' child before a nonBlocking
+    LocalCommand named 'Foo' is added.  _rootAttached must detect the
+    collision and raise pr.NodeError."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Pre-plant the colliding variable BEFORE the command.
+        self.add(pr.LocalVariable(
+            name='FooRunning',
+            value=False,
+            description='Pre-existing variable whose name collides with the generated sibling.',
+        ))
+        # Without the pre-injection collision check in _rootAttached,
+        # parent._nodes['FooRunning'] would be silently overwritten by the
+        # auto-generated sibling, destroying the pre-existing variable.
+        self.add(pr.LocalCommand(
+            name='Foo',
+            function=_noop_fn,
+            nonBlocking=True,
+            description='nonBlocking LocalCommand whose FooRunning sibling name collides.',
+        ))
+
+
+class _CollisionRoot(pr.Root):
+    def __init__(self):
+        super().__init__(name='CollisionRoot', pollEn=False)
+        self.add(_CollisionDevice(name='Dev'))
+
+
+# ---------------------------------------------------------------------------
+# Device / Root definitions — non-collision control (LocalCommand path)
+# ---------------------------------------------------------------------------
+
+class _BarDevice(pr.Device):
+    """Device with a nonBlocking LocalCommand named 'Bar' and NO pre-existing
+    BarRunning/BarResult/BarError children.  Must attach cleanly."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.LocalCommand(
+            name='Bar',
+            function=_noop_fn,
+            nonBlocking=True,
+            description='Non-blocking LocalCommand with no colliding siblings.',
+        ))
+
+
+class _BarRoot(pr.Root):
+    def __init__(self):
+        super().__init__(name='BarRoot', pollEn=False)
+        self.add(_BarDevice(name='Dev'))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_remote_command_nonblocking_constructs():
+    """RemoteCommand(nonBlocking=True) constructs, attaches, and auto-injects
+    its three sibling status variables (AsyncRegRunning, AsyncRegResult,
+    AsyncRegError) on start().
+    """
+    with _AsyncRegRoot() as root:
+        # Construction and start() completed without TypeError.
+        dev = root.Dev
+        # The three sibling status variables must exist on the parent Device.
+        assert 'AsyncRegRunning' in dev.nodes, \
+            "AsyncRegRunning sibling not injected by _rootAttached"
+        assert 'AsyncRegResult' in dev.nodes, \
+            "AsyncRegResult sibling not injected by _rootAttached"
+        assert 'AsyncRegError' in dev.nodes, \
+            "AsyncRegError sibling not injected by _rootAttached"
+
+
+def test_remote_command_default_unchanged():
+    """Backward-compat: a RemoteCommand constructed WITHOUT nonBlocking must
+    attach cleanly and must NOT create any sibling status variables.  Pins the
+    promise that default BaseCommand behaviour is unchanged.
+    """
+    with _SyncRegRoot() as root:
+        dev = root.Dev
+        assert 'SyncReg' in dev.nodes, "SyncReg command not found on device"
+        assert 'SyncRegRunning' not in dev.nodes, \
+            "SyncRegRunning sibling must not exist for a default (sync) RemoteCommand"
+        assert 'SyncRegResult' not in dev.nodes, \
+            "SyncRegResult sibling must not exist for a default (sync) RemoteCommand"
+        assert 'SyncRegError' not in dev.nodes, \
+            "SyncRegError sibling must not exist for a default (sync) RemoteCommand"
+
+
+def test_sibling_injection_collision_raises_nodeerror():
+    """When a parent Device already contains a child whose name collides with
+    a generated {name}Running / {name}Result / {name}Error sibling,
+    BaseCommand._rootAttached must raise pr.NodeError BEFORE any
+    parent._nodes mutation — the pre-existing node must not be overwritten.
+    """
+    with pytest.raises(pr.NodeError):
+        with _CollisionRoot():
+            pass
+
+
+def test_sibling_injection_no_collision_ok():
+    """A nonBlocking LocalCommand with no pre-existing sibling name collisions
+    must attach cleanly and create its three status siblings.  Proves the
+    collision guard does not false-positive on the normal path.
+    """
+    with _BarRoot() as root:
+        dev = root.Dev
+        assert 'Bar' in dev.nodes, "Bar command not found on device"
+        assert 'BarRunning' in dev.nodes, \
+            "BarRunning sibling not injected for non-colliding nonBlocking LocalCommand"
+        assert 'BarResult' in dev.nodes, \
+            "BarResult sibling not injected for non-colliding nonBlocking LocalCommand"
+        assert 'BarError' in dev.nodes, \
+            "BarError sibling not injected for non-colliding nonBlocking LocalCommand"

--- a/tests/interfaces/test_interfaces_command_nonblocking.py
+++ b/tests/interfaces/test_interfaces_command_nonblocking.py
@@ -1,0 +1,381 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import threading
+import time
+
+import pytest
+import pyrogue as pr
+import pyrogue.interfaces as pr_interfaces
+
+
+pytestmark = pytest.mark.integration
+
+
+# TEST-04 uses _LogRecorder to capture server-side log warnings from the live command.
+class _LogRecorder:
+    """Minimal logger stub that records warning() calls for TEST-04 assertions."""
+
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, message):
+        self.messages.append(message)
+
+    def __getattr__(self, name):
+        # Absorb any other logger surface (debug/info/error/critical/exception)
+        # without raising AttributeError.  Keeps TEST-04 robust against future
+        # implementation changes that might add new self._log calls inside the
+        # non-blocking dispatch path.
+        return lambda *a, **k: None
+
+
+def raise_boom():
+    """Module-level raising function — keeps the traceback readable for TEST-06."""
+    raise RuntimeError("boom")
+
+
+def _async_sleep_fn():
+    """Sleep 2 seconds and return a fixed string result."""
+    time.sleep(2.0)
+    return 'done'
+
+
+class ZmqIntegrationDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # TEST-01 (#1243): synchronous long-running command; blocks the client for the
+        # full function duration regardless of linkTimeout.  A 3-second sleep stands in
+        # for the issue #1243 blocking pattern within the CI time budget.
+        self.add(pr.LocalCommand(
+            name='SyncSleep',
+            description='Synchronous sleep — blocks caller for full duration.',
+            function=lambda: time.sleep(3),
+        ))
+
+        # TEST-02: same pattern with nonBlocking=True; call returns immediately and
+        # the client polls the auto-added Running/Result/Error sibling variables.
+        self.add(pr.LocalCommand(
+            name='AsyncSleep',
+            description='Non-blocking sleep — returns immediately; poll AsyncSleepRunning.',
+            function=_async_sleep_fn,
+            nonBlocking=True,
+            retValue='',
+        ))
+
+        # Sync regression: default-construction command must still return its
+        # function value synchronously after the nonBlocking feature is introduced.
+        self.add(pr.LocalCommand(
+            name='SyncMul',
+            description='Synchronous multiply — returns arg * 3.',
+            value=0,
+            retValue=0,
+            function=lambda arg: arg * 3,
+        ))
+
+        # TEST-04: 2-second sleep — used for re-entry rejection test.
+        self.add(pr.LocalCommand(
+            name='AsyncSlow',
+            description='Non-blocking 2-second sleep — re-entry rejection test.',
+            function=lambda: time.sleep(2.0),
+            nonBlocking=True,
+            retValue='',
+        ))
+
+        # TEST-05: 5-second sleep — used for Root.stop() clean-join test.
+        self.add(pr.LocalCommand(
+            name='AsyncLong',
+            description='Non-blocking 5-second sleep — shutdown join test.',
+            function=lambda: time.sleep(5.0),
+            nonBlocking=True,
+            retValue='',
+        ))
+
+        # TEST-06: raises RuntimeError — used for worker error-path test.
+        self.add(pr.LocalCommand(
+            name='AsyncBoom',
+            description='Non-blocking command that raises — error-path test.',
+            function=raise_boom,
+            nonBlocking=True,
+        ))
+
+
+class ZmqIntegrationRoot(pr.Root):
+    def __init__(self, *, port):
+        super().__init__(name='Top', pollEn=False)
+        self.add(ZmqIntegrationDevice(name='Dev'))
+
+        self.zmqServer = pr_interfaces.ZmqServer(root=self, addr='*', port=port)
+        self.addInterface(self.zmqServer)
+
+
+def test_sync_command_baseline_blocks_link(free_zmq_port):
+    # TEST-01 (#1243): a synchronous LocalCommand over ZMQ blocks the client thread
+    # for the entire duration of the server-side function.  The VirtualClient does NOT
+    # raise after linkTimeout when a request is in flight (the idle-timeout check is
+    # suppressed while reqPending=True).  This test asserts the blocking behaviour so
+    # that the contrast with TEST-02 (nonBlocking=True) is explicit.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=2.0,
+        )
+        try:
+            remote_dev = client.root.Dev
+            t0 = time.monotonic()
+            remote_dev.SyncSleep()
+            elapsed = time.monotonic() - t0
+            # The synchronous call must block for the full 3-second sleep.
+            # TEST-01 assertion shape: wall-clock >= sleep_duration - 0.5 s.
+            assert elapsed >= 2.5, (
+                f"Sync command should block for ~3 s but returned in {elapsed:.2f} s"
+            )
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
+
+
+def test_nonblocking_command_returns_immediately(wait_until, free_zmq_port):
+    # TEST-02: with nonBlocking=True the command call returns immediately (well under
+    # linkTimeout=2.0).  The auto-added AsyncSleepRunning / AsyncSleepResult /
+    # AsyncSleepError sibling LocalVariables are polled via the VirtualClient until
+    # the worker completes naturally.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=2.0,
+        )
+        try:
+            remote_dev = client.root.Dev
+
+            t0 = time.monotonic()
+            remote_dev.AsyncSleep()
+            elapsed = time.monotonic() - t0
+
+            # (a) Call must return immediately — well under linkTimeout.
+            assert elapsed < 1.0, (
+                f"nonBlocking call should return immediately but took {elapsed:.2f} s"
+            )
+
+            # (b) Running flips to True while the worker is in flight.
+            assert wait_until(
+                lambda: remote_dev.AsyncSleepRunning.get() is True,
+                timeout=5.0,
+            ), "AsyncSleepRunning never became True"
+
+            # (c) Running flips to False once the 2-second worker completes.
+            assert wait_until(
+                lambda: remote_dev.AsyncSleepRunning.get() is False,
+                timeout=10.0,
+            ), "AsyncSleepRunning never returned to False"
+
+            # (d) Result carries the function's return value.
+            assert remote_dev.AsyncSleepResult.get() == 'done', (
+                f"Expected AsyncSleepResult='done', got {remote_dev.AsyncSleepResult.get()!r}"
+            )
+
+            # (e) Error is empty on a successful run.
+            assert remote_dev.AsyncSleepError.get() == '', (
+                f"Expected empty AsyncSleepError, got {remote_dev.AsyncSleepError.get()!r}"
+            )
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
+
+
+def test_sync_command_returns_value(free_zmq_port):
+    # Sync regression: default-construction LocalCommand (nonBlocking=False) must
+    # continue to return the function's value synchronously over VirtualClient.
+    # Pins the "default-False keeps every existing example unchanged" promise.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=2.0,
+        )
+        try:
+            remote_dev = client.root.Dev
+            result = remote_dev.SyncMul(4)
+            assert result == 12, f"Expected SyncMul(4)==12, got {result!r}"
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
+
+
+def test_reentrant_call_is_rejected_and_logged(wait_until, free_zmq_port):
+    # TEST-04 (#1243): a second call to a non-blocking Command while it is running
+    # is logged as "Command already running!" and silently rejected — no parallel
+    # worker is spawned and Result is not modified.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=5.0,
+        )
+        cmd = root.Dev.AsyncSlow
+        original_log = cmd._log
+        recorder = _LogRecorder()
+        cmd._log = recorder
+        try:
+            remote_dev = client.root.Dev
+
+            # Snapshot Result before the first call — unchanged-sentinel for (c).
+            result_before = remote_dev.AsyncSlowResult.get()
+
+            # First call — worker spawns and begins its 2-second sleep.
+            remote_dev.AsyncSlow()
+
+            # Wait for Running to flip True before issuing the re-entry call.
+            assert wait_until(
+                lambda: remote_dev.AsyncSlowRunning.get() is True,
+                timeout=5.0,
+            ), "AsyncSlowRunning never became True after first call"
+
+            # Second call while the worker is in flight — must be silently rejected.
+            result = remote_dev.AsyncSlow()
+            assert result is None, (
+                f"Re-entry call should return None, got {result!r}"
+            )
+
+            # (a) Exactly one warning logged on the server side.
+            assert recorder.messages == ["Command already running!"], (
+                f"Expected ['Command already running!'] but got {recorder.messages!r}"
+            )
+
+            # (b) Only one worker thread alive for this command path.
+            worker_threads = [
+                t for t in threading.enumerate()
+                if t.name == f'{cmd.path}.worker'
+            ]
+            assert len(worker_threads) == 1, (
+                f"Expected 1 worker thread, found {len(worker_threads)}"
+            )
+
+            # (c) Result is unchanged — re-entry rejection did not modify it.
+            assert remote_dev.AsyncSlowResult.get() == result_before, (
+                f"Result changed after re-entry rejection: "
+                f"before={result_before!r}, after={remote_dev.AsyncSlowResult.get()!r}"
+            )
+
+            # Wait for the first worker to finish naturally before cleanup.
+            assert wait_until(
+                lambda: remote_dev.AsyncSlowRunning.get() is False,
+                timeout=10.0,
+            ), "AsyncSlowRunning never returned to False after worker completion"
+
+        finally:
+            cmd._log = original_log
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
+
+
+def test_root_stop_joins_in_flight_worker(wait_until, free_zmq_port):
+    # TEST-05 (#1243): Root.stop() (via ZmqIntegrationRoot context exit) joins
+    # any in-flight non-blocking Command worker indefinitely — no .worker thread
+    # survives shutdown.  Workers are daemon=False and Root.stop() joins them
+    # without a timeout.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=10.0,
+        )
+        try:
+            remote_dev = client.root.Dev
+
+            # Start the 5-second worker.
+            remote_dev.AsyncLong()
+
+            # Confirm the worker is in flight before triggering shutdown.
+            assert wait_until(
+                lambda: remote_dev.AsyncLongRunning.get() is True,
+                timeout=5.0,
+            ), "AsyncLongRunning never became True"
+
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
+
+    # with block exit: root.stop() is called, which joins the in-flight worker
+    # indefinitely.  The 5-second sleep must complete before this line is reached.
+    # Scope the leak check to threads this feature owns (".worker") to avoid
+    # false positives from unrelated background threads (pytest, ZMQ, logging).
+    post_threads = {t.name for t in threading.enumerate()}
+    leaked_workers = [name for name in post_threads if name.endswith('.worker')]
+    assert not leaked_workers, (
+        f"Worker threads survived root.stop(): {leaked_workers}"
+    )
+
+
+def test_worker_exception_sets_error_and_preserves_result(wait_until, free_zmq_port):
+    # TEST-06 (#1243): when the worker function raises, str(exc) lands in
+    # {name}Error, Running is cleared to False, and Result is left unchanged.
+    pr_interfaces.VirtualClient.ClientCache.clear()
+
+    with ZmqIntegrationRoot(port=free_zmq_port) as root:
+        client = pr_interfaces.VirtualClient(
+            addr='127.0.0.1',
+            port=root.zmqServer.port(),
+            linkTimeout=5.0,
+        )
+        try:
+            remote_dev = client.root.Dev
+
+            # Pre-call: Error must be empty before any invocation.
+            assert remote_dev.AsyncBoomError.get() == "", (
+                f"Expected empty AsyncBoomError before call, "
+                f"got {remote_dev.AsyncBoomError.get()!r}"
+            )
+
+            # Snapshot Result before the call — unchanged-sentinel independent
+            # of the chosen default value.
+            result_before = remote_dev.AsyncBoomResult.get()
+
+            # Fire the raising command — returns None immediately (nonBlocking).
+            remote_dev.AsyncBoom()
+
+            # Wait for the worker to exit after raising.
+            assert wait_until(
+                lambda: remote_dev.AsyncBoomRunning.get() is False,
+                timeout=10.0,
+            ), "AsyncBoomRunning never cleared after worker exception"
+
+            # Error carries str(exc) only.
+            assert remote_dev.AsyncBoomError.get() == "boom", (
+                f"Expected AsyncBoomError='boom', got {remote_dev.AsyncBoomError.get()!r}"
+            )
+
+            # Running is False — cleared in the error branch.
+            assert remote_dev.AsyncBoomRunning.get() is False, (
+                "AsyncBoomRunning should be False after exception"
+            )
+
+            # Result is UNCHANGED — the error branch does not update Result.
+            assert remote_dev.AsyncBoomResult.get() == result_before, (
+                f"Result changed after exception: "
+                f"before={result_before!r}, after={remote_dev.AsyncBoomResult.get()!r}"
+            )
+
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()

--- a/tests/interfaces/test_interfaces_simple_client_nonblocking.py
+++ b/tests/interfaces/test_interfaces_simple_client_nonblocking.py
@@ -1,0 +1,97 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import time
+
+import pytest
+import pyrogue as pr
+import pyrogue.interfaces as pr_interfaces
+
+
+pytestmark = pytest.mark.integration
+
+
+def _apply_config_fn():
+    """Simulate a multi-step configuration apply (1 second total)."""
+    time.sleep(1.0)
+    return 'configured'
+
+
+class NonBlockingDevice(pr.Device):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add(pr.LocalCommand(
+            name='ApplyConfig',
+            description='Non-blocking config apply — returns immediately.',
+            function=_apply_config_fn,
+            nonBlocking=True,
+            retValue='',
+        ))
+
+
+class NonBlockingRoot(pr.Root):
+    def __init__(self, *, port):
+        super().__init__(name='Top', pollEn=False)
+        self.add(NonBlockingDevice(name='Dev'))
+        self.zmqServer = pr_interfaces.ZmqServer(root=self, addr='*', port=port)
+        self.addInterface(self.zmqServer)
+
+
+def test_simpleclient_exec_nonblocking_returns_immediately(wait_until, free_zmq_port):
+    # TEST-03: SimpleClient.exec on a nonBlocking=True Command returns immediately
+    # (well under the worker's 1-second duration) without raising.  Polling via
+    # client.get() shows Running flip True->False and Result population.
+    # SimpleClient uses a raw zmq.REQ socket with no recv timeout and no cache.
+
+    with NonBlockingRoot(port=free_zmq_port) as root:
+        with pr_interfaces.SimpleClient(addr='127.0.0.1', port=root.zmqServer.port()) as client:
+            t0 = time.monotonic()
+            result = client.exec('Top.Dev.ApplyConfig')
+            elapsed = time.monotonic() - t0
+
+            # (a) exec returns None immediately — well under the 1-second worker duration.
+            assert result is None, f"Expected None, got {result!r}"
+            assert elapsed < 1.0, (
+                f"nonBlocking exec should return immediately but took {elapsed:.2f} s"
+            )
+
+            # (b) Running flips to True while the worker is in flight.
+            assert wait_until(
+                lambda: client.get('Top.Dev.ApplyConfigRunning') is True,
+                timeout=5.0,
+            ), "ApplyConfigRunning never became True"
+
+            # (c) Running clears once the 1-second worker finishes.
+            assert wait_until(
+                lambda: client.get('Top.Dev.ApplyConfigRunning') is False,
+                timeout=10.0,
+            ), "ApplyConfigRunning never returned to False"
+
+            # (d) Result carries the function's return value.
+            assert client.get('Top.Dev.ApplyConfigResult') == 'configured', (
+                f"Expected 'configured', got {client.get('Top.Dev.ApplyConfigResult')!r}"
+            )
+
+            # (e) Error is empty on a successful run.
+            assert client.get('Top.Dev.ApplyConfigError') == '', (
+                f"Expected empty Error, got {client.get('Top.Dev.ApplyConfigError')!r}"
+            )
+
+
+def test_cookbook_example_runs_headless(free_zmq_port):
+    # Smoke test: import and run the cookbook main() headlessly to verify it
+    # completes without error and returns the expected Result string.  Prevents
+    # the cookbook example from silently rotting.
+    from pyrogue.examples._NonBlockingCommandExample import main
+
+    result = main(port=free_zmq_port)
+    assert result == 'configured', (
+        f"Cookbook example should return 'configured', got {result!r}"
+    )

--- a/tests/interfaces/test_zmq_client.py
+++ b/tests/interfaces/test_zmq_client.py
@@ -120,7 +120,7 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
     state machine.
 
     On unpatched main this test is EXPECTED to fail (crash, timeout, or
-    ZMQ protocol error) within ~30 s. Phase 2 adds a std::mutex in C++
+    ZMQ protocol error) within ~30 s. The fix adds a std::mutex in C++
     ZmqClient to serialize the REQ cycle; the same test must then pass.
     """
     N_COMMANDS = 500
@@ -166,10 +166,10 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
         def _watchdog():
             # Fires iff the test process is still alive after WATCHDOG_SECONDS.
             # On unpatched HEAD the corrupted ZMQ_REQ socket can deadlock
-            # teardown (srv._stop/root.stop), so setting stop_event alone
-            # is insufficient to satisfy REPRO-03 (< 30s).  Hard-exit is
-            # the only mechanism that bypasses a C++/GIL deadlock; a
-            # non-zero exit preserves the Phase 1 FAIL-on-unpatched signal.
+            # teardown (srv._stop/root.stop), so setting stop_event alone is
+            # insufficient to bound the test runtime.  Hard-exit is the only
+            # mechanism that bypasses a C++/GIL deadlock; a non-zero exit
+            # preserves the FAIL-on-unpatched signal.
             timeout_flag["fired"] = True
             stop_event.set()
             sys.stderr.write(
@@ -200,13 +200,13 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
             watchdog.cancel()
             poll_thread.join(timeout=JOIN_TIMEOUT)
 
-        # REPRO-03 invariants: the polling thread MUST have exited, and
-        # the watchdog MUST NOT have fired (otherwise we blew the 30 s budget).
+        # Invariants: the polling thread MUST have exited, and the watchdog
+        # MUST NOT have fired (otherwise we blew the 30 s budget).
         assert not poll_thread.is_alive(), "polling thread did not join within %.1fs" % JOIN_TIMEOUT
         assert not timeout_flag["fired"], "watchdog fired: test exceeded %.1fs budget" % WATCHDOG_SECONDS
 
         # Re-raise any error captured in the polling thread so a poller-only
-        # crash still fails the pytest run (D-12).
+        # crash still fails the pytest run.
         if errors:
             raise AssertionError(
                 "concurrent RPC race: polling thread raised %d error(s); first: %r"


### PR DESCRIPTION
## Summary

Closes the discoverability and ergonomics gap reported in #1243: a long-running `Command` invoked over ZMQ (`SimpleClient.exec` / `VirtualClient`) ties up the client past `linkTimeout` / `requestStallTimeout`, and `pr.Process` was the only documented escape hatch.

This PR adds an opt-in `nonBlocking=True` kwarg on `BaseCommand` so a user with an existing `pr.LocalCommand(function=long_thing)` can flip one flag and stop fighting client timeouts. `pr.Process` and `Command(nonBlocking=True)` are now the two canonical patterns for long-running work, documented side-by-side.

## What ships

### Core API (`python/pyrogue/_Command.py`, `python/pyrogue/_Device.py`)

- `BaseCommand(nonBlocking=True)` opt-in kwarg. Default behavior unchanged — sync `call()` returns the function's value as before.
- `RemoteCommand` explicitly forwards `nonBlocking` to `BaseCommand.__init__` only; it is not in `**kwargs` and therefore cannot reach `RemoteVariable.__init__`.
- Worker thread per call (`daemon=False`, name `{path}.worker`). Auto-injects three sibling `LocalVariable`s on the parent `Device`: `{name}Running` (bool), `{name}Result` (last return value, sticky on success), `{name}Error` (last exception string, cleared at dispatch).
- Re-entry guard uses live thread aliveness (`self._thread.is_alive()`), not the `_runEn` flag, closing the race where `_stopWorker` cleared the flag before joining.
- Sync-path parity: when the callback accepts an `arg` and this is a `LocalCommand`, the resolved argument is cached into `self._default` and an update is queued before worker dispatch, so `cmd.get()` reflects the last invocation.
- Sibling-injection collision guard: pre-checks `parent._nodes` for `{name}Running` / `{name}Result` / `{name}Error` before any mutation; raises `pr.NodeError` on conflict so a third-sibling collision never leaves a half-injected state.
- `Device._stop()` joins non-blocking command workers **before** stopping managed interfaces, mirroring `Process._stop` calling `_stopProcess` first. Worker functions that touch interfaces or memory during teardown stay safe.
- `Device._rootAttached` snapshots `_nodes` before iterating so the sibling-variable injection done by child `BaseCommand._rootAttached` cannot raise `RuntimeError: dictionary changed size during iteration`.
- Worker lifecycle (`_runWorker`, `_stopWorker`, `_stop`) mirrors `pr.Process` — including the self-thread guard that prevents deadlock if the user function triggers `Root.stop()` from within itself.

### Cookbook example (`python/pyrogue/examples/_NonBlockingCommandExample.py`)

- `ApplyConfig` non-blocking `LocalCommand` plus `SimpleClient` hand-rolled `Running` / `Result` / `Error` poll loop.
- `main()` raises `TimeoutError` on deadline expiry to match its documented behavior.
- Exported from the `pyrogue.examples` barrel (`examples/__init__.py`).
- Runnable headlessly (`python -m pyrogue.examples._NonBlockingCommandExample`); also used as the `literalinclude` source for the docs polling-pattern snippet.

### Documentation (`docs/src/`)

- New Sphinx page `pyrogue_tree/builtin_devices/long_running_operations.rst` — decision rule, side-by-side comparison table (`pr.Process` vs `Command(nonBlocking=True)`), parallel recipes, client-side polling pattern, and an explicit "Interaction with linkTimeout and requestStallTimeout" section explaining that `linkTimeout` is an **idle** timeout and that `requestStallTimeout` defaults to disabled.
- `.. versionadded:: 6.14.0` on the new page and on the `nonBlocking` parameter in `BaseCommand`'s docstring.
- `:ref:` cross-references inside `BaseCommand.nonBlocking` (`_Command.py`) and `VirtualClient.linkTimeout` / `requestStallTimeout` (`_Virtual.py`) so `autoclass` and `help()` surface the link next to the relevant parameter.
- "Related Topics" / "What To Explore Next" cross-links added to `process.rst`, `core/command.rst`, `core/local_command.rst`, `client_interfaces/virtual.rst`, `client_interfaces/simple.rst`, and `builtin_devices/index.rst` so a #1243-style reader lands on the new page from any entry point.

### Tests

- `tests/core/test_core_command_nonblocking_construction.py` — backward-compat construction, `RemoteCommand(nonBlocking=True)` attaches cleanly, sibling-injection collision raises `pr.NodeError`.
- `tests/interfaces/test_interfaces_command_nonblocking.py` — happy-path, re-entry rejection, `Root.stop()` clean-join (no `.worker` thread survives shutdown), error path (`str(exc)` in `Error`, `Running=False`, `Result` unchanged).
- `tests/interfaces/test_interfaces_simple_client_nonblocking.py` — `SimpleClient.exec` returns in well under 1 s for a multi-second non-blocking command; polls `ApplyConfigRunning` via full `Top.Dev.*` paths.

## Compatibility

- Default `BaseCommand` behavior unchanged. `nonBlocking=True` is opt-in.
- No new C++ dependencies. Pure-Python worker, mirroring `pr.Process`.
- No changes to existing examples or downstream consumers (`python/pyrogue/examples/`, `python/pyrogue/pydm/`) unless explicitly migrated.
- Targeted at v6.14.0 — does not block RC #1240 / v6.13.1.
