### PR TITLE
Add Python 3.14 conda build variant

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -5,6 +5,7 @@
 # conda render conda-recipe --variants "{python: 3.11, python_abi: '3.11 *_cp311'}"
 # conda render conda-recipe --variants "{python: 3.12, python_abi: '3.12 *_cp312'}"
 # conda render conda-recipe --variants "{python: 3.13, python_abi: '3.13 *_cp313'}"
+# conda render conda-recipe --variants "{python: 3.14, python_abi: '3.14 *_cp314'}"
 ###############################################################################################
 
 # Define the python variants to be built
@@ -13,6 +14,7 @@ python:
   - 3.11
   - 3.12
   - 3.13
+  - 3.14
 
 # Lock to CPython ABI, not PyPy
 python_abi:
@@ -20,8 +22,9 @@ python_abi:
   - 3.11 *_cp311
   - 3.12 *_cp312
   - 3.13 *_cp313
+  - 3.14 *_cp314
 
-# Pair python and python_abi so we get 4 variants, not the 16-way cross product
+# Pair python and python_abi so we get 5 variants, not the 25-way cross product
 zip_keys:
   - - python
     - python_abi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - numpy >=2.0
     - rdma-core  # [linux]
   run:
-    - python >=3.10,<3.14
+    - python >=3.10,<3.15
     - numpy
     - libboost-python
     - bzip2

--- a/conda.yml
+++ b/conda.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python >=3.10,<3.14
+  - python >=3.10,<3.15
   - pip
   - c-compiler
   - cxx-compiler


### PR DESCRIPTION
### Description
Add a Python 3.14 (cp314) build variant to the conda package. conda-forge boost 1.91.0 now ships `libboost-python` cp314 builds (e.g. `libboost-python-1.91.0-py314h3a4f467_0` on linux-64), which was the original blocker for 3.14 support.

- `conda-recipe/conda_build_config.yaml`: add `3.14` to the `python` list and `3.14 *_cp314` to `python_abi` (zipped, so 5 variants), plus the matching render-check comment.
- `conda-recipe/meta.yaml`: lift the runtime cap from `python >=3.10,<3.14` to `<3.15`.
- `conda.yml`: bump the dev/build environment cap to `<3.15` to stay consistent with the recipe.

### Details
Validated locally with `conda render` of the 3.14 variant — the dependency graph solves, pulling `python 3.14 *_cp314`, `python_abi 3.14.* *_cp314`, `libboost-python 1.91.0 py314h3a4f467_0`, and `numpy 2.5 py314`. cp314/noarch availability also confirmed for the other compiled/runtime deps (p4p 4.2.2, pyqt 5.15.11, pyzmq 27.1.0, pydm noarch). The `conda_build_lib` CI job will build all 5 variants end-to-end.