### PR TITLE
Fix YAML serialization of display-formatted floats

### DIFF
--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -336,22 +336,21 @@ def dataToYaml(data: Any) -> str:
         pass
 
     def _var_representer(dumper: yaml.Dumper, data: pr.VariableValue) -> Any:
-        """Represent ``VariableValue`` using display formatting and YAML typing."""
-        if isinstance(data.value, bool):
+        """Represent floats natively and other values by display text."""
+        if data.valueDisp is None:
+            return dumper.represent_scalar('tag:yaml.org,2002:null',u'null')
+        elif isinstance(data.value, bool):
             enc = 'tag:yaml.org,2002:bool'
         elif data.enum is not None:
             enc = 'tag:yaml.org,2002:str'
         elif isinstance(data.value, int):
             enc = 'tag:yaml.org,2002:int'
         elif isinstance(data.value, float):
-            enc = 'tag:yaml.org,2002:float'
+            return dumper.represent_data(data.value)
         else:
             enc = 'tag:yaml.org,2002:str'
 
-        if data.valueDisp is None:
-            return dumper.represent_scalar('tag:yaml.org,2002:null',u'null')
-        else:
-            return dumper.represent_scalar(enc, data.valueDisp)
+        return dumper.represent_scalar(enc, data.valueDisp)
 
     def _dict_representer(dumper: yaml.Dumper, data: odict) -> Any:
         """Represent ``OrderedDict`` values while preserving key order."""

--- a/python/pyrogue/_HelperFunctions.py
+++ b/python/pyrogue/_HelperFunctions.py
@@ -344,9 +344,11 @@ def dataToYaml(data: Any) -> str:
         elif data.enum is not None:
             enc = 'tag:yaml.org,2002:str'
         elif isinstance(data.value, int):
+            # Preserve readable integer formats such as hexadecimal in saved
+            # configs; unsafe display formats need a separate compatibility policy.
             enc = 'tag:yaml.org,2002:int'
         elif isinstance(data.value, float):
-            return dumper.represent_data(data.value)
+            return dumper.represent_float(float(data.value))
         else:
             enc = 'tag:yaml.org,2002:str'
 

--- a/tests/fileio/test_core_fileio.py
+++ b/tests/fileio/test_core_fileio.py
@@ -10,6 +10,7 @@
 
 import struct
 
+import numpy as np
 import pyrogue as pr
 import pyrogue.utilities.fileio
 import pytest
@@ -119,13 +120,21 @@ def test_file_reader_decodes_float_with_grouped_display_format(tmp_path):
         value=256939.708,
         disp="{:,.3f}",
     ))
+    writer.add(pr.LocalVariable(
+        name="NumpyBandwidth",
+        mode="RO",
+        value=np.float64(256939.708),
+        disp="{:,.3f}",
+    ))
     root.add(writer)
 
     with root:
         assert writer.Bandwidth.getDisp(read=False) == "256,939.708"
+        assert writer.NumpyBandwidth.getDisp(read=False) == "256,939.708"
         config_payload = root.getYaml(readFirst=False).encode("utf-8")
 
     assert b"256,939.708" not in config_payload
+    assert b"!!python/object" not in config_payload
 
     data_path = tmp_path / "grouped-float-config.dat"
     _write_record(data_path, 7, config_payload)
@@ -133,6 +142,7 @@ def test_file_reader_decodes_float_with_grouped_display_format(tmp_path):
     reader = pyrogue.utilities.fileio.FileReader(files=str(data_path), configChan=7)
     assert list(reader.records()) == []
     assert reader.configValue("root.DataWriter.Bandwidth") == 256939.708
+    assert reader.configValue("root.DataWriter.NumpyBandwidth") == 256939.708
 
 
 def test_file_reader_missing_path_raises(tmp_path):

--- a/tests/fileio/test_core_fileio.py
+++ b/tests/fileio/test_core_fileio.py
@@ -110,6 +110,31 @@ def test_file_reader_reads_records_and_config(tmp_path):
     assert reader.configValue("root.Child.Value") == 9
 
 
+def test_file_reader_decodes_float_with_grouped_display_format(tmp_path):
+    root = pr.Root(name="root", pollEn=False, initRead=False)
+    writer = pr.Device(name="DataWriter")
+    writer.add(pr.LocalVariable(
+        name="Bandwidth",
+        mode="RO",
+        value=256939.708,
+        disp="{:,.3f}",
+    ))
+    root.add(writer)
+
+    with root:
+        assert writer.Bandwidth.getDisp(read=False) == "256,939.708"
+        config_payload = root.getYaml(readFirst=False).encode("utf-8")
+
+    assert b"256,939.708" not in config_payload
+
+    data_path = tmp_path / "grouped-float-config.dat"
+    _write_record(data_path, 7, config_payload)
+
+    reader = pyrogue.utilities.fileio.FileReader(files=str(data_path), configChan=7)
+    assert list(reader.records()) == []
+    assert reader.configValue("root.DataWriter.Bandwidth") == 256939.708
+
+
 def test_file_reader_missing_path_raises(tmp_path):
     data_path = tmp_path / "empty.dat"
     _write_record(data_path, 1, bytes([9, 8]))


### PR DESCRIPTION
### Description

Serialize PyRogue float `VariableValue` objects from their native values rather than their display-formatted strings. This keeps configuration and status YAML round-trippable when a float display format contains thousands separators, fixing `FileReader(configChan=...)` failures for `DataWriter.Bandwidth`.

### Details

`DataWriter.Bandwidth` uses `disp='{:,.3f}'`. The serializer previously tagged the display text as `!!float`, producing values such as `!!float '256,939.708'` that PyYAML could not parse. Float values now use PyYAML's native float representation, while boolean, enum, integer, and string display behavior remains unchanged.

Native float serialization also preserves full precision rather than the rounded display value. This is the intended round-trip behavior, but downstream golden configuration files may show expected float-value changes.

NumPy float scalars are converted to Python floats before representation so the YAML remains portable and contains no Python-specific NumPy object tags.

Integer display text remains unchanged to preserve readable formats such as hexadecimal register values. Safe handling of non-YAML integer display formats such as comma-grouped decimal output is tracked in #1284.

A regression test verifies that grouped float display formatting is preserved for the UI, omitted from persisted YAML, and decoded by `FileReader` as a native float. It also covers `np.float64` and rejects Python-specific object tags.

Validation:

- 71 focused YAML, configuration, stream, and file-I/O tests passed
- Original `StreamWriter` to `FileReader` reproduction passed
- Python compilation passed
- `git diff --check` passed

### Related

Fixes #1282
Follow-up: #1284