### PR TITLE
Make RoCEv2/libibverbs and CMake-driven pip install optional for cross/packaged builds (#1264)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ project (rogue)
 
 option(ROGUE_BUILD_TESTS "Build Rogue native C++ tests" OFF)
 option(ROGUE_COVERAGE    "Build rogue-core with gcov instrumentation (CI only)" OFF)
+option(NO_ROCEV2         "Disable RoCEv2 / libibverbs support" OFF)
+option(ROGUE_SKIP_PIP_INSTALL "Skip the cmake-driven pip install of the python package (for packaging systems that install it themselves into DESTDIR)" OFF)
 
 # Current Apple support target is arm64 only.
 if (APPLE AND NOT ((CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") OR (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")))
@@ -54,23 +56,27 @@ if (APPLE AND NOT ((CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") OR (CMAKE_SYSTEM_PR
 endif()
 
 #####################################
-# RoCEv2 / libibverbs (Linux only, always enabled)
+# RoCEv2 / libibverbs (Linux only, optional via -DNO_ROCEV2=ON)
 #####################################
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-   find_library(IBVERBS_LIBRARY NAMES ibverbs)
-   find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
-
-   if ((NOT IBVERBS_LIBRARY) OR (NOT IBVERBS_INCLUDE_DIR))
-      message(FATAL_ERROR
-         "RoCEv2 requires libibverbs which was not found.\n"
-         "Install rdma-core:\n"
-         "  Ubuntu/Debian:  sudo apt-get install libibverbs-dev rdma-core\n"
-         "  Fedora/RHEL:    sudo dnf install rdma-core-devel\n"
-         "  conda-forge:    conda install -c conda-forge rdma-core")
-   endif()
-
    add_definitions(-DROGUE_LINUX_BUILD)
-   include_directories(${IBVERBS_INCLUDE_DIR})
+
+   if (NOT NO_ROCEV2)
+      find_library(IBVERBS_LIBRARY NAMES ibverbs)
+      find_path(IBVERBS_INCLUDE_DIR NAMES infiniband/verbs.h)
+
+      if ((NOT IBVERBS_LIBRARY) OR (NOT IBVERBS_INCLUDE_DIR))
+         message(FATAL_ERROR
+            "RoCEv2 requires libibverbs which was not found.\n"
+            "Install rdma-core, or reconfigure with -DNO_ROCEV2=ON to build without RoCEv2:\n"
+            "  Ubuntu/Debian:  sudo apt-get install libibverbs-dev rdma-core\n"
+            "  Fedora/RHEL:    sudo dnf install rdma-core-devel\n"
+            "  conda-forge:    conda install -c conda-forge rdma-core")
+      endif()
+
+      add_definitions(-DROGUE_ROCEV2)
+      include_directories(${IBVERBS_INCLUDE_DIR})
+   endif()
 endif()
 
 # C/C++
@@ -318,7 +324,7 @@ else()
    TARGET_LINK_LIBRARIES(rogue-core-shared PUBLIC rt)
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT NO_ROCEV2)
    TARGET_LINK_LIBRARIES(rogue-core-shared PUBLIC ${IBVERBS_LIBRARY})
 endif()
 
@@ -349,7 +355,7 @@ if(STATIC_LIB)
        TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC rt)
     endif()
 
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT NO_ROCEV2)
        TARGET_LINK_LIBRARIES(rogue-core-static PUBLIC ${IBVERBS_LIBRARY})
     endif()
 
@@ -472,7 +478,9 @@ if (NOT NO_PYTHON)
 
    # Use pip with python3 for system or miniforge
    elseif ((${ROGUE_INSTALL} STREQUAL "system") OR (${ROGUE_INSTALL} STREQUAL "conda"))
-      install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install --no-deps --no-build-isolation ${PROJECT_BINARY_DIR}/ COMMAND_ERROR_IS_FATAL ANY)")
+      if (NOT ROGUE_SKIP_PIP_INSTALL)
+         install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install --no-deps --no-build-isolation ${PROJECT_BINARY_DIR}/ COMMAND_ERROR_IS_FATAL ANY)")
+      endif()
    endif()
 
    # Do byte compile for custom or local
