### PR TITLE
protocols/rssi: clamp peer-advertised connection parameters

### DIFF
--- a/include/rogue/protocols/rssi/Controller.h
+++ b/include/rogue/protocols/rssi/Controller.h
@@ -401,6 +401,40 @@ class Controller : public rogue::EnableSharedFromThis<rogue::protocols::rssi::Co
      */
     uint8_t curMaxCumAck();
 
+    /**
+     * @brief Clamps peer-advertised connection parameters to the locally legal range.
+     *
+     * @details
+     * The RSSI SYN/SYN-ACK handshake adopts the peer's advertised parameters. A peer
+     * advertising out-of-range values (zero outstanding segments, zero timeouts, a
+     * sub-header-size segment, or a window larger than the locally offered maximum)
+     * would otherwise drive the controller into illegal state (for example
+     * `curMaxBuffers == 0` makes the outbound wait loop spin forever). This helper
+     * clamps in place to the legal range instead of rejecting the connection, which
+     * preserves backward/forward compatibility with conformant peers. SLAC firmware
+     * never advertises invalid parameters, so in practice this is defense-in-depth.
+     *
+     * Pure (no member state) so it can be unit tested directly. Mirrors the firmware
+     * `validPeerParams`/`clampWindowSize`/`clampBufferSize` checks in surf
+     * `protocols/rssi/v1/rtl/RssiConnFsm.vhd`.
+     *
+     * @param maxBuffers     Peer max outstanding segments; clamped to [1, locMaxBuffers].
+     * @param maxSegment     Peer max segment size; clamped to [HeaderSize, locMaxSegment].
+     * @param cumAckTout     Peer cumulative-ACK timeout; clamped to >= 1.
+     * @param retranTout     Peer retransmit timeout; clamped to >= 1.
+     * @param nullTout       Peer null-segment timeout; clamped to >= 1.
+     * @param locMaxBuffers  Locally offered max outstanding segments (upper bound).
+     * @param locMaxSegment  Locally offered max segment size (upper bound).
+     * @return True if any parameter was modified, false if all were already legal.
+     */
+    static bool clampPeerParams(uint8_t& maxBuffers,
+                                uint16_t& maxSegment,
+                                uint16_t& cumAckTout,
+                                uint16_t& retranTout,
+                                uint16_t& nullTout,
+                                uint8_t locMaxBuffers,
+                                uint16_t locMaxSegment);
+
     /** @brief Resets runtime counters. */
     void resetCounters();
 

--- a/src/rogue/protocols/rssi/Controller.cpp
+++ b/src/rogue/protocols/rssi/Controller.cpp
@@ -696,6 +696,51 @@ int8_t rpr::Controller::retransmit(uint8_t id) {
     return 1;
 }
 
