### PR TITLE
fix(pyrogue): bound waitOnUpdate() with a barrier sentinel

### DIFF
--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -613,8 +613,40 @@ class Root(pr.Device):
 
     @pr.expose
     def waitOnUpdate(self) -> None:
-        """Wait until all update queue items have been processed."""
-        self._updateQueue.join()
+        """Block until update-queue items present at call time have been processed.
+
+        A barrier sentinel (``threading.Event``) is appended to the update
+        queue and this method blocks until the update worker reaches it.
+        Items added to the queue *while* this method is waiting are NOT
+        included in the wait — the wait is bounded by the queue contents
+        at the moment of this call.
+
+        This is intentional: the previous implementation called
+        ``_updateQueue.join()``, which only returns once the unfinished-task
+        counter reaches zero. Under sustained producer load (poll thread,
+        listener-fired sets, UDP listeners) the counter never settles and
+        the call could silently take minutes.
+
+        To flush updates that the calling thread has accumulated inside
+        an ``updateGroup()`` context, call this method *outside* that
+        context. While inside ``updateGroup()`` the calling thread's
+        pending updates remain buffered in its ``UpdateTracker`` and
+        have not yet been queued.
+        """
+        if not self._running:
+            return
+
+        barrier = threading.Event()
+        self._updateQueue.put(barrier)
+
+        # Race guard: stop() can flip _running and enqueue the None stop
+        # sentinel between this method's _running check and the put() above.
+        # If our barrier ends up behind the stop sentinel the worker will
+        # consume None and exit before reaching us, leaving barrier.wait()
+        # blocked forever. Poll _running so we return after stop() runs.
+        while not barrier.wait(timeout=0.5):
+            if not self._running:
+                return
 
     def hardReset(self) -> None:
         """Generate a hard reset on all devices.
@@ -1122,6 +1154,14 @@ class Root(pr.Device):
                 self._log.info("Stopping update thread")
                 self._updateQueue.task_done()
                 return
+
+            # Barrier sentinel posted by waitOnUpdate(). Items queued before
+            # the barrier have already been processed by the time we reach
+            # it; signal the waiter and continue.
+            if isinstance(uvars, threading.Event):
+                uvars.set()
+                self._updateQueue.task_done()
+                continue
 
             # Process list
             elif len(uvars) > 0:

--- a/tests/core/test_wait_on_update_bounded.py
+++ b/tests/core/test_wait_on_update_bounded.py
@@ -1,0 +1,179 @@
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+# Regression for the unbounded-`waitOnUpdate()` hang reported by SO/LAT
+# rogue 6 deployments. The user pattern was:
+#
+#     with self.root.updateGroup():
+#         self.root.waitOnUpdate()
+#
+# `waitOnUpdate()` previously called `_updateQueue.join()`, which only
+# returns when the queue's unfinished-task counter reaches zero. Under
+# sustained producer load (poll thread, listener-fired sets, UDP
+# listeners) the counter never settles at zero, so the wait could
+# silently take >2 minutes and trip the ZMQ client linkTimeout.
+#
+# The fix changes `waitOnUpdate()` to a bounded barrier: an Event sentinel
+# is appended to the queue and the call returns the moment the worker
+# reaches it. Items added during the wait are NOT included.
+#-----------------------------------------------------------------------------
+
+import threading
+import time
+
+import pyrogue as pr
+
+
+class _VarRoot(pr.Root):
+    def __init__(self):
+        super().__init__(name="root", pollEn=False)
+        for i in range(8):
+            self.add(pr.LocalVariable(name=f"V{i}", value=0))
+
+
+def _spawn_set_producer(root, var_name, stop_event):
+    # Hammer var.set() from a background thread. Each set() with the
+    # default `write=True` runs through LocalBlock._checkTransaction()
+    # and queues a notification on the update worker, mirroring what
+    # the SO pysmurf-monitor pipeline sees from polled hardware
+    # variables and listener-fired updates.
+    def producer():
+        v = getattr(root, var_name)
+        i = 0
+        while not stop_event.is_set():
+            v.set(i)
+            i += 1
+
+    t = threading.Thread(target=producer, daemon=True)
+    t.start()
+    return t
+
+
+def test_wait_on_update_returns_promptly_with_idle_queue():
+    # Sanity: with no producer, waitOnUpdate returns essentially immediately.
+    with _VarRoot() as root:
+        t0 = time.monotonic()
+        root.waitOnUpdate()
+        assert time.monotonic() - t0 < 1.0
+
+
+def test_wait_on_update_bounded_under_concurrent_producer():
+    # Reproduces the >2 minute hang. With the bounded-barrier fix, the
+    # call returns within a small bounded time even though another thread
+    # keeps queueing variable updates the entire time.
+    with _VarRoot() as root:
+        stop = threading.Event()
+        producer = _spawn_set_producer(root, "V0", stop)
+
+        try:
+            # Let the producer get rolling so the queue is non-empty.
+            time.sleep(0.1)
+
+            t0 = time.monotonic()
+            root.waitOnUpdate()
+            elapsed = time.monotonic() - t0
+
+            # 5 s is generous — the actual barrier-drain is sub-second on a
+            # quiet machine. Hangs from the old `Queue.join()` behavior
+            # would blow well past this.
+            assert elapsed < 5.0, f"waitOnUpdate took {elapsed:.2f}s"
+        finally:
+            stop.set()
+            producer.join(timeout=2.0)
+
+
+def test_wait_on_update_inside_update_group_bounded():
+    # Tristan's exact pattern: waitOnUpdate() inside updateGroup() must
+    # also be bounded under concurrent producer load.
+    with _VarRoot() as root:
+        stop = threading.Event()
+        producer = _spawn_set_producer(root, "V1", stop)
+
+        try:
+            time.sleep(0.1)
+
+            t0 = time.monotonic()
+            with root.updateGroup():
+                root.waitOnUpdate()
+            elapsed = time.monotonic() - t0
+
+            assert elapsed < 5.0, (
+                f"waitOnUpdate inside updateGroup took {elapsed:.2f}s"
+            )
+        finally:
+            stop.set()
+            producer.join(timeout=2.0)
+
+
+def test_wait_on_update_bounded_under_listener_self_storm():
+    # The "indeterminate loop" Tristan was worried about: a varListener
+    # that re-fires the *same* variable from the worker thread, so each
+    # callback queues another update before task_done() can complete.
+    # Without the bounded-barrier fix, Queue.join()'s unfinished-task
+    # counter never settles to zero and the call hangs.
+    with _VarRoot() as root:
+        stop_listener = threading.Event()
+        kick_count = [0]
+        kick_lock = threading.Lock()
+
+        def listener(path, value):
+            with kick_lock:
+                if path.endswith(".V2") and not stop_listener.is_set():
+                    kick_count[0] += 1
+                    # Re-fire the same variable from the worker thread.
+                    # This satisfies the listener condition again on the
+                    # next callback, producing an unbounded self-storm
+                    # until stop_listener is set.
+                    root.V2.set(kick_count[0])
+
+        root.addVarListener(listener)
+
+        try:
+            # Prime the chain and let the listener-driven storm get rolling.
+            root.V2.set(1)
+            time.sleep(0.1)
+
+            t0 = time.monotonic()
+            root.waitOnUpdate()
+            elapsed = time.monotonic() - t0
+
+            assert elapsed < 5.0, f"waitOnUpdate under listener self-storm took {elapsed:.2f}s"
+        finally:
+            # Stop the self-storm so Root.stop() can drain cleanly.
+            stop_listener.set()
+
+
+def test_wait_on_update_drains_pending_listener_callbacks():
+    # The whole point of waitOnUpdate is that, after it returns, items
+    # queued before the call have actually fired their root listeners.
+    # Verify that contract still holds with the bounded-barrier
+    # implementation.
+    with _VarRoot() as root:
+        seen = []
+        seen_lock = threading.Lock()
+
+        def listener(path, value):
+            with seen_lock:
+                seen.append((path, value.value))
+
+        root.addVarListener(listener)
+
+        with root.updateGroup():
+            root.V4.set(42)
+            root.V5.set(43)
+
+        # Without waitOnUpdate the worker may not have processed the batch
+        # yet. After waitOnUpdate, the pre-queue updates must be visible.
+        root.waitOnUpdate()
+
+        with seen_lock:
+            seen_map = {p: v for p, v in seen}
+
+        assert seen_map.get("root.V4") == 42
+        assert seen_map.get("root.V5") == 43


### PR DESCRIPTION
## Summary

`Root.waitOnUpdate()` could silently take **>2 minutes** under sustained variable-update load, long enough to trip the ZMQ client `linkTimeout`. Reported by Tristan Pinsonneault-Marotte on the LAT/SO rogue 6 deployments, where the metadata-frame setup before `open_g3stream.set(1)` occasionally stalled on:

```python
with self.root.updateGroup():
    self.root.waitOnUpdate()
```

with timing observed as 130.6s in one instance, with most calls completing in <2s.

## Root cause

`waitOnUpdate()` called `self._updateQueue.join()`. Python's `Queue.join()` only returns when the **unfinished-task counter reaches zero**. But `updateGroup()` is **per-thread** — `tid = threading.get_ident()`, only the calling thread's `UpdateTracker` is suspended. Other producers continue queueing the entire time:

- The poll thread (`PollQueue._poll()` in `_PollQueue.py:160`) keeps its own UpdateTracker and posts polled-block updates on every cycle.
- `_updateWorker` itself dispatches `varListener` callbacks on each batch; any user callback that calls `var.set()` queues from the worker thread (which is not in any `updateGroup()`).
- Any other application thread (UDP listener, ZMQ server, etc.) firing variables.

Under steady producer load the unfinished-task counter never settles at zero → `join()` blocks indefinitely.

The user's `with updateGroup(): waitOnUpdate()` pattern was the right *intent* (flush before next set) but did not actually stop other threads' updates, and inside that `with` the calling thread's own pending updates remain buffered in its tracker — they aren't even in the queue yet.

## Fix

Replace `Queue.join()` with a **barrier sentinel**:

1. `waitOnUpdate()` pushes a `threading.Event` into `_updateQueue` and waits on it.
2. `_updateWorker` recognizes the sentinel via `isinstance(uvars, threading.Event)`, calls `event.set()`, calls `task_done()`, and continues.

The wait is bounded by **queue contents at the moment of the call**. Items queued during the wait are processed *after* the barrier and don't extend it. This is exactly the flush-before-next-set semantics callers actually need, and it eliminates the indeterminate-loop hazard regardless of producer rate.

`_updateQueue.put()` and `Event.wait()` are thread-safe; the existing `None` stop-sentinel path is unchanged.

## Verification

New regression test `tests/core/test_wait_on_update_bounded.py` (5 cases):

| Test | Behavior |
|------|----------|
| `test_wait_on_update_returns_promptly_with_idle_queue` | Sanity: empty-queue case |
| `test_wait_on_update_bounded_under_concurrent_producer` | Background thread continuously calls `var.set()`; verifies `waitOnUpdate()` returns within 5s |
| `test_wait_on_update_inside_update_group_bounded` | **Tristan's exact pattern** (`with updateGroup(): waitOnUpdate()`) under producer load |
| `test_wait_on_update_bounded_under_listener_self_storm` | varListener that re-fires variable updates from the worker thread |
| `test_wait_on_update_drains_pending_listener_callbacks` | Correctness: items queued before the call have actually fired listeners after return |

The two producer-thread cases **hang on unfixed code (pytest 15s timeout)** and **pass in ~5s after the fix** — direct proof of the bug and the fix.

### Test run

- `tests/core/` — **273 passed**
- `tests/interfaces/` — **116 passed, 5 skipped, 1 pre-existing failure** (`test_pydm_rogue_plugin.py::test_rogue_connection_link_state_refreshes_static_name_channels` — `object.__new__(RogueConnection)` TypeError; verified to fail identically on `git stash`, unrelated to this change)
- `./scripts/run_linters.sh` — exit 0

## Compatibility

- Public API of `waitOnUpdate()` is unchanged — same signature, same caller contract semantically (waits for previously-queued updates to be processed). Stronger guarantee: the wait is now bounded.
- ZMQ-exposed via existing `@pr.expose`; no client changes needed.
- No new dependencies. `threading.Event` is stdlib.

## Out of scope (follow-up)

Tristan also reported a separate **burstiness** symptom (10k+ variable updates/min crashing a UDP monitor process). That is a downstream-batching design issue: when a varListener calls `var.set()` from the worker thread, the worker is not inside any `updateGroup()`, so each `set()` flushes a 1-element dict to the queue. Best handled by either wrapping the SO callback chain in `updateGroup(period=...)` on the application side, or auto-batching from `_updateWorker` with a small period. **Not** changed in this PR — this PR is surgically scoped to the `waitOnUpdate()` hang.

## Targeting

`pre-release` — fix is independent of any open RC content and small enough to ship in v6.13.1.