@@ -512,8 +520,10 @@ message("")
 message("-- Found Bzip2: ${BZIP2_INCLUDE_DIR}")
 message("")
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT NO_ROCEV2)
    message("-- RoCEv2 support: ENABLED (${IBVERBS_LIBRARY})")
+elseif (NO_ROCEV2)
+   message("-- RoCEv2 support: disabled (-DNO_ROCEV2=ON)")
 else()
    message("-- RoCEv2 support: disabled (Linux only)")
 endif()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -177,6 +177,14 @@ Common CMake options:
 - `-DROGUE_INSTALL=conda`: install into the active conda environment.
 - `-DROGUE_BUILD_TESTS=ON`: build native C++ tests under `tests/cpp`.
 - `-DNO_PYTHON=1 -DSTATIC_LIB=1`: small static no-Python build.
+- `-DNO_ROCEV2=ON`: build without RoCEv2 / `libibverbs` (Linux). Skips ibverbs
+  discovery and linking and excludes the `rocev2` sources, so `rdma-core` is not
+  required. For cross-compiled / packaged builds that do not need RoCEv2.
+- `-DROGUE_SKIP_PIP_INSTALL=ON`: with `-DROGUE_INSTALL=system` (or `conda`), still
+  install the C++ libraries, headers, and `RogueConfig.cmake`, but skip the
+  cmake-driven `pip install` of the Python package. For packaging systems
+  (Yocto `setuptools3`, distro `%py_install`, etc.) that stage the Python package
+  into `DESTDIR` themselves.
 
 For day-to-day local builds, use one of two modes:
 

--- a/docs/src/installing/yocto.rst
+++ b/docs/src/installing/yocto.rst
@@ -115,6 +115,24 @@ Update the `ROGUE_VERSION` line for an updated version when appropriate. You wil
 
 RDEPENDS is the  Runtime Dependencies. If your rogue application requires additional python libraries you can add them to the RDEPENDS += line in the above text.
 
+.. note::
+
+   As of rogue v6.14.0, two optional CMake flags make cross-compiled / packaged
+   builds simpler. Add them to ``EXTRA_OECMAKE`` when you do not want RoCEv2 and
+   want the recipe (``setuptools3``) to install the Python package into
+   ``DESTDIR`` itself:
+
+   .. code::
+
+      EXTRA_OECMAKE += "-DROGUE_INSTALL=system -DNO_ROCEV2=1 -DROGUE_SKIP_PIP_INSTALL=1"
+
+   * ``-DNO_ROCEV2=1`` builds without RoCEv2 / ``libibverbs``, so you do not need
+     to add ``rdma-core`` to ``DEPENDS``/``RDEPENDS``.
+   * ``-DROGUE_SKIP_PIP_INSTALL=1`` skips the cmake-driven ``pip install`` (which
+     uses the build-host interpreter and ignores ``DESTDIR``); the C++ libraries,
+     headers, and ``RogueConfig.cmake`` are still installed, and ``setuptools3``
+     handles the Python package into ``DESTDIR``.
+
 Step 3 - Add your application to the image installation list
 
 To enable compilation and installation of the rogue package in your Yocto project execute the following command:

--- a/python/pyrogue/protocols/_RoCEv2.py
+++ b/python/pyrogue/protocols/_RoCEv2.py
@@ -766,10 +766,11 @@ class RoCEv2Server(pr.Device):
         if not _ROCEV2_AVAILABLE:
             raise ImportError(
                 "RoCEv2Server requires a Linux build of rogue with "
-                "libibverbs/rdma-core available at runtime.  Install "
-                "rdma-core (`conda install -c conda-forge rdma-core` or "
-                "`apt install libibverbs-dev`) and rebuild rogue on Linux "
-                "with those libraries available."
+                "libibverbs/rdma-core available at runtime.  This module is "
+                "also absent when rogue was built with -DNO_ROCEV2=ON.  "
+                "Install rdma-core (`conda install -c conda-forge rdma-core` "
+                "or `apt install libibverbs-dev`) and rebuild rogue on Linux "
+                "without -DNO_ROCEV2 and with those libraries available."
             )
         if not (1 <= pmtu <= 5):
             raise rogue.GeneralError(

--- a/src/rogue/protocols/CMakeLists.txt
+++ b/src/rogue/protocols/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory("udp")
 add_subdirectory("batcher")
 add_subdirectory("xilinx")
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT NO_ROCEV2)
    add_subdirectory("rocev2")
 endif()
 