+//! Clamp peer-advertised connection parameters to the locally legal range
+bool rpr::Controller::clampPeerParams(uint8_t& maxBuffers,
+                                      uint16_t& maxSegment,
+                                      uint16_t& cumAckTout,
+                                      uint16_t& retranTout,
+                                      uint16_t& nullTout,
+                                      uint8_t locMaxBuffers,
+                                      uint16_t locMaxSegment) {
+    bool clamped = false;
+
+    // Max outstanding segments: at least 1, never more than locally offered
+    if (maxBuffers == 0) {
+        maxBuffers = 1;
+        clamped    = true;
+    } else if (maxBuffers > locMaxBuffers) {
+        maxBuffers = locMaxBuffers;
+        clamped    = true;
+    }
+
+    // Max segment size: must hold at least a header, never more than locally offered
+    if (maxSegment < static_cast<uint16_t>(rpr::Header::HeaderSize)) {
+        maxSegment = static_cast<uint16_t>(rpr::Header::HeaderSize);
+        clamped    = true;
+    } else if (maxSegment > locMaxSegment) {
+        maxSegment = locMaxSegment;
+        clamped    = true;
+    }
+
+    // Timeouts: a zero value would make the corresponding timer expire immediately
+    if (cumAckTout == 0) {
+        cumAckTout = 1;
+        clamped    = true;
+    }
+    if (retranTout == 0) {
+        retranTout = 1;
+        clamped    = true;
+    }
+    if (nullTout == 0) {
+        nullTout = 1;
+        clamped  = true;
+    }
+
+    return clamped;
+}
+
 //! Convert rssi time to microseconds
 void rpr::Controller::convTime(struct timeval& tme, uint32_t rssiTime) {
     float units = std::pow(10, -TimeoutUnit);
@@ -789,6 +834,19 @@ struct timeval& rpr::Controller::stateClosedWait() {
             curMaxRetran_  = head->maxRetransmissions;
             curMaxCumAck_  = head->maxCumulativeAck;
             lastAckRx_     = head->acknowledge;
+
+            // Clamp peer-advertised parameters to the locally legal range before
+            // they are converted to timers or used as window/buffer bounds. A
+            // conformant peer (including SLAC firmware) is unaffected.
+            if (clampPeerParams(curMaxBuffers_,
+                                curMaxSegment_,
+                                curCumAckTout_,
+                                curRetranTout_,
+                                curNullTout_,
+                                locMaxBuffers_,
+                                locMaxSegment_)) {
+                log_->warning("Clamped out-of-range peer RSSI parameters. server=%d", server_);
+            }
 
             // Convert times
             convTime(retranToutD1_, curRetranTout_);

--- a/tests/cpp/protocols/CMakeLists.txt
+++ b/tests/cpp/protocols/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(packetizer)
+add_subdirectory(rssi)
 
 if (NOT NO_PYTHON)
    add_subdirectory(xilinx)

--- a/tests/cpp/protocols/rssi/CMakeLists.txt
+++ b/tests/cpp/protocols/rssi/CMakeLists.txt
@@ -1,0 +1,7 @@
+rogue_add_cpp_test(rogue-cpp-protocols-rssi-param-clamp
+   SOURCES
+      test_param_clamp.cpp
+   LABELS
+      cpp-core
+      no-python
+)

--- a/tests/cpp/protocols/rssi/test_param_clamp.cpp
+++ b/tests/cpp/protocols/rssi/test_param_clamp.cpp
@@ -1,0 +1,178 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression: rpr::Controller::clampPeerParams() clamps peer-advertised RSSI
+ * connection parameters to the locally legal range. The SYN/SYN-ACK handshake
+ * adopts the peer's advertised parameters verbatim; an out-of-range peer value
+ * (zero outstanding segments, zero timeouts, a sub-header-size segment, or a
+ * window larger than the locally offered maximum) would otherwise drive the
+ * controller into illegal state (for example curMaxBuffers == 0 makes the
+ * outbound wait loop spin forever). Conformant peers, including SLAC firmware,
+ * must be left untouched.
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+
+#include <cstdint>
+
+#include "doctest/doctest.h"
+#include "rogue/protocols/rssi/Controller.h"
+#include "rogue/protocols/rssi/Header.h"
+
+namespace rpr = rogue::protocols::rssi;
+
+// Local bounds used by the tests (rogue defaults: 32 buffers, 1400 byte segment)
+static const uint8_t kLocMaxBuffers  = 32;
+static const uint16_t kLocMaxSegment = 1400;
+
+TEST_CASE("clampPeerParams leaves a conformant peer untouched") {
+    uint8_t maxBuffers  = 8;
+    uint16_t maxSegment = 512;
+    uint16_t cumAckTout = 5;
+    uint16_t retranTout = 20;
+    uint16_t nullTout   = 1000;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK_FALSE(clamped);
+    CHECK_EQ(maxBuffers, static_cast<uint8_t>(8));
+    CHECK_EQ(maxSegment, static_cast<uint16_t>(512));
+    CHECK_EQ(cumAckTout, static_cast<uint16_t>(5));
+    CHECK_EQ(retranTout, static_cast<uint16_t>(20));
+    CHECK_EQ(nullTout, static_cast<uint16_t>(1000));
+}
+
+TEST_CASE("clampPeerParams raises a zero outstanding-segment count to 1") {
+    uint8_t maxBuffers  = 0;
+    uint16_t maxSegment = 512;
+    uint16_t cumAckTout = 5;
+    uint16_t retranTout = 20;
+    uint16_t nullTout   = 1000;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(maxBuffers, static_cast<uint8_t>(1));
+}
+
+TEST_CASE("clampPeerParams caps an oversized window at the local maximum") {
+    uint8_t maxBuffers  = 200;
+    uint16_t maxSegment = 512;
+    uint16_t cumAckTout = 5;
+    uint16_t retranTout = 20;
+    uint16_t nullTout   = 1000;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(maxBuffers, kLocMaxBuffers);
+}
+
+TEST_CASE("clampPeerParams raises a sub-header segment size to the header size") {
+    uint8_t maxBuffers  = 8;
+    uint16_t maxSegment = 4;  // smaller than the 8-byte header
+    uint16_t cumAckTout = 5;
+    uint16_t retranTout = 20;
+    uint16_t nullTout   = 1000;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(maxSegment, static_cast<uint16_t>(rpr::Header::HeaderSize));
+}
+
+TEST_CASE("clampPeerParams caps an oversized segment at the local maximum") {
+    uint8_t maxBuffers  = 8;
+    uint16_t maxSegment = 9000;  // larger than locally offered
+    uint16_t cumAckTout = 5;
+    uint16_t retranTout = 20;
+    uint16_t nullTout   = 1000;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(maxSegment, kLocMaxSegment);
+}
+
+TEST_CASE("clampPeerParams raises zero timeouts to 1") {
+    uint8_t maxBuffers  = 8;
+    uint16_t maxSegment = 512;
+    uint16_t cumAckTout = 0;
+    uint16_t retranTout = 0;
+    uint16_t nullTout   = 0;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(cumAckTout, static_cast<uint16_t>(1));
+    CHECK_EQ(retranTout, static_cast<uint16_t>(1));
+    CHECK_EQ(nullTout, static_cast<uint16_t>(1));
+}
+
+TEST_CASE("clampPeerParams clamps multiple out-of-range fields at once") {
+    uint8_t maxBuffers  = 0;
+    uint16_t maxSegment = 0;
+    uint16_t cumAckTout = 0;
+    uint16_t retranTout = 0;
+    uint16_t nullTout   = 0;
+
+    bool clamped = rpr::Controller::clampPeerParams(maxBuffers,
+                                                    maxSegment,
+                                                    cumAckTout,
+                                                    retranTout,
+                                                    nullTout,
+                                                    kLocMaxBuffers,
+                                                    kLocMaxSegment);
+
+    CHECK(clamped);
+    CHECK_EQ(maxBuffers, static_cast<uint8_t>(1));
+    CHECK_EQ(maxSegment, static_cast<uint16_t>(rpr::Header::HeaderSize));
+    CHECK_EQ(cumAckTout, static_cast<uint16_t>(1));
+    CHECK_EQ(retranTout, static_cast<uint16_t>(1));
+    CHECK_EQ(nullTout, static_cast<uint16_t>(1));
+}


### PR DESCRIPTION
## Summary

Hardens the rogue RSSI endpoint by clamping peer-advertised connection parameters to the locally legal range during the SYN/SYN-ACK handshake. This is defense-in-depth parity with the firmware-side validation added in **surf [#1427](https://github.com/slaclab/surf/pull/1427)** (`RssiConnFsm.vhd` `validPeerParams` / `clampWindowSize` / `clampBufferSize`).

`Controller::stateClosedWait()` previously adopted the peer's advertised parameters verbatim. An out-of-range peer value could drive the controller into illegal state — most concretely, `curMaxBuffers == 0` makes the `applicationRx()` outbound wait loop (`while (txListCount_ >= curMaxBuffers_)`) spin forever. The new `Controller::clampPeerParams()` clamps in place:

| Parameter | Clamp |
|---|---|
| `curMaxBuffers_` | `[1, locMaxBuffers_]` |
| `curMaxSegment_` | `[HeaderSize(8), locMaxSegment_]` |
| `curCumAckTout_`, `curRetranTout_`, `curNullTout_` | `>= 1` |

**Clamp, not reject** — the connection is never torn down, preserving backward/forward compatibility with conformant peers. SLAC firmware never advertises invalid parameters (and `surf#1427` makes the FW self-clamp), so in practice this only engages against a malformed/buggy peer, where it now logs a warning instead of hanging.

## Testing

- New `tests/cpp/protocols/rssi/test_param_clamp.cpp` (doctest, `cpp-core`/`no-python`) exercises every clamp branch plus the no-op case for legal input. Auto-run by the existing `ctest -L cpp` / `-L no-python` CI steps — no workflow changes needed.
- Local: full `ctest -L cpp` (13/13) and `tests/integration/test_rssi_loopback.py` (4/4) pass — the loopback negotiates legal parameters, so the clamp is a verified no-op on the happy path (behavior identical to `pre-release`).
- `cpplint` clean on changed files.

## Context: audit of surf#1427

This change came out of an audit of surf#1427 (RSSI RTL fixes + cocotb regression suite). Findings:

- The PR #1427 production RTL changes (`RssiAxiLiteRegItf`, `RssiConnFsm`, `RssiCore`, `RssiMonitor`, `RssiRxFsm`, `RssiTxFsm`) are **valid by analysis** and narrow. rogue's RSSI C++ is **byte-identical to `pre-release`** and **requires no functional change** to interoperate — the new strict FW receiver plus rogue's existing out-of-order buffering recover from every gap scenario via retransmit.
- This clamp is the one defensible *hardening* surfaced by the audit. It is **not** required for interop; it is robustness only.
- Note: surf#1427's validation is cocotb-vs-Python-oracle only. The `RssiRxFsm` registered-RAM payload length/timing rewrite in that PR is its highest-risk change and is worth confirming on hardware before merge.

## Deferred: Candidate 2 (NULL-while-data-outstanding suppression) — intentionally not done

surf#1427 also makes the FW **suppress NULL while its transmit buffer is non-empty** (`RssiTxFsm`). A symmetric change in rogue (suppress NULL while `txListCount_ > 0`) was evaluated and **deliberately deferred** as high-risk / no-reward against currently deployed firmware:

- **No-op in the normal case.** While data is outstanding and the peer is not busy, rogue retransmits the oldest unacked frame every ~20 ms (`stateOpen()`), which refreshes `txTime_`, so the ~333 ms NULL timer never fires anyway. Suppression changes nothing here.
- **Its only active effect is during a sustained remote-BUSY stall**, where the periodic NULL is the *sole* keepalive. The firmware has a **receive-side null-timeout**; rogue does **not** (asymmetry — rogue infers peer death only via retransmit-max). Suppressing rogue's NULL there would let the FW (old *and* new) RST the link after ~1 null-timeout (~1 s default) of backpressure in the software→FPGA direction — a link bounce + reconnect, not a graceful retransmit recovery.
- **The benefit cannot occur against current firmware.** The "NULL advances past lost DATA" failure it guards against requires a non-strict receiver; surf#1427's new `RssiRxFsm` is strict (drops duplicate/out-of-order) and rogue's receiver buffers out-of-order correctly.

**Recommendation:** revisit Candidate 2 once surf#1427 firmware is widespread in production. At that point the FW's periodic BUSY-ACK behavior (also added in #1427) makes the parity change low-risk to roll out.

## Checklist

- [x] Reviewer confirms the clamp-vs-reject choice and the bounds.
- [x] Hardware/interop validation against surf#1427 firmware (out of scope here — no FW↔rogue co-sim exists).
