### PR TITLE
feat: make blocking/non-blocking a call-site argument on Command

### DIFF
--- a/docs/src/pyrogue_tree/builtin_devices/index.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/index.rst
@@ -59,7 +59,7 @@ Related Topics
 * Data receive/read path: :doc:`data_receiver`
 * Lower-level modules and wrappers: :doc:`/built_in_modules/index`
 * External process integration: :doc:`process`
-* Long-running operations: comparing pr.Process vs Command(nonBlocking=True): :doc:`long_running_operations`
+* Long-running operations: comparing pr.Process vs Command(blocking=False): :doc:`long_running_operations`
 
 .. toctree::
    :maxdepth: 1

--- a/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
@@ -20,16 +20,16 @@ exceeded.  Either way the right answer is not to enlarge a timeout — it is to
 choose the right dispatch pattern so the long work runs on the server while
 the client thread stays responsive.  PyRogue offers two canonical approaches:
 :py:class:`~pyrogue.Process` for stateful procedures that benefit from
-GUI-visible progress, and ``LocalCommand(nonBlocking=True)`` for ad-hoc
-fire-and-poll dispatch where a simple pass/fail result is enough.
+GUI-visible progress, and ``cmd(blocking=False)`` for ad-hoc fire-and-poll
+dispatch where a simple pass/fail result is enough.
 
 Both patterns run the work on a background thread and return immediately to the
 caller.  The difference is in what the tree exposes while the work is running.
 Choose :py:class:`~pyrogue.Process` when the operation is multi-step and you
 want built-in ``Running`` / ``Progress`` / ``Message`` status Variables that
-GUI clients and scripts can poll.  Choose ``Command(nonBlocking=True)`` when
+GUI clients and scripts can poll.  Choose ``cmd(blocking=False)`` when
 you need the simplest possible mechanism: fire the command, get ``None`` back
-immediately, and poll a ``Running`` flag until the work finishes.
+immediately, and poll the ``running`` property until the work finishes.
 
 Comparison
 ==========
@@ -40,31 +40,28 @@ Comparison
 
    * - Attribute
      - ``pr.Process``
-     - ``Command(nonBlocking=True)``
+     - ``cmd(blocking=False)``
    * - Use case
      - Stateful multi-step procedure with GUI-visible progress and status text
-     - Ad-hoc one-shot command; caller polls for completion via sibling Variables
+     - Ad-hoc one-shot command; caller polls for completion via exposed properties
    * - State held across calls
      - Yes — ``Progress``, ``Step``, ``TotalSteps``, ``Message`` persist on the
        ``Device`` between invocations
-     - Minimal — only the auto-injected ``{name}Running``, ``{name}Result``, and
-       ``{name}Error`` siblings persist on the ``Device``.  Each call sets
-       ``{name}Running`` ``True`` at dispatch and ``False`` on exit and clears
-       ``{name}Error`` at dispatch; ``{name}Result`` is updated only on
-       successful return so the previous value remains visible while a new
-       call is in flight
+     - Minimal — ``running``, ``result``, and ``error`` are properties on the
+       Command itself; no sibling variables are added to the tree
    * - Progress / step UI
      - Built in: ``Progress`` (fraction), ``Step`` / ``TotalSteps`` (count-based),
        ``Message`` (free text); GUI widgets consume these automatically
      - Not built in; progress must flow through separate tree Variables if needed
    * - Cancel primitive
      - Built-in ``Stop`` command; procedure checks ``self._runEn``
-     - None in v1 — no ``Stop`` equivalent for non-blocking Commands (deferred)
-   * - Status variables exposed
+     - None — no ``Stop`` equivalent for non-blocking Commands
+   * - Status exposed
      - ``Running``, ``Progress``, ``Step``, ``TotalSteps``, ``Message``; optional
-       ``argVariable`` and ``returnVariable``
-     - ``{name}Running`` (bool), ``{name}Result`` (last return value),
-       ``{name}Error`` (last exception string, empty on success)
+       ``argVariable`` and ``returnVariable`` as tree Variables
+     - ``running`` (bool), ``result`` (last return value),
+       ``error`` (last exception string, empty on success) as properties on the
+       Command node
    * - Best when
      - The operation is long-running, multi-step, needs operator-visible status,
        or must be cancellable via ``Stop``
@@ -97,14 +94,12 @@ tree.  A minimal sketch:
 For the full ``CaptureProcess`` example with operator-facing input and result
 Variables, see :doc:`process`.
 
-Pattern 2: Command(nonBlocking=True)
-=====================================
+Pattern 2: Command(blocking=False)
+===================================
 
-Add ``nonBlocking=True`` to any :py:class:`~pyrogue.LocalCommand` to enable
-fire-and-poll dispatch.  PyRogue automatically injects three sibling
-``LocalVariable``\s — ``{name}Running``, ``{name}Result``, and
-``{name}Error`` — onto the parent ``Device``.  The server-side definition is
-unchanged from a normal ``LocalCommand`` except for the one kwarg:
+Any :py:class:`~pyrogue.LocalCommand` can be called with ``blocking=False``
+to enable fire-and-poll dispatch.  No special construction-time flags are
+needed — whether to block is a call-site decision:
 
 .. code-block:: python
 
@@ -123,25 +118,24 @@ unchanged from a normal ``LocalCommand`` except for the one kwarg:
            super().__init__(**kwargs)
            self.add(pr.LocalCommand(
                name='ApplyConfig',
-               description='Apply full device configuration.  Returns immediately.',
+               description='Apply full device configuration.',
                function=_apply_config,
-               nonBlocking=True,
                retValue='',
            ))
 
-Calling ``client.exec('Top.Dev.ApplyConfig')`` over ZMQ returns ``None``
-immediately because the server dispatches a worker thread and replies before
-the function finishes.  Poll ``ApplyConfigRunning`` on the client side to
-detect completion — see the next section.
+Calling ``cmd(blocking=False)`` returns ``None`` immediately because the
+server dispatches a worker thread and replies before the function finishes.
+Poll the command's ``running`` property on the client side to detect
+completion — see the next section.
 
 Client-Side Polling Pattern
 ============================
 
-After ``exec`` returns, poll the auto-injected ``{name}Running`` sibling
-Variable until it transitions to ``False``, then read ``{name}Result`` and
-``{name}Error``.  This mirrors the :py:class:`~pyrogue.Process` pattern
-(``Running`` / ``Progress`` / ``Message``) but uses the lighter-weight triplet
-(``Running`` / ``Result`` / ``Error``) that requires no ``Process`` subclass.
+After calling with ``blocking=False``, poll the command's ``running``
+property until it becomes ``False``, then read ``result`` and ``error``.
+These are ``@pr.expose``-d properties on the Command itself, so they are
+accessible through VirtualClient as properties and through SimpleClient
+via ``_remoteAttr``.
 
 The example below is the canonical reference shape for the hand-rolled loop:
 
@@ -150,35 +144,40 @@ The example below is the canonical reference shape for the hand-rolled loop:
    :pyobject: main
    :caption: SimpleClient hand-rolled polling loop
 
-For :py:class:`~pyrogue.VirtualClient` users, the equivalent approach is a
-per-variable listener or ``VariableWait`` rather than an explicit loop — see
-:doc:`/pyrogue_tree/client_interfaces/virtual` for those APIs.
+For :py:class:`~pyrogue.VirtualClient` users, the equivalent approach uses
+property access on the virtual command node:
+
+.. code-block:: python
+
+   remote_cmd = client.root.Dev.ApplyConfig
+   remote_cmd(blocking=False)
+
+   while remote_cmd.running:
+       time.sleep(0.1)
+
+   if remote_cmd.error:
+       raise RuntimeError(remote_cmd.error)
+   print(remote_cmd.result)
 
 Interaction with linkTimeout and requestStallTimeout
 =====================================================
 
-A non-blocking ``exec`` RPC returns immediately once the server has dispatched
+A non-blocking call returns immediately once the server has dispatched
 the worker thread — before the function body runs.  Because the reply travels
 over the wire before any long-running work begins, neither ``linkTimeout`` nor
 ``requestStallTimeout`` fires for the dispatch call itself.
 
 The only RPCs that race a timeout after dispatch are the subsequent
-``client.get(...)`` polls of ``{name}Running``, ``{name}Result``, and
-``{name}Error``.  Those are lightweight reads of in-memory ``LocalVariable``
-values and complete in well under a millisecond on any non-pathological
-connection, so they are not a practical timeout concern.
-
-``requestStallTimeout`` defaults to ``None`` (disabled), meaning there is no
-global stall deadline on in-flight requests today.  A future release may add
-awareness of non-blocking polls to this timeout; until then, the hand-rolled
-loop in the previous section is the supported approach.
+property reads of ``running``, ``result``, and ``error``.  Those are
+lightweight attribute lookups and complete in well under a millisecond on
+any non-pathological connection, so they are not a practical timeout concern.
 
 Related Topics
 ==============
 
 * Process-based long-running operations with progress UI: :doc:`process`
 * Command behavior and dispatch semantics: :doc:`/pyrogue_tree/core/command`
