### PR TITLE
protocols/RoCEv2: soft-reset transport core before QP setup

### DIFF
--- a/python/pyrogue/protocols/_RoCEv2.py
+++ b/python/pyrogue/protocols/_RoCEv2.py
@@ -551,6 +551,20 @@ def _roce_setup_connection(engine, host_qpn, host_rq_psn, host_sq_psn,
         except Exception:
             pass
 
+    # Clear any stale RoCE transport state (QP / PSN tables) left behind by a
+    # prior session. Without this, a software reconnect reuses a stale FPGA
+    # transmit PSN and the host NIC silently drops every RDMA WRITE as
+    # out-of-sequence (FPGA SuccessCounter and host rxCount both stay 0). The
+    # SoftReset fires an FW one-shot that re-initialises the transport core
+    # (equivalent to an FPGA reload of the engine datapath) without disturbing
+    # the RUDP/UDP link. Best-effort: older firmware lacks the register.
+    try:
+        engine.SoftReset()
+        _time.sleep(0.05)
+    except AttributeError:
+        warn("RoceEngine has no SoftReset register — a software reconnect may "
+             "require an FPGA reload to clear stale QP/PSN state")
+
     # Ensure SendMetaData starts at 0 for a clean first rising edge
     engine.SendMetaData.set(0)
     _time.sleep(0.1)


### PR DESCRIPTION
## Problem

A software reconnect to the FPGA RoCEv2 engine fails on the second and
subsequent connections: the FPGA transmit PSN persists from the prior
session (the transport core latches its QP/PSN context only on the first
QP creation after `ethRst`), so the host NIC drops every RDMA WRITE as
out-of-sequence. The FPGA `SuccessCounter` and host `rxCount` both stay 0,
and only an FPGA reload recovered.

## Fix

Pulse `RoceEngine.SoftReset()` at the start of `_roce_setup_connection`,
before PD alloc, so the transport core is re-initialised (equivalent to an
FPGA reload of the engine datapath) on every connection — without
disturbing the RUDP/UDP link. This is the only place that can do it: the
connection is established during `Root()` construction, before user scripts
run. Best-effort: firmware without the `SoftReset` register is tolerated
via `AttributeError`.

Requires the companion surf change that adds the `SoftReset` register
(`0xF50`) to `RoceConfigurator`/`RoCEv2Engine` and ORs it into the transport
core reset.

## Test

- `tests/protocols/test_rocev2.py` + `test_rocev2_corner_cases.py`: 114 passed, 5 skipped (hardware-gated).
- Hardware (KCU105, 10GbE RUDP + RoCEv2): 4 consecutive `runPrbs.py` reconnects all PASS without reprogramming; previously run 2 failed with `SuccessCounter=0`. NIC `out_of_sequence` stayed 0 throughout.