### PR TITLE
fix(memory): make Block getBytes/setBytes GIL release conditional

### DIFF
--- a/src/rogue/interfaces/memory/Block.cpp
+++ b/src/rogue/interfaces/memory/Block.cpp
@@ -38,6 +38,7 @@ namespace bp = boost::python;
 #include <exception>
 #include <iomanip>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -655,8 +656,18 @@ void rim::Block::setBytes(const uint8_t* data, rim::Variable* var, uint32_t inde
     uint8_t tmp;
     uint8_t* buff;
 
-    rogue::GilRelease noGil;
-    std::lock_guard<std::mutex> lock(mtx_);
+    // Fast path: take mtx_ without dropping the GIL. The body below is pure
+    // in-memory work (memcpy/copyBits/byte-reverse) with no Python calls, so
+    // holding the GIL across it is correct and avoids the release/re-acquire
+    // thrash that dominates bulk update-queue drains (SLAC rogue #1262). Only
+    // when mtx_ is actually contended -- held by a memory-transaction worker
+    // that may need the GIL for a Python callback -- do we drop the GIL while
+    // blocking, preserving the deadlock-avoidance contract.
+    std::unique_lock<std::mutex> lock(mtx_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        rogue::GilRelease noGil;
+        lock.lock();
+    }
 
     // Set stale flag
     if (var->mode_ != "RO") stale_ = true;