-* Python-defined commands with ``nonBlocking`` support: :doc:`/pyrogue_tree/core/local_command`
+* Python-defined commands: :doc:`/pyrogue_tree/core/local_command`
 * Mirrored-tree remote client with ``linkTimeout`` and ``requestStallTimeout``: :doc:`/pyrogue_tree/client_interfaces/virtual`
 * Lightweight string-path client (``SimpleClient``): :doc:`/pyrogue_tree/client_interfaces/simple`
 

--- a/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
+++ b/docs/src/pyrogue_tree/builtin_devices/long_running_operations.rst
@@ -133,31 +133,15 @@ Client-Side Polling Pattern
 
 After calling with ``blocking=False``, poll the command's ``running``
 property until it becomes ``False``, then read ``result`` and ``error``.
-These are ``@pr.expose``-d properties on the Command itself, so they are
-accessible through VirtualClient as properties and through SimpleClient
-via ``_remoteAttr``.
+These are ``@pr.expose``-d properties on the Command itself, accessible
+as direct property access through :py:class:`~pyrogue.interfaces.VirtualClient`.
 
-The example below is the canonical reference shape for the hand-rolled loop:
+The example below is the canonical reference shape for the polling loop:
 
 .. literalinclude:: ../../../../python/pyrogue/examples/_NonBlockingCommandExample.py
    :language: python
    :pyobject: main
-   :caption: SimpleClient hand-rolled polling loop
-
-For :py:class:`~pyrogue.VirtualClient` users, the equivalent approach uses
-property access on the virtual command node:
-
-.. code-block:: python
-
-   remote_cmd = client.root.Dev.ApplyConfig
-   remote_cmd(blocking=False)
-
-   while remote_cmd.running:
-       time.sleep(0.1)
-
-   if remote_cmd.error:
-       raise RuntimeError(remote_cmd.error)
-   print(remote_cmd.result)
+   :caption: VirtualClient polling loop
 
 Interaction with linkTimeout and requestStallTimeout
 =====================================================

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -57,22 +57,7 @@ class BaseCommand(pr.BaseVariable):
         callback may accept any subset of these names.
         Default to no-op for command if None.
     background : bool, optional (default = False)
-        Reserved for future use; not implemented. Use ``nonBlocking=True``
-        to dispatch the function on a worker thread.
-    nonBlocking : bool, optional (default = False)
-        When ``True``, ``call()`` dispatches the function on a non-daemon
-        worker thread and returns ``None`` immediately.  Three sibling
-        ``LocalVariable``\\s are auto-added to the parent ``Device``:
-        ``{name}Running`` (bool), ``{name}Result`` (last return value),
-        and ``{name}Error`` (last exception string, empty when none).
-        Re-entrant calls while the worker is running are logged as a
-        warning and ignored.  The worker is joined on ``Root.stop()``.
-        Mirrors the ``pr.Process`` worker-thread lifecycle.
-
-        See :ref:`pyrogue_tree_builtin_devices_long_running_ops` for the
-        polling pattern and timeout interactions.
-
-        .. versionadded:: 6.14.0
+        Reserved for future use; not implemented.
     guiGroup : str, optional
         GUI grouping label.
     **kwargs : Any
@@ -93,7 +78,6 @@ class BaseCommand(pr.BaseVariable):
         maximum: Any | None = None,
         function: Callable[..., Any] | None = None,
         background: bool = False,
-        nonBlocking: bool = False,
         guiGroup: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -121,11 +105,8 @@ class BaseCommand(pr.BaseVariable):
         self._runEn  = False
         self._retDisp = "{}"
 
-        self._nonBlocking = nonBlocking
-        self._nonBlockingVarsAdded = False
-        self._varRunning = None
-        self._varResult  = None
-        self._varError   = None
+        self._workerResult = None
+        self._workerError  = ''
 
         if retValue is None:
             self._retTypeStr = None
@@ -154,61 +135,27 @@ class BaseCommand(pr.BaseVariable):
         """Return the display string for the return type."""
         return self._retTypeStr
 
-    def _rootAttached(self, parent: Any, root: Any) -> None:
-        """Attach this command into the rooted tree; inject sibling status vars."""
-        pr.BaseVariable._rootAttached(self, parent, root)
+    @pr.expose
+    @property
+    def running(self) -> bool:
+        """Return True if a non-blocking worker thread is in flight."""
+        with self._lock:
+            thr = self._thread
+        return thr is not None and thr.is_alive()
 
-        if not self._nonBlocking or self._nonBlockingVarsAdded:
-            return
-        if not isinstance(parent, pr.Device):
-            return
+    @pr.expose
+    @property
+    def result(self) -> Any:
+        """Return the last successful return value from a non-blocking call."""
+        with self._lock:
+            return self._workerResult
 
-        # Inject three sibling LocalVariables onto the parent Device.
-        # parent.add() cannot be used here because parent._root is already set
-        # (Device._rootAttached sets it before iterating children).  Instead we
-        # place the vars directly into parent._nodes and call _rootAttached on
-        # each so they receive their path, logger, and block setup.
-        lv_running = pr.LocalVariable(
-            name=f'{self.name}Running',
-            mode='RO',
-            value=False,
-            pollInterval=1.0,
-            description=f'Running status for {self.path}.',
-        )
-        lv_result = pr.LocalVariable(
-            name=f'{self.name}Result',
-            mode='RO',
-            value='',
-            pollInterval=1.0,
-            typeCheck=False,
-            description=f'Last successful return value of {self.path}.',
-        )
-        lv_error = pr.LocalVariable(
-            name=f'{self.name}Error',
-            mode='RO',
-            value='',
-            pollInterval=1.0,
-            description=f'Last error from {self.path}. Empty string when none.',
-        )
-
-        # Check for name collisions BEFORE any parent._nodes mutation so a
-        # collision on the second or third sibling does not leave a
-        # half-injected state.  Mirrors Node.add()'s duplicate guard, which is
-        # bypassed here because parent.add() raises when the tree is already
-        # started.
-        for lv in (lv_running, lv_result, lv_error):
-            if lv.name in parent._nodes:
-                raise pr.NodeError(
-                    'Error adding node with name %s to %s. Name collision.' % (lv.name, parent.name))
-
-        for lv in (lv_running, lv_result, lv_error):
-            parent._nodes[lv.name] = lv
-            lv._rootAttached(parent, root)
-
-        self._varRunning = lv_running
-        self._varResult  = lv_result
-        self._varError   = lv_error
-        self._nonBlockingVarsAdded = True
+    @pr.expose
+    @property
+    def error(self) -> str:
+        """Return the last error string from a non-blocking call, or ''."""
+        with self._lock:
+            return self._workerError
 
     def _resolveArg(self, arg: Any) -> Any:
         """Parse raw call argument into the canonical command value.
@@ -223,15 +170,23 @@ class BaseCommand(pr.BaseVariable):
             return self._default
         return self.parseDisp(arg)
 
-    def __call__(self, arg: Any = None) -> Any:
+    def __call__(self, arg: Any = None, *, blocking: bool = True) -> Any:
         """Invoke the command.
 
         Parameters
         ----------
         arg : object, optional
             Command argument. If ``None``, uses the default value.
+        blocking : bool, optional (default = True)
+            When ``True`` (the default), execute the command synchronously and
+            return the result.  When ``False``, dispatch the command on a
+            worker thread and return ``None`` immediately.  Use the
+            :attr:`running`, :attr:`result`, and :attr:`error` properties to
+            monitor progress and retrieve the outcome.
+
+            .. versionadded:: 6.14.0
         """
-        if not self._nonBlocking:
+        if blocking:
             return self._doFunc(arg)
 
         # Non-blocking path: dispatch worker thread and return immediately.
@@ -242,9 +197,6 @@ class BaseCommand(pr.BaseVariable):
 
         with self._lock:
             if self._thread is None or not self._thread.is_alive():
-                # Mirror the _doFunc sync path: when the callback accepts an
-                # arg and this is a LocalCommand, cache the resolved argument
-                # so cmd.get() reflects the last invocation.
                 if self._arg and not isinstance(self, RemoteCommand):
                     self._default = resolvedArg
                     self._queueUpdate()
@@ -297,45 +249,44 @@ class BaseCommand(pr.BaseVariable):
             raise e
 
     @pr.expose
-    def call(self, arg: Any = None) -> Any:
+    def call(self, arg: Any = None, *, blocking: bool = True) -> Any:
         """Invoke the command and return the raw result.
 
         Parameters
         ----------
         arg : object, optional
             Command argument.
+        blocking : bool, optional (default = True)
+            When ``False``, dispatch on a worker thread and return ``None``.
         """
-        return self.__call__(arg)
+        return self.__call__(arg, blocking=blocking)
 
     @pr.expose
-    def callDisp(self, arg: Any = None) -> str:
+    def callDisp(self, arg: Any = None, *, blocking: bool = True) -> str:
         """Invoke the command and return the display-formatted result.
 
         Parameters
         ----------
         arg : object, optional
             Command argument.
+        blocking : bool, optional (default = True)
+            When ``False``, dispatch on a worker thread and return ``""``.
         """
-        if self._nonBlocking:
-            self.__call__(arg)
+        if not blocking:
+            self.__call__(arg, blocking=False)
             return ""
-        return self.genDisp(self.__call__(arg),useDisp=self._retDisp)
+        return self.genDisp(self.__call__(arg), useDisp=self._retDisp)
 
     def _runWorker(self, arg: Any) -> None:
         """Execute the command function on a worker thread.
 
-        Mirrors ``pr.Process._run``.  State transitions are batched via
-        ``Root.updateGroup()`` so clients receive one coherent snapshot per
-        phase.  Exceptions are logged server-side; only ``str(exc)`` is
-        surfaced to clients via the ``{name}Error`` sibling variable.
+        Mirrors ``pr.Process._run``.  Exceptions are logged server-side;
+        only ``str(exc)`` is surfaced to clients via the :attr:`error`
+        property.
         """
-        # Start transition: clear previous error, advertise running.
-        with self.root.updateGroup():
-            self._varError.set('')
-            self._varRunning.set(True)
+        with self._lock:
+            self._workerError = ''
 
-        ret = None
-        err = None
         try:
             with self.root.updateGroup(period=1.0):
                 ret = self._functionWrap(
@@ -347,23 +298,14 @@ class BaseCommand(pr.BaseVariable):
                 )
         except Exception as e:
             pr.logException(self._log, e)
-            err = str(e)
-
-        # End transition: publish result or error, clear running.
-        if err is not None:
-            with self.root.updateGroup():
-                self._varError.set(err)
-                self._varRunning.set(False)
+            with self._lock:
+                self._workerError = str(e)
         else:
-            with self.root.updateGroup():
-                self._varResult.set(ret)
-                self._varRunning.set(False)
+            with self._lock:
+                self._workerResult = ret
 
-        # Release the run-enable flag last so re-entry detection is accurate
-        # throughout the variable-update phase above.
         with self._lock:
             self._runEn  = False
-            self._thread = None
 
     def _stopWorker(self) -> None:
         """Signal the worker to stop and wait for it to exit.
@@ -384,12 +326,11 @@ class BaseCommand(pr.BaseVariable):
             thr.join()
 
     def _stop(self) -> None:
-        """Join the in-flight worker thread if nonBlocking.
+        """Join any in-flight worker thread.
 
         Called by ``Device._stop`` during ``Root.stop()``.
         """
-        if self._nonBlocking:
-            self._stopWorker()
+        self._stopWorker()
 
     @staticmethod
     def nothing() -> None:
@@ -660,10 +601,6 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         keyword arguments ``root``, ``dev``, ``cmd``, and ``arg``; the
         callback may accept any subset of these names.
         Default to no-op for command if None.
-    nonBlocking : bool, optional (default = False)
-        When ``True``, ``call()`` dispatches the function on a non-daemon
-        worker thread and returns ``None`` immediately.  Forwarded only to
-        ``BaseCommand.__init__``; not passed to ``RemoteVariable.__init__``.
     base : object, optional (default = ``pr.UInt``)
         Base data type for the underlying remote variable.
     offset : int, optional
@@ -693,7 +630,6 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         minimum: Any | None = None,
         maximum: Any | None = None,
         function: Callable[..., Any] | None = None,
-        nonBlocking: bool = False,
         base: Any = pr.UInt,
         offset: int | None = None,
         bitSize: int = 32,
@@ -703,16 +639,11 @@ class RemoteCommand(BaseCommand, pr.RemoteVariable):
         **kwargs: Any,
     ) -> None:
         """Initialize a remote command."""
-
-        # nonBlocking is explicit here so it is NOT in **kwargs and therefore
-        # does not reach pr.RemoteVariable.__init__ (which does not accept it).
-        # Forward it only to BaseCommand.__init__.
         BaseCommand.__init__(
             self,
             name=name,
             retValue=retValue,
             function=function,
-            nonBlocking=nonBlocking,
             guiGroup=guiGroup,
             **kwargs)
 

--- a/python/pyrogue/_Command.py
+++ b/python/pyrogue/_Command.py
@@ -242,10 +242,16 @@ class BaseCommand(pr.BaseVariable):
                 self._default = arg
                 self._queueUpdate()
 
+            with self._lock:
+                self._workerResult = ret
+                self._workerError  = ''
+
             return ret
 
         except Exception as e:
             pr.logException(self._log,e)
+            with self._lock:
+                self._workerError = str(e)
             raise e
 
     @pr.expose

--- a/python/pyrogue/_Device.py
+++ b/python/pyrogue/_Device.py
@@ -1110,11 +1110,7 @@ class Device(pr.Node,rim.Hub):
         """Attach this device into the rooted tree and build variable blocks."""
         pr.Node._rootAttached(self, parent, root)
 
-        # Snapshot _nodes before iterating: nonBlocking BaseCommand._rootAttached
-        # may inject sibling LocalVariables into _nodes during the loop; a live
-        # dict view would raise RuntimeError.  Newly added siblings are processed
-        # by _buildBlocks below since they are in _nodes by the time it runs.
-        for key,value in list(self._nodes.items()):
+        for key,value in self._nodes.items():
             value._rootAttached(self,root)
 
         self._buildBlocks()

--- a/python/pyrogue/examples/_NonBlockingCommandExample.py
+++ b/python/pyrogue/examples/_NonBlockingCommandExample.py
@@ -4,9 +4,9 @@
 #-----------------------------------------------------------------------------
 #  Description:
 #       Cookbook: non-blocking Command with client-side polling loop.
-#       Demonstrates a setDefaults-shaped configuration-apply Command using
-#       nonBlocking=True and the matching hand-rolled polling loop driven by
-#       SimpleClient.  Run directly:
+#       Demonstrates calling a long-running Command with blocking=False
+#       and polling the command's exposed properties via SimpleClient.
+#       Run directly:
 #           python -m pyrogue.examples._NonBlockingCommandExample
 #       Import and call main() from a smoke test for CI coverage.
 #-----------------------------------------------------------------------------
@@ -24,12 +24,7 @@ import pyrogue.interfaces as pr_interfaces
 
 
 def _apply_config(cmd):
-    """Simulate a multi-step configuration apply (the long-running work).
-
-    Models a setDefaults-style operation: iterate over named steps, each
-    with a short delay to simulate real register/DMA traffic, then return
-    a status string that populates the ApplyConfigResult sibling variable.
-    """
+    """Simulate a multi-step configuration apply (the long-running work)."""
     steps = [
         ('reset_defaults',   0.3),
         ('load_cal_table',   0.3),
@@ -44,10 +39,9 @@ def _apply_config(cmd):
 class ConfigDevice(pr.Device):
     """Device that exposes a single long-running ApplyConfig command.
 
-    The command is marked nonBlocking=True so that ZMQ clients (e.g.
-    SimpleClient, VirtualClient) receive None immediately and can poll
-    the ApplyConfigRunning / ApplyConfigResult / ApplyConfigError sibling
-    variables for completion status.
+    Any command can be called with ``blocking=False`` to dispatch on a
+    worker thread.  The caller polls ``cmd.running``, ``cmd.result``,
+    and ``cmd.error`` for completion status.
     """
 
     def __init__(self, **kwargs):
@@ -56,11 +50,10 @@ class ConfigDevice(pr.Device):
             name='ApplyConfig',
             description=(
                 'Apply full device configuration (setDefaults-style). '
-                'Returns immediately; poll ApplyConfigRunning for completion. '
-                'Result is available in ApplyConfigResult once Running is False.'
+                'Call with blocking=False to return immediately; poll '
+                'the running property for completion.'
             ),
             function=_apply_config,
-            nonBlocking=True,
             retValue='',
         ))
 
@@ -71,9 +64,7 @@ class NonBlockingCommandRoot(pr.Root):
     Parameters
     ----------
     port : int
-        Base ZMQ port.  0 (default) lets the server auto-assign from 9099
-        upward.  Pass an explicit port when the caller must control binding
-        (e.g. in a smoke test that supplies a free port).
+        Base ZMQ port.  0 (default) lets the server auto-assign.
     """
 
     def __init__(self, *, port=0):
@@ -86,43 +77,35 @@ class NonBlockingCommandRoot(pr.Root):
 def main(port=0, poll_interval=0.1, timeout=30.0):
     """Run the non-blocking Command example and return the Result string.
 
-    This function is the canonical reference shape for the hand-rolled
-    client-side polling loop that pairs with a nonBlocking=True Command:
-
-    1. Fire the command via SimpleClient.exec — returns None immediately.
-    2. Poll ApplyConfigRunning until it becomes False (bounded by timeout).
-    3. Read ApplyConfigError; raise RuntimeError if non-empty.
-    4. Return ApplyConfigResult.
+    1. Fire the command via SimpleClient.exec(blocking=False).
+    2. Poll the command's ``running`` property until False.
+    3. Check ``error``; raise RuntimeError if non-empty.
+    4. Return ``result``.
 
     Parameters
     ----------
     port : int
         ZMQ base port passed to NonBlockingCommandRoot.  0 = auto-assign.
     poll_interval : float
-        Seconds between ApplyConfigRunning polls.
+        Seconds between polls.
     timeout : float
-        Maximum seconds to wait for the command to finish before raising.
+        Maximum seconds to wait before raising.
 
     Returns
     -------
     str
-        The value stored in ApplyConfigResult on successful completion.
+        The command's result value on successful completion.
     """
     with NonBlockingCommandRoot(port=port) as root:
         actual_port = root.zmqServer.port()
         with pr_interfaces.SimpleClient(addr='127.0.0.1', port=actual_port) as client:
 
-            # Fire the long-running command — returns None immediately because
-            # the server dispatches a worker thread and replies before it finishes.
-            client.exec('Top.Dev.ApplyConfig')
+            client.exec('Top.Dev.ApplyConfig', blocking=False)
 
-            # Hand-rolled polling loop: the canonical pattern for nonBlocking Commands.
-            # Poll the auto-injected ApplyConfigRunning sibling variable until it
-            # transitions to False, indicating the worker thread has completed.
             deadline  = time.monotonic() + timeout
             completed = False
             while time.monotonic() < deadline:
-                if not client.get('Top.Dev.ApplyConfigRunning'):
+                if not client._remoteAttr('Top.Dev.ApplyConfig', 'running'):
                     completed = True
                     break
                 time.sleep(poll_interval)
@@ -131,8 +114,8 @@ def main(port=0, poll_interval=0.1, timeout=30.0):
                 raise TimeoutError(
                     f'ApplyConfig did not complete within {timeout:.1f}s')
 
-            error  = client.get('Top.Dev.ApplyConfigError')
-            result = client.get('Top.Dev.ApplyConfigResult')
+            error  = client._remoteAttr('Top.Dev.ApplyConfig', 'error')
+            result = client._remoteAttr('Top.Dev.ApplyConfig', 'result')
 
             if error:
                 raise RuntimeError(f'ApplyConfig failed: {error}')

--- a/python/pyrogue/examples/_NonBlockingCommandExample.py
+++ b/python/pyrogue/examples/_NonBlockingCommandExample.py
@@ -5,7 +5,7 @@
 #  Description:
 #       Cookbook: non-blocking Command with client-side polling loop.
 #       Demonstrates calling a long-running Command with blocking=False
-#       and polling the command's exposed properties via SimpleClient.
+#       and polling the command's exposed properties via VirtualClient.
 #       Run directly:
 #           python -m pyrogue.examples._NonBlockingCommandExample
 #       Import and call main() from a smoke test for CI coverage.
@@ -77,7 +77,7 @@ class NonBlockingCommandRoot(pr.Root):
 def main(port=0, poll_interval=0.1, timeout=30.0):
     """Run the non-blocking Command example and return the Result string.
 
-    1. Fire the command via SimpleClient.exec(blocking=False).
+    1. Fire the command with ``blocking=False`` via VirtualClient.
     2. Poll the command's ``running`` property until False.
     3. Check ``error``; raise RuntimeError if non-empty.
     4. Return ``result``.
@@ -98,14 +98,16 @@ def main(port=0, poll_interval=0.1, timeout=30.0):
     """
     with NonBlockingCommandRoot(port=port) as root:
         actual_port = root.zmqServer.port()
-        with pr_interfaces.SimpleClient(addr='127.0.0.1', port=actual_port) as client:
+        client = pr_interfaces.VirtualClient(addr='127.0.0.1', port=actual_port)
+        try:
+            cmd = client.root.Dev.ApplyConfig
 
-            client.exec('Top.Dev.ApplyConfig', blocking=False)
+            cmd(blocking=False)
 
             deadline  = time.monotonic() + timeout
             completed = False
             while time.monotonic() < deadline:
-                if not client._remoteAttr('Top.Dev.ApplyConfig', 'running'):
+                if not cmd.running:
                     completed = True
                     break
                 time.sleep(poll_interval)
@@ -114,13 +116,13 @@ def main(port=0, poll_interval=0.1, timeout=30.0):
                 raise TimeoutError(
                     f'ApplyConfig did not complete within {timeout:.1f}s')
 
-            error  = client._remoteAttr('Top.Dev.ApplyConfig', 'error')
-            result = client._remoteAttr('Top.Dev.ApplyConfig', 'result')
+            if cmd.error:
+                raise RuntimeError(f'ApplyConfig failed: {cmd.error}')
 
-            if error:
-                raise RuntimeError(f'ApplyConfig failed: {error}')
-
-            return result
+            return cmd.result
+        finally:
+            client.stop()
+            pr_interfaces.VirtualClient.ClientCache.clear()
 
 
 if __name__ == '__main__':

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -247,7 +247,7 @@ class SimpleClient(object):
         """
         return self._remoteAttr(path, 'setDisp', value)
 
-    def exec(self, path: str, arg: Any = None) -> Any:
+    def exec(self, path: str, arg: Any = None, *, blocking: bool = True) -> Any:
         """
         Call a command, with the optional arg
 
@@ -259,12 +259,15 @@ class SimpleClient(object):
         arg : obj
             Command argument, in native or string form
 
+        blocking : bool, optional (default = True)
+            When ``False``, dispatch on a worker thread and return ``None``.
+
         Returns
         -------
         obj
             Return value of the underlying command
         """
-        return self._remoteAttr(path, '__call__', arg)
+        return self._remoteAttr(path, '__call__', arg, blocking=blocking)
 
     def __enter__(self) -> "SimpleClient":
         """Return self for context-manager use."""

--- a/python/pyrogue/interfaces/_SimpleClient.py
+++ b/python/pyrogue/interfaces/_SimpleClient.py
@@ -267,7 +267,9 @@ class SimpleClient(object):
         obj
             Return value of the underlying command
         """
-        return self._remoteAttr(path, '__call__', arg, blocking=blocking)
+        if blocking:
+            return self._remoteAttr(path, '__call__', arg)
+        return self._remoteAttr(path, '__call__', arg, blocking=False)
 
     def __enter__(self) -> "SimpleClient":
         """Return self for context-manager use."""

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -340,18 +340,11 @@ class VirtualClient(rogue.interfaces.ZmqClient):
         primary operational timeout knob for both hardware and simulation
         applications.
 
-        For Commands whose work duration legitimately exceeds this timeout,
-        see :ref:`pyrogue_tree_builtin_devices_long_running_ops` for the
-        non-blocking dispatch pattern.
-
     requestStallTimeout : float | None, optional
         Optional policy timeout for how long a single in-flight request may
         remain outstanding before the client declares the connection stalled.
         This is disabled by default and is typically only useful when a
         deployment has a well-defined upper bound for legitimate request time.
-
-        See :ref:`pyrogue_tree_builtin_devices_long_running_ops` for how
-        this interacts with non-blocking Command polling.
 
     Attributes
     ----------

--- a/tests/core/test_core_command_nonblocking_construction.py
+++ b/tests/core/test_core_command_nonblocking_construction.py
@@ -8,14 +8,15 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import time
+
 import pytest
 import pyrogue as pr
 from conftest import MemoryRoot
 
 
 # ---------------------------------------------------------------------------
-# Helpers — plain functions (not lambdas) so the arg introspection in
-# BaseCommand.__init__ succeeds without raising on C-extension paths.
+# Helpers
 # ---------------------------------------------------------------------------
 
 def _noop_fn(root=None, dev=None, cmd=None, arg=None):
@@ -23,181 +24,146 @@ def _noop_fn(root=None, dev=None, cmd=None, arg=None):
     return None
 
 
