### PR TITLE
Fix logging arg interpolation; document stream GIL contract

### DIFF
--- a/docs/src/stream_interface/receiving.rst
+++ b/docs/src/stream_interface/receiving.rst
@@ -112,6 +112,19 @@ This is usually the right choice when the receiver is performance-sensitive,
 when it must do substantial processing in C++, or when it needs tight control
 over how bytes are copied or interpreted.
 
+.. warning::
+
+   Rogue does not hold the Python GIL when it invokes a C++ ``acceptFrame``
+   override. Frames are frequently sent from pure-C++ worker threads (DMA,
+   receiver, file, and network paths) that never acquire the GIL, so a C++
+   ``Slave`` must not assume the GIL is held. A pure-C++ override like the one
+   below needs no action. An override that constructs, manipulates, or destroys
+   Python-wrapped objects (Boost.Python, pybind11, or NumPy) — either inside
+   ``acceptFrame`` or on its own worker threads that outlive the call — must
+   hold the GIL while doing so, for example with ``rogue::ScopedGil``. Touching
+   Python objects without the GIL races CPython's allocator and can segfault.
+   See :doc:`/api/cpp/interfaces/stream/slave` for the full contract.
+
 .. code-block:: cpp
 
    #include <algorithm>

--- a/include/rogue/interfaces/stream/Master.h
+++ b/include/rogue/interfaces/stream/Master.h
@@ -149,6 +149,15 @@ class Master : public rogue::EnableSharedFromThis<rogue::interfaces::stream::Mas
      * order of attachment, followed last by the primary Slave. If the Frame is a
      * zero copy frame it will most likely be empty when the sendFrame() method returns
      *
+     * GIL note: `sendFrame()` releases the Python GIL only briefly, while it
+     * snapshots the attached-slave list under `slaveMtx_` (see `rogue::GilRelease`).
+     * The subsequent `acceptFrame()` dispatch is not wrapped in that release; it
+     * runs with whatever GIL state the calling thread holds. Because stream frames
+     * are frequently sent from pure-C++ worker threads (DMA/receiver/file/network
+     * paths) that do not hold the GIL, attached slaves can be invoked without it.
+     * See `Slave::acceptFrame()` for the GIL contract that downstream consumers
+     * touching Python-wrapped objects must follow.
+     *
      * Exposed as `_sendFrame()` in Python.
      *
      * @param frame Frame to send.

--- a/include/rogue/interfaces/stream/Slave.h
+++ b/include/rogue/interfaces/stream/Slave.h
@@ -151,6 +151,26 @@ class Slave : public rogue::interfaces::stream::Pool,
      *
      * Re-implemented as `_acceptFrame()` in Python subclasses.
      *
+     * @warning
+     * GIL contract: Rogue does not acquire the Python GIL before invoking a
+     * C++ `acceptFrame()` override, nor does it release it around the dispatch.
+     * `Master::sendFrame()` drops the GIL only briefly while it snapshots its
+     * slave list (see `rogue::GilRelease`); the `acceptFrame()` call then runs
+     * with whatever GIL state the sending thread holds. Because frames are
+     * commonly sent from pure-C++ worker threads (DMA/receiver/file/network paths)
+     * that never hold the GIL, a C++ `acceptFrame()` override must not assume the
+     * GIL is held. Pure-C++ subclasses need no action. A subclass that constructs,
+     * manipulates, or destroys Python-wrapped objects (for example
+     * Boost.Python / pybind11 / NumPy objects) — either inside `acceptFrame()`
+     * or, critically, on its own worker threads that outlive this call — MUST
+     * hold the GIL while doing so, e.g. via `rogue::ScopedGil` (or
+     * `PyGILState_Ensure()` / `PyGILState_Release()`). Touching Python objects
+     * without the GIL races CPython's allocator/GC and can segfault (typically
+     * in `PyObject_GC_Del` during object teardown). The base `Slave::acceptFrame()`
+     * itself releases the GIL while it runs; Python subclasses that override
+     * `_acceptFrame()` are always invoked with the GIL held (via `rogue::ScopedGil`
+     * in the binding wrapper), so they need no action.
+     *
      * @param frame Frame pointer (FramePtr).
      */
     virtual void acceptFrame(std::shared_ptr<rogue::interfaces::stream::Frame> frame);

--- a/python/pyrogue/_Root.py
+++ b/python/pyrogue/_Root.py
@@ -228,7 +228,10 @@ class Root(pr.Device):
             pr.setUnifiedLogging(True)
 
         # Create log listener to add to SystemLog variable