@@ -739,8 +750,15 @@ void rim::Block::getBytes(uint8_t* data, rim::Variable* var, uint32_t index) {
     uint32_t dstBit;
     uint32_t x;
 
-    rogue::GilRelease noGil;
-    std::lock_guard<std::mutex> lock(mtx_);
+    // Fast path: take mtx_ without dropping the GIL. See setBytes() for the full
+    // rationale -- the body is pure in-memory work, so we only release the GIL
+    // on the contended-wait path to preserve deadlock avoidance (SLAC rogue
+    // #1262).
+    std::unique_lock<std::mutex> lock(mtx_, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        rogue::GilRelease noGil;
+        lock.lock();
+    }
 
     // List variable
     if (var->numValues_ != 0) {

--- a/tests/core/test_block_gil_fastpath_roundtrip.py
+++ b/tests/core/test_block_gil_fastpath_roundtrip.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Block getBytes/setBytes conditional-GIL fast-path tests
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Pins getBytes/setBytes value equivalence after the #1262 conditional-GIL
+# change. The fast path now holds the Python GIL across the in-memory body and
+# only drops it when the Block mutex is actually contended. These tests prove
+# that staged (write=False / read=False) values still round-trip on the scalar,
+# list, and byte-reversed (malloc-copy) paths, and that the try_to_lock fallback
+# branch -- taken when two threads hit the same Block -- stays correct because
+# the mutex still serializes access; only the GIL handling changed.
+
+import threading
+
+import pyrogue as pr
+import rogue.interfaces.memory
+
+
+class _MixRoot(pr.Root):
+    def __init__(self) -> None:
+        super().__init__(name="MixRoot", description="GIL fast-path test", pollEn=False)
+        sim = rogue.interfaces.memory.Emulate(4, 0x1000)
+        self.addInterface(sim)
+        self.add(pr.Device(name="Dev", offset=0, memBase=sim))
+        self.Dev.add(pr.RemoteVariable(
+            name="Scalar",
+            offset=0x0,
+            bitOffset=0,
+            bitSize=32,
+            base=pr.UInt,
+            mode="RW",
+        ))
+        self.Dev.add(pr.RemoteVariable(
+            name="List",
+            offset=0x10,
+            bitOffset=0,
+            base=pr.UInt,
+            mode="RW",
+            disp="{}",
+            numValues=8,
+            valueBits=32,
+            valueStride=32,
+        ))
+        self.Dev.add(pr.RemoteVariable(
+            name="ListBE",
+            offset=0x40,
+            bitOffset=0,
+            base=pr.UIntBE,        # forces byteReverse_ = True (malloc-copy path)
+            mode="RW",
+            disp="{}",
+            numValues=8,
+            valueBits=32,
+            valueStride=32,
+        ))
+
+
+def test_fastpath_roundtrip_single_thread():
+    """Staged set/get round-trips on scalar, list, and byte-reversed paths."""
+    with _MixRoot() as root:
+        root.Dev.Scalar.set(0xDEADBEEF, write=False)
+        assert root.Dev.Scalar.get(read=False) == 0xDEADBEEF
+
+        for i in range(8):
+            root.Dev.List.set(0x1000 + i, index=i, write=False)
+            root.Dev.ListBE.set(0x2000 + i, index=i, write=False)
+        for i in range(8):
+            assert root.Dev.List.get(index=i, read=False) == 0x1000 + i
+            assert root.Dev.ListBE.get(index=i, read=False) == 0x2000 + i
+
+
+def test_fastpath_roundtrip_under_contention():
+    """Two threads hitting the same Block force the try_to_lock fallback branch.
+
+    The main thread owns index 0 of the list and verifies its own writes; a
+    background thread hammers indices 1-7 of the same variable. Both go through
+    the same Block mutex, so the fast-path try_to_lock will fail often enough to
+    exercise the GIL-drop fallback. Values must stay exact because the mutex
+    still serializes access.
+    """
+    with _MixRoot() as root:
+        var = root.Dev.List
+        stop = threading.Event()
+        errors = []
+
+        def worker():
+            try:
+                i = 0
+                while not stop.is_set():
+                    idx = 1 + (i % 7)
+                    var.set(i & 0xFFFFFFFF, index=idx, write=False)
+                    var.get(index=idx, read=False)
+                    i += 1
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        try:
+            for i in range(20000):
+                var.set(i & 0xFFFFFFFF, index=0, write=False)
+                assert var.get(index=0, read=False) == (i & 0xFFFFFFFF)
+        finally:
+            stop.set()
+            t.join(timeout=5.0)
+
+        assert not errors, f"worker raised: {errors}"

--- a/tests/perf/test_block_gil_contention_perf.py
+++ b/tests/perf/test_block_gil_contention_perf.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# Title      : Block getBytes/setBytes GIL-contention drain perf regression
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+#
+# Reproduces SLAC rogue #1262: the v6 update-queue drain stalls because
+# Block::getBytes / Block::setBytes released the Python GIL unconditionally on
+# every call. During a bulk drain (~42k staged variable updates) that is ~42k
+# PyEval_SaveThread/PyEval_RestoreThread cycles; with another Python thread
+# contending for the GIL, each hand-off costs milliseconds and the drain stalls
+# for tens of seconds.
+#
+# This test drives a ~42k staged set(write=False)/get(read=False) drain -- the
+# pure Block::setBytes/getBytes path, no hardware transaction -- while a busy
+# pure-Python thread contends for the GIL. The drain is timed both with and
+# without the contender. Pre-fix the contended drain blows past the ceiling;
+# post-fix the uncontended fast path keeps the GIL and the drain stays fast.
+
+import threading
+import time
+
+import pyrogue as pr
+import pytest
+import rogue.interfaces.memory
+
+from tests.perf._perf_metrics import emit_perf_result
+
+pytestmark = pytest.mark.perf
+
+# Mirrors the ~42k entry update-queue drain from the #1262 report.
+DRAIN_COUNT = 42000
+
+# Host-robust ceiling. Pre-fix the contended drain runs in the tens of seconds
+# (the reported 42-126 s stall under load); post-fix it completes in well under
+# a second on any CI host, so a wide margin keeps the test deterministic.
+CEILING_S = 10.0
+
+
+class _DrainRoot(pr.Root):
+    def __init__(self) -> None:
+        super().__init__(name="DrainRoot", description="GIL contention drain", pollEn=False)
+        sim = rogue.interfaces.memory.Emulate(4, 0x1000)
+        self.addInterface(sim)
+        self.add(pr.Device(name="Dev", offset=0, memBase=sim))
+        self.Dev.add(pr.RemoteVariable(
+            name="Reg",
+            offset=0,
+            bitOffset=0,
+            bitSize=32,
+            base=pr.UInt,
+            mode="RW",
+        ))
+
+
+def _spawn_gil_contender(stop_event):
+    """Always-runnable pure-Python thread that maximizes GIL hand-off cost.
+
+    It never blocks on I/O, so it is always ready to grab the GIL the instant a
+    pre-fix getBytes/setBytes releases it -- which is exactly what turns each
+    release/re-acquire into a multi-millisecond stall under the interpreter's
+    GIL hand-off interval.
+    """
+    def churn():
+        x = 0
+        while not stop_event.is_set():
+            x = (x + 1) % 1_000_003
+    t = threading.Thread(target=churn, daemon=True)
+    t.start()
+    return t
+
+
+def _drain(var, count):
+    """Pure staged set/get drain: setBytes via set(write=False), getBytes via
+    get(read=False). No transaction is issued, so the Block mutex is
+    uncontended; the only variable is whether the GIL is thrashed per call."""
+    for i in range(count):
+        var.set(i & 0xFFFFFFFF, write=False)
+        var.get(read=False)
+
+
+def test_block_getset_drain_under_gil_contention():
+    with _DrainRoot() as root:
+        var = root.Dev.Reg
+
+        # Baseline drain with no GIL contender.
+        start = time.perf_counter()
+        _drain(var, DRAIN_COUNT)
+        baseline_s = time.perf_counter() - start
+
+        # Drain again with a background GIL-contending thread.
+        stop = threading.Event()
+        contender = _spawn_gil_contender(stop)
+        try:
+            time.sleep(0.05)
+            start = time.perf_counter()
+            _drain(var, DRAIN_COUNT)
+            contended_s = time.perf_counter() - start
+        finally:
+            stop.set()
+            contender.join(timeout=5.0)
+
+        ratio = contended_s / baseline_s if baseline_s > 0 else float("inf")
+        threshold_pass = contended_s < CEILING_S
+
+        print(
+            f"drain {DRAIN_COUNT}: baseline {baseline_s:.3f}s, "
+            f"contended {contended_s:.3f}s, ratio {ratio:.1f}x, "
+            f"ceiling {CEILING_S:.1f}s"
+        )
+
+        emit_perf_result(
+            "block_gil_contention_drain",
+            drain_count=DRAIN_COUNT,
+            baseline_s=baseline_s,
+            contended_s=contended_s,
+            slowdown_ratio=ratio,
+            ceiling_s=CEILING_S,
+            threshold_pass=threshold_pass,
+        )
+
+        # The contended drain is the #1262 regression signal. Pre-fix it trips
+        # the ceiling (tens of seconds); post-fix it stays well under it.
+        assert threshold_pass, (
+            f"contended drain took {contended_s:.2f}s (>{CEILING_S:.1f}s ceiling); "
+            f"baseline {baseline_s:.2f}s, slowdown {ratio:.1f}x -- #1262 GIL thrash"
+        )
+
+
+if __name__ == "__main__":
+    test_block_getset_drain_under_gil_contention()


### PR DESCRIPTION
### Description
Fixes a v6 performance regression (#1262) where the Root update-queue drain stalls for tens of seconds. `Block::getBytes` and `Block::setBytes` released the Python GIL unconditionally on every call; a bulk drain of ~42k staged variable updates therefore performed ~42k GIL release/re-acquire cycles, and under GIL contention each hand-off costs milliseconds. The method bodies are pure in-memory work (memcpy/copyBits/byte-reverse) with no Python calls, so the GIL now stays held on the uncontended fast path and is released only while blocking on a contended block mutex, preserving the deadlock-avoidance contract with memory-transaction workers. Contended 42k-entry drain improves from ~16 s to ~0.05 s in the reproduction.

### Details
- `Block::setBytes` / `Block::getBytes` now acquire `mtx_` with `std::unique_lock(mtx_, std::try_to_lock)`. On the uncontended path the GIL is never dropped (kills the per-call thrash). Only when the lock is contended -- the case that could deadlock against a transaction worker holding `mtx_` while needing the GIL for a Python callback -- is `rogue::GilRelease` used while blocking on `lock.lock()`. `intStartTransaction` / `checkTransaction` (which genuinely block via `waitTransaction`) are intentionally left unchanged.
- Reproduction: `tests/perf/test_block_gil_contention_perf.py` (marked `perf`) drives a 42k staged `set(write=False)`/`get(read=False)` drain with and without a background GIL-contending thread. Pre-fix the contended drain trips the ceiling (~16 s, ~517x slowdown); post-fix it stays sub-second.
- Correctness: `tests/core/test_block_gil_fastpath_roundtrip.py` pins staged set/get round-trip equivalence on the scalar, list, and byte-reversed (malloc-copy) paths, single-threaded and under same-Block contention (exercising the `try_to_lock` fallback branch).
- Verified locally: full Python suite passes (one unrelated pre-existing PyDM/PyQt test failure), `ctest -L cpp` 15/15, no-Python small build `ctest -L no-python` 12/12, `check_whitespace.sh` and `run_linters.sh` clean.
- Secondary per-entry overheads in `_Root.py::_updateWorker` noted in #1262 are left out of scope to keep the change surgical; they touch listener fan-out semantics and warrant their own change + tests.

### JIRA
N/A

### Related
Closes #1262