-# ---------------------------------------------------------------------------
-# Device / Root definitions — RemoteCommand cases (need memory backing)
-# ---------------------------------------------------------------------------
-
-class _AsyncRegDevice(pr.Device):
-    """Device that adds a RemoteCommand with nonBlocking=True."""
-
-    def __init__(self, mem_base, **kwargs):
-        super().__init__(memBase=mem_base, **kwargs)
-        # The explicit `nonBlocking` kwarg on RemoteCommand.__init__ routes
-        # nonBlocking only to BaseCommand.__init__ and keeps it out of the
-        # **kwargs handed to pr.RemoteVariable.__init__.  pr.RemoteVariable
-        # accepts **kwargs and silently absorbs unknown keywords, so this
-        # routing is documentation rather than a crash fix.
-        self.add(pr.RemoteCommand(
-            name='AsyncReg',
-            offset=0x00,
-            bitSize=8,
-            base=pr.UInt,
-            value=0,
-            function=_noop_fn,
-            nonBlocking=True,
-            description='Non-blocking remote command — construction guard.',
-        ))
-
-
-class _AsyncRegRoot(MemoryRoot):
-    def __init__(self):
-        super().__init__(name='AsyncRegRoot')
-        self.add(_AsyncRegDevice(name='Dev', mem_base=self._mem))
+def _slow_fn():
+    """Sleep briefly and return a fixed value."""
+    time.sleep(0.3)
+    return 'done'
 
 
 # ---------------------------------------------------------------------------
-# Device / Root definitions — default RemoteCommand (backward-compat)
+# Device / Root definitions
 # ---------------------------------------------------------------------------
 
-class _SyncRegDevice(pr.Device):
-    """Device that adds a default (no nonBlocking kwarg) RemoteCommand."""
+class _SimpleDevice(pr.Device):
+    """Device with a plain LocalCommand and a RemoteCommand."""
 
-    def __init__(self, mem_base, **kwargs):
-        super().__init__(memBase=mem_base, **kwargs)
-        self.add(pr.RemoteCommand(
-            name='SyncReg',
-            offset=0x00,
-            bitSize=8,
-            base=pr.UInt,
-            value=0,
-            function=_noop_fn,
-            description='Default (sync) remote command — backward-compat guard.',
-        ))
+    def __init__(self, mem_base=None, **kwargs):
+        kw = {}
+        if mem_base is not None:
+            kw['memBase'] = mem_base
+        super().__init__(**kw, **kwargs)
 
-
-class _SyncRegRoot(MemoryRoot):
-    def __init__(self):
-        super().__init__(name='SyncRegRoot')
-        self.add(_SyncRegDevice(name='Dev', mem_base=self._mem))
-
-
-# ---------------------------------------------------------------------------
-# Device / Root definitions — sibling-name collision (LocalCommand path)
-# ---------------------------------------------------------------------------
-
-class _CollisionDevice(pr.Device):
-    """Device with a pre-existing 'FooRunning' child before a nonBlocking
-    LocalCommand named 'Foo' is added.  _rootAttached must detect the
-    collision and raise pr.NodeError."""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        # Pre-plant the colliding variable BEFORE the command.
-        self.add(pr.LocalVariable(
-            name='FooRunning',
-            value=False,
-            description='Pre-existing variable whose name collides with the generated sibling.',
-        ))
-        # Without the pre-injection collision check in _rootAttached,
-        # parent._nodes['FooRunning'] would be silently overwritten by the
-        # auto-generated sibling, destroying the pre-existing variable.
         self.add(pr.LocalCommand(
-            name='Foo',
-            function=_noop_fn,
-            nonBlocking=True,
-            description='nonBlocking LocalCommand whose FooRunning sibling name collides.',
+            name='Local',
+            function=_slow_fn,
+            retValue='',
+            description='LocalCommand for blocking/non-blocking tests.',
         ))
 
+        if mem_base is not None:
+            self.add(pr.RemoteCommand(
+                name='Remote',
+                offset=0x00,
+                bitSize=8,
+                base=pr.UInt,
+                value=0,
+                function=_noop_fn,
+                description='RemoteCommand for construction tests.',
+            ))
 
-class _CollisionRoot(pr.Root):
+
+class _SimpleRoot(pr.Root):
     def __init__(self):
-        super().__init__(name='CollisionRoot', pollEn=False)
-        self.add(_CollisionDevice(name='Dev'))
+        super().__init__(name='SimpleRoot', pollEn=False)
+        self.add(_SimpleDevice(name='Dev'))
 
 
-# ---------------------------------------------------------------------------
-# Device / Root definitions — non-collision control (LocalCommand path)
-# ---------------------------------------------------------------------------
-
-class _BarDevice(pr.Device):
-    """Device with a nonBlocking LocalCommand named 'Bar' and NO pre-existing
-    BarRunning/BarResult/BarError children.  Must attach cleanly."""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.add(pr.LocalCommand(
-            name='Bar',
-            function=_noop_fn,
-            nonBlocking=True,
-            description='Non-blocking LocalCommand with no colliding siblings.',
-        ))
-
-
-class _BarRoot(pr.Root):
+class _RemoteRoot(MemoryRoot):
     def __init__(self):
-        super().__init__(name='BarRoot', pollEn=False)
-        self.add(_BarDevice(name='Dev'))
+        super().__init__(name='RemoteRoot')
+        self.add(_SimpleDevice(name='Dev', mem_base=self._mem))
 
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
-def test_remote_command_nonblocking_constructs():
-    """RemoteCommand(nonBlocking=True) constructs, attaches, and auto-injects
-    its three sibling status variables (AsyncRegRunning, AsyncRegResult,
-    AsyncRegError) on start().
-    """
-    with _AsyncRegRoot() as root:
-        # Construction and start() completed without TypeError.
+def test_no_sibling_variables_created():
+    """Commands must NOT inject any sibling status variables into the tree.
+    The running/result/error status is exposed via properties on the Command."""
+    with _SimpleRoot() as root:
         dev = root.Dev
-        # The three sibling status variables must exist on the parent Device.
-        assert 'AsyncRegRunning' in dev.nodes, \
-            "AsyncRegRunning sibling not injected by _rootAttached"
-        assert 'AsyncRegResult' in dev.nodes, \
-            "AsyncRegResult sibling not injected by _rootAttached"
-        assert 'AsyncRegError' in dev.nodes, \
-            "AsyncRegError sibling not injected by _rootAttached"
+        assert 'LocalRunning' not in dev.nodes
+        assert 'LocalResult' not in dev.nodes
+        assert 'LocalError' not in dev.nodes
 
 
-def test_remote_command_default_unchanged():
-    """Backward-compat: a RemoteCommand constructed WITHOUT nonBlocking must
-    attach cleanly and must NOT create any sibling status variables.  Pins the
-    promise that default BaseCommand behaviour is unchanged.
-    """
-    with _SyncRegRoot() as root:
+def test_blocking_true_returns_synchronously():
+    """Default call (blocking=True) executes synchronously and returns the
+    function's return value."""
+    with _SimpleRoot() as root:
+        result = root.Dev.Local()
+        assert result == 'done'
+
+
+def test_blocking_false_returns_immediately():
+    """call(blocking=False) dispatches a worker thread and returns None
+    immediately, well before the function completes."""
+    with _SimpleRoot() as root:
+        cmd = root.Dev.Local
+        t0 = time.monotonic()
+        result = cmd(blocking=False)
+        elapsed = time.monotonic() - t0
+
+        assert result is None
+        assert elapsed < 0.2, f"blocking=False should return immediately, took {elapsed:.2f}s"
+
+        # Wait for the worker to complete.
+        deadline = time.monotonic() + 5.0
+        while cmd.running and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not cmd.running
+        assert cmd.result == 'done'
+        assert cmd.error == ''
+
+
+def test_running_property_tracks_worker():
+    """The `running` property is True while the worker is alive."""
+    with _SimpleRoot() as root:
+        cmd = root.Dev.Local
+
+        assert not cmd.running
+
+        cmd(blocking=False)
+        # Give the thread a moment to start.
+        time.sleep(0.05)
+        assert cmd.running
+
+        # Wait for completion.
+        deadline = time.monotonic() + 5.0
+        while cmd.running and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not cmd.running
+
+
+def test_error_property_captures_exception():
+    """When the worker function raises, `error` captures str(exc) and
+    `result` is unchanged."""
+    def _boom():
+        raise RuntimeError("test error")
+
+    with _SimpleRoot() as root:
+        cmd = root.Dev.Local
+        cmd.replaceFunction(_boom)
+
+        result_before = cmd.result
+
+        cmd(blocking=False)
+        deadline = time.monotonic() + 5.0
+        while cmd.running and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert not cmd.running
+        assert cmd.error == 'test error'
+        assert cmd.result == result_before
+
+
+def test_remote_command_constructs_without_nonblocking():
+    """RemoteCommand no longer accepts a nonBlocking parameter and
+    constructs cleanly without it."""
+    with _RemoteRoot() as root:
         dev = root.Dev
