### PR TITLE
fix(rocev2.Server): free RX slab in destructor to fix zero-copy teardown segfault

### DIFF
--- a/docs/src/api/cpp/protocols/rocev2/server.rst
+++ b/docs/src/api/cpp/protocols/rocev2/server.rst
@@ -72,16 +72,24 @@ Class Reference
 
    .. cpp:function:: ~Server()
 
-      Calls ``stop()``; ``stop()`` releases the slab MR and CQ/QP
-      resources, and the inherited ``Core`` destructor releases the PD
-      and ibverbs context.
+      Calls ``stop()`` to release the CQ/QP and MR resources, then frees
+      the RX slab **last**. The slab is deliberately freed here rather than
+      in ``stop()``: it is this ``Pool``'s buffer backing, and every
+      zero-copy ``Buffer`` handed downstream holds a ``shared_ptr`` to this
+      ``Server``, so the destructor cannot run until the last outstanding
+      frame is released — the slab is therefore never freed while a
+      downstream frame still references it. The inherited ``Core``
+      destructor then releases the PD and ibverbs context.
 
    .. cpp:function:: void stop()
 
       Signals the receive thread to exit, joins and deletes it, then
-      releases the ibverbs resources owned by ``Server``: destroys the
-      QP and CQ, deregisters the MR, and frees the slab. Idempotent —
-      safe to call multiple times (also called by ``~Server()``).
+      releases the external ibverbs resources owned by ``Server``: destroys
+      the QP and CQ and deregisters the MR. Does **not** free the RX slab —
+      that is the ``Pool`` buffer backing and is freed by ``~Server()`` (see
+      above), so a zero-copy ``Buffer`` still held downstream is never
+      stranded. Idempotent — safe to call multiple times (also called by
+      ``~Server()``).
 
    .. cpp:function:: void setFpgaGid(const std::string& gidBytes)
 

--- a/docs/src/api/cpp/protocols/rocev2/server.rst
+++ b/docs/src/api/cpp/protocols/rocev2/server.rst
@@ -27,6 +27,11 @@ Threading and Lifecycle
 - An ibverbs failure inside ``postRecvWr()`` is caught inside the poll
   thread; the thread logs the error and exits cleanly instead of
   escaping the thread entry point and triggering ``std::terminate``.
+- Before calling ``stop()``, callers must quiesce ``completeConnection()``
+  and other public operations that use the Server's ibverbs resources.
+  Deferred returns from zero-copy buffers already issued by the Server may
+  overlap ``stop()``; their receive-WR re-posts are serialized against QP/MR
+  teardown internally.
 
 
 Python binding
@@ -89,7 +94,10 @@ Class Reference
       that is the ``Pool`` buffer backing and is freed by ``~Server()`` (see
       above), so a zero-copy ``Buffer`` still held downstream is never
       stranded. Idempotent — safe to call multiple times (also called by
-      ``~Server()``).
+      ``~Server()``). Callers must first quiesce ``completeConnection()`` and
+      other public ibverbs-resource operations. Deferred zero-copy buffer
+      returns may overlap ``stop()`` and are serialized internally against
+      destruction of the QP and MR.
 
    .. cpp:function:: void setFpgaGid(const std::string& gidBytes)
 

--- a/include/rogue/protocols/rocev2/Server.h
+++ b/include/rogue/protocols/rocev2/Server.h
@@ -105,9 +105,12 @@ class Server : public rogue::protocols::rocev2::Core,
     // poll/drain loop in runThread() exits.
     void processCompletion(struct ibv_wc& wc);
 
-    // Idempotent helper that releases every ibverbs / heap resource owned by
-    // Server in reverse allocation order.  Called by stop() and from the
-    // failed-construction path in the constructor.
+    // Releases the external ibverbs resources owned by Server (QP, CQ,
+    // comp-channel, MR registration, wake pipe) in reverse allocation order.
+    // Idempotent.  Does NOT free the RX slab: that is this Pool's buffer backing
+    // and lives with the Server object (freed in ~Server, mirroring
+    // ris::Pool::~Pool), so a zero-copy Buffer still held downstream is never
+    // stranded.  The failed-construction path frees the slab explicitly.
     void cleanupResources();
 
   protected:

--- a/include/rogue/protocols/rocev2/Server.h
+++ b/include/rogue/protocols/rocev2/Server.h
@@ -114,7 +114,9 @@ class Server : public rogue::protocols::rocev2::Core,
     // Idempotent.  Does NOT free the RX slab: that is this Pool's buffer backing
     // and lives with the Server object (freed in ~Server, mirroring
     // ris::Pool::~Pool), so a zero-copy Buffer still held downstream is never
-    // stranded.  The failed-construction path frees the slab explicitly.
+    // stranded.  Resource teardown is serialized with postRecvWr() so deferred
+    // buffer returns cannot use a QP or MR while it is being destroyed.  The
+    // failed-construction path frees the slab explicitly.
     void cleanupResources();
 
   protected:
@@ -140,6 +142,20 @@ class Server : public rogue::protocols::rocev2::Core,
            uint32_t           rxQueueDepth);
 
     ~Server();
+
+    /**
+     * @brief Stops the receive thread and releases external ibverbs resources.
+     *
+     * @details
+     * Before calling `stop()`, callers must ensure that `completeConnection()`
+     * and any other public operations using the Server's ibverbs resources have
+     * completed and that no new ones can begin.  Deferred returns from
+     * previously issued zero-copy buffers may overlap `stop()`; their receive-WR
+     * re-posts are serialized against QP/MR teardown internally.
+     *
+     * The RX slab remains valid until destruction so retained zero-copy buffers
+     * do not reference freed memory after `stop()`.
+     */
     void stop();
 
     void setFpgaGid(const std::string& gidBytes);

--- a/include/rogue/protocols/rocev2/Server.h
+++ b/include/rogue/protocols/rocev2/Server.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -85,6 +86,9 @@ class Server : public rogue::protocols::rocev2::Core,
     // for prompt, sleepless shutdown. stop() writes one byte to wakeFd_[1];
     // runThread() selects on wakeFd_[0]. Both ends are non-blocking.
     int wakeFd_[2];