--- a/src/rogue/protocols/module.cpp
+++ b/src/rogue/protocols/module.cpp
@@ -25,7 +25,7 @@
 
 #include "rogue/protocols/batcher/module.h"
 #include "rogue/protocols/packetizer/module.h"
-#ifdef ROGUE_LINUX_BUILD
+#ifdef ROGUE_ROCEV2
 #include "rogue/protocols/rocev2/module.h"
 #endif
 #include "rogue/protocols/rssi/module.h"
@@ -51,7 +51,7 @@ void rogue::protocols::setup_module() {
     rogue::protocols::udp::setup_module();
     rogue::protocols::batcher::setup_module();
     rogue::protocols::xilinx::setup_module();
-#ifdef ROGUE_LINUX_BUILD
+#ifdef ROGUE_ROCEV2
     rogue::protocols::rocev2::setup_module();
 #endif
 }

--- a/tests/cpp/protocols/CMakeLists.txt
+++ b/tests/cpp/protocols/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(packetizer)
 
-if (NOT NO_PYTHON AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (NOT NO_PYTHON AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT NO_ROCEV2)
    add_subdirectory(rocev2)
 endif()
 


### PR DESCRIPTION
### Description

Adds two opt-out CMake flags so cross-compiled / packaged builds (Yocto/PetaLinux, distro packaging) can build without RoCEv2 and without the embedded pip install. Both default `OFF`, so existing builds are unchanged.

- **`-DNO_ROCEV2`** — build without RoCEv2 / `libibverbs`. Decouples `ROGUE_LINUX_BUILD` (kept for all Linux builds) from a new `ROGUE_ROCEV2` define; gates the libibverbs discovery and linking (shared and static targets); excludes the `rocev2` sources from `rogue-core` (mirroring the existing `NO_PYTHON` exclude-from-build pattern); switches the protocols Python module registration guard to `ROGUE_ROCEV2`; and skips the ibverbs-linking C++ test. `rdma-core` is no longer required when `-DNO_ROCEV2=ON`.
- **`-DROGUE_SKIP_PIP_INSTALL`** — for `-DROGUE_INSTALL=system` (or `conda`), skip only the cmake-driven `pip install` of the Python package. C++ libraries, headers, and `RogueConfig.cmake` are still installed, leaving Python packaging to the caller (e.g. Yocto `setuptools3` into `DESTDIR`).

Resolves #1264.

### Details

Before v6.14.0 these behaviors were mandatory with no opt-out:

1. `CMakeLists.txt` hard-failed at configure if `libibverbs` was missing and unconditionally linked it into `rogue-core`.
2. The `system`/`conda` install path always ran `pip install` via `cmake --install`, using the build-host interpreter (which may lack `pip`) and ignoring `DESTDIR`.

The pyrogue `RoCEv2Server` already fails safe through a guarded import (`try/except ImportError` → `_ROCEV2_AVAILABLE`), so `import pyrogue` continues to work in a `NO_ROCEV2` build; its `ImportError` message now also names `-DNO_ROCEV2=ON` as a possible cause. Both flags are documented in `DEVELOPMENT.md` and the Yocto recipe guidance in `docs/src/installing/yocto.rst`.

**Validation** (local from-source build):

- Default build: `RoCEv2 support: ENABLED`; `librogue-core.so` links `libibverbs`; `rogue.protocols.rocev2` and `pyrogue.protocols.RoCEv2Server` present.
- `-DNO_ROCEV2=ON`: `RoCEv2 support: disabled`; rocev2 sources not compiled; no `libibverbs` in the link; `import pyrogue` works; `RoCEv2Server(...)` raises a clear `ImportError`.
- `-DROGUE_SKIP_PIP_INSTALL=ON` with `-DROGUE_INSTALL=system`: the `pip install` line is absent from `cmake_install.cmake` (present without the flag).
- Linters (`check_whitespace.sh`, `flake8`, `cpplint`) pass on the changed files.