-        formatter = logging.Formatter("%(msg)s")
+        # Use %(message)s (record.getMessage()) so printf-style logging args are
+        # interpolated; %(msg)s would emit the raw format string (e.g. a literal
+        # "Making device %s") whenever the record is rendered through this handler.
+        formatter = logging.Formatter("%(message)s")
         handler = RootLogHandler(root=self)
         handler.setFormatter(formatter)
         self._logger = logging.getLogger('pyrogue')

--- a/tests/core/test_core_logging.py
+++ b/tests/core/test_core_logging.py
@@ -143,6 +143,41 @@ def test_root_log_handler_ignores_system_log_bookkeeping_records():
             logger.addHandler(existing)
 
 
+def test_root_log_handler_formatter_interpolates_args():
+    # Regression: Root must install a %(message)s formatter on its RootLogHandler
+    # (not %(msg)s) so printf-style logging args are interpolated instead of
+    # rendering the raw format string (e.g. a literal "Making device %s").
+    #
+    # Format through the handler that Root actually attaches to the global
+    # 'pyrogue' logger. A RootLogHandler built in isolation has no formatter set,
+    # so logging.Handler.format() falls back to the default %(message)s and would
+    # pass even if Root regressed to %(msg)s, masking the regression.
+    logger = logging.getLogger('pyrogue')
+    old_handlers = list(logger.handlers)
+
+    record = logging.LogRecord(
+        'pyrogue.Device.TenGigEthReg.EthPhy[0]', logging.INFO,
+        '<rogue>', 0, 'Making device %s', ('EthPhy0',), None)
+
+    with pr.Root(name='root', pollEn=False):
+        handlers = [h for h in logger.handlers
+                    if isinstance(h, RootLogHandler) and h not in old_handlers]
+
+        assert handlers, 'Root did not attach a RootLogHandler to the pyrogue logger'
+
+        for handler in handlers:
+            # Assert the formatter is explicitly configured (not the default
+            # fallback) and that it interpolates printf-style args.
+            assert handler.formatter is not None, \
+                'Root left RootLogHandler without an explicit formatter'
+            assert handler.format(record) == 'Making device EthPhy0'
+
+    # Root.stop() does not detach the handler; restore the logger for isolation.
+    for handler in list(logger.handlers):
+        if handler not in old_handlers:
+            logger.removeHandler(handler)
+
+
 def test_root_debug_logging_does_not_feedback_through_system_log(monkeypatch):
     logger = logging.getLogger('pyrogue')
     trigger_logger = logging.getLogger('pyrogue.test.feedback')


### PR DESCRIPTION
## Summary

Two independent fixes that surfaced while investigating a field-reported segfault
in a downstream stream consumer (the Simons Observatory `smurf-streamer`) under
rogue 6 / Python 3.12.

### 1. `fix(pyrogue)`: log args were not interpolated

`RootLogHandler`'s formatter used `%(msg)s`, which renders `record.msg` — the raw
format string — so printf-style logging args were never substituted. Records like:

```python
log.info("Making device %s", name)
```

were emitted as the literal `Making device %s`. Switched the formatter to
`%(message)s` (`record.getMessage()`), which applies the args, and added a
regression test pinning the behavior.

### 2. `docs(stream)`: document the GIL contract for downstream consumers

`Master::sendFrame()` releases the Python GIL around downstream dispatch, so
attached `Slave::acceptFrame()` implementations run **without** the GIL held. A
pure-C++ subclass needs no action, but a subclass that constructs, manipulates,
or destroys Python-wrapped objects (Boost.Python / pybind11 / NumPy) — either
inside `acceptFrame()` or, critically, on its own worker threads — **must** hold
the GIL while doing so (e.g. `rogue::ScopedGil`). Touching Python objects without
the GIL races CPython's allocator/GC and can segfault in `PyObject_GC_Del` during
teardown.

This is documentation only — rogue itself is GIL-correct (it acquires the GIL
before invoking Python slaves and only releases it around pure-C++/IO). The note
makes the contract explicit for C++ subclasses so the class of bug that bit the
downstream streamer is harder to reintroduce.

## Notes

- No functional/behavioral change to the stream pipeline; (2) is comment-only.
- Logging suite (`tests/core/test_core_logging.py`) passes (10/10); `run_linters.sh`
  and `check_whitespace.sh` clean.