+
+    // Serializes ibverbs resource teardown against deferred buffer re-posts.
+    std::mutex resourcesMtx_;
 
     // Intentional shadow: both Core and stream::Slave expose a `log_` member,
     // so any unqualified `log_` from inside Server would otherwise be

--- a/src/rogue/protocols/rocev2/Server.cpp
+++ b/src/rogue/protocols/rocev2/Server.cpp
@@ -770,6 +770,11 @@ void rpr::Server::acceptFrame(ris::FramePtr /*frame*/) {
 // stop / destructor
 // ---------------------------------------------------------------------------
 void rpr::Server::stop() {
+    // Callers must quiesce completeConnection() and other public ibverbs
+    // resource operations before shutdown.  Deferred zero-copy buffer returns
+    // are the one operation allowed to overlap stop(); resourcesMtx_ serializes
+    // their receive-WR re-posts with cleanupResources() below.
+
     // Release the GIL for the duration of teardown.  stop() is driven from Python
     // (RoCEv2Server._stop) with the GIL held, and the receive thread re-acquires
     // the GIL via ScopedGil inside sendFrame() when a downstream slave is Python;

--- a/src/rogue/protocols/rocev2/Server.cpp
+++ b/src/rogue/protocols/rocev2/Server.cpp
@@ -311,8 +311,13 @@ rpr::Server::Server(const std::string& deviceName,
 // Buffer still held downstream (each points into slab_ and keeps this Server
 // alive via shared_ptr<Pool>).  ~Server frees the slab; the failed-construction
 // path frees it explicitly (the destructor does not run on a partial object).
+//
+// Serialized with postRecvWr() so a deferred retBuffer() cannot re-post using
+// qp_/mr_ while stop() is destroying them.
 // ---------------------------------------------------------------------------
 void rpr::Server::cleanupResources() {
+    std::lock_guard<std::mutex> lock(resourcesMtx_);
+
     if (qp_) {
         ibv_destroy_qp(qp_);
         qp_ = nullptr;
@@ -478,6 +483,8 @@ std::string rpr::Server::getGid() const {
 // wr_id == slot index so no lookup is needed on completion
 // ---------------------------------------------------------------------------
 void rpr::Server::postRecvWr(uint32_t slot) {
+    std::lock_guard<std::mutex> lock(resourcesMtx_);
+
     // Defensive: slot indexes into slab_; a corrupted wr_id (from the CQ)
     // or meta (from retBuffer) must not produce an out-of-bounds slab
     // pointer.  Normal control flow keeps slot < numBufs_ because we set
@@ -487,6 +494,11 @@ void rpr::Server::postRecvWr(uint32_t slot) {
         throw(rogue::GeneralError::create("rocev2::Server::postRecvWr",
                                           "slot=%u out of range (numBufs=%u)",
                                           slot, numBufs_));
+
+    if (!qp_ || !mr_ || !slab_)
+        throw(rogue::GeneralError::create("rocev2::Server::postRecvWr",
+                                          "resources are not available for slot=%u",
+                                          slot));
 
     uint8_t* bufStart = slab_ + (static_cast<uint64_t>(slot) * bufSize_);
 
@@ -528,7 +540,7 @@ void rpr::Server::retBuffer(uint8_t* data, uint32_t meta, uint32_t rawSize) {
 
     log_->debug("retBuffer: re-posting slot=%u", slot);
 
-    if (threadEn_.load() && qp_) {
+    if (threadEn_.load()) {
         try {
             postRecvWr(slot);
         } catch (...) {
@@ -786,13 +798,14 @@ void rpr::Server::stop() {
         thread_ = nullptr;
     }
     // Release the external ibverbs resources now — QP/CQ/MR(dereg)/comp-channel
-    // and the wake pipe — mirroring AxiStreamDma::stop(), which releases its
-    // external kernel resources (DMA mmap + fd) at stop().  But NOT slab_: the RX
-    // slab is this Pool's buffer backing, and zero-copy Buffers handed downstream
-    // still point into it.  Per the base Pool contract (ris::Pool::~Pool() frees
-    // its buffer memory at destruction, and every Buffer holds a shared_ptr to
-    // its Pool), the slab's lifetime is the Server object's; it is freed in
-    // ~Server (below), after the last outstanding Buffer has released the Server.
+    // and the wake pipe — mirroring AxiStreamDma::stop(), which closes its
+    // per-instance fd while leaving zero-copy backing memory alive until
+    // destruction.  The RX slab is this Pool's buffer backing, and zero-copy
+    // Buffers handed downstream still point into it.  Per the base Pool contract
+    // (ris::Pool::~Pool() frees its buffer memory at destruction, and every
+    // Buffer holds a shared_ptr to its Pool), the slab's lifetime is the Server
+    // object's; it is freed in ~Server (below), after the last outstanding Buffer
+    // has released the Server.
     cleanupResources();
 }
 

--- a/src/rogue/protocols/rocev2/Server.cpp
+++ b/src/rogue/protocols/rocev2/Server.cpp
@@ -102,6 +102,13 @@ rpr::Server::Server(const std::string& deviceName,
     memset(fpgaGid_, 0, 16);
     wakeFd_[0] = wakeFd_[1] = -1;
 
+    // Release the GIL for the ibverbs bring-up below (open device, reg_mr, create
+    // CQ/QP, modify to INIT, query GID) — blocking syscalls run while the Python
+    // caller holds the GIL.  Matches AxiStreamDma's constructor.  On a throw,
+    // GilRelease's destructor re-acquires the GIL before the boost.python
+    // exception translator runs.
+    rogue::GilRelease noGil;
+
     // The destructor does NOT run on a partially-constructed object, so any
     // throw between here and the end of the body would leak slab_ / mr_ /
     // cq_ / qp_.  Wrap the body in try/catch and call cleanupResources() on
@@ -281,15 +288,29 @@ rpr::Server::Server(const std::string& deviceName,
         log_->info("RC QP ready: qpn=0x%06x rqPsn=0x%06x sqPsn=0x%06x",
                    hostQpn_, hostRqPsn_, hostSqPsn_);
     } catch (...) {
+        // Failed construction: the destructor does NOT run on a partially
+        // constructed object, so release the ibverbs resources and free the slab
+        // here.  No zero-copy Buffer exists yet, so freeing the slab is safe.
         cleanupResources();
+        if (slab_) {
+            free(slab_);
+            slab_ = nullptr;
+        }
         throw;
     }
 }
 
 // ---------------------------------------------------------------------------
-// cleanupResources — release every ibverbs / heap resource owned by Server,
-// in reverse order of allocation.  Idempotent (safe to call from both the
-// failed-construction path and stop()).
+// cleanupResources — release the EXTERNAL ibverbs resources owned by Server
+// (QP, CQ, comp-channel, MR registration, wake pipe), in reverse order of
+// allocation.  Idempotent.
+//
+// The RX slab is deliberately NOT freed here: it is this Pool's buffer backing,
+// and per the base Pool convention (ris::Pool::~Pool) its lifetime is the Server
+// object's.  Freeing it in stop() would be a use-after-free for any zero-copy
+// Buffer still held downstream (each points into slab_ and keeps this Server
+// alive via shared_ptr<Pool>).  ~Server frees the slab; the failed-construction
+// path frees it explicitly (the destructor does not run on a partial object).
 // ---------------------------------------------------------------------------
 void rpr::Server::cleanupResources() {
     if (qp_) {
@@ -308,10 +329,8 @@ void rpr::Server::cleanupResources() {
         ibv_dereg_mr(mr_);
         mr_ = nullptr;
     }
-    if (slab_) {
-        free(slab_);
-        slab_ = nullptr;
-    }
+    // slab_ is intentionally NOT freed here — it is the Pool buffer backing (see
+    // the comment above); ~Server and the failed-construction path free it.
     for (int i = 0; i < 2; ++i) {
         if (wakeFd_[i] >= 0) {
             close(wakeFd_[i]);
@@ -337,6 +356,11 @@ void rpr::Server::setFpgaGid(const std::string& gidBytes) {
 // ---------------------------------------------------------------------------
 void rpr::Server::completeConnection(uint32_t fpgaQpn, uint32_t fpgaRqPsn,
                                      uint32_t pmtu, uint32_t minRnrTimer) {
+    // Release the GIL for the ibverbs bring-up (two ibv_modify_qp transitions and
+    // the recv-WR pre-post loop) — blocking syscalls run from Python with the GIL
+    // held.  Mirrors the GIL handling in AxiStreamDma's construction/bring-up.
+    rogue::GilRelease noGil;
+
     // Single-use: a second call would reassign thread_ and orphan the
     // original std::thread.  Real misuse would also be caught by
     // ibv_modify_qp rejecting INIT→RTR when the QP is already in RTS,
@@ -495,6 +519,11 @@ void rpr::Server::postRecvWr(uint32_t slot) {
 // meta lower 24 bits = slot index (set in createBuffer() call in runThread)
 // ---------------------------------------------------------------------------
 void rpr::Server::retBuffer(uint8_t* data, uint32_t meta, uint32_t rawSize) {
+    // retBuffer runs from Buffer::~Buffer(), which can fire on a Python thread
+    // holding the GIL; release it around the ibv_post_recv re-post and decCounter
+    // (which locks).  Matches ris::Pool::retBuffer() and AxiStreamDma::retBuffer().
+    rogue::GilRelease noGil;
+
     uint32_t slot = meta & 0x00FFFFFF;
 
     log_->debug("retBuffer: re-posting slot=%u", slot);
@@ -729,6 +758,13 @@ void rpr::Server::acceptFrame(ris::FramePtr /*frame*/) {
 // stop / destructor
 // ---------------------------------------------------------------------------
 void rpr::Server::stop() {
+    // Release the GIL for the duration of teardown.  stop() is driven from Python
+    // (RoCEv2Server._stop) with the GIL held, and the receive thread re-acquires
+    // the GIL via ScopedGil inside sendFrame() when a downstream slave is Python;
+    // joining that thread below while holding the GIL would deadlock.  Matches
+    // AxiStreamDma::stop() / udp::Server::stop() / TcpCore::stop().
+    rogue::GilRelease noGil;
+
     // Signal the thread to exit if it is still running.  Always join /
     // delete thread_ when it is non-null: runThread() may have already
     // cleared threadEn_ itself (e.g. on IBV_WC_WR_FLUSH_ERR or a caught
@@ -749,10 +785,31 @@ void rpr::Server::stop() {
         delete thread_;
         thread_ = nullptr;
     }
+    // Release the external ibverbs resources now — QP/CQ/MR(dereg)/comp-channel
+    // and the wake pipe — mirroring AxiStreamDma::stop(), which releases its
+    // external kernel resources (DMA mmap + fd) at stop().  But NOT slab_: the RX
+    // slab is this Pool's buffer backing, and zero-copy Buffers handed downstream
+    // still point into it.  Per the base Pool contract (ris::Pool::~Pool() frees
+    // its buffer memory at destruction, and every Buffer holds a shared_ptr to
+    // its Pool), the slab's lifetime is the Server object's; it is freed in
+    // ~Server (below), after the last outstanding Buffer has released the Server.
     cleanupResources();
 }
 
-rpr::Server::~Server() { this->stop(); }
+rpr::Server::~Server() {
+    this->stop();
+
+    // Free the RX slab last, following the base Pool convention: ris::Pool::~Pool()
+    // frees its buffer backing (dataQ_) at destruction, never in a stop().  Every
+    // zero-copy Buffer created over slab_ holds a shared_ptr to this Server
+    // (Pool::createBuffer -> Buffer::source_), so the destructor cannot run until
+    // the last outstanding Buffer is gone — the slab is therefore safe to free
+    // here and is never freed while a downstream frame still references it.
+    if (slab_) {
+        free(slab_);
+        slab_ = nullptr;
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Python bindings

--- a/tests/cpp/protocols/rocev2/CMakeLists.txt
+++ b/tests/cpp/protocols/rocev2/CMakeLists.txt
@@ -19,3 +19,16 @@ rogue_add_cpp_test(rogue-cpp-rocev2
    LIBRARIES
       ibverbs
 )
+
+# Isolated in its own binary: on a buggy (unpatched) build this test provokes a
+# genuine use-after-free (SIGSEGV) at the teardown read, so keeping it separate
+# means a regression here cannot abort the other rocev2 cpp cases.
+rogue_add_cpp_test(rogue-cpp-rocev2-teardown
+   SOURCES
+      test_rocev2_teardown.cpp
+   LABELS
+      cpp-rocev2
+      requires-python
+   LIBRARIES
+      ibverbs
+)

--- a/tests/cpp/protocols/rocev2/test_rocev2_teardown.cpp
+++ b/tests/cpp/protocols/rocev2/test_rocev2_teardown.cpp
@@ -1,0 +1,416 @@
+/**
+ * ----------------------------------------------------------------------------
+ * Company    : SLAC National Accelerator Laboratory
+ * ----------------------------------------------------------------------------
+ * Description:
+ * Regression test for the RoCEv2 Server zero-copy teardown lifetime bug.
+ *
+ * The Server hands frames downstream ZERO-COPY: each rogue Buffer points
+ * directly into the registered RX slab (slab_).  A Buffer holds a shared_ptr
+ * to its Pool (the Server, see Pool::createBuffer -> Buffer::source_), so the
+ * Server object itself always outlives every outstanding Buffer.  The BUG is
+ * that the explicit Server::stop() (driven from Python RoCEv2Server._stop())
+ * freed slab_ immediately, while frames still queued downstream (a
+ * depacketizer / PrbsRx) point into it — a use-after-free.  With the default
+ * multi-hundred-KB slab that region is mmap-backed, so free() munmaps it and
+ * the later read SIGSEGVs (the "Segmentation fault" seen at GUI close).
+ *
+ * This test reproduces it deterministically over a single-process Soft-RoCE
+ * (rxe0) loopback: a client RC QP SENDs one frame to the Server, a downstream
+ * Slave RETAINS the frame, then Server::stop() is called and the retained
+ * frame is read back.  On the buggy code the read faults / returns garbage;
+ * with the fix (slab freed in ~Server, after all Buffers are gone) the bytes
+ * are intact.
+ *
+ * Hardware-gated: runs only when a Soft-RoCE device named "rxe0" is present
+ * (same `if (!rxeAvailable()) return;` skip idiom as test_rocev2.cpp).
+ * ----------------------------------------------------------------------------
+ * This file is part of the rogue software platform. It is subject to
+ * the license terms in the LICENSE.txt file found in the top-level directory
+ * of this distribution and at:
+ *    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+ * No part of the rogue software platform, including this file, may be
+ * copied, modified, propagated, or distributed except according to the terms
+ * contained in the LICENSE.txt file.
+ * ----------------------------------------------------------------------------
+ **/
+#include "rogue/Directives.h"
+
+#include <arpa/inet.h>
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "rogue/interfaces/stream/Frame.h"
+#include "rogue/interfaces/stream/FrameIterator.h"
+#include "rogue/interfaces/stream/Slave.h"
+#include "rogue/protocols/rocev2/Server.h"
+
+namespace rpr = rogue::protocols::rocev2;
+namespace ris = rogue::interfaces::stream;
+
+namespace {
+
+constexpr const char* kDev = "rxe0";
+
+// Slab geometry: bufSize_ = maxPayload, slab = maxPayload * rxQueueDepth.
+// 4096 * 256 = 1 MiB — comfortably above glibc's default 128 KiB MMAP_THRESHOLD,
+// so the slab is large enough to be mmap-backed (mirrors the real ~1 MiB app
+// slab).  Whether a premature free() then munmaps the region (buggy read faults)
+// or returns it to the allocator arena (buggy read sees stale/reused bytes) is
+// allocator- and threshold-dependent, so the test does not rely on a fault; it
+// deterministically reclaims the freed region instead (see the clobber below).
+constexpr uint32_t kMaxPayload   = 4096;
+constexpr uint32_t kQueueDepth   = 256;
+constexpr uint32_t kMinRnrTimer  = 12;
+constexpr uint32_t kPayloadLen   = 1024;   // bytes actually SENT (<= bufSize_)
+// path_mtu is chosen at runtime from the port's active_mtu: rxe0 inherits the
+// backing netdev MTU (typically 1500 -> IBV_MTU_1024), so a fixed 4096 would be
+// rejected at INIT->RTR. The RC layer segments the SEND into path_mtu packets;
+// the receive slot (bufSize_ = maxPayload) still holds the reassembled payload.
+constexpr uint32_t kClientSqPsn  = 0x000100;
+
+// Runtime probe: true iff an ibverbs device named "rxe0" is registered.
+bool rxeAvailable() {
+    int          num  = 0;
+    ibv_device** list = ibv_get_device_list(&num);
+    if (!list) return false;
+    bool found = false;
+    for (int i = 0; i < num; ++i) {
+        if (std::string(kDev) == ibv_get_device_name(list[i])) {
+            found = true;
+            break;
+        }
+    }
+    ibv_free_device_list(list);
+    return found;
+}
+
+// First GID-table index whose GID is IPv4-mapped (::ffff:a.b.c.d) and non-zero.
+// rxe0 index 0 is the link-local fe80:: GID and RTR is rejected with it; the
+// IPv4-mapped GID on the netdev's subnet is the RoCEv2 data-plane GID (the same
+// one the app's RoCEv2Server.detectGidIndex picks).
+int findIpv4GidIndex(ibv_context* ctx, uint8_t port) {
+    // gid_tbl_len is device-dependent and can be large (rdma_rxe reports 1024,
+    // see Server.cpp) — the IPv4-mapped GID is not guaranteed to land in the
+    // first handful of slots, so scan the whole table rather than a fixed 16.
+    ibv_port_attr pattr;
+    memset(&pattr, 0, sizeof(pattr));
+    if (ibv_query_port(ctx, port, &pattr) != 0) return -1;
+    for (int i = 0; i < pattr.gid_tbl_len; ++i) {
+        ibv_gid g;
+        if (ibv_query_gid(ctx, port, i, &g) != 0) continue;
+        // Match the full IPv4-mapped prefix ::ffff:0:0/96 — bytes[0..9] must be
+        // zero and bytes[10..11] == 0xffff — so a non-IPv4-mapped GID whose
+        // bytes[0..9] happen to be non-zero cannot be mistaken for one.
+        bool prefixZero = true;
+        for (int b = 0; b < 10; ++b) {
+            if (g.raw[b] != 0) {
+                prefixZero = false;
+                break;
+            }
+        }
+        if (prefixZero && g.raw[10] == 0xff && g.raw[11] == 0xff &&
+            (g.raw[12] | g.raw[13] | g.raw[14] | g.raw[15]) != 0)
+            return i;
+    }
+    return -1;
+}
+
+// Downstream Slave that RETAINS every frame — the depacketizer/PrbsRx stand-in
+// that still holds a zero-copy buffer when the Server tears down.
+class HoldingSlave : public ris::Slave {
+  public:
+    void acceptFrame(ris::FramePtr frame) override {
+        std::lock_guard<std::mutex> lk(mtx_);
+        frames_.push_back(frame);
+    }
+    size_t count() {
+        std::lock_guard<std::mutex> lk(mtx_);
+        return frames_.size();
+    }
+    ris::FramePtr front() {
+        std::lock_guard<std::mutex> lk(mtx_);
+        return frames_.empty() ? nullptr : frames_.front();
+    }
+
+  private:
+    std::mutex                 mtx_;
+    std::vector<ris::FramePtr> frames_;
+};
+
+// Minimal loopback client: an RC QP on rxe0 that SENDs one frame to the Server.
+// Raw ibverbs (rogue has no TX Server); torn down by destroy().  destroy() is
+// idempotent and also runs from the destructor, so a REQUIRE() failure part-way
+// through open()/connectTo() still releases every ibverbs kernel object as the
+// stack unwinds.  Copy/assign are deleted to prevent a double-free of the raw
+// owning handles.
+struct LoopbackClient {
+    ibv_context* ctx = nullptr;
+    ibv_pd*      pd  = nullptr;
+    ibv_cq*      cq  = nullptr;
+    ibv_qp*      qp  = nullptr;
+    ibv_mr*      mr  = nullptr;
+    std::vector<uint8_t> sbuf;
+    ibv_gid  gid{};
+    uint8_t  gidIndex = 0;
+
+    LoopbackClient()  = default;
+    ~LoopbackClient() { destroy(); }
+    LoopbackClient(const LoopbackClient&)            = delete;
+    LoopbackClient& operator=(const LoopbackClient&) = delete;
+
+    bool open() {
+        int          num  = 0;
+        ibv_device** list = ibv_get_device_list(&num);
+        if (!list) return false;
+        ibv_device* dev = nullptr;
+        for (int i = 0; i < num; ++i) {
+            if (std::string(kDev) == ibv_get_device_name(list[i])) {
+                dev = list[i];
+                break;
+            }
+        }
+        if (dev) ctx = ibv_open_device(dev);
+        ibv_free_device_list(list);
+        if (!ctx) return false;
+
+        pd = ibv_alloc_pd(ctx);
+        if (!pd) return false;
+        cq = ibv_create_cq(ctx, 16, nullptr, nullptr, 0);
+        if (!cq) return false;
+
+        sbuf.assign(kPayloadLen, 0);
+        for (uint32_t i = 0; i < kPayloadLen; ++i)
+            sbuf[i] = static_cast<uint8_t>((i * 7 + 3) & 0xFF);   // deterministic pattern
+        mr = ibv_reg_mr(pd, sbuf.data(), kPayloadLen, IBV_ACCESS_LOCAL_WRITE);
+        if (!mr) return false;
+
+        ibv_qp_init_attr ia;
+        memset(&ia, 0, sizeof(ia));
+        ia.qp_type          = IBV_QPT_RC;
+        ia.send_cq          = cq;
+        ia.recv_cq          = cq;
+        ia.cap.max_send_wr  = 4;
+        ia.cap.max_recv_wr  = 4;
+        ia.cap.max_send_sge = 1;
+        ia.cap.max_recv_sge = 1;
+        qp = ibv_create_qp(pd, &ia);
+        if (!qp) return false;
+
+        return true;
+    }
+
+    // Query + store the GID at `idx` and remember idx for the AH sgid_index.
+    // On rxe0 loopback this GID is both the client's source GID and (same
+    // device/index) the Server's destination GID.
+    bool queryGid(uint8_t idx) {
+        gidIndex = idx;
+        if (ibv_query_gid(ctx, 1, idx, &gid) != 0) return false;
+        for (int i = 0; i < 16; ++i)
+            if (gid.raw[i]) return true;   // non-zero GID
+        return false;
+    }
+
+    // Move client QP INIT -> RTR -> RTS aimed at the Server's QP.
+    bool connectTo(uint32_t serverQpn, uint32_t serverSqPsn, uint32_t pmtu) {
+        {   // INIT
+            ibv_qp_attr a;
+            memset(&a, 0, sizeof(a));
+            a.qp_state        = IBV_QPS_INIT;
+            a.pkey_index      = 0;
+            a.port_num        = 1;
+            a.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+                                IBV_ACCESS_REMOTE_READ;
+            if (ibv_modify_qp(qp, &a, IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+                                          IBV_QP_PORT | IBV_QP_ACCESS_FLAGS))
+                return false;
+        }
+        {   // RTR — dest = Server QP; our RQ expects the Server's SQ PSN
+            ibv_qp_attr a;
+            memset(&a, 0, sizeof(a));
+            a.qp_state           = IBV_QPS_RTR;
+            a.path_mtu           = static_cast<ibv_mtu>(pmtu);
+            a.dest_qp_num        = serverQpn;
+            a.rq_psn             = serverSqPsn;
+            a.max_dest_rd_atomic = 1;
+            a.min_rnr_timer      = kMinRnrTimer;
+            a.ah_attr.is_global      = 1;
+            a.ah_attr.grh.dgid       = gid;   // loopback: Server GID == our GID
+            a.ah_attr.grh.sgid_index = gidIndex;
+            a.ah_attr.grh.hop_limit  = 64;
+            a.ah_attr.port_num       = 1;
+            a.ah_attr.sl             = 0;
+            if (ibv_modify_qp(qp, &a, IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+                                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+                                          IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER))
+                return false;
+        }
+        {   // RTS — our SQ PSN must match the Server's RQ PSN (= kClientSqPsn)
+            ibv_qp_attr a;
+            memset(&a, 0, sizeof(a));
+            a.qp_state      = IBV_QPS_RTS;
+            a.sq_psn        = kClientSqPsn;
+            a.timeout       = 14;
+            a.retry_cnt     = 7;
+            a.rnr_retry     = 7;
+            a.max_rd_atomic = 1;
+            if (ibv_modify_qp(qp, &a, IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT |
+                                          IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
+                                          IBV_QP_MAX_QP_RD_ATOMIC))
+                return false;
+        }
+        return true;
+    }
+
+    // One RDMA SEND-with-immediate.  imm low byte = channel (Server decodes
+    // ntohl(imm) & 0xFF); 0 is fine.
+    bool send() {
+        ibv_sge sge;
+        memset(&sge, 0, sizeof(sge));
+        sge.addr   = reinterpret_cast<uint64_t>(sbuf.data());
+        sge.length = kPayloadLen;
+        sge.lkey   = mr->lkey;
+
+        ibv_send_wr wr;
+        memset(&wr, 0, sizeof(wr));
+        wr.wr_id      = 1;
+        wr.sg_list    = &sge;
+        wr.num_sge    = 1;
+        wr.opcode     = IBV_WR_SEND_WITH_IMM;
+        wr.send_flags = IBV_SEND_SIGNALED;
+        wr.imm_data   = htonl(0);   // channel 0
+
+        ibv_send_wr* bad = nullptr;
+        return ibv_post_send(qp, &wr, &bad) == 0;
+    }
+
+    void destroy() {
+        if (qp) {
+            ibv_destroy_qp(qp);
+            qp = nullptr;
+        }
+        if (mr) {
+            ibv_dereg_mr(mr);
+            mr = nullptr;
+        }
+        if (cq) {
+            ibv_destroy_cq(cq);
+            cq = nullptr;
+        }
+        if (pd) {
+            ibv_dealloc_pd(pd);
+            pd = nullptr;
+        }
+        if (ctx) {
+            ibv_close_device(ctx);
+            ctx = nullptr;
+        }
+    }
+};
+
+}  // namespace
+
+TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame is held") {
+    if (!rxeAvailable()) return;  // runtime-skip idiom (doctest 2.4.12 has no skip macro)
+
+    // Loopback client — open first so we can pick a GID index usable by both.
+    LoopbackClient client;
+    REQUIRE(client.open());
+
+    // Use the IPv4-mapped RoCEv2 GID (skip the link-local fe80:: at index 0,
+    // which rxe rejects at INIT->RTR). Same index for the Server and client.
+    const int gidIdx = findIpv4GidIndex(client.ctx, 1);
+    REQUIRE(gidIdx >= 0);
+    // sgid_index (ibv_ah_attr.grh) and Server::create's gidIndex are both
+    // uint8_t, so an index past 255 (gid_tbl_len can be 1024) would silently
+    // truncate and test the wrong GID.  Bound-check, then use one uint8_t value.
+    REQUIRE(gidIdx <= 255);
+    const uint8_t gidIndex = static_cast<uint8_t>(gidIdx);
+    REQUIRE(client.queryGid(gidIndex));
+
+    // Server (receiver) on rxe0 at the IPv4-mapped GID index.
+    auto server = rpr::Server::create(kDev, 1, gidIndex, kMaxPayload, kQueueDepth);
+    REQUIRE(server != nullptr);
+
+    auto slave = std::make_shared<HoldingSlave>();
+    server->addSlave(slave);
+
+    // path_mtu = the port's active MTU (rxe0 inherits the netdev MTU); a fixed
+    // 4096 is rejected at INIT->RTR when the netdev MTU is smaller.
+    ibv_port_attr pattr;
+    memset(&pattr, 0, sizeof(pattr));
+    REQUIRE(ibv_query_port(client.ctx, 1, &pattr) == 0);
+    const uint32_t pmtu = static_cast<uint32_t>(pattr.active_mtu);  // IBV_MTU_* enum
+
+    // Tell the Server about the client, then bring both QPs to RTS.  The
+    // Server's RQ PSN is set to kClientSqPsn (its completeConnection second
+    // arg = remote SQ start); the client's RQ PSN tracks the Server SQ PSN.
+    std::string clientGid(reinterpret_cast<const char*>(client.gid.raw), 16);
+    server->setFpgaGid(clientGid);
+    server->completeConnection(client.qp->qp_num, kClientSqPsn, pmtu, kMinRnrTimer);
+    REQUIRE(client.connectTo(server->getQpn(), server->getSqPsn(), pmtu));
+
+    REQUIRE(client.send());
+
+    // Wait (bounded) for the Server's receive thread to deliver the frame.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (slave->count() == 0 && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    REQUIRE(slave->count() >= 1);
+
+    ris::FramePtr frame = slave->front();
+    REQUIRE(frame != nullptr);
+    REQUIRE(frame->getPayload() == kPayloadLen);
+
+    // Read the zero-copy payload BEFORE teardown — sanity that the frame really
+    // carried our SEND straight out of the slab.
+    std::vector<uint8_t> before(kPayloadLen);
+    {
+        auto it = frame->beginRead();
+        ris::fromFrame(it, kPayloadLen, before.data());
+    }
+    CHECK_EQ(std::memcmp(before.data(), client.sbuf.data(), kPayloadLen), 0);
+
+    // TEARDOWN while `frame` is still held downstream.  On the buggy build
+    // Server::stop() -> cleanupResources() free()s the slab that `frame` still
+    // points into.  (Fixed build: the slab is freed only in ~Server, which the
+    // frame's shared_ptr<Pool> keeps alive, so it outlives the frame.)
+    server->stop();
+
+    // Reclaim the freed region: many same-size allocations, each fully written,
+    // so the allocator hands the just-freed slab chunk back and we overwrite it.
+    // A premature free() may munmap the slab (a later read then faults) or return
+    // it to the allocator arena (the stale bytes linger until reused) depending on
+    // the allocator and its mmap threshold; this clobber is a best-effort provoke
+    // of reuse so the failure is a deterministic byte mismatch when it does not
+    // fault outright.  On the fixed build the slab is still live, so these land
+    // elsewhere and the frame is untouched.
+    const size_t slabBytes = static_cast<size_t>(kMaxPayload) * kQueueDepth;
+    std::vector<std::vector<uint8_t>> clobber;
+    clobber.reserve(64);   // avoid outer-vector regrowth during the loop
+    for (int i = 0; i < 64; ++i)
+        clobber.emplace_back(slabBytes, 0xAA);
+
+    // Re-read the SAME frame.  Fixed build: slab intact -> bytes still match.
+    // Buggy build: use-after-free -> bytes are the 0xAA clobber (or a fault).
+    std::vector<uint8_t> after(kPayloadLen, 0);
+    {
+        auto it = frame->beginRead();
+        ris::fromFrame(it, kPayloadLen, after.data());
+    }
+    CHECK_EQ(std::memcmp(after.data(), client.sbuf.data(), kPayloadLen), 0);
+
+    // Release the held frame before the client MR/QP it (indirectly) races.
+    frame.reset();
+    client.destroy();
+}

--- a/tests/cpp/protocols/rocev2/test_rocev2_teardown.cpp
+++ b/tests/cpp/protocols/rocev2/test_rocev2_teardown.cpp
@@ -41,11 +41,14 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "doctest/doctest.h"
@@ -73,6 +76,7 @@ constexpr uint32_t kMaxPayload   = 4096;
 constexpr uint32_t kQueueDepth   = 256;
 constexpr uint32_t kMinRnrTimer  = 12;
 constexpr uint32_t kPayloadLen   = 1024;   // bytes actually SENT (<= bufSize_)
+constexpr size_t   kFrameCount   = 4;
 // path_mtu is chosen at runtime from the port's active_mtu: rxe0 inherits the
 // backing netdev MTU (typically 1500 -> IBV_MTU_1024), so a fixed 4096 would be
 // rejected at INIT->RTR. The RC layer segments the SEND into path_mtu packets;
@@ -138,14 +142,49 @@ class HoldingSlave : public ris::Slave {
         std::lock_guard<std::mutex> lk(mtx_);
         return frames_.size();
     }
-    ris::FramePtr front() {
+    std::vector<ris::FramePtr> takeAll() {
         std::lock_guard<std::mutex> lk(mtx_);
-        return frames_.empty() ? nullptr : frames_.front();
+        std::vector<ris::FramePtr> frames;
+        frames.swap(frames_);
+        return frames;
+    }
+    void clear() {
+        std::lock_guard<std::mutex> lk(mtx_);
+        frames_.clear();
     }
 
   private:
     std::mutex                 mtx_;
     std::vector<ris::FramePtr> frames_;
+};
+
+// Break the Server -> HoldingSlave -> Frame -> Buffer -> Server ownership
+// cycle if a fatal doctest assertion unwinds the test before takeAll().
+class HoldingSlaveCleanup {
+  public:
+    HoldingSlaveCleanup(const std::shared_ptr<rpr::Server>& server,
+                        const std::shared_ptr<HoldingSlave>& slave)
+        : server_(server), slave_(slave) {}
+    ~HoldingSlaveCleanup() {
+        // Stop delivery before clearing retained frames; otherwise a frame
+        // arriving between clear() and local shared_ptr teardown could recreate
+        // the ownership cycle this guard exists to break.
+        if (auto server = server_.lock()) {
+            try {
+                server->stop();
+            } catch (...) {
+                // Best-effort cleanup during assertion unwinding.
+            }
+        }
+        slave_->clear();
+    }
+
+    HoldingSlaveCleanup(const HoldingSlaveCleanup&)            = delete;
+    HoldingSlaveCleanup& operator=(const HoldingSlaveCleanup&) = delete;
+
+  private:
+    std::weak_ptr<rpr::Server>       server_;
+    std::shared_ptr<HoldingSlave>    slave_;
 };
 
 // Minimal loopback client: an RC QP on rxe0 that SENDs one frame to the Server.
@@ -320,7 +359,7 @@ struct LoopbackClient {
 
 }  // namespace
 
-TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame is held") {
+TEST_CASE("rocev2 Server preserves zero-copy lifetime and serializes returns with stop") {
     if (!rxeAvailable()) return;  // runtime-skip idiom (doctest 2.4.12 has no skip macro)
 
     // Loopback client — open first so we can pick a GID index usable by both.
@@ -344,6 +383,7 @@ TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame
 
     auto slave = std::make_shared<HoldingSlave>();
     server->addSlave(slave);
+    HoldingSlaveCleanup slaveCleanup(server, slave);
 
     // path_mtu = the port's active MTU (rxe0 inherits the netdev MTU); a fixed
     // 4096 is rejected at INIT->RTR when the netdev MTU is smaller.
@@ -360,15 +400,22 @@ TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame
     server->completeConnection(client.qp->qp_num, kClientSqPsn, pmtu, kMinRnrTimer);
     REQUIRE(client.connectTo(server->getQpn(), server->getSqPsn(), pmtu));
 
-    REQUIRE(client.send());
+    for (size_t i = 0; i < kFrameCount; ++i) REQUIRE(client.send());
 
-    // Wait (bounded) for the Server's receive thread to deliver the frame.
+    // Wait (bounded) for the Server's receive thread to deliver the frames.
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (slave->count() == 0 && std::chrono::steady_clock::now() < deadline)
+    while (slave->count() < kFrameCount && std::chrono::steady_clock::now() < deadline)
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    REQUIRE(slave->count() >= 1);
+    REQUIRE(slave->count() >= kFrameCount);
 
-    ris::FramePtr frame = slave->front();
+    // Detach every retained frame from HoldingSlave.  This breaks the
+    // Server -> Slave -> Frame -> Buffer -> Server ownership cycle while
+    // preserving explicit references for the lifetime and teardown-race checks
+    // below.
+    std::vector<ris::FramePtr> returnedFrames = slave->takeAll();
+    REQUIRE(returnedFrames.size() >= kFrameCount);
+    ris::FramePtr frame = std::move(returnedFrames.front());
+    returnedFrames.erase(returnedFrames.begin());
     REQUIRE(frame != nullptr);
     REQUIRE(frame->getPayload() == kPayloadLen);
 
@@ -381,11 +428,58 @@ TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame
     }
     CHECK_EQ(std::memcmp(before.data(), client.sbuf.data(), kPayloadLen), 0);
 
-    // TEARDOWN while `frame` is still held downstream.  On the buggy build
+    // Release several deferred zero-copy buffers concurrently with stop().
+    // Both workers rendezvous before proceeding to maximize the practical race
+    // coverage on real ibverbs hardware.  retBuffer()/postRecvWr() and
+    // cleanupResources() share resourcesMtx_, so either the re-post finishes
+    // before teardown or it observes that the resources are already gone.
+    std::mutex startMtx;
+    std::condition_variable startCv;
+    uint32_t ready = 0;
+    bool start      = false;
+    auto awaitStart = [&] {
+        std::unique_lock<std::mutex> lock(startMtx);
+        ++ready;
+        startCv.notify_all();
+        startCv.wait(lock, [&] { return start; });
+    };
+
+    std::exception_ptr stopError;
+    std::exception_ptr returnError;
+    std::thread stopper([&] {
+        awaitStart();
+        try {
+            server->stop();
+        } catch (...) {
+            stopError = std::current_exception();
+        }
+    });
+    std::thread returner([&] {
+        awaitStart();
+        try {
+            returnedFrames.clear();
+        } catch (...) {
+            returnError = std::current_exception();
+        }
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(startMtx);
+        startCv.wait(lock, [&] { return ready == 2; });
+        start = true;
+    }
+    startCv.notify_all();
+
+    stopper.join();
+    returner.join();
+    CHECK(returnedFrames.empty());
+    if (stopError) std::rethrow_exception(stopError);
+    if (returnError) std::rethrow_exception(returnError);
+
+    // TEARDOWN completed while `frame` remains held.  On the buggy build,
     // Server::stop() -> cleanupResources() free()s the slab that `frame` still
-    // points into.  (Fixed build: the slab is freed only in ~Server, which the
-    // frame's shared_ptr<Pool> keeps alive, so it outlives the frame.)
-    server->stop();
+    // points into.  On the fixed build the slab is freed only in ~Server, which
+    // the frame's shared_ptr<Pool> keeps alive, so it outlives stop().
 
     // Reclaim the freed region: many same-size allocations, each fully written,
     // so the allocator hands the just-freed slab chunk back and we overwrite it.
@@ -410,7 +504,12 @@ TEST_CASE("rocev2 Server::stop must not free the RX slab while a zero-copy frame
     }
     CHECK_EQ(std::memcmp(after.data(), client.sbuf.data(), kPayloadLen), 0);
 
-    // Release the held frame before the client MR/QP it (indirectly) races.
+    // Release the last held zero-copy frame, then drop the explicit Server
+    // owner.  HoldingSlave no longer owns any frames, so the Server must be
+    // destructible rather than remaining in a Server/Slave/Frame/Buffer cycle.
+    std::weak_ptr<rpr::Server> weakServer = server;
     frame.reset();
     client.destroy();
+    server.reset();
+    CHECK(weakServer.expired());
 }


### PR DESCRIPTION
### Description

Fix a use-after-free in `rogue::protocols::rocev2::Server` teardown. `stop()` freed the registered RX slab while zero-copy `Buffer`s already handed downstream still pointed into it, which surfaced as a segmentation fault during process or GUI teardown.

The slab is now the `Pool`'s buffer backing and lives until `~Server()`; `stop()` releases only the external ibverbs resources. This applies the same shutdown contract that landed for `AxiStreamDma` in #1277.

### Changes

- `~Server()` frees the RX slab; `stop()` destroys only the QP/CQ/comp-channel and deregisters the MR. Each zero-copy `Buffer` holds a `shared_ptr` to its `Pool`, so the backing outlives every outstanding frame. The failed-construction path still frees the slab explicitly.
- `resourcesMtx_` serializes `postRecvWr()` against `cleanupResources()`. The QP/MR validity check and `ibv_post_recv()` run inside that lock, so a deferred return either re-posts before teardown or observes the resources are gone. `retBuffer()` no longer reads `threadEn_`/`qp_` outside the lock.
- `completeConnection()` rejects use after `stop()` with a lifecycle error before any ibverbs call.
- Adds missing `GilRelease` coverage around ibverbs bring-up, connection completion, deferred returns, and shutdown (`stop()` joins a receive thread that re-acquires the GIL).
- Hardware-gated `rxe0` regression covering retained-frame validity across `stop()`, concurrent returns versus `stop()`, the post-stop `completeConnection()` guard, `stop()` idempotency, and `weak_ptr`-verified destruction.

### Lifecycle contract

Callers must quiesce `completeConnection()` and other ibverbs-resource operations before calling `stop()`. Returns of previously issued zero-copy buffers are the only operation allowed to overlap shutdown.

### Validation

- Linux build clean; `ctest -L cpp` 18/18 pass; `cpplint` and `check_whitespace.sh` clean.
- Teardown regression run against a real RoCEv2 NIC: 22/22 assertions pass. Reverting the slab-lifetime fix makes it crash with SIGSEGV at the post-teardown read; removing the `completeConnection()` entry guard makes the error surface from `postRecvWr()` instead and fails the new assertion.
- Earlier end-to-end validation against a 10 GbE RoCEv2 firmware target: 25/25 PRBS runs with no teardown segfault.

### Known limitation

The return-versus-`stop()` regression starts both operations from a rendezvous and returns several buffers, but it cannot force a specific interleaving inside `libibverbs` the way #1277's fake-driver shim can. Each active zero-copy return also takes one extra mutex before the existing `decCounter()` lock; there is no focused RoCE return-throughput measurement in this PR.

### JIRA

N/A