-        assert 'SyncReg' in dev.nodes, "SyncReg command not found on device"
-        assert 'SyncRegRunning' not in dev.nodes, \
-            "SyncRegRunning sibling must not exist for a default (sync) RemoteCommand"
-        assert 'SyncRegResult' not in dev.nodes, \
-            "SyncRegResult sibling must not exist for a default (sync) RemoteCommand"
-        assert 'SyncRegError' not in dev.nodes, \
-            "SyncRegError sibling must not exist for a default (sync) RemoteCommand"
-
-
-def test_sibling_injection_collision_raises_nodeerror():
-    """When a parent Device already contains a child whose name collides with
-    a generated {name}Running / {name}Result / {name}Error sibling,
-    BaseCommand._rootAttached must raise pr.NodeError BEFORE any
-    parent._nodes mutation — the pre-existing node must not be overwritten.
-    """
-    with pytest.raises(pr.NodeError):
-        with _CollisionRoot():
-            pass
-
-
-def test_sibling_injection_no_collision_ok():
-    """A nonBlocking LocalCommand with no pre-existing sibling name collisions
-    must attach cleanly and create its three status siblings.  Proves the
-    collision guard does not false-positive on the normal path.
-    """
-    with _BarRoot() as root:
-        dev = root.Dev
-        assert 'Bar' in dev.nodes, "Bar command not found on device"
-        assert 'BarRunning' in dev.nodes, \
-            "BarRunning sibling not injected for non-colliding nonBlocking LocalCommand"
-        assert 'BarResult' in dev.nodes, \
-            "BarResult sibling not injected for non-colliding nonBlocking LocalCommand"
-        assert 'BarError' in dev.nodes, \
-            "BarError sibling not injected for non-colliding nonBlocking LocalCommand"
+        assert 'Remote' in dev.nodes
+        assert not dev.Remote.running

--- a/tests/core/test_core_command_nonblocking_construction.py
+++ b/tests/core/test_core_command_nonblocking_construction.py
@@ -10,7 +10,6 @@
 
 import time
 
-import pytest
 import pyrogue as pr
 from conftest import MemoryRoot
 

--- a/tests/interfaces/test_interfaces_command_nonblocking.py
+++ b/tests/interfaces/test_interfaces_command_nonblocking.py
@@ -19,9 +19,8 @@ import pyrogue.interfaces as pr_interfaces
 pytestmark = pytest.mark.integration
 
 
-# TEST-04 uses _LogRecorder to capture server-side log warnings from the live command.
 class _LogRecorder:
-    """Minimal logger stub that records warning() calls for TEST-04 assertions."""
+    """Minimal logger stub that records warning() calls."""
 
     def __init__(self):
         self.messages = []
@@ -30,20 +29,14 @@ class _LogRecorder:
         self.messages.append(message)
 
     def __getattr__(self, name):
-        # Absorb any other logger surface (debug/info/error/critical/exception)
-        # without raising AttributeError.  Keeps TEST-04 robust against future
-        # implementation changes that might add new self._log calls inside the
-        # non-blocking dispatch path.
         return lambda *a, **k: None
 
 
 def raise_boom():
-    """Module-level raising function — keeps the traceback readable for TEST-06."""
     raise RuntimeError("boom")
 
 
 def _async_sleep_fn():
-    """Sleep 2 seconds and return a fixed string result."""
     time.sleep(2.0)
     return 'done'
 
@@ -52,59 +45,45 @@ class ZmqIntegrationDevice(pr.Device):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # TEST-01 (#1243): synchronous long-running command; blocks the client for the
-        # full function duration regardless of linkTimeout.  A 3-second sleep stands in
-        # for the issue #1243 blocking pattern within the CI time budget.
         self.add(pr.LocalCommand(
             name='SyncSleep',
-            description='Synchronous sleep — blocks caller for full duration.',
+            description='Synchronous sleep.',
             function=lambda: time.sleep(3),
         ))
 
-        # TEST-02: same pattern with nonBlocking=True; call returns immediately and
-        # the client polls the auto-added Running/Result/Error sibling variables.
         self.add(pr.LocalCommand(
             name='AsyncSleep',
-            description='Non-blocking sleep — returns immediately; poll AsyncSleepRunning.',
+            description='Used with blocking=False.',
             function=_async_sleep_fn,
-            nonBlocking=True,
             retValue='',
         ))
 
-        # Sync regression: default-construction command must still return its
-        # function value synchronously after the nonBlocking feature is introduced.
         self.add(pr.LocalCommand(
             name='SyncMul',
-            description='Synchronous multiply — returns arg * 3.',
+            description='Synchronous multiply.',
             value=0,
             retValue=0,
             function=lambda arg: arg * 3,
         ))
 
-        # TEST-04: 2-second sleep — used for re-entry rejection test.
         self.add(pr.LocalCommand(
             name='AsyncSlow',
-            description='Non-blocking 2-second sleep — re-entry rejection test.',
+            description='2-second sleep for re-entry test.',
             function=lambda: time.sleep(2.0),
-            nonBlocking=True,
             retValue='',
         ))
 
-        # TEST-05: 5-second sleep — used for Root.stop() clean-join test.
         self.add(pr.LocalCommand(
             name='AsyncLong',
-            description='Non-blocking 5-second sleep — shutdown join test.',
+            description='5-second sleep for shutdown test.',
             function=lambda: time.sleep(5.0),
-            nonBlocking=True,
             retValue='',
         ))
 
-        # TEST-06: raises RuntimeError — used for worker error-path test.
         self.add(pr.LocalCommand(
             name='AsyncBoom',
-            description='Non-blocking command that raises — error-path test.',
+            description='Raises RuntimeError for error-path test.',
             function=raise_boom,
-            nonBlocking=True,
         ))
 
 
@@ -118,11 +97,7 @@ class ZmqIntegrationRoot(pr.Root):
 
 
 def test_sync_command_baseline_blocks_link(free_zmq_port):
-    # TEST-01 (#1243): a synchronous LocalCommand over ZMQ blocks the client thread
-    # for the entire duration of the server-side function.  The VirtualClient does NOT
-    # raise after linkTimeout when a request is in flight (the idle-timeout check is
-    # suppressed while reqPending=True).  This test asserts the blocking behaviour so
-    # that the contrast with TEST-02 (nonBlocking=True) is explicit.
+    """Synchronous call blocks the client for the full duration."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -136,8 +111,6 @@ def test_sync_command_baseline_blocks_link(free_zmq_port):
             t0 = time.monotonic()
             remote_dev.SyncSleep()
             elapsed = time.monotonic() - t0
-            # The synchronous call must block for the full 3-second sleep.
-            # TEST-01 assertion shape: wall-clock >= sleep_duration - 0.5 s.
             assert elapsed >= 2.5, (
                 f"Sync command should block for ~3 s but returned in {elapsed:.2f} s"
             )
@@ -147,10 +120,8 @@ def test_sync_command_baseline_blocks_link(free_zmq_port):
 
 
 def test_nonblocking_command_returns_immediately(wait_until, free_zmq_port):
-    # TEST-02: with nonBlocking=True the command call returns immediately (well under
-    # linkTimeout=2.0).  The auto-added AsyncSleepRunning / AsyncSleepResult /
-    # AsyncSleepError sibling LocalVariables are polled via the VirtualClient until
-    # the worker completes naturally.
+    """blocking=False returns immediately; status is polled via exposed
+    properties on the command node."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -160,37 +131,32 @@ def test_nonblocking_command_returns_immediately(wait_until, free_zmq_port):
             linkTimeout=2.0,
         )
         try:
-            remote_dev = client.root.Dev
+            remote_cmd = client.root.Dev.AsyncSleep
 
             t0 = time.monotonic()
-            remote_dev.AsyncSleep()
+            remote_cmd(blocking=False)
             elapsed = time.monotonic() - t0
 
-            # (a) Call must return immediately — well under linkTimeout.
             assert elapsed < 1.0, (
-                f"nonBlocking call should return immediately but took {elapsed:.2f} s"
+                f"blocking=False should return immediately but took {elapsed:.2f} s"
             )
 
-            # (b) Running flips to True while the worker is in flight.
             assert wait_until(
-                lambda: remote_dev.AsyncSleepRunning.get() is True,
+                lambda: remote_cmd.running is True,
                 timeout=5.0,
-            ), "AsyncSleepRunning never became True"
+            ), "running never became True"
 
-            # (c) Running flips to False once the 2-second worker completes.
             assert wait_until(
-                lambda: remote_dev.AsyncSleepRunning.get() is False,
+                lambda: remote_cmd.running is False,
                 timeout=10.0,
-            ), "AsyncSleepRunning never returned to False"
+            ), "running never returned to False"
 
