### PR TITLE
fix(epicsV7): correct softioc install instructions in import warning

### DIFF
--- a/python/pyrogue/protocols/epicsV7.py
+++ b/python/pyrogue/protocols/epicsV7.py
@@ -26,9 +26,7 @@ except Exception:
     warnings.warn(
         "softioc (pythonSoftIOC) is not installed.\n\n"
         "To install with pip:\n"
-        "    pip install softioc\n\n"
-        "To install with Conda:\n"
-        "    conda install -c conda-forge softioc\n\n"
+        "    python -m pip install softioc p4p\n\n"
         "Note: softioc requires EPICS base to be available on your system."
     )
 


### PR DESCRIPTION
### Description
The `softioc` (pythonSoftIOC) import-guard warning in `python/pyrogue/protocols/epicsV7.py` advertised `conda install -c conda-forge softioc`, which can never succeed. `softioc` is published on PyPI only and has no conda-forge feedstock, so that command fails with `PackagesNotFoundError`. The pip line was also incomplete, since this module needs both `softioc` and `p4p`.

The warning now emits a single working command, `python -m pip install softioc p4p`, and the two Conda lines are removed. Using `python -m pip` rather than bare `pip` ensures the install targets the active interpreter instead of whichever `pip` happens to be first on `PATH`, which matters inside a conda environment.

### Details
Scope is deliberately limited to the string literals in the first `except Exception:` block.

The p4p import-guard warning immediately below it keeps its Conda line, which is correct: `p4p` does have a conda-forge feedstock and is already listed in `conda.yml`. By contrast `softioc` appears in `pip_requirements.txt` and `pip_requirements_ci.txt` but in neither `conda.yml` nor `conda-recipe/meta.yaml`, consistent with it being pip-only.

The equivalent warning in `epicsV4.py` is untouched.

Verification: `scripts/run_linters.sh` passes (compileall, flake8, cpplint, cmake-sync).