-            # (d) Result carries the function's return value.
-            assert remote_dev.AsyncSleepResult.get() == 'done', (
-                f"Expected AsyncSleepResult='done', got {remote_dev.AsyncSleepResult.get()!r}"
+            assert remote_cmd.result == 'done', (
+                f"Expected result='done', got {remote_cmd.result!r}"
             )
 
-            # (e) Error is empty on a successful run.
-            assert remote_dev.AsyncSleepError.get() == '', (
-                f"Expected empty AsyncSleepError, got {remote_dev.AsyncSleepError.get()!r}"
+            assert remote_cmd.error == '', (
+                f"Expected empty error, got {remote_cmd.error!r}"
             )
         finally:
             client.stop()
@@ -198,9 +164,7 @@ def test_nonblocking_command_returns_immediately(wait_until, free_zmq_port):
 
 
 def test_sync_command_returns_value(free_zmq_port):
-    # Sync regression: default-construction LocalCommand (nonBlocking=False) must
-    # continue to return the function's value synchronously over VirtualClient.
-    # Pins the "default-False keeps every existing example unchanged" promise.
+    """Default blocking=True returns the function value synchronously."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -219,9 +183,7 @@ def test_sync_command_returns_value(free_zmq_port):
 
 
 def test_reentrant_call_is_rejected_and_logged(wait_until, free_zmq_port):
-    # TEST-04 (#1243): a second call to a non-blocking Command while it is running
-    # is logged as "Command already running!" and silently rejected — no parallel
-    # worker is spawned and Result is not modified.
+    """A second blocking=False call while the worker is running is rejected."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -235,51 +197,34 @@ def test_reentrant_call_is_rejected_and_logged(wait_until, free_zmq_port):
         recorder = _LogRecorder()
         cmd._log = recorder
         try:
-            remote_dev = client.root.Dev
+            remote_cmd = client.root.Dev.AsyncSlow
 
-            # Snapshot Result before the first call — unchanged-sentinel for (c).
-            result_before = remote_dev.AsyncSlowResult.get()
+            result_before = remote_cmd.result
 
-            # First call — worker spawns and begins its 2-second sleep.
-            remote_dev.AsyncSlow()
+            remote_cmd(blocking=False)
 
-            # Wait for Running to flip True before issuing the re-entry call.
             assert wait_until(
-                lambda: remote_dev.AsyncSlowRunning.get() is True,
+                lambda: remote_cmd.running is True,
                 timeout=5.0,
-            ), "AsyncSlowRunning never became True after first call"
+            ), "running never became True after first call"
 
-            # Second call while the worker is in flight — must be silently rejected.
-            result = remote_dev.AsyncSlow()
-            assert result is None, (
-                f"Re-entry call should return None, got {result!r}"
-            )
+            result = remote_cmd(blocking=False)
+            assert result is None
 
-            # (a) Exactly one warning logged on the server side.
-            assert recorder.messages == ["Command already running!"], (
-                f"Expected ['Command already running!'] but got {recorder.messages!r}"
-            )
+            assert recorder.messages == ["Command already running!"]
 
-            # (b) Only one worker thread alive for this command path.
             worker_threads = [
                 t for t in threading.enumerate()
                 if t.name == f'{cmd.path}.worker'
             ]
-            assert len(worker_threads) == 1, (
-                f"Expected 1 worker thread, found {len(worker_threads)}"
-            )
+            assert len(worker_threads) == 1
 
-            # (c) Result is unchanged — re-entry rejection did not modify it.
-            assert remote_dev.AsyncSlowResult.get() == result_before, (
-                f"Result changed after re-entry rejection: "
-                f"before={result_before!r}, after={remote_dev.AsyncSlowResult.get()!r}"
-            )
+            assert remote_cmd.result == result_before
 
-            # Wait for the first worker to finish naturally before cleanup.
             assert wait_until(
-                lambda: remote_dev.AsyncSlowRunning.get() is False,
+                lambda: remote_cmd.running is False,
                 timeout=10.0,
-            ), "AsyncSlowRunning never returned to False after worker completion"
+            ), "running never returned to False"
 
         finally:
             cmd._log = original_log
@@ -288,10 +233,7 @@ def test_reentrant_call_is_rejected_and_logged(wait_until, free_zmq_port):
 
 
 def test_root_stop_joins_in_flight_worker(wait_until, free_zmq_port):
-    # TEST-05 (#1243): Root.stop() (via ZmqIntegrationRoot context exit) joins
-    # any in-flight non-blocking Command worker indefinitely — no .worker thread
-    # survives shutdown.  Workers are daemon=False and Root.stop() joins them
-    # without a timeout.
+    """Root.stop() joins any in-flight worker thread."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -301,25 +243,19 @@ def test_root_stop_joins_in_flight_worker(wait_until, free_zmq_port):
             linkTimeout=10.0,
         )
         try:
-            remote_dev = client.root.Dev
+            remote_cmd = client.root.Dev.AsyncLong
 
-            # Start the 5-second worker.
-            remote_dev.AsyncLong()
+            remote_cmd(blocking=False)
 
-            # Confirm the worker is in flight before triggering shutdown.
             assert wait_until(
-                lambda: remote_dev.AsyncLongRunning.get() is True,
+                lambda: remote_cmd.running is True,
                 timeout=5.0,
-            ), "AsyncLongRunning never became True"
+            ), "running never became True"
 
         finally:
             client.stop()
             pr_interfaces.VirtualClient.ClientCache.clear()
 
-    # with block exit: root.stop() is called, which joins the in-flight worker
-    # indefinitely.  The 5-second sleep must complete before this line is reached.
-    # Scope the leak check to threads this feature owns (".worker") to avoid
-    # false positives from unrelated background threads (pytest, ZMQ, logging).
     post_threads = {t.name for t in threading.enumerate()}
     leaked_workers = [name for name in post_threads if name.endswith('.worker')]
     assert not leaked_workers, (
@@ -328,8 +264,7 @@ def test_root_stop_joins_in_flight_worker(wait_until, free_zmq_port):
 
 
 def test_worker_exception_sets_error_and_preserves_result(wait_until, free_zmq_port):
-    # TEST-06 (#1243): when the worker function raises, str(exc) lands in
-    # {name}Error, Running is cleared to False, and Result is left unchanged.
+    """When the worker raises, error captures str(exc) and result is unchanged."""
     pr_interfaces.VirtualClient.ClientCache.clear()
 
     with ZmqIntegrationRoot(port=free_zmq_port) as root:
@@ -339,42 +274,22 @@ def test_worker_exception_sets_error_and_preserves_result(wait_until, free_zmq_p
             linkTimeout=5.0,
         )
         try:
-            remote_dev = client.root.Dev
+            remote_cmd = client.root.Dev.AsyncBoom
 
-            # Pre-call: Error must be empty before any invocation.
-            assert remote_dev.AsyncBoomError.get() == "", (
-                f"Expected empty AsyncBoomError before call, "
-                f"got {remote_dev.AsyncBoomError.get()!r}"
-            )
+            assert remote_cmd.error == ''
 
-            # Snapshot Result before the call — unchanged-sentinel independent
-            # of the chosen default value.
-            result_before = remote_dev.AsyncBoomResult.get()
+            result_before = remote_cmd.result
 
-            # Fire the raising command — returns None immediately (nonBlocking).
-            remote_dev.AsyncBoom()
+            remote_cmd(blocking=False)
 
-            # Wait for the worker to exit after raising.
             assert wait_until(
-                lambda: remote_dev.AsyncBoomRunning.get() is False,
+                lambda: remote_cmd.running is False,
                 timeout=10.0,
-            ), "AsyncBoomRunning never cleared after worker exception"
+            ), "running never cleared after worker exception"
 
-            # Error carries str(exc) only.
-            assert remote_dev.AsyncBoomError.get() == "boom", (
-                f"Expected AsyncBoomError='boom', got {remote_dev.AsyncBoomError.get()!r}"
-            )
-
-            # Running is False — cleared in the error branch.
-            assert remote_dev.AsyncBoomRunning.get() is False, (
-                "AsyncBoomRunning should be False after exception"
-            )
-
-            # Result is UNCHANGED — the error branch does not update Result.
-            assert remote_dev.AsyncBoomResult.get() == result_before, (
-                f"Result changed after exception: "
-                f"before={result_before!r}, after={remote_dev.AsyncBoomResult.get()!r}"
-            )
+            assert remote_cmd.error == "boom"
+            assert remote_cmd.running is False
+            assert remote_cmd.result == result_before
 
         finally:
             client.stop()

--- a/tests/interfaces/test_interfaces_simple_client_nonblocking.py
+++ b/tests/interfaces/test_interfaces_simple_client_nonblocking.py
@@ -29,9 +29,8 @@ class NonBlockingDevice(pr.Device):
         super().__init__(**kwargs)
         self.add(pr.LocalCommand(
             name='ApplyConfig',
-            description='Non-blocking config apply — returns immediately.',
+            description='Config apply command.',
             function=_apply_config_fn,
-            nonBlocking=True,
             retValue='',
         ))
 
@@ -45,50 +44,41 @@ class NonBlockingRoot(pr.Root):
 
 
 def test_simpleclient_exec_nonblocking_returns_immediately(wait_until, free_zmq_port):
-    # TEST-03: SimpleClient.exec on a nonBlocking=True Command returns immediately
-    # (well under the worker's 1-second duration) without raising.  Polling via
-    # client.get() shows Running flip True->False and Result population.
-    # SimpleClient uses a raw zmq.REQ socket with no recv timeout and no cache.
+    """SimpleClient.exec(blocking=False) returns immediately. Status is
+    polled via the exposed properties on the command."""
 
     with NonBlockingRoot(port=free_zmq_port) as root:
         with pr_interfaces.SimpleClient(addr='127.0.0.1', port=root.zmqServer.port()) as client:
             t0 = time.monotonic()
-            result = client.exec('Top.Dev.ApplyConfig')
+            result = client.exec('Top.Dev.ApplyConfig', blocking=False)
             elapsed = time.monotonic() - t0
 
-            # (a) exec returns None immediately — well under the 1-second worker duration.
             assert result is None, f"Expected None, got {result!r}"
             assert elapsed < 1.0, (
-                f"nonBlocking exec should return immediately but took {elapsed:.2f} s"
+                f"blocking=False exec should return immediately but took {elapsed:.2f} s"
             )
 
-            # (b) Running flips to True while the worker is in flight.
             assert wait_until(
-                lambda: client.get('Top.Dev.ApplyConfigRunning') is True,
+                lambda: client._remoteAttr('Top.Dev.ApplyConfig', 'running') is True,
                 timeout=5.0,
-            ), "ApplyConfigRunning never became True"
+            ), "running never became True"
 
-            # (c) Running clears once the 1-second worker finishes.
             assert wait_until(
-                lambda: client.get('Top.Dev.ApplyConfigRunning') is False,
+                lambda: client._remoteAttr('Top.Dev.ApplyConfig', 'running') is False,
                 timeout=10.0,
-            ), "ApplyConfigRunning never returned to False"
+            ), "running never returned to False"
 
-            # (d) Result carries the function's return value.
-            assert client.get('Top.Dev.ApplyConfigResult') == 'configured', (
-                f"Expected 'configured', got {client.get('Top.Dev.ApplyConfigResult')!r}"
+            assert client._remoteAttr('Top.Dev.ApplyConfig', 'result') == 'configured', (
+                f"Expected 'configured', got {client._remoteAttr('Top.Dev.ApplyConfig', 'result')!r}"
             )
 
-            # (e) Error is empty on a successful run.
-            assert client.get('Top.Dev.ApplyConfigError') == '', (
-                f"Expected empty Error, got {client.get('Top.Dev.ApplyConfigError')!r}"
+            assert client._remoteAttr('Top.Dev.ApplyConfig', 'error') == '', (
+                f"Expected empty error, got {client._remoteAttr('Top.Dev.ApplyConfig', 'error')!r}"
             )
 
 
 def test_cookbook_example_runs_headless(free_zmq_port):
-    # Smoke test: import and run the cookbook main() headlessly to verify it
-    # completes without error and returns the expected Result string.  Prevents
-    # the cookbook example from silently rotting.
+    """Smoke test: the cookbook example completes without error."""
     from pyrogue.examples._NonBlockingCommandExample import main
 
     result = main(port=free_zmq_port)

--- a/tests/interfaces/test_interfaces_simple_client_nonblocking.py
+++ b/tests/interfaces/test_interfaces_simple_client_nonblocking.py
@@ -45,7 +45,7 @@ class NonBlockingRoot(pr.Root):
 
 def test_simpleclient_exec_nonblocking_returns_immediately(wait_until, free_zmq_port):
     """SimpleClient.exec(blocking=False) returns immediately. Status is
-    polled via the exposed properties on the command."""
+    polled via _remoteAttr on the exposed command properties."""
 
     with NonBlockingRoot(port=free_zmq_port) as root:
         with pr_interfaces.SimpleClient(addr='127.0.0.1', port=root.zmqServer.port()) as client:

--- a/tests/interfaces/test_zmq_client.py
+++ b/tests/interfaces/test_zmq_client.py
@@ -120,7 +120,7 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
     state machine.
 
     On unpatched main this test is EXPECTED to fail (crash, timeout, or
-    ZMQ protocol error) within ~30 s. The fix adds a std::mutex in C++
+    ZMQ protocol error) within ~30 s. Phase 2 adds a std::mutex in C++
     ZmqClient to serialize the REQ cycle; the same test must then pass.
     """
     N_COMMANDS = 500
@@ -166,10 +166,10 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
         def _watchdog():
             # Fires iff the test process is still alive after WATCHDOG_SECONDS.
             # On unpatched HEAD the corrupted ZMQ_REQ socket can deadlock
-            # teardown (srv._stop/root.stop), so setting stop_event alone is
-            # insufficient to bound the test runtime.  Hard-exit is the only
-            # mechanism that bypasses a C++/GIL deadlock; a non-zero exit
-            # preserves the FAIL-on-unpatched signal.
+            # teardown (srv._stop/root.stop), so setting stop_event alone
+            # is insufficient to satisfy REPRO-03 (< 30s).  Hard-exit is
+            # the only mechanism that bypasses a C++/GIL deadlock; a
+            # non-zero exit preserves the Phase 1 FAIL-on-unpatched signal.
             timeout_flag["fired"] = True
             stop_event.set()
             sys.stderr.write(
@@ -200,13 +200,13 @@ def test_virtual_client_concurrent_threadsafety(free_zmq_port):
             watchdog.cancel()
             poll_thread.join(timeout=JOIN_TIMEOUT)
 
-        # Invariants: the polling thread MUST have exited, and the watchdog
-        # MUST NOT have fired (otherwise we blew the 30 s budget).
+        # REPRO-03 invariants: the polling thread MUST have exited, and
+        # the watchdog MUST NOT have fired (otherwise we blew the 30 s budget).
         assert not poll_thread.is_alive(), "polling thread did not join within %.1fs" % JOIN_TIMEOUT
         assert not timeout_flag["fired"], "watchdog fired: test exceeded %.1fs budget" % WATCHDOG_SECONDS
 
         # Re-raise any error captured in the polling thread so a poller-only
-        # crash still fails the pytest run.
+        # crash still fails the pytest run (D-12).
         if errors:
             raise AssertionError(
                 "concurrent RPC race: polling thread raised %d error(s); first: %r"


### PR DESCRIPTION
## Summary

Replaces the construction-time `nonBlocking=True` flag from PR #1244 with a call-site `blocking=False` keyword argument on `__call__`/`call`/`callDisp`. This addresses the design concern raised in [#1244 review](https://github.com/slaclab/rogue/pull/1244#discussion): whether to block is a function of the calling context, not a property of the command itself.

Key changes:

- **`blocking` kwarg on `__call__`/`call`/`callDisp`** (default `True`) — any Command can now be called non-blocking without construction-time opt-in
- **`@pr.expose` properties** (`running`, `result`, `error`) on `BaseCommand` — status is accessed directly on the command node instead of via injected sibling `LocalVariable`s, keeping the rogue tree clean
- **`SimpleClient.exec`** gains a `blocking` kwarg, forwarded through ZMQ
- **No sibling variable injection** — removes `_rootAttached` override, the `list()` snapshot workaround in `Device._rootAttached`, and all `_nonBlocking`/`_varRunning`/`_varResult`/`_varError` internals
- **`RemoteCommand`** no longer accepts `nonBlocking` — the `blocking` kwarg works uniformly through `__call__`

### Usage

```python
# Server — no construction-time flag needed
self.add(pr.LocalCommand(name='ApplyConfig', function=my_fn, retValue=''))

# Client — caller decides whether to block
cmd = client.root.Dev.ApplyConfig
cmd(blocking=False)          # returns None immediately

while cmd.running:           # exposed property
    time.sleep(0.1)

if cmd.error:                # exposed property
    raise RuntimeError(cmd.error)
print(cmd.result)            # exposed property
```

## Test plan

- [ ] `pytest tests/core/test_core_command_nonblocking_construction.py -v` — construction, properties, error path
- [ ] `pytest tests/interfaces/test_interfaces_command_nonblocking.py -v` — ZMQ integration: blocking/non-blocking, re-entry, shutdown join, error path
- [ ] `pytest tests/interfaces/test_interfaces_simple_client_nonblocking.py -v` — SimpleClient exec + cookbook example smoke test
- [ ] `python -m pyrogue.examples._NonBlockingCommandExample` — cookbook example runs headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)