### PR TITLE
Add optional embedded terminal and IPython console tabs to the default PyDM GUI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - pydm >=1.18
     - qtpy >=2.0
     - pyqtgraph >=0.13
+    - pyte >=0.8
     - matplotlib
     - rdma-core  # [linux]
 

--- a/conda.yml
+++ b/conda.yml
@@ -35,3 +35,4 @@ dependencies:
   - pyqt>=5.15
   - qtpy>=2.0
   - pyqtgraph>=0.13
+  - pyte>=0.8

--- a/docker/rogue/Dockerfile
+++ b/docker/rogue/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 
 # PIP Packages
 RUN pip3 install PyYAML parse click ipython pyzmq packaging matplotlib numpy p4p jsonpickle sqlalchemy pyserial
-RUN pip3 install pydm>=1.18.0
+RUN pip3 install 'pydm>=1.18.0' 'pyte>=0.8'
 
 # Install Rogue
 ARG branch=main

--- a/docs/src/api/python/pyrogue/pydm_widgets/index.rst
+++ b/docs/src/api/python/pyrogue/pydm_widgets/index.rst
@@ -25,6 +25,7 @@ Widget Classes
    runcontrol
    datawriter
    systemlog
+   linuxterminal
    process
    debugtree
    pyroguelabel

--- a/docs/src/api/python/pyrogue/pydm_widgets/index.rst
+++ b/docs/src/api/python/pyrogue/pydm_widgets/index.rst
@@ -26,6 +26,7 @@ Widget Classes
    datawriter
    systemlog
    linuxterminal
+   ipythonpanel
    process
    debugtree
    pyroguelabel

--- a/docs/src/api/python/pyrogue/pydm_widgets/ipythonpanel.rst
+++ b/docs/src/api/python/pyrogue/pydm_widgets/ipythonpanel.rst
@@ -1,0 +1,18 @@
+.. _api_python_pyrogue_pydm_widgets_ipythonpanel:
+
+============
+IPythonPanel
+============
+
+For conceptual usage, see:
+
+- :doc:`/pydm/ipython_tab`
+- :doc:`/pydm/rogue_widgets`
+
+.. autoclass:: pyrogue.pydm.widgets.IPythonPanel
+   :members:
+   :undoc-members:
+
+.. autofunction:: pyrogue.pydm.widgets.ipython_core.ipythonArgv
+
+.. autofunction:: pyrogue.pydm.widgets.ipython_core.startupCode

--- a/docs/src/api/python/pyrogue/pydm_widgets/linuxterminal.rst
+++ b/docs/src/api/python/pyrogue/pydm_widgets/linuxterminal.rst
@@ -1,0 +1,22 @@
+.. _api_python_pyrogue_pydm_widgets_linuxterminal:
+
+=============
+LinuxTerminal
+=============
+
+For conceptual usage, see:
+
+- :doc:`/pydm/terminal_tab`
+- :doc:`/pydm/rogue_widgets`
+
+.. autoclass:: pyrogue.pydm.widgets.TerminalPanel
+   :members:
+   :undoc-members:
+
+.. autoclass:: pyrogue.pydm.widgets.LinuxTerminal
+   :members:
+   :undoc-members:
+
+.. autofunction:: pyrogue.pydm.widgets.terminal.keyToBytes
+
+.. autofunction:: pyrogue.pydm.widgets.terminal.resolveColor

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -62,6 +62,7 @@ autodoc_mock_imports = [
     'PyQt5.QtDesigner',
     'matplotlib',
     'pyqtgraph',
+    'pyte',
     'sip',
     'softioc',
     'softioc.asyncio_dispatcher',

--- a/docs/src/pydm/index.rst
+++ b/docs/src/pydm/index.rst
@@ -75,6 +75,7 @@ What To Explore Next
 - :doc:`timeplot_gui` for time-series plotting workflows
 - :doc:`channel_urls` for the Rogue-specific PyDM channel syntax
 - :doc:`rogue_widgets` for the widget set used in custom screens
+- :doc:`terminal_tab` for the optional embedded shell beside the system log
 
 Related Topics
 ==============
@@ -90,3 +91,4 @@ Related Topics
    timeplot_gui
    channel_urls
    rogue_widgets
+   terminal_tab

--- a/docs/src/pydm/index.rst
+++ b/docs/src/pydm/index.rst
@@ -76,6 +76,7 @@ What To Explore Next
 - :doc:`channel_urls` for the Rogue-specific PyDM channel syntax
 - :doc:`rogue_widgets` for the widget set used in custom screens
 - :doc:`terminal_tab` for the optional embedded shell beside the system log
+- :doc:`ipython_tab` for the optional IPython console with a connected client
 
 Related Topics
 ==============
@@ -92,3 +93,4 @@ Related Topics
    channel_urls
    rogue_widgets
    terminal_tab
+   ipython_tab

--- a/docs/src/pydm/ipython_tab.rst
+++ b/docs/src/pydm/ipython_tab.rst
@@ -1,0 +1,209 @@
+.. _ipython_tab:
+
+=========================
+The IPython Console Tab
+=========================
+
+The stock debug GUI can show an interactive IPython session in its own top-level
+tab, with a Rogue client already connected. When enabled, an ``IPython`` tab
+appears alongside ``System`` and ``Debug Tree``. It is added last, so the existing
+tab positions do not change, and ``Debug Tree`` remains the tab shown on startup.
+
+This is the session the Rogue server suggests when it starts::
+
+    To use a virtual client: client = pyrogue.interfaces.VirtualClient(addr='localhost', port=9099)
+
+opened for you rather than typed out. It is useful whenever a task is easier to
+express as a line of Python than as a sequence of clicks: reading a whole device
+at once, looping over channels, computing a value from several variables, or
+scripting a bring-up step while watching the ``Debug Tree`` update next to it.
+
+The feature is off by default, and independent of the ``Terminal`` tab. Either
+can be enabled without the other.
+
+What Is Already Connected
+=========================
+
+The session starts with two names bound:
+
+===============  ==============================================================
+Name             Value
+===============  ==============================================================
+``client``       A connected ``pyrogue.interfaces.VirtualClient``
+``root``         ``client.root``, the top of the tree
+``pr``           ``pyrogue``, for everything else
+===============  ==============================================================
+
+So the tree is reachable immediately:
+
+.. code-block:: python
+
+   In [1]: root.LocalTime.get()
+   In [2]: [v.get() for v in root.AxiVersion.variables.values()]
+
+The client connects to the same server the rest of the GUI is using, taken from
+the first entry of ``ROGUE_SERVERS``, which is what ``--server`` and the
+``serverList`` argument set. The detached window title names that server, so a
+console is never ambiguous about which system it is driving.
+
+It is a separate client in a separate process, not the one the GUI's own displays
+share. A session that is stopped, wedged, or exited therefore cannot take the
+GUI's channels down with it. If the server is not reachable the console says so
+and still hands over a prompt, along with the line to retry with once it is up.
+
+Where It Runs
+=============
+
+.. warning::
+
+   The console runs **on the machine displaying the GUI, as the user who launched
+   the GUI**. It is not a session on the Rogue server. It reaches the tree the
+   same way any other client does, over ZMQ.
+
+The distinction matters for everything that is not tree access. ``os``,
+``subprocess``, file paths, and ``!command`` all act on the machine showing the
+GUI, which is frequently not the DAQ host.
+
+Enabling It
+===========
+
+From the command line:
+
+.. code-block:: bash
+
+   $ python -m pyrogue gui --server localhost:9099 --ipython
+
+From a launcher script:
+
+.. code-block:: python
+
+   import pyrogue.pydm
+
+   pyrogue.pydm.runPyDM(serverList='localhost:9099', enableIPython=True)
+
+Both tabs together:
+
+.. code-block:: bash
+
+   $ python -m pyrogue gui --server localhost:9099 --terminal --ipython
+
+The console can also be placed in a custom screen. It takes the same kind of
+channel as the other Rogue widgets, and uses it only to decide which server to
+connect to:
+
+.. code-block:: python
+
+   from pyrogue.pydm.widgets import IPythonPanel
+
+   panel = IPythonPanel(parent=None)                                   # rogue://0/root
+   other = IPythonPanel(parent=None, init_channel='rogue://host:9099/root')
+
+The detach button only acts when the panel is a page of a ``QTabWidget``, since
+that is where it returns to. Elsewhere it does nothing rather than stranding the
+console in a window it cannot come back from.
+
+When The Session Starts
+=======================
+
+IPython starts the first time the tab is actually displayed, not when the GUI is
+built. Two consequences follow:
+
+- Enabling the feature costs nothing until someone opens the tab. No process
+  exists and no connection is attempted before that.
+- The connection attempt, which can take a few seconds against an absent server,
+  never delays the GUI coming up.
+
+Exiting, with ``exit`` or Ctrl-D, immediately starts a fresh session that
+reconnects, as if the tab had just been opened for the first time. Ctrl-D is easy
+to press by accident, and there is no reason for it to leave a dead tab that can
+only be recovered by restarting the GUI. Note that a fresh session starts with a
+fresh namespace: anything defined at the prompt is gone.
+
+If a session exits without anything having been typed then it never started at
+all, for example because IPython is not installed. After a few of those in a row
+the tab stops retrying and says so, rather than spawning processes in a loop.
+
+Security Considerations
+=======================
+
+Anyone who can reach the GUI window can execute arbitrary Python, and therefore
+arbitrary code, with the privileges of the account running the GUI. The
+considerations are the same as for :doc:`terminal_tab`, and for the same reasons:
+
+- **This includes a shell.** ``!command`` and ``subprocess`` are ordinary IPython
+  and Python features. Treat the console as equivalent to the terminal tab, not
+  as something narrower because it is a Python prompt.
+- **PyDM read-only mode does not constrain it.** ``PYDM_READ_ONLY`` gates channel
+  writes. A read-only PyDM session with the console enabled is still fully
+  writable, both through the shell and through ``root``.
+- **Privileges are inherited.** If the GUI is launched with elevated rights for
+  hardware access, the console gets them too. Do not enable it when the GUI runs
+  as ``root`` or under a shared, kiosk, or service account.
+- **A shared display is a shared session.** On a display reachable through X11
+  forwarding or an unauthenticated VNC session, anyone who can see the window can
+  use the console.
+- **There is no audit trail.** IPython history goes to the launching user's normal
+  history database, and the Rogue ``SystemLog`` records nothing about console
+  activity. Sites needing accountability must use host-level auditing.
+
+Because enabling the console requires editing the launching command or script, it
+is always a deliberate act by someone who can already run arbitrary code in that
+process. The option does not widen anyone's privileges; it changes who can
+conveniently reach a prompt.
+
+Detaching Into Its Own Window
+=============================
+
+The ``Detach`` button above the console moves it into a separate window, which
+can be sized and positioned independently or moved to another monitor. That makes
+a long session or a wide table of values readable without resizing the whole GUI,
+and it allows the console and the ``Debug Tree`` to be watched side by side. The
+button becomes ``Reattach`` to put it back in its original tab position.
+
+Detaching does not disturb the session. The interpreter is held by a file
+descriptor, not by a window, so the same session keeps running with its namespace,
+history, and scrollback intact. Closing the detached window reattaches the console
+rather than destroying it, and the detached window stays owned by the GUI, so
+closing the GUI closes it too.
+
+Appearance And Limitations
+==========================
+
+The console is the terminal widget of :doc:`terminal_tab` running IPython instead
+of a shell, so its rendering, dark theme, 2000 line scrollback, color support and
+key bindings are exactly as documented there, including ``Ctrl+Shift+C`` and
+``Ctrl+Shift+V`` for the clipboard so that ``Ctrl-C`` can interrupt.
+
+What that inherits, in practice:
+
+- Syntax highlighting, tab completion, history search, ``%magics``, and
+  multi-line editing all work, because they are terminal features of IPython.
+- Completion is IPython's own, from ``dir()``, with jedi turned off. That is what
+  makes ``root.<TAB>`` work at all: the tree resolves its children through
+  ``__getattr__``, which jedi's static analysis cannot follow and in practice
+  crashes on, leaving Tab doing nothing. What is given up is jedi's type
+  inference on ordinary Python, mostly completions on expressions that were
+  never assigned to a name.
+- Completion listings and the ``?`` pager render as they do in a terminal, not as
+  popups.
+- Rich output does not. There is no inline plotting and no HTML rendering, since
+  the view is a text screen. ``%matplotlib`` opens a separate window, as it does
+  from a terminal IPython.
+- Linux and macOS only. The implementation uses pseudo-terminals, which have no
+  Windows equivalent.
+
+IPython itself must be installed. It is part of the ``gui`` extra and of the conda
+environment, so this is normally already true.
+
+What To Explore Next
+====================
+
+- :doc:`terminal_tab` for the shell tab and the rendering both tabs share
+- :doc:`starting_gui` for the other runtime options of the stock GUI
+- :doc:`/pyrogue_tree/client_interfaces/virtual` for what ``client`` can do
+
+API Reference
+=============
+
+- :doc:`/api/python/pyrogue/pydm_widgets/ipythonpanel`
+- :doc:`/api/python/pyrogue/pydm_runpydm`

--- a/docs/src/pydm/rogue_widgets.rst
+++ b/docs/src/pydm/rogue_widgets.rst
@@ -16,6 +16,9 @@ The main widgets exported by ``pyrogue.pydm.widgets`` are:
 - ``RunControl``: Widget for a ``pyrogue.RunControl`` Device.
 - ``DataWriter``: Widget for a ``pyrogue.DataWriter`` Device.
 - ``SystemLog``: Widget that displays the Rogue system log.
+- ``TerminalPanel``: Interactive local shell with a detach button. Takes no
+  channel. See :doc:`terminal_tab`.
+- ``LinuxTerminal``: The terminal on its own, without the detach button.
 - ``Process``: Widget for a ``pyrogue.Process`` Device.
 - ``DebugTree``: Tree browser for Devices, Variables, and Commands.
 - ``PyRogueLabel``: Label widget with Rogue-oriented unit display handling.
@@ -47,6 +50,10 @@ specific Device or Variable path. In general:
 - ``SystemWindow`` and ``DebugTree`` are Root-oriented.
 - ``Process``, ``RunControl``, and ``DataWriter`` are Device-oriented.
 - ``PyRogueLabel`` and ``PyRogueLineEdit`` are typically Variable-oriented.
+- ``LinuxTerminal`` binds to nothing. It takes no channel and is deliberately
+  not registered in Qt Designer, because Designer instantiates registered
+  widgets eagerly and that would spawn a shell inside the design tool. Add it
+  from Python instead.
 
 When in doubt, inspect the widget's constructor and ``connection_changed``
 implementation in ``python/pyrogue/pydm/widgets``. Most path requirements are

--- a/docs/src/pydm/rogue_widgets.rst
+++ b/docs/src/pydm/rogue_widgets.rst
@@ -19,6 +19,8 @@ The main widgets exported by ``pyrogue.pydm.widgets`` are:
 - ``TerminalPanel``: Interactive local shell with a detach button. Takes no
   channel. See :doc:`terminal_tab`.
 - ``LinuxTerminal``: The terminal on its own, without the detach button.
+- ``IPythonPanel``: Interactive IPython session with a connected client and a
+  detach button. See :doc:`ipython_tab`.
 - ``Process``: Widget for a ``pyrogue.Process`` Device.
 - ``DebugTree``: Tree browser for Devices, Variables, and Commands.
 - ``PyRogueLabel``: Label widget with Rogue-oriented unit display handling.
@@ -54,6 +56,10 @@ specific Device or Variable path. In general:
   not registered in Qt Designer, because Designer instantiates registered
   widgets eagerly and that would spawn a shell inside the design tool. Add it
   from Python instead.
+- ``IPythonPanel`` is Root-oriented, but only to decide which server its client
+  connects to; it does not display the node. It is kept out of Qt Designer for
+  the same reason as the terminal, since being instantiated would start an
+  IPython session inside the design tool.
 
 When in doubt, inspect the widget's constructor and ``connection_changed``
 implementation in ``python/pyrogue/pydm/widgets``. Most path requirements are

--- a/docs/src/pydm/starting_gui.rst
+++ b/docs/src/pydm/starting_gui.rst
@@ -23,6 +23,10 @@ The default top-level display is implemented in
   widgets, and the system log.
 - ``Debug Tree`` for the full tree browser.
 
+``Debug Tree`` is the tab shown on startup. With ``enableTerminal=True`` a third
+``Terminal`` tab is appended, which does not change the position of the other
+two. See :doc:`terminal_tab`.
+
 That structure is useful context when deciding whether the stock GUI is enough
 or whether a custom screen would better match the operator workflow.
 
@@ -225,6 +229,15 @@ The main :py:func:`pyrogue.pydm.runPyDM` options are:
   ``VirtualClient`` instances. This is disabled by default and usually only
   makes sense when the application has a strict upper bound for valid request
   duration.
+- ``enableTerminal``: Add an interactive shell as a top-level ``Terminal`` tab.
+  Defaults to ``False``. Also available as ``--terminal`` on the command line.
+
+.. warning::
+
+   ``enableTerminal`` exposes a shell running on the machine displaying the GUI,
+   as the user who launched it, not on the Rogue server. PyDM read-only mode does
+   not restrict it. Read :doc:`terminal_tab` before enabling it on an operator
+   console.
 
 The command-line launcher defaults to ``localhost:9099``. The Python helper's
 function signature currently defaults to ``localhost:9090``, so in practice it

--- a/docs/src/pydm/starting_gui.rst
+++ b/docs/src/pydm/starting_gui.rst
@@ -24,8 +24,9 @@ The default top-level display is implemented in
 - ``Debug Tree`` for the full tree browser.
 
 ``Debug Tree`` is the tab shown on startup. With ``enableTerminal=True`` a third
-``Terminal`` tab is appended, which does not change the position of the other
-two. See :doc:`terminal_tab`.
+``Terminal`` tab is appended, and with ``enableIPython=True`` an ``IPython`` tab
+is appended after it. Both are appended, so neither changes the position of the
+other tabs. See :doc:`terminal_tab` and :doc:`ipython_tab`.
 
 That structure is useful context when deciding whether the stock GUI is enough
 or whether a custom screen would better match the operator workflow.
@@ -231,12 +232,16 @@ The main :py:func:`pyrogue.pydm.runPyDM` options are:
   duration.
 - ``enableTerminal``: Add an interactive shell as a top-level ``Terminal`` tab.
   Defaults to ``False``. Also available as ``--terminal`` on the command line.
+- ``enableIPython``: Add an IPython session with a connected client as a
+  top-level ``IPython`` tab. Defaults to ``False``. Independent of
+  ``enableTerminal``. Also available as ``--ipython`` on the command line.
 
 .. warning::
 
-   ``enableTerminal`` exposes a shell running on the machine displaying the GUI,
-   as the user who launched it, not on the Rogue server. PyDM read-only mode does
-   not restrict it. Read :doc:`terminal_tab` before enabling it on an operator
+   ``enableTerminal`` and ``enableIPython`` both expose arbitrary code execution
+   on the machine displaying the GUI, as the user who launched it, not on the
+   Rogue server. PyDM read-only mode does not restrict either of them. Read
+   :doc:`terminal_tab` or :doc:`ipython_tab` before enabling them on an operator
    console.
 
 The command-line launcher defaults to ``localhost:9099``. The Python helper's

--- a/docs/src/pydm/terminal_tab.rst
+++ b/docs/src/pydm/terminal_tab.rst
@@ -1,0 +1,218 @@
+.. _terminal_tab:
+
+==========================
+The Embedded Terminal Tab
+==========================
+
+The stock debug GUI can show an interactive shell in its own top-level tab. When
+enabled, a ``Terminal`` tab appears alongside ``System`` and ``Debug Tree``. It
+is added last, so the existing tab positions do not change, and ``Debug Tree``
+remains the tab shown on startup.
+
+Giving the terminal a top-level tab means it gets the full height of the window,
+which keeps it readable even in a small window.
+
+This is useful during bring-up and debugging, when checking ``dmesg``, tailing a
+file, inspecting ``/proc``, or restarting a service would otherwise mean leaving
+the GUI to find a separate terminal.
+
+The feature is off by default. Nothing changes for an existing GUI unless it is
+explicitly turned on.
+
+Where The Shell Runs
+====================
+
+.. warning::
+
+   The shell runs **on the machine displaying the GUI, as the user who launched
+   the GUI**. It is not a shell on the Rogue server.
+
+This matters because the GUI is frequently a remote client: ``runPyDM`` connects
+to ``serverList`` over ZMQ, so the GUI and the ``Root`` often live on different
+machines. Running a destructive command in the terminal believing you are on the
+DAQ host is the realistic accident this warning is here to prevent. Run
+``hostname`` in the terminal if there is any doubt.
+
+Enabling It
+===========
+
+From the command line:
+
+.. code-block:: bash
+
+   $ python -m pyrogue gui --server localhost:9099 --terminal
+
+From a launcher script:
+
+.. code-block:: python
+
+   import pyrogue.pydm
+
+   pyrogue.pydm.runPyDM(serverList='localhost:9099', enableTerminal=True)
+
+The terminal can also be placed in a custom screen. Neither widget takes a
+channel or any arguments. Use ``TerminalPanel`` to get the detach button, or
+``LinuxTerminal`` for just the terminal with no surrounding controls:
+
+.. code-block:: python
+
+   from pyrogue.pydm.widgets import LinuxTerminal, TerminalPanel
+
+   panel = TerminalPanel(parent=None)     # terminal plus the detach button
+   term = LinuxTerminal(parent=None)      # terminal on its own
+
+The detach button only acts when the panel is a page of a ``QTabWidget``, since
+that is where it returns to. Elsewhere it does nothing rather than stranding the
+terminal in a window it cannot come back from.
+
+When The Shell Starts
+=====================
+
+Exiting the shell, with ``exit`` or Ctrl-D, immediately starts a fresh session in
+a clean state, as if the GUI had just been opened. Ctrl-D is easy to press by
+accident, and there is no reason for it to leave a dead terminal that can only be
+recovered by restarting the GUI.
+
+If a shell exits without the user having typed anything then it never started at
+all, for example because ``$SHELL`` is not runnable. After a few of those in a
+row the terminal stops retrying and says so, rather than spawning processes in a
+loop.
+
+The shell starts the first time the tab is actually displayed, not when the GUI
+is built. Two consequences follow:
+
+- Enabling the feature costs nothing until someone opens the tab. No shell
+  process exists before that.
+- The terminal needs no Rogue channel, so unlike the other tabs it still works
+  while the Rogue link is down, which is exactly when a shell tends to be most
+  useful.
+
+Security Considerations
+=======================
+
+Anyone who can reach the GUI window gets an interactive shell with the
+privileges of the account running the GUI. Before enabling it, consider:
+
+- **PyDM read-only mode does not constrain it.** ``PYDM_READ_ONLY`` gates
+  channel writes. A read-only PyDM session with the terminal enabled is still
+  fully writable through the shell.
+- **Privileges are inherited.** If the GUI is launched with elevated rights for
+  hardware access, the shell gets them too. Do not enable the terminal when the
+  GUI runs as ``root`` or under a shared, kiosk, or service account.
+- **A shared display is a shared shell.** On a display reachable through X11
+  forwarding or an unauthenticated VNC session, anyone who can see the window
+  can use the shell.
+- **There is no audit trail.** Shell history goes to the launching user's normal
+  history file, and the Rogue ``SystemLog`` records nothing about terminal
+  activity. Sites needing accountability must use host-level auditing.
+
+Because enabling the terminal requires editing the launching command or script,
+it is always a deliberate act by someone who can already run arbitrary code in
+that process. The option does not widen anyone's privileges; it changes who can
+conveniently reach a shell.
+
+Detaching Into Its Own Window
+=============================
+
+A tab is only as tall as the window it lives in. The ``Detach`` button above the
+terminal moves it into a separate window, which can be sized and positioned
+independently or moved to another monitor. That makes a long build log or a full
+screen program readable without resizing the whole GUI. The button becomes
+``Reattach`` to put it back in its original tab position.
+
+Detaching does not disturb the shell. The child process is held by a file
+descriptor, not by a window, so the same shell keeps running with its working
+directory, command history, and scrollback intact.
+
+Two details worth knowing:
+
+- Closing the detached window reattaches the terminal rather than destroying it,
+  so there is no way to lose a running shell by closing the wrong window.
+- The detached window stays owned by the GUI, so closing the GUI closes it too
+  and the process exits normally.
+
+Appearance And Scrollback
+=========================
+
+The view is dark themed and uses the platform's fixed-pitch font. It keeps
+2000 lines of scrollback above the live screen, with a scrollbar on the right.
+
+The emulated screen is a fixed grid that exactly fills the view, so it behaves
+like any other terminal. Once enough output has accumulated the prompt sits on
+the bottom row and output scrolls up past it. Immediately after starting, or
+after ``clear``, the prompt is at the top with blank space beneath it, because
+the screen genuinely is empty at that point.
+
+``clear`` blanks the view as expected. Earlier output is not destroyed, it moves
+into the scrollback and can still be reached by scrolling up.
+
+Color
+=====
+
+Colored output is rendered, so ``ls``, ``grep --color``, ``git``, and compiler
+diagnostics look the way they do in any other terminal. The full range is
+supported: the sixteen named colors, 256 color, and 24 bit true color, along with
+bold, italic, underline, strikethrough, and reverse video. Colors are kept when a
+line scrolls into the scrollback.
+
+Bold combined with a color is rendered in the bright shade of that color, which
+is the convention colorizing tools assume. Blink is deliberately ignored.
+
+The palette comes from the standard xterm colors, so it matches what other
+terminals show for the same escape sequences.
+
+Scrolling behaves the way a terminal should: while you are scrolled up the view
+stays where you left it, so a burst of output will not yank you back. Once the
+view is at the bottom again it resumes following new output. Select with the
+mouse and copy with ``Ctrl+Shift+C``.
+
+The scrollback bound is what keeps a terminal left open for days from growing
+without limit. Oldest lines are dropped once it is reached.
+
+Current Limitations
+===================
+
+The terminal emulates a VT-style screen with `pyte
+<https://pypi.org/project/pyte/>`_ and renders it into a plain Qt text view.
+Interactive shells, job control, scrollback, and full-screen programs work. The
+following are not implemented:
+
+- **No alternate screen buffer.** Programs such as ``vim`` and ``htop`` run and
+  respond normally, but on exit they leave their last frame on screen instead of
+  restoring what was there before. Press Enter to get a fresh prompt.
+- **No mouse reporting.** Mouse-driven full-screen programs are keyboard-only.
+  The mouse selects text in the widget instead.
+- **No input method support.** Dead keys and compose sequences are ignored.
+- **Linux and macOS only.** The implementation uses pseudo-terminals, which have
+  no Windows equivalent.
+
+Key Bindings
+============
+
+Keys are forwarded to the shell, so ``Ctrl-C``, ``Ctrl-Z``, ``Ctrl-D``, and tab
+completion behave as they would in any terminal. Because ``Ctrl-C`` must reach
+the shell as an interrupt, the clipboard uses shifted chords:
+
+=========================  ====================================================
+Binding                    Action
+=========================  ====================================================
+``Ctrl+Shift+C``           Copy the selection
+``Ctrl+Shift+V``           Paste into the shell
+``Ctrl+C``                 Interrupt the foreground job, as usual
+=========================  ====================================================
+
+Multi-line pastes are wrapped in bracketed-paste markers when the shell has that
+mode enabled, so a pasted block is presented as a single line for review rather
+than executing each line as it arrives.
+
+What To Explore Next
+====================
+
+- :doc:`starting_gui` for the other runtime options of the stock GUI
+- :doc:`rogue_widgets` for the rest of the Rogue widget set
+
+API Reference
+=============
+
+- :doc:`/api/python/pyrogue/pydm_widgets/linuxterminal`
+- :doc:`/api/python/pyrogue/pydm_runpydm`

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -27,5 +27,6 @@ pygithub
 pydm
 qtpy
 pyte
+ipython
 matplotlib
 hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -26,5 +26,6 @@ gitpython
 pygithub
 pydm
 qtpy
+pyte
 matplotlib
 hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/pip_requirements_ci.txt
+++ b/pip_requirements_ci.txt
@@ -18,5 +18,6 @@ numpy
 flake8
 cpplint
 pydm
+pyte
 matplotlib
 hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/pip_requirements_ci.txt
+++ b/pip_requirements_ci.txt
@@ -19,5 +19,6 @@ flake8
 cpplint
 pydm
 pyte
+ipython
 matplotlib
 hwcounter; platform_system == "Linux" and platform_machine == "x86_64"

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -28,6 +28,10 @@ parser.add_argument('--ui',
                     help='UI File for gui (cmd=gui)',
                     default=None)
 
+parser.add_argument('--terminal',
+                    help='Add a local shell terminal tab beside the system log (cmd=gui)',
+                    action='store_true')
+
 parser.add_argument('--details',
                     help='Show log details with stacktrace (cmd=syslog)',
                     action='store_true')
@@ -66,7 +70,7 @@ print("Connecting to {}".format(args.server))
 # GUI Client
 if args.cmd == 'gui':
     import pyrogue.pydm
-    pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui)
+    pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui,enableTerminal=args.terminal)
 
 elif args.cmd == 'timeplot':
     import pyrogue.pydm

--- a/python/pyrogue/__main__.py
+++ b/python/pyrogue/__main__.py
@@ -32,6 +32,10 @@ parser.add_argument('--terminal',
                     help='Add a local shell terminal tab beside the system log (cmd=gui)',
                     action='store_true')
 
+parser.add_argument('--ipython',
+                    help='Add an IPython console tab with a connected client (cmd=gui)',
+                    action='store_true')
+
 parser.add_argument('--details',
                     help='Show log details with stacktrace (cmd=syslog)',
                     action='store_true')
@@ -70,7 +74,7 @@ print("Connecting to {}".format(args.server))
 # GUI Client
 if args.cmd == 'gui':
     import pyrogue.pydm
-    pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui,enableTerminal=args.terminal)
+    pyrogue.pydm.runPyDM(serverList=args.server,ui=args.ui,enableTerminal=args.terminal,enableIPython=args.ipython)
 
 elif args.cmd == 'timeplot':
     import pyrogue.pydm

--- a/python/pyrogue/interfaces/_Virtual.py
+++ b/python/pyrogue/interfaces/_Virtual.py
@@ -510,7 +510,7 @@ class VirtualClient(rogue.interfaces.ZmqClient):
 
         # Create monitoring thread
         self._monEnable = True
-        self._monThread = threading.Thread(target=self._monWorker)
+        self._monThread = threading.Thread(target=self._monWorker, daemon=True)
         self._monThread.start()
 
     def _removeFromCache(self) -> None:

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -119,6 +119,7 @@ def runPyDM(
     maxListSize: int = 100,
     linkTimeout: float = 10.0,
     requestStallTimeout: float | None = None,
+    enableTerminal: bool = False,
 ) -> None:
     """Launch the default Rogue PyDM application.
 
@@ -152,6 +153,11 @@ def runPyDM(
         server stalled. ``None`` disables stalled-request detection, which is
         usually the right default unless the application has a strict upper
         bound for valid request duration.
+    enableTerminal : bool, optional
+        Add a local shell terminal tab beside the system log in the ``System``
+        tab. Defaults to ``False``. When enabled the GUI exposes an interactive
+        shell running as the user who launched the GUI, on the machine
+        displaying the GUI, not on the Rogue server.
 
     Returns
     -------
@@ -237,6 +243,7 @@ def runPyDM(
     args.append(f"title='{title}'")
     args.append(f"maxListExpand={maxListExpand}")
     args.append(f"maxListSize={maxListSize}")
+    args.append(f"enableTerminal={enableTerminal}")
 
     pydm.data_plugins.initialize_plugins_if_needed()
 

--- a/python/pyrogue/pydm/__init__.py
+++ b/python/pyrogue/pydm/__init__.py
@@ -120,6 +120,7 @@ def runPyDM(
     linkTimeout: float = 10.0,
     requestStallTimeout: float | None = None,
     enableTerminal: bool = False,
+    enableIPython: bool = False,
 ) -> None:
     """Launch the default Rogue PyDM application.
 
@@ -158,6 +159,13 @@ def runPyDM(
         tab. Defaults to ``False``. When enabled the GUI exposes an interactive
         shell running as the user who launched the GUI, on the machine
         displaying the GUI, not on the Rogue server.
+    enableIPython : bool, optional
+        Add an ``IPython`` tab holding an interactive session with a connected
+        :class:`pyrogue.interfaces.VirtualClient` bound as ``client`` and the
+        tree root as ``root``. Defaults to ``False``. Independent of
+        ``enableTerminal``. When enabled the GUI exposes arbitrary Python
+        execution as the user who launched the GUI, on the machine displaying
+        the GUI, not on the Rogue server.
 
     Returns
     -------
@@ -244,6 +252,7 @@ def runPyDM(
     args.append(f"maxListExpand={maxListExpand}")
     args.append(f"maxListSize={maxListSize}")
     args.append(f"enableTerminal={enableTerminal}")
+    args.append(f"enableIPython={enableIPython}")
 
     pydm.data_plugins.initialize_plugins_if_needed()
 

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -17,6 +17,7 @@ from pydm import Display
 from qtpy.QtWidgets import (QVBoxLayout, QTabWidget, QWidget)
 
 from pyrogue.pydm.widgets import DebugTree
+from pyrogue.pydm.widgets import IPythonPanel
 from pyrogue.pydm.widgets import TerminalPanel
 from pyrogue.pydm.widgets import SystemWindow
 
@@ -75,6 +76,7 @@ class DefaultTop(Display):
         self.sizeY  = None
         self.title  = None
         self.enableTerminal = False
+        self.enableIPython = False
 
         if args is None:
             args = []
@@ -90,6 +92,10 @@ class DefaultTop(Display):
         enableTerminal = _parseBoolArg(args, 'enableTerminal')
         if enableTerminal is not None:
             self.enableTerminal = enableTerminal
+
+        enableIPython = _parseBoolArg(args, 'enableIPython')
+        if enableIPython is not None:
+            self.enableIPython = enableIPython
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
@@ -123,6 +129,15 @@ class DefaultTop(Display):
         if self.enableTerminal:
             self.terminal = TerminalPanel(parent=None)
             self.tab.addTab(self.terminal,'Terminal')
+
+        # IPython Tab, appended after the terminal for the same reason: the two
+        # options are independent, so neither one may move the tabs the other
+        # added. Unlike the terminal this one does use the channel, to reach the
+        # same server as the tabs above rather than a hardcoded address.
+        self.ipython = None
+        if self.enableIPython:
+            self.ipython = IPythonPanel(parent=None, init_channel=Channel)
+            self.tab.addTab(self.ipython,'IPython')
 
         # Set the default Tab view
         self.tab.setCurrentIndex(1)

--- a/python/pyrogue/pydm/pydmTop.py
+++ b/python/pyrogue/pydm/pydmTop.py
@@ -17,9 +17,39 @@ from pydm import Display
 from qtpy.QtWidgets import (QVBoxLayout, QTabWidget, QWidget)
 
 from pyrogue.pydm.widgets import DebugTree
+from pyrogue.pydm.widgets import TerminalPanel
 from pyrogue.pydm.widgets import SystemWindow
 
 Channel = 'rogue://0/root'
+
+
+def _parseBoolArg(args: list[str], name: str) -> bool | None:
+    """Return the boolean value of a ``name=<value>`` display argument.
+
+    Returns ``None`` when the argument is absent so the caller keeps its own
+    default. Matches on a leading prefix rather than the substring test used by
+    the older size and title arguments, which would otherwise false-positive on
+    a title that happened to contain the argument name.
+
+    Parameters
+    ----------
+    args : list[str]
+        Display argument list, each entry formatted as ``key=value``.
+    name : str
+        Argument name to look for.
+
+    Returns
+    -------
+    bool | None
+        Parsed value, or ``None`` when the argument is not present.
+    """
+    prefix = name + '='
+
+    for a in args:
+        if a.startswith(prefix):
+            return a[len(prefix):].strip().strip('\'"').lower() in ('1','true','yes','on')
+
+    return None
 
 
 class DefaultTop(Display):
@@ -44,6 +74,7 @@ class DefaultTop(Display):
         self.sizeX  = None
         self.sizeY  = None
         self.title  = None
+        self.enableTerminal = False
 
         if args is None:
             args = []
@@ -55,6 +86,10 @@ class DefaultTop(Display):
                 self.sizeY = int(a.split('=')[1])
             if 'title=' in a:
                 self.title = a.split('=')[1]
+
+        enableTerminal = _parseBoolArg(args, 'enableTerminal')
+        if enableTerminal is not None:
+            self.enableTerminal = enableTerminal
 
         if self.title is None:
             self.title = "Rogue Server: {}".format(os.getenv('ROGUE_SERVERS'))
@@ -79,6 +114,15 @@ class DefaultTop(Display):
         # Debug Tree Tab  (Tab Index=1)
         var = DebugTree(parent=None, init_channel=Channel)
         self.tab.addTab(var,'Debug Tree')
+
+        # Terminal Tab  (Tab Index=2), added last so the existing tab indexes
+        # are unchanged whether or not the terminal is enabled. A top level tab
+        # gives the terminal the full window height, and unlike the other tabs
+        # it needs no Rogue channel, so it also works while the link is down.
+        self.terminal = None
+        if self.enableTerminal:
+            self.terminal = TerminalPanel(parent=None)
+            self.tab.addTab(self.terminal,'Terminal')
 
         # Set the default Tab view
         self.tab.setCurrentIndex(1)

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -20,6 +20,7 @@ from pyrogue.pydm.widgets.root_control         import RootControl
 from pyrogue.pydm.widgets.run_control          import RunControl
 from pyrogue.pydm.widgets.system_log           import SystemLog
 from pyrogue.pydm.widgets.terminal             import LinuxTerminal, TerminalPanel
+from pyrogue.pydm.widgets.ipython              import IPythonPanel
 from pyrogue.pydm.widgets.system_window        import SystemWindow
 from pyrogue.pydm.widgets.debug_tree           import DebugTree
 from pyrogue.pydm.widgets.process              import Process

--- a/python/pyrogue/pydm/widgets/__init__.py
+++ b/python/pyrogue/pydm/widgets/__init__.py
@@ -19,6 +19,7 @@ from pyrogue.pydm.widgets.data_writer          import DataWriter
 from pyrogue.pydm.widgets.root_control         import RootControl
 from pyrogue.pydm.widgets.run_control          import RunControl
 from pyrogue.pydm.widgets.system_log           import SystemLog
+from pyrogue.pydm.widgets.terminal             import LinuxTerminal, TerminalPanel
 from pyrogue.pydm.widgets.system_window        import SystemWindow
 from pyrogue.pydm.widgets.debug_tree           import DebugTree
 from pyrogue.pydm.widgets.process              import Process

--- a/python/pyrogue/pydm/widgets/ipython.py
+++ b/python/pyrogue/pydm/widgets/ipython.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       PyRogue PyDM Embedded IPython Console Widget
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+from qtpy.QtWidgets import QWidget
+
+from pyrogue.pydm.data_plugins.rogue_plugin import parseAddress
+from pyrogue.pydm.widgets.ipython_core import ipythonArgv
+from pyrogue.pydm.widgets.terminal import TerminalPanel
+
+# Same server index the System and Debug Tree tabs bind to, so the console talks
+# to whatever ROGUE_SERVERS entry the rest of the GUI is using.
+DEFAULT_CHANNEL = 'rogue://0/root'
+
+
+class IPythonPanel(TerminalPanel):
+    """An IPython session with a connected Rogue client, in a detachable tab.
+
+    A pseudo-terminal running IPython, with
+    :class:`pyrogue.interfaces.VirtualClient` already connected and bound as
+    ``client``, and the tree root as ``root``. It is the session the Rogue server
+    suggests at startup, opened for the user instead of typed out.
+
+    The console runs on the machine displaying the GUI as the user who launched
+    it, **not** on the Rogue server, and it reaches the tree the same way any
+    other client does, over ZMQ. Anyone who can reach the GUI window can run
+    arbitrary Python, and anything Python can reach, with that user's privileges,
+    which is why the feature is opt-in.
+
+    The connection is its own client in its own process, not the one the PyDM
+    channels share, so a session that is stopped or wedged from the prompt cannot
+    take the rest of the GUI's channels with it.
+
+    IPython starts on first display rather than on construction, so enabling the
+    feature costs nothing until the tab is opened, and the up to five second
+    connection attempt never delays the GUI coming up. Exiting the session starts
+    a fresh, reconnected one.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    init_channel : str | None, optional
+        Rogue channel whose server the client connects to. Defaults to
+        ``rogue://0/root``, the first entry of ``ROGUE_SERVERS``.
+    """
+
+    def __init__(self, parent: QWidget | None = None,
+                 init_channel: str | None = None) -> None:
+        addr, port, _path, _mode, _index = parseAddress(init_channel or DEFAULT_CHANNEL)
+
+        TerminalPanel.__init__(
+            self, parent,
+            argv=ipythonArgv(addr, port),
+            label='IPython',
+            windowTitle=f'Rogue IPython Console: {addr}:{port}',
+            noun='console',
+        )

--- a/python/pyrogue/pydm/widgets/ipython_core.py
+++ b/python/pyrogue/pydm/widgets/ipython_core.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       PyRogue PyDM Embedded IPython Console Startup Support
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# This module deliberately imports no Qt. It builds the command line that starts
+# the console and the code that runs inside it before the user gets the prompt,
+# so both stay testable in a CI environment with no Qt binding.
+
+import sys
+
+
+def startupCode(addr: str, port: int) -> str:
+    """Return the code IPython runs before handing over the prompt.
+
+    Connects a :class:`pyrogue.interfaces.VirtualClient` and leaves it bound as
+    ``client``, with the tree root as ``root``, which is the naming the Rogue
+    server itself suggests when it starts and the one the notebooks and docs use.
+
+    A failure to connect is caught rather than left to propagate. The console is
+    still useful without a link, and the user gets the exact line to retry with
+    once the server is up. ``VirtualClient`` prints its own connection banner, so
+    the success path only names what is now in scope.
+
+    Parameters
+    ----------
+    addr : str
+        Rogue server host name or address.
+    port : int
+        Rogue server base ZMQ port.
+
+    Returns
+    -------
+    str
+        Python source, passed to IPython as a single ``-c`` argument.
+    """
+    # The address is only ever interpolated through repr(): into the call as a
+    # literal, and into the messages as whole pre-built strings. Interpolating it
+    # into a quoted message directly would collide with its own quoting.
+    connect = f"pr.interfaces.VirtualClient(addr={addr!r}, port={port})"
+    ready = "Rogue console: 'client' and 'root' are ready"
+    failed = f"Rogue console: cannot reach {addr}:{port}: "
+    retry = f"Retry with: client = {connect}"
+
+    return (
+        "import pyrogue as pr\n"
+        # Importing the package alone does not bind the interfaces submodule, so
+        # without this the client construction fails with an AttributeError.
+        "import pyrogue.interfaces\n"
+        "\n"
+        "try:\n"
+        f"    client = {connect}\n"
+        "    root = client.root\n"
+        f"    print({ready!r})\n"
+        "except Exception as exc:\n"
+        f"    print({failed!r} + str(exc))\n"
+        f"    print({retry!r})\n"
+    )
+
+
+def ipythonArgv(addr: str, port: int, executable: str | None = None) -> list[str]:
+    """Return the argv that starts IPython with the client already connected.
+
+    Started as ``-m IPython`` on the interpreter running the GUI rather than
+    through an ``ipython`` found on ``PATH``. A console that runs on a different
+    interpreter would import a different, or no, ``pyrogue``, and would not see
+    the ``PYTHONPATH`` of a local Rogue build.
+
+    ``-i`` is what keeps the session alive after the ``-c`` code has run, so the
+    connected client stays in the namespace the user types into.
+
+    Parameters
+    ----------
+    addr : str
+        Rogue server host name or address.
+    port : int
+        Rogue server base ZMQ port.
+    executable : str | None, optional
+        Interpreter to run. Defaults to the running interpreter.
+
+    Returns
+    -------
+    list[str]
+        Argument vector suitable for
+        :func:`pyrogue.pydm.widgets.terminal_core.spawnShell`.
+    """
+    return [
+        executable or sys.executable,
+        '-m', 'IPython',
+        # Exiting is how the session is restarted, so a confirmation prompt would
+        # only be in the way.
+        '--no-confirm-exit',
+        # Completing on the tree is the reason the console exists, and jedi
+        # cannot do it: its static analysis crashes on the dynamic __getattr__
+        # nodes with "'TreeInstance' object has no attribute 'with_generics'",
+        # and IPython then offers that crash text as the only candidate, so Tab
+        # appears to do nothing after `root.`. IPython's own completer works
+        # from dir(), which the tree answers correctly. Even without the crash
+        # jedi would refuse to resolve attributes it has to call __getattr__
+        # for, so this is not a workaround for one broken version.
+        '--IPCompleter.use_jedi=False',
+        '-i',
+        '-c', startupCode(addr, port),
+    ]

--- a/python/pyrogue/pydm/widgets/terminal.py
+++ b/python/pyrogue/pydm/widgets/terminal.py
@@ -256,11 +256,17 @@ class LinuxTerminal(QPlainTextEdit):
     ----------
     parent : QWidget | None, optional
         Parent Qt widget.
+    argv : list[str] | None, optional
+        Program to run on the pseudo-terminal. Defaults to the user's login
+        shell. Restarting reuses this, so a program that exits is replaced by
+        the same program rather than by a shell.
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None, *,
+                 argv: list[str] | None = None) -> None:
         QPlainTextEdit.__init__(self, parent)
 
+        self._argv = argv
         self._masterFd = -1
         self._proc = None
         self._readNotifier = None
@@ -449,7 +455,8 @@ class LinuxTerminal(QPlainTextEdit):
         self._sawInput = False
 
         try:
-            self._proc, self._masterFd = spawnShell(self._screen.lines, self._screen.columns)
+            self._proc, self._masterFd = spawnShell(self._screen.lines, self._screen.columns,
+                                                    argv=self._argv)
         except (OSError, ValueError) as exc:
             self._notice(f'[cannot start a shell: {exc}]')
             return
@@ -890,19 +897,35 @@ class TerminalPanel(QWidget):
     ----------
     parent : QWidget | None, optional
         Parent Qt widget.
+    argv : list[str] | None, optional
+        Program to run, passed through to :class:`LinuxTerminal`. Defaults to
+        the user's login shell.
+    label : str, optional
+        Tab label to restore when reattaching.
+    windowTitle : str, optional
+        Title of the detached window.
+    noun : str, optional
+        What the detach button tooltips call the contents.
     """
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, parent: QWidget | None = None, *,
+                 argv: list[str] | None = None,
+                 label: str = 'Terminal',
+                 windowTitle: str = 'Rogue Terminal',
+                 noun: str = 'terminal') -> None:
         QWidget.__init__(self, parent)
 
         self._tab = None
         self._tabIndex = 0
-        self._tabLabel = 'Terminal'
+        self._tabLabel = label
+        self._windowTitle = windowTitle
+        self._attachTip = f'Move the {noun} into its own window'
+        self._detachTip = f'Put the {noun} back in the main window'
 
-        self.terminal = LinuxTerminal(parent=None)
+        self.terminal = LinuxTerminal(parent=None, argv=argv)
 
         self._button = QPushButton('Detach')
-        self._button.setToolTip('Move the terminal into its own window')
+        self._button.setToolTip(self._attachTip)
         # No focus, so clicking it does not take the keyboard away from the
         # shell and Tab completion is never captured by the button.
         self._button.setFocusPolicy(Qt.NoFocus)
@@ -966,11 +989,11 @@ class TerminalPanel(QWidget):
         # the GUI, so closing the GUI takes it down too instead of leaving a
         # stray window keeping the process alive.
         self.setParent(owner, Qt.Window)
-        self.setWindowTitle('Rogue Terminal')
+        self.setWindowTitle(self._windowTitle)
         self.resize(*_DETACHED_SIZE)
 
         self._button.setText('Reattach')
-        self._button.setToolTip('Put the terminal back in the main window')
+        self._button.setToolTip(self._detachTip)
 
         self.show()
         self.raise_()
@@ -994,7 +1017,7 @@ class TerminalPanel(QWidget):
         tab.setCurrentIndex(index)
 
         self._button.setText('Detach')
-        self._button.setToolTip('Move the terminal into its own window')
+        self._button.setToolTip(self._attachTip)
 
         self.terminal.setFocus(Qt.OtherFocusReason)
 

--- a/python/pyrogue/pydm/widgets/terminal.py
+++ b/python/pyrogue/pydm/widgets/terminal.py
@@ -1,0 +1,1016 @@
+from __future__ import annotations
+
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       PyRogue PyDM Embedded Linux Terminal Widget
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+import errno
+import os
+import re
+
+import pyte
+import pyte.graphics
+from qtpy.QtCore import QSocketNotifier, QTimer, Qt
+from qtpy.QtGui import (
+    QColor,
+    QFont,
+    QFontDatabase,
+    QFontMetricsF,
+    QPalette,
+    QTextCharFormat,
+    QTextCursor,
+)
+from qtpy.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QPlainTextEdit,
+    QPushButton,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from pyrogue.pydm.widgets.terminal_core import (
+    SCROLLBACK_LINES,
+    TerminalScreen,
+    closeShell,
+    computeGrid,
+    screenRuns,
+    setWinSize,
+    spawnShell,
+)
+
+# Repaint coalescing interval in milliseconds. A shell dumping output arrives as
+# many small reads; without coalescing each one would trigger a full repaint.
+_REPAINT_MS = 30
+
+# Resize debounce. Every TIOCSWINSZ raises SIGWINCH and an interactive shell
+# redraws its prompt, so dragging a window edge would otherwise storm the pty.
+_RESIZE_MS = 50
+
+_READ_CHUNK = 8192
+
+# Ceiling on bytes absorbed per readable notification. pyte's feed() is pure
+# Python, so an unbounded drain of `cat bigfile` would stall the event loop for
+# seconds. QSocketNotifier is level triggered, so the remainder simply re-fires
+# on the next event loop turn and the GUI stays responsive.
+_MAX_BYTES_PER_POLL = 64 * 1024
+
+# pyte stores DEC private modes shifted left by 5. 2004 is bracketed paste,
+# which bash enables by default from 5.1 onward.
+_BRACKETED_PASTE = 2004 << 5
+
+# Size of the detached terminal window, used only when it has no better hint.
+_DETACHED_SIZE = (900, 600)
+
+# A shell that exits without the user having typed anything was not exited on
+# purpose, it failed to start. After this many such exits in a row the terminal
+# stops restarting, so a shell that cannot run does not spawn in a loop.
+#
+# Elapsed time is deliberately not used to make this distinction. Exiting twice
+# in quick succession is something a user can easily do, and treating that as a
+# failure would dead-end the terminal exactly as it did before it restarted.
+_MAX_STARTUP_FAILURES = 3
+
+# Dark theme. A terminal is read as a terminal, so it keeps its own colors
+# rather than following the surrounding PyDM palette.
+_COLOR_BG = '#1e1e1e'
+_COLOR_FG = '#d4d4d4'
+_COLOR_SELECTION = '#264f78'
+
+# pyte names the eight base colors after the SGR 30-37 order, so a name maps
+# straight onto an index into its own 256 color table. Entries 0-7 are the
+# normal shades and 8-15 the bright ones, which keeps the palette in one place
+# instead of a hand-maintained copy.
+_COLOR_INDEX = {name: index for index, name in enumerate(
+    ('black', 'red', 'green', 'brown', 'blue', 'magenta', 'cyan', 'white'))}
+
+# 256 color and 24 bit values arrive from pyte already as six hex digits.
+_HEX_COLOR = re.compile(r'[0-9a-fA-F]{6}')
+
+
+def resolveColor(value: str, bright: bool = False) -> QColor | None:
+    """Map a ``pyte`` color to a ``QColor``.
+
+    Parameters
+    ----------
+    value : str
+        Colour as pyte reports it: ``'default'``, one of the eight base names,
+        a ``bright``-prefixed name, or six hex digits for 256 colour and 24 bit.
+    bright : bool, optional
+        Select the bright shade of a base name. Bold text is rendered in the
+        bright shade, which is the convention every colorizing tool assumes.
+
+    Returns
+    -------
+    QColor | None
+        ``None`` when the value is the default or is not recognised, so the
+        caller can fall back to the theme colour. pyte's own tables contain at
+        least one misspelled name, so unrecognised input has to be tolerated.
+    """
+    if not value or value == 'default':
+        return None
+
+    name = value[6:] if value.startswith('bright') else value
+    index = _COLOR_INDEX.get(name)
+
+    if index is not None:
+        if bright or value.startswith('bright'):
+            index += 8
+        return QColor('#' + pyte.graphics.FG_BG_256[index])
+
+    if _HEX_COLOR.fullmatch(value):
+        return QColor('#' + value)
+
+    return None
+
+
+def keyToBytes(key: int, modifiers: int, text: str) -> bytes:
+    """Translate a Qt key press into the byte sequence a terminal expects.
+
+    Kept free of ``QKeyEvent`` so it can be unit tested without constructing a
+    ``QApplication``. The sequences follow the ``xterm`` conventions, matching
+    the ``TERM`` value exported to the child shell. Changing one requires
+    changing the other.
+
+    Parameters
+    ----------
+    key : int
+        Qt key code, for example ``Qt.Key_Up``.
+    modifiers : int
+        Qt keyboard modifier flags.
+    text : str
+        Text the key event produced, used for ordinary printable input.
+
+    Returns
+    -------
+    bytes
+        Bytes to write to the pty, or ``b''`` when the key produces no input.
+
+    Notes
+    -----
+    Ctrl-C has to reach the shell as ``ETX`` so it can interrupt the foreground
+    job, so copy and paste are bound to Ctrl+Shift+C and Ctrl+Shift+V. Those
+    two chords return ``b''`` here and are handled as clipboard actions by the
+    widget.
+    """
+    ctrl = bool(modifiers & Qt.ControlModifier)
+    shift = bool(modifiers & Qt.ShiftModifier)
+    alt = bool(modifiers & Qt.AltModifier)
+
+    if ctrl and shift and key in (Qt.Key_C, Qt.Key_V):
+        return b''
+
+    if key in (Qt.Key_Shift, Qt.Key_Control, Qt.Key_Alt, Qt.Key_Meta,
+               Qt.Key_CapsLock, Qt.Key_NumLock, Qt.Key_ScrollLock):
+        return b''
+
+    # Control characters are computed rather than taken from text(), which Qt
+    # populates for Ctrl+A..Z on some platforms but not for Ctrl+Space or the
+    # bracket group.
+    if ctrl and not alt:
+        if key == Qt.Key_Space:
+            return b'\x00'
+        if Qt.Key_A <= key <= Qt.Key_Underscore:
+            return bytes([key & 0x1f])
+
+    simple = {
+        Qt.Key_Return:    b'\r',
+        Qt.Key_Enter:     b'\r',
+        Qt.Key_Backspace: b'\x7f',
+        Qt.Key_Tab:       b'\t',
+        Qt.Key_Backtab:   b'\x1b[Z',
+        Qt.Key_Escape:    b'\x1b',
+        Qt.Key_Up:        b'\x1b[A',
+        Qt.Key_Down:      b'\x1b[B',
+        Qt.Key_Right:     b'\x1b[C',
+        Qt.Key_Left:      b'\x1b[D',
+        Qt.Key_Home:      b'\x1b[H',
+        Qt.Key_End:       b'\x1b[F',
+        Qt.Key_Insert:    b'\x1b[2~',
+        Qt.Key_Delete:    b'\x1b[3~',
+        Qt.Key_PageUp:    b'\x1b[5~',
+        Qt.Key_PageDown:  b'\x1b[6~',
+        Qt.Key_F1:        b'\x1bOP',
+        Qt.Key_F2:        b'\x1bOQ',
+        Qt.Key_F3:        b'\x1bOR',
+        Qt.Key_F4:        b'\x1bOS',
+        Qt.Key_F5:        b'\x1b[15~',
+        Qt.Key_F6:        b'\x1b[17~',
+        Qt.Key_F7:        b'\x1b[18~',
+        Qt.Key_F8:        b'\x1b[19~',
+        Qt.Key_F9:        b'\x1b[20~',
+        Qt.Key_F10:       b'\x1b[21~',
+        Qt.Key_F11:       b'\x1b[23~',
+        Qt.Key_F12:       b'\x1b[24~',
+    }
+
+    # Named keys are matched before text() because Qt reports text() as '\x08'
+    # for Backspace and '\r' for Return, and readline wants DEL for Backspace.
+    seq = simple.get(key)
+    if seq is not None:
+        return (b'\x1b' + seq) if alt else seq
+
+    if text:
+        data = text.encode('utf-8', errors='replace')
+        return (b'\x1b' + data) if alt else data
+
+    return b''
+
+
+class LinuxTerminal(QPlainTextEdit):
+    """Interactive local shell rendered into a read-only text view.
+
+    A shell is spawned on a pseudo-terminal, its output is fed to a ``pyte``
+    screen emulator, and that screen is painted into this widget.
+
+    The shell is a child of the GUI process, so it runs on the machine
+    displaying the GUI as the user who launched it, **not** on the Rogue server.
+    Anyone who can reach the GUI window gets an interactive shell with that
+    user's privileges, which is why the feature is opt-in.
+
+    The shell starts on first display rather than on construction, so enabling
+    the feature costs nothing until the tab is actually opened.
+
+    The view is dark themed and keeps a bounded scrollback above the live
+    screen, so output can be scrolled back through. Scrolling up pins the view
+    in place; new output only follows the bottom when the view is already there.
+
+    Rendering is monochrome. ``pyte`` does not implement the alternate screen
+    buffer, so full screen programs such as ``vim`` and ``htop`` work but leave
+    their last frame behind on exit instead of restoring the previous screen.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        QPlainTextEdit.__init__(self, parent)
+
+        self._masterFd = -1
+        self._proc = None
+        self._readNotifier = None
+        self._writeNotifier = None
+        self._writeBuf = bytearray()
+        self._spawned = False
+        self._finished = False
+        self._sawInput = False
+        self._startupFailures = 0
+
+        # Number of blocks at the end of the document holding the live screen.
+        # Everything before them is committed scrollback and never rewritten.
+        self._liveRows = 0
+
+        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        font.setStyleHint(QFont.Monospace)
+        font.setFixedPitch(True)
+        self.setFont(font)
+        self.document().setDefaultFont(font)
+        self.document().setDocumentMargin(0.0)
+
+        self.setReadOnly(True)
+        self.setUndoRedoEnabled(False)
+        self.setLineWrapMode(QPlainTextEdit.NoWrap)
+        self.setFocusPolicy(Qt.StrongFocus)
+
+        # Always on rather than as-needed: an as-needed bar appears and
+        # disappears as content crosses the viewport height, and because the bar
+        # takes horizontal space that changes the column count, which can
+        # oscillate.
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        self._applyDarkTheme()
+
+        self._cellWidth, self._cellHeight = self._measureCell()
+
+        self._themeFg = QColor(_COLOR_FG)
+        self._themeBg = QColor(_COLOR_BG)
+
+        # Keyed on the pyte attribute tuple. Real output uses only a handful of
+        # distinct combinations, so this stays tiny.
+        self._formatCache = {}
+
+        cols, rows = computeGrid(self.viewport().width(), self.viewport().height(),
+                                 self._cellWidth, self._cellHeight)
+        self._screen = TerminalScreen(cols, rows, self.writeBytes)
+        self._stream = pyte.ByteStream(self._screen)
+        self._setBlockLimit(rows)
+
+        self._repaintTimer = QTimer(self)
+        self._repaintTimer.setSingleShot(True)
+        self._repaintTimer.timeout.connect(self._repaint)
+
+        self._resizeTimer = QTimer(self)
+        self._resizeTimer.setSingleShot(True)
+        self._resizeTimer.timeout.connect(self._applyGeometry)
+
+        # Qt does not deliver a close event to a non-window child widget when
+        # its parent is destroyed, so the shell is reaped from application
+        # shutdown instead.
+        app = QApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self.shutdown)
+
+    def _applyDarkTheme(self) -> None:
+        """Give the view its own dark palette.
+
+        Both a palette and a style sheet are set. The palette keeps derived
+        colors such as the selection consistent, and the style sheet makes the
+        result survive an application-wide PyDM style sheet, which would
+        otherwise win over the palette.
+        """
+        palette = self.palette()
+        palette.setColor(QPalette.Base, QColor(_COLOR_BG))
+        palette.setColor(QPalette.Text, QColor(_COLOR_FG))
+        palette.setColor(QPalette.Highlight, QColor(_COLOR_SELECTION))
+        palette.setColor(QPalette.HighlightedText, QColor(_COLOR_FG))
+        self.setPalette(palette)
+
+        self.setStyleSheet(
+            'QPlainTextEdit {'
+            f' background-color: {_COLOR_BG};'
+            f' color: {_COLOR_FG};'
+            f' selection-background-color: {_COLOR_SELECTION};'
+            f' selection-color: {_COLOR_FG};'
+            ' border: none; }'
+        )
+
+    def _colors(self, fg: str, bg: str, bold: bool, reverse: bool) -> tuple[QColor, QColor]:
+        """Resolve a cell's foreground and background to concrete colors."""
+        foreground = resolveColor(fg, bright=bold) or self._themeFg
+        # Bold brightens the text, never the background.
+        background = resolveColor(bg) or self._themeBg
+
+        if reverse:
+            foreground, background = background, foreground
+
+        return (foreground, background)
+
+    def _formatFor(self, attrs: tuple) -> QTextCharFormat:
+        """Return the character format for a ``pyte`` attribute tuple.
+
+        ``attrs`` is a ``Char`` with the data removed, so
+        ``(fg, bg, bold, italics, underscore, strikethrough, reverse, blink)``.
+        Blink is deliberately ignored.
+        """
+        cached = self._formatCache.get(attrs)
+        if cached is not None:
+            return cached
+
+        fg, bg, bold, italics, underscore, strikethrough, reverse, _blink = attrs
+        foreground, background = self._colors(fg, bg, bold, reverse)
+
+        fmt = QTextCharFormat()
+        fmt.setForeground(foreground)
+
+        # Only paint a background when it differs from the view, so ordinary
+        # text is not covered in same-colored rectangles.
+        if background != self._themeBg:
+            fmt.setBackground(background)
+
+        if bold:
+            fmt.setFontWeight(QFont.Bold)
+        if italics:
+            fmt.setFontItalic(True)
+        if underscore:
+            fmt.setFontUnderline(True)
+        if strikethrough:
+            fmt.setFontStrikeOut(True)
+
+        self._formatCache[attrs] = fmt
+        return fmt
+
+    def _setBlockLimit(self, rows: int) -> None:
+        """Bound the document to the scrollback plus the live screen.
+
+        Qt drops the oldest blocks once the limit is reached, which is what
+        keeps a long-lived terminal from growing without bound.
+        """
+        self.document().setMaximumBlockCount(SCROLLBACK_LINES + rows)
+
+    def _measureCell(self) -> tuple[float, float]:
+        """Measure one character cell, avoiding integer rounding drift.
+
+        The row height comes from the document layout rather than the font
+        metrics. ``QFontMetricsF.lineSpacing()`` can be smaller than the height
+        Qt actually gives a text block, and dividing the viewport by the smaller
+        value yields one row more than really fits, which leaves the top row
+        permanently scrolled out of view.
+        """
+        fm = QFontMetricsF(self.font())
+        width = max(1.0, fm.horizontalAdvance('M'))
+
+        height = 0.0
+        layout = self.document().documentLayout()
+        if layout is not None:
+            height = layout.blockBoundingRect(self.document().firstBlock()).height()
+
+        if height <= 0.0:
+            height = fm.height()
+
+        return (width, max(1.0, height))
+
+    def _viewportRows(self) -> int:
+        """Return how many text rows the viewport can display."""
+        return max(1, int(self.viewport().height() // self._cellHeight))
+
+    def showEvent(self, event) -> None:
+        """Spawn the shell on first display and take the keyboard.
+
+        Clicking a tab in a ``QTabWidget`` leaves the keyboard focus on the tab
+        bar, so without this the terminal would appear ready but swallow nothing
+        until it was clicked a second time.
+        """
+        QPlainTextEdit.showEvent(self, event)
+
+        if not self._spawned:
+            self._spawned = True
+            self._spawn()
+
+        self.setFocus(Qt.OtherFocusReason)
+
+    def _spawn(self) -> None:
+        """Start a shell on a new pseudo-terminal."""
+        self._sawInput = False
+
+        try:
+            self._proc, self._masterFd = spawnShell(self._screen.lines, self._screen.columns)
+        except (OSError, ValueError) as exc:
+            self._notice(f'[cannot start a shell: {exc}]')
+            return
+
+        self._readNotifier = QSocketNotifier(self._masterFd, QSocketNotifier.Read, self)
+        self._readNotifier.activated.connect(self._onReadable)
+
+    def restart(self) -> None:
+        """Discard the current session and start a fresh shell.
+
+        Returns the terminal to the state it had when the GUI was opened: an
+        empty screen, no scrollback, and a new prompt.
+        """
+        self._closeProcess()
+        self._releaseNotifiers()
+        self._writeBuf.clear()
+        self._finished = False
+
+        # A new screen rather than a reset one, so no emulator state can carry
+        # over from the old session.
+        self._screen = TerminalScreen(self._screen.columns, self._screen.lines, self.writeBytes)
+        self._stream = pyte.ByteStream(self._screen)
+
+        self._repaintTimer.stop()
+        self._liveRows = 0
+        self.clear()
+        self.setExtraSelections([])
+
+        self._spawned = True
+        self._spawn()
+
+    def _releaseNotifiers(self) -> None:
+        """Drop the socket notifiers so new ones can be bound to a new pty."""
+        for name in ('_readNotifier', '_writeNotifier'):
+            notifier = getattr(self, name)
+            if notifier is not None:
+                notifier.setEnabled(False)
+                notifier.deleteLater()
+                setattr(self, name, None)
+
+    def _onReadable(self, *_args) -> None:
+        """Drain the pty master into the screen emulator.
+
+        Accepts extra arguments because the ``activated`` signal carries an int
+        on Qt 5 and a ``QSocketDescriptor`` plus a type on Qt 6.
+        """
+        if self._finished or self._masterFd < 0:
+            return
+
+        # The notifier is level triggered, so it is disabled for the duration of
+        # the handler to prevent re-entrancy.
+        self._readNotifier.setEnabled(False)
+        total = 0
+
+        try:
+            while total < _MAX_BYTES_PER_POLL:
+                try:
+                    chunk = os.read(self._masterFd, _READ_CHUNK)
+                except BlockingIOError:
+                    break
+                except InterruptedError:
+                    continue
+                except OSError as exc:
+                    # Linux raises EIO on the master once the child is gone
+                    # rather than returning an empty read. macOS returns b''.
+                    if exc.errno in (errno.EIO, errno.EBADF):
+                        self._onChildGone()
+                        return
+                    raise
+
+                if not chunk:
+                    self._onChildGone()
+                    return
+
+                total += len(chunk)
+                # ByteStream keeps an incremental UTF-8 decoder, so a multi-byte
+                # character split across reads is reassembled for us.
+                self._stream.feed(chunk)
+
+            self._armRepaint()
+        finally:
+            if not self._finished and self._readNotifier is not None:
+                self._readNotifier.setEnabled(True)
+
+    def writeBytes(self, data: bytes) -> None:
+        """Queue bytes for the child process.
+
+        Parameters
+        ----------
+        data : bytes
+            Bytes to send to the shell.
+        """
+        if self._masterFd < 0 or not data:
+            return
+
+        self._writeBuf += data
+        self._flushWrite()
+
+    def _flushWrite(self) -> None:
+        """Push as much of the write queue as the pty will take."""
+        while self._writeBuf:
+            try:
+                written = os.write(self._masterFd, bytes(self._writeBuf[:_READ_CHUNK]))
+            except BlockingIOError:
+                # The pty buffer is full, which a large paste will do. Finish
+                # from a write notifier instead of blocking the GUI thread.
+                self._enableWriteNotifier()
+                return
+            except InterruptedError:
+                continue
+            except OSError:
+                self._onChildGone()
+                return
+
+            del self._writeBuf[:written]
+
+        self._disableWriteNotifier()
+
+    def _enableWriteNotifier(self) -> None:
+        """Arm the write notifier so a stalled write can finish later."""
+        if self._writeNotifier is None:
+            self._writeNotifier = QSocketNotifier(self._masterFd, QSocketNotifier.Write, self)
+            self._writeNotifier.activated.connect(self._onWritable)
+
+        self._writeNotifier.setEnabled(True)
+
+    def _disableWriteNotifier(self) -> None:
+        """Disarm the write notifier.
+
+        A write notifier left enabled on a writable descriptor fires on every
+        event loop iteration, which is a busy spin at 100% CPU.
+        """
+        if self._writeNotifier is not None:
+            self._writeNotifier.setEnabled(False)
+
+    def _onWritable(self, *_args) -> None:
+        """Continue a write that previously filled the pty buffer."""
+        if self._finished or self._masterFd < 0:
+            self._disableWriteNotifier()
+            return
+
+        self._flushWrite()
+
+    def _armRepaint(self) -> None:
+        """Schedule a coalesced repaint. An idle terminal costs nothing."""
+        if not self._repaintTimer.isActive():
+            self._repaintTimer.start(_REPAINT_MS)
+
+    def _repaint(self) -> None:
+        """Commit scrolled-off lines, repaint the live screen, place the cursor.
+
+        Only the tail of the document is rewritten. Replacing the whole document
+        would be both wasteful and wrong: it resets the scroll position, so any
+        output would yank a user who had scrolled up back to the bottom.
+        """
+        screen = self._screen
+
+        pending = []
+        while screen.scrolledOff:
+            pending.append(screen.scrolledOff.popleft())
+
+        if not screen.dirty and not pending:
+            return
+
+        # pyte never clears this; the consumer is required to.
+        screen.dirty.clear()
+
+        # The whole emulated grid, blank rows included. A terminal is a fixed
+        # grid of rows, and the shell decides where in it the cursor sits, so
+        # trimming blank rows would break anything that positions within the
+        # screen. It is also what makes `clear` work: the cleared grid has to
+        # cover the viewport, otherwise the scrollback underneath shows through.
+        live = screenRuns(screen)
+        doc = self.document()
+        scrollBar = self.verticalScrollBar()
+
+        # Follow new output only when the view is already at the bottom, so
+        # scrolling back to read is not undone by the next line of output.
+        follow = scrollBar.value() >= scrollBar.maximum() - 1
+
+        cursor = QTextCursor(doc)
+        cursor.beginEditBlock()
+
+        if self._liveRows == 0:
+            cursor.select(QTextCursor.Document)
+            cursor.removeSelectedText()
+        else:
+            # Removing to the end leaves the first live block in place but
+            # empty, so the following insert lands in it with no extra newline.
+            first = max(0, doc.blockCount() - self._liveRows)
+            cursor.setPosition(doc.findBlockByNumber(first).position())
+            cursor.movePosition(QTextCursor.End, QTextCursor.KeepAnchor)
+            cursor.removeSelectedText()
+
+        for index, runs in enumerate(pending + live):
+            if index:
+                cursor.insertText('\n')
+            for text, attrs in runs:
+                if text:
+                    cursor.insertText(text, self._formatFor(attrs))
+
+        cursor.endEditBlock()
+
+        self._liveRows = len(live)
+
+        if follow:
+            scrollBar.setValue(scrollBar.maximum())
+
+        self._applyCursor()
+
+    def _applyCursor(self) -> None:
+        """Draw the terminal cursor as an inverted cell."""
+        cursor = self._screen.cursor
+
+        if cursor.hidden:
+            self.setExtraSelections([])
+            return
+
+        doc = self.document()
+
+        # The live screen occupies the last _liveRows blocks, so the cursor row
+        # is an offset into that region rather than an absolute block number.
+        liveStart = max(0, doc.blockCount() - self._liveRows)
+        block = doc.findBlockByNumber(min(liveStart + cursor.y, doc.blockCount() - 1))
+
+        if not block.isValid():
+            return
+
+        # A row can be shorter than the screen width when it holds double width
+        # characters, so clamp rather than trusting the column.
+        column = min(cursor.x, max(0, block.length() - 1))
+
+        selection = QTextEdit.ExtraSelection()
+        selection.cursor = QTextCursor(block)
+        selection.cursor.setPosition(block.position() + column)
+        selection.cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
+        selection.format = self._cursorFormatAt(cursor.y, cursor.x)
+        self.setExtraSelections([selection])
+
+    def _cursorFormatAt(self, row: int, column: int) -> QTextCharFormat:
+        """Build the cursor block by inverting the colors of the cell under it.
+
+        Inverting fixed theme colors instead would make the cursor disappear
+        wherever it happens to land on text that is already close to those
+        colors.
+        """
+        cell = self._screen.buffer[row][column]
+        foreground, background = self._colors(cell.fg, cell.bg, cell.bold, cell.reverse)
+
+        fmt = QTextCharFormat()
+        fmt.setForeground(background)
+        fmt.setBackground(foreground)
+        return fmt
+
+    def keyPressEvent(self, event) -> None:
+        """Forward key presses to the shell instead of editing the view."""
+        modifiers = event.modifiers()
+        key = event.key()
+
+        # Copy stays available after the shell exits so output can be salvaged.
+        if (modifiers & Qt.ControlModifier) and (modifiers & Qt.ShiftModifier):
+            if key == Qt.Key_C:
+                self.copy()
+                event.accept()
+                return
+            if key == Qt.Key_V:
+                self._paste()
+                event.accept()
+                return
+
+        self.sendInput(keyToBytes(key, modifiers, event.text()))
+        event.accept()
+
+    def sendInput(self, data: bytes) -> None:
+        """Send user input to the shell.
+
+        Separate from :meth:`writeBytes` because the emulator also writes to the
+        pty on its own to answer terminal queries. Only real input shows that the
+        session reached a usable state, which is what distinguishes a user
+        exiting a shell from a shell that never started.
+
+        Parameters
+        ----------
+        data : bytes
+            Bytes produced by a key press or a paste.
+        """
+        if not data:
+            return
+
+        self._sawInput = True
+        self.writeBytes(data)
+
+    def _paste(self) -> None:
+        """Send the clipboard to the shell."""
+        clipboard = QApplication.clipboard()
+        if clipboard is None:
+            return
+
+        text = clipboard.text()
+        if not text:
+            return
+
+        data = text.replace('\r\n', '\r').replace('\n', '\r').encode('utf-8', errors='replace')
+
+        # Without the bracketed paste markers a multi-line paste executes every
+        # line as it arrives, which is a real hazard in a hardware control GUI.
+        if _BRACKETED_PASTE in self._screen.mode:
+            data = b'\x1b[200~' + data + b'\x1b[201~'
+
+        self.sendInput(data)
+
+    def focusNextPrevChild(self, forward: bool) -> bool:
+        """Keep Tab for the shell rather than moving focus."""
+        return False
+
+    def inputMethodEvent(self, event) -> None:
+        """Swallow input method events; composition is not supported."""
+        event.accept()
+
+    def resizeEvent(self, event) -> None:
+        """Debounce a geometry change before reflowing the shell."""
+        QPlainTextEdit.resizeEvent(self, event)
+        self._resizeTimer.start(_RESIZE_MS)
+
+    def _applyGeometry(self) -> None:
+        """Reflow the emulated screen and the pty to the current widget size."""
+        cols, rows = computeGrid(self.viewport().width(), self.viewport().height(),
+                                 self._cellWidth, self._cellHeight)
+
+        if cols == self._screen.columns and rows == self._screen.lines:
+            return
+
+        # pyte.Screen() takes columns first but Screen.resize() takes lines
+        # first, and struct winsize takes rows first. Pass by keyword where the
+        # API allows it so the ordering cannot silently transpose.
+        self._screen.resize(lines=rows, columns=cols)
+        self._setBlockLimit(rows)
+
+        if self._masterFd >= 0:
+            try:
+                setWinSize(self._masterFd, rows, cols)
+            except OSError:
+                pass
+
+        self._screen.dirty.update(range(rows))
+        self._armRepaint()
+
+    def _notice(self, message: str) -> None:
+        """Show an out-of-band status line in the view.
+
+        Written through the emulator rather than appended directly so it becomes
+        part of the screen, and so it cannot desynchronise the live region
+        accounting in :meth:`_repaint`.
+        """
+        self._stream.feed(f'\r\n{message}\r\n'.encode())
+        self._repaintTimer.stop()
+        self._repaint()
+
+    def _onChildGone(self) -> None:
+        """Handle the shell exiting, normally by starting a fresh one.
+
+        Exiting the shell with ``exit`` or Ctrl-D is easy to do by accident, and
+        leaving a dead terminal behind would mean restarting the whole GUI to get
+        it back, so a new session is started instead.
+        """
+        if self._finished:
+            return
+
+        self._finished = True
+
+        if self._readNotifier is not None:
+            self._readNotifier.setEnabled(False)
+        self._disableWriteNotifier()
+
+        # Exiting is something the user does, so it always follows a keystroke.
+        # A session that ends without one never got started, and restarting it
+        # would spawn processes in a loop.
+        if self._sawInput:
+            self._startupFailures = 0
+        else:
+            self._startupFailures += 1
+
+        if self._startupFailures >= _MAX_STARTUP_FAILURES:
+            status = self._proc.poll() if self._proc is not None else None
+            # Two short lines rather than one long one, so the notice does not
+            # wrap mid word in a narrow terminal.
+            self._stream.feed(
+                f'\r\n[shell exited with status {status}]'
+                f'\r\n[exits immediately, not restarting]\r\n'.encode())
+            self._screen.cursor.hidden = True
+            self._repaintTimer.stop()
+            self._repaint()
+
+            # Defer closing the descriptor out of the notifier callback.
+            QTimer.singleShot(0, self._closeProcess)
+            return
+
+        # Deferred for the same reason: this runs inside the read notifier's own
+        # callback, and it closes the descriptor that notifier is watching.
+        QTimer.singleShot(0, self.restart)
+
+    def _closeProcess(self) -> None:
+        """Close the pty and reap the child. Safe to call more than once."""
+        proc, self._proc = self._proc, None
+        self._masterFd = closeShell(proc, self._masterFd)
+
+    def shutdown(self) -> None:
+        """Stop all I/O and terminate the shell. Safe to call more than once."""
+        self._finished = True
+
+        for notifier in (self._readNotifier, self._writeNotifier):
+            if notifier is not None:
+                notifier.setEnabled(False)
+
+        self._repaintTimer.stop()
+        self._resizeTimer.stop()
+        self._closeProcess()
+
+    def closeEvent(self, event) -> None:
+        """Tear down the shell when this widget is closed as a window."""
+        self.shutdown()
+        QPlainTextEdit.closeEvent(self, event)
+
+
+class TerminalPanel(QWidget):
+    """A :class:`LinuxTerminal` with a button to detach it into its own window.
+
+    Detaching is useful because a tab is only as tall as the window it lives in.
+    A separate window can be sized and placed independently, or moved to another
+    monitor, which makes a long build log or a full screen program readable.
+
+    Reparenting does not disturb the shell. The child process is held by a file
+    descriptor and a socket notifier, neither of which is tied to a window, so
+    detaching and reattaching keep the same shell, its working directory, and
+    its scrollback.
+
+    Parameters
+    ----------
+    parent : QWidget | None, optional
+        Parent Qt widget.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        QWidget.__init__(self, parent)
+
+        self._tab = None
+        self._tabIndex = 0
+        self._tabLabel = 'Terminal'
+
+        self.terminal = LinuxTerminal(parent=None)
+
+        self._button = QPushButton('Detach')
+        self._button.setToolTip('Move the terminal into its own window')
+        # No focus, so clicking it does not take the keyboard away from the
+        # shell and Tab completion is never captured by the button.
+        self._button.setFocusPolicy(Qt.NoFocus)
+        self._button.clicked.connect(self.toggleDetached)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.addWidget(self._button)
+        header.addStretch(1)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(header)
+        layout.addWidget(self.terminal, 1)
+        self.setLayout(layout)
+
+    def isDetached(self) -> bool:
+        """Return whether the terminal is currently its own window."""
+        return self._tab is not None
+
+    def _findTabWidget(self) -> QTabWidget | None:
+        """Return the tab widget this panel is a page of, if any.
+
+        Pages of a ``QTabWidget`` are children of an internal stack widget, so
+        this walks up rather than checking the immediate parent.
+        """
+        widget = self.parentWidget()
+
+        while widget is not None:
+            if isinstance(widget, QTabWidget):
+                return widget
+            widget = widget.parentWidget()
+
+        return None
+
+    def toggleDetached(self) -> None:
+        """Detach into a window, or put it back in its tab."""
+        if self.isDetached():
+            self.reattach()
+        else:
+            self.detach()
+
+    def detach(self) -> None:
+        """Move the terminal out of its tab and into its own window."""
+        if self.isDetached():
+            return
+
+        tab = self._findTabWidget()
+        if tab is None:
+            return
+
+        self._tab = tab
+        self._tabIndex = tab.indexOf(self)
+        self._tabLabel = tab.tabText(self._tabIndex)
+
+        owner = tab.window()
+        tab.removeTab(self._tabIndex)
+
+        # Reparented to the main window rather than to nothing, with the window
+        # flag set. It still behaves as a separate window, but it stays owned by
+        # the GUI, so closing the GUI takes it down too instead of leaving a
+        # stray window keeping the process alive.
+        self.setParent(owner, Qt.Window)
+        self.setWindowTitle('Rogue Terminal')
+        self.resize(*_DETACHED_SIZE)
+
+        self._button.setText('Reattach')
+        self._button.setToolTip('Put the terminal back in the main window')
+
+        self.show()
+        self.raise_()
+        self.activateWindow()
+        self.terminal.setFocus(Qt.OtherFocusReason)
+
+    def reattach(self) -> None:
+        """Put the terminal back where it came from."""
+        if not self.isDetached():
+            return
+
+        tab = self._tab
+        self._tab = None
+
+        # The tab count can have changed while detached, so clamp rather than
+        # trusting the remembered index.
+        index = min(self._tabIndex, tab.count())
+
+        self.setWindowFlags(Qt.Widget)
+        tab.insertTab(index, self, self._tabLabel)
+        tab.setCurrentIndex(index)
+
+        self._button.setText('Detach')
+        self._button.setToolTip('Move the terminal into its own window')
+
+        self.terminal.setFocus(Qt.OtherFocusReason)
+
+    def shutdown(self) -> None:
+        """Terminate the shell. Safe to call more than once."""
+        self.terminal.shutdown()
+
+    def closeEvent(self, event) -> None:
+        """Reattach instead of closing when detached.
+
+        Closing the detached window would otherwise leave the terminal with no
+        way back into the GUI, so the close is treated as a request to reattach.
+        """
+        if self.isDetached():
+            event.ignore()
+            self.reattach()
+            return
+
+        QWidget.closeEvent(self, event)

--- a/python/pyrogue/pydm/widgets/terminal_core.py
+++ b/python/pyrogue/pydm/widgets/terminal_core.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+#-----------------------------------------------------------------------------
+# Company    : SLAC National Accelerator Laboratory
+#-----------------------------------------------------------------------------
+#  Description:
+#       PyRogue PyDM Terminal Pseudo-Terminal And Screen Support
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# This module deliberately imports no Qt. It holds the pseudo-terminal and
+# screen-emulation half of the embedded terminal so that the parts with the
+# least obvious failure modes, controlling-terminal setup, child reaping and
+# descriptor cleanup, stay testable in a CI environment with no Qt binding.
+
+import collections
+import fcntl
+import os
+import shutil
+import signal
+import struct
+import subprocess
+import termios
+import time
+
+import pyte
+from pyte.screens import Margins
+
+# Fallback grid used before a widget has been laid out.
+DEFAULT_COLS = 80
+DEFAULT_ROWS = 24
+
+# Smallest grid worth emulating, so a collapsed splitter cannot produce a 0x0
+# screen and make cursor arithmetic meaningless.
+MIN_COLS = 20
+MIN_ROWS = 4
+
+# How long to wait for a shell to honor SIGHUP before sending SIGKILL.
+HUP_WAIT_S = 0.3
+
+# Lines of scrollback retained above the live screen.
+SCROLLBACK_LINES = 2000
+
+# Run through /bin/sh, which reopens the pty slave from inside the new session
+# so that it becomes the controlling terminal, then execs the real program over
+# itself. $1 is the slave path and the rest is the command. See spawnShell.
+_CTTY_SCRIPT = 'exec 0<>"$1" 1>&0 2>&0; shift; exec "$@"'
+
+
+def computeGrid(width: float, height: float, cellWidth: float, cellHeight: float) -> tuple[int, int]:
+    """Return the ``(columns, lines)`` grid that fits a viewport.
+
+    Parameters
+    ----------
+    width : float
+        Viewport width in pixels.
+    height : float
+        Viewport height in pixels.
+    cellWidth : float
+        Width of one character cell in pixels.
+    cellHeight : float
+        Height of one character cell in pixels.
+
+    Returns
+    -------
+    tuple[int, int]
+        Columns and lines, each clamped to a usable minimum.
+    """
+    if cellWidth <= 0.0 or cellHeight <= 0.0:
+        return (DEFAULT_COLS, DEFAULT_ROWS)
+
+    return (max(MIN_COLS, int(width // cellWidth)),
+            max(MIN_ROWS, int(height // cellHeight)))
+
+
+def resolveShell() -> str:
+    """Return an absolute path to the shell to run.
+
+    Resolved in the parent process so that no ``PATH`` lookup ever happens in a
+    child process.
+
+    Returns
+    -------
+    str
+        Absolute path to an executable shell.
+
+    Raises
+    ------
+    FileNotFoundError
+        If neither ``$SHELL`` nor any known fallback is executable.
+    """
+    candidate = os.environ.get('SHELL') or 'bash'
+    path = candidate if os.path.isabs(candidate) else shutil.which(candidate)
+
+    if path is not None and os.access(path, os.X_OK):
+        return path
+
+    for fallback in ('/bin/bash', '/bin/sh'):
+        if os.access(fallback, os.X_OK):
+            return fallback
+
+    raise FileNotFoundError(f"no usable shell found (tried {candidate!r})")
+
+
+def buildEnv() -> dict[str, str]:
+    """Build the child environment for the shell.
+
+    ``COLUMNS`` and ``LINES`` are removed so that ``TIOCSWINSZ`` stays the
+    single source of truth for geometry.
+
+    Returns
+    -------
+    dict[str, str]
+        Environment for the child process.
+    """
+    env = dict(os.environ)
+    env.pop('COLUMNS', None)
+    env.pop('LINES', None)
+    env['TERM'] = 'xterm'
+    env['TERM_PROGRAM'] = 'pyrogue-pydm-terminal'
+    return env
+
+
+def setWinSize(fd: int, rows: int, cols: int) -> None:
+    """Push a window size onto a pty master.
+
+    ``struct winsize`` is ``{ws_row, ws_col, ws_xpixel, ws_ypixel}``, so rows
+    come first here. That is the opposite order from ``pyte.Screen(columns,
+    lines)``, which is why callers should not pass these positionally without
+    checking.
+
+    Parameters
+    ----------
+    fd : int
+        Pty master descriptor.
+    rows : int
+        Terminal height in characters.
+    cols : int
+        Terminal width in characters.
+    """
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', rows, cols, 0, 0))
+
+
+def spawnShell(rows: int, cols: int, argv: list[str] | None = None, useCtty: bool = True):
+    """Start an interactive shell on a new pseudo-terminal.
+
+    ``subprocess`` is used rather than :func:`pty.fork` because
+    :func:`os.forkpty` raises a ``DeprecationWarning`` in a multi-threaded
+    process from Python 3.12 onward, and the Rogue GUI always has Rogue,
+    ZeroMQ and Qt threads running. ``subprocess`` execs through the
+    async-signal-safe path in ``_posixsubprocess`` instead.
+
+    ``start_new_session`` makes the child a session leader but cannot give it a
+    controlling terminal, because a controlling terminal is only acquired when a
+    session leader *opens* a tty itself and here the parent opened the slave.
+    Without one there is no foreground process group, so terminal-generated
+    signals go nowhere and Ctrl-C, Ctrl-Z and shell job control silently stop
+    working. The ``/bin/sh`` step exists to fix exactly that: it reopens this
+    same slave from inside the new session, which acquires it as the controlling
+    terminal, then execs the real shell over itself.
+
+    Parameters
+    ----------
+    rows : int
+        Initial terminal height in characters.
+    cols : int
+        Initial terminal width in characters.
+    argv : list[str] | None, optional
+        Command to run. Defaults to an interactive :func:`resolveShell`.
+    useCtty : bool, optional
+        Acquire a controlling terminal. Defaults to ``True``. Setting this to
+        ``False`` produces a child with no controlling terminal, and exists so
+        that tests can pin the difference.
+
+    Returns
+    -------
+    tuple[subprocess.Popen, int]
+        The child process and the pty master descriptor, already set
+        non-blocking.
+
+    Notes
+    -----
+    Whether a child ends up with a controlling terminal otherwise depends on
+    what is being run: an interactive ``bash`` acquires one itself, while most
+    programs do not. Routing through ``/bin/sh`` makes it guaranteed instead of
+    dependent on undocumented shell behavior.
+    """
+    if argv is None:
+        argv = [resolveShell(), '-i']
+
+    masterFd, slaveFd = os.openpty()
+
+    try:
+        # Set the size before exec so the first prompt is drawn at the right
+        # width instead of needing a redraw.
+        setWinSize(masterFd, rows, cols)
+        os.set_blocking(masterFd, False)
+
+        if useCtty:
+            command = ['/bin/sh', '-c', _CTTY_SCRIPT, 'sh', os.ttyname(slaveFd)] + argv
+        else:
+            command = list(argv)
+
+        proc = subprocess.Popen(
+            command,
+            stdin=slaveFd,
+            stdout=slaveFd,
+            stderr=slaveFd,
+            start_new_session=True,
+            env=buildEnv(),
+        )
+    except BaseException:
+        os.close(masterFd)
+        raise
+    finally:
+        # Mandatory: while the parent holds a slave descriptor open, the master
+        # never reports end of file when the child exits.
+        try:
+            os.close(slaveFd)
+        except OSError:
+            pass
+
+    return (proc, masterFd)
+
+
+def signalGroup(pid: int, sig: int) -> None:
+    """Signal a child's process group, falling back to the child alone.
+
+    Parameters
+    ----------
+    pid : int
+        Child process id.
+    sig : int
+        Signal number to send.
+    """
+    try:
+        os.killpg(os.getpgid(pid), sig)
+        return
+    except OSError:
+        pass
+
+    try:
+        os.kill(pid, sig)
+    except OSError:
+        pass
+
+
+def closeShell(proc, masterFd: int, hupWait: float = HUP_WAIT_S) -> int:
+    """Close a pty and terminate the shell, leaving no zombie behind.
+
+    Safe to call more than once.
+
+    ``SIGHUP`` is sent before ``SIGKILL`` rather than ``SIGTERM`` because an
+    interactive ``bash`` ignores ``SIGTERM`` but does exit on a hangup.
+
+    Parameters
+    ----------
+    proc : subprocess.Popen | None
+        Child process, or ``None`` if there is nothing to reap.
+    masterFd : int
+        Pty master descriptor, or a negative value if already closed.
+    hupWait : float, optional
+        Seconds to wait for the hangup to take effect before forcing.
+
+    Returns
+    -------
+    int
+        The pty master descriptor to store back, always ``-1``.
+    """
+    if masterFd >= 0:
+        try:
+            os.close(masterFd)
+        except OSError:
+            pass
+
+    if proc is None:
+        return -1
+
+    if proc.poll() is None:
+        signalGroup(proc.pid, signal.SIGHUP)
+
+        deadline = time.monotonic() + hupWait
+        while proc.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    if proc.poll() is None:
+        signalGroup(proc.pid, signal.SIGKILL)
+        try:
+            proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            pass
+
+    return -1
+
+
+def rowRuns(screen: pyte.Screen, y: int, trim: bool = False) -> list[tuple[str, tuple]]:
+    """Run-length encode one screen row into ``(text, attributes)`` pairs.
+
+    Terminal output is overwhelmingly long stretches of one attribute, so a row
+    of 120 cells typically collapses to a handful of runs. ``attributes`` is the
+    ``pyte.screens.Char`` tuple with the character data removed, that is
+    ``(fg, bg, bold, italics, underscore, strikethrough, reverse, blink)``. It is
+    hashable, which makes it usable directly as a render cache key.
+
+    Parameters
+    ----------
+    screen : pyte.Screen
+        Screen to read.
+    y : int
+        Row index.
+    trim : bool, optional
+        Drop trailing blank cells. Used for scrollback, where nothing depends on
+        column positions. The live screen must not be trimmed, because the
+        renderer maps a string column onto a screen column when placing the
+        cursor.
+
+    Returns
+    -------
+    list[tuple[str, tuple]]
+        Runs in left to right order. Empty for a row that trims away entirely.
+    """
+    row = screen.buffer[y]
+    columns = screen.columns
+
+    if trim:
+        # A blank cell with a non-default background is kept, because a colored
+        # background is visible even with no character in it.
+        while columns > 0:
+            cell = row[columns - 1]
+            if cell.data != ' ' or cell.bg != 'default' or cell.reverse:
+                break
+            columns -= 1
+
+    runs = []
+    start = 0
+
+    while start < columns:
+        attrs = row[start][1:]
+        end = start + 1
+
+        while end < columns and row[end][1:] == attrs:
+            end += 1
+
+        runs.append((''.join(row[x].data for x in range(start, end)), attrs))
+        start = end
+
+    return runs
+
+
+def screenRuns(screen: pyte.Screen) -> list[list[tuple[str, tuple]]]:
+    """Run-length encode the whole live screen, one entry per row.
+
+    Parameters
+    ----------
+    screen : pyte.Screen
+        Screen to read.
+
+    Returns
+    -------
+    list[list[tuple[str, tuple]]]
+        One list of runs per screen row.
+    """
+    return [rowRuns(screen, y) for y in range(screen.lines)]
+
+
+class TerminalScreen(pyte.Screen):
+    """A ``pyte`` screen with query replies and scrollback capture.
+
+    Two behaviours are added to the base screen.
+
+    ``pyte.Screen.write_process_input`` is a no-op by default, which silently
+    breaks anything that probes the terminal. Cursor position reports
+    (``ESC[6n``) and device attribute requests (``ESC[c``) are used by readline,
+    ``less`` and many shell prompts, and a program that sends one will wait for
+    a reply that never arrives.
+
+    ``index`` is overloaded to keep lines that scroll off the top, which the
+    base screen simply discards. ``pyte.HistoryScreen`` also offers scrollback
+    but is not used here: it hooks ``__getattribute__`` and builds a fresh
+    wrapper closure on every access to a wrapped event, including ``draw``,
+    which the stream calls once per character. It also repurposes ``display``
+    to show the paged view, so cursor arithmetic would have to become
+    history-position aware.
+
+    Parameters
+    ----------
+    columns : int
+        Screen width in characters.
+    lines : int
+        Screen height in characters.
+    writer : callable
+        Called with the reply bytes to send to the child process.
+    scrollback : int, optional
+        Maximum number of scrolled-off lines to retain.
+
+    Attributes
+    ----------
+    scrolledOff : collections.deque
+        Rows that have scrolled off the top and not yet been consumed by a
+        renderer, each as a list of ``(text, attributes)`` runs. Callers are
+        expected to drain this. Attributes are kept rather than flattened to
+        plain text so that colored output keeps its colors after scrolling out
+        of the live screen.
+    """
+
+    def __init__(self, columns: int, lines: int, writer,
+                 scrollback: int = SCROLLBACK_LINES) -> None:
+        # Assigned before the base constructor because Screen.__init__ calls
+        # reset(), which can already route through these.
+        self._writer = writer
+        self.scrolledOff = collections.deque(maxlen=scrollback)
+        pyte.Screen.__init__(self, columns, lines)
+
+    def write_process_input(self, data: str) -> None:
+        """Send a terminal reply back to the child process."""
+        self._writer(data.encode('utf-8', errors='replace'))
+
+    def index(self) -> None:
+        """Scroll down, keeping the line that leaves the top."""
+        top, bottom = self.margins or Margins(0, self.lines - 1)
+
+        if self.cursor.y == bottom:
+            # Trailing padding is dropped here. Only the live region needs
+            # column-exact text, because that is where the cursor is drawn.
+            self.scrolledOff.append(rowRuns(self, top, trim=True))
+
+        pyte.Screen.index(self)
+
+    def resize(self, lines: int | None = None, columns: int | None = None) -> None:
+        """Resize the screen, keeping rows that a shrink would discard.
+
+        The base implementation drops the excess rows off the top by deleting
+        them outright rather than scrolling them, so they never pass through
+        :meth:`index` and would otherwise be lost. Making the window shorter
+        should move that content into the scrollback, not destroy it.
+        """
+        newLines = self.lines if lines is None else lines
+
+        for y in range(max(0, self.lines - newLines)):
+            runs = rowRuns(self, y, trim=True)
+            # Blank rows carry no history. Skipping them keeps a first layout,
+            # which usually shrinks the screen from its unshown default size,
+            # from filling the scrollback with empty lines.
+            if runs:
+                self.scrolledOff.append(runs)
+
+        pyte.Screen.resize(self, lines=lines, columns=columns)
+
+
+def screenLines(screen: pyte.Screen) -> list[str]:
+    """Return the current screen rows as text.
+
+    Rows keep their trailing padding so a character column in the string
+    matches the same column on the emulated screen, which is what makes cursor
+    placement exact.
+
+    Parameters
+    ----------
+    screen : pyte.Screen
+        Screen whose current viewport should be rendered.
+
+    Returns
+    -------
+    list[str]
+        One string per screen row.
+    """
+    try:
+        return list(screen.display)
+    except AssertionError:
+        # pyte asserts on some combining character sequences. A bad frame must
+        # not take the GUI down with it.
+        return [''] * screen.lines
+
+
+def screenToText(screen: pyte.Screen) -> str:
+    """Flatten a ``pyte`` screen viewport into displayable text.
+
+    Parameters
+    ----------
+    screen : pyte.Screen
+        Screen whose current viewport should be rendered.
+
+    Returns
+    -------
+    str
+        Newline-joined screen rows.
+    """
+    return '\n'.join(screenLines(screen))

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -85,6 +85,7 @@ setup (
             'pydm>=1.18',
             'qtpy>=2.0',
             'pyqtgraph>=0.13',
+            'pyte>=0.8',
         ],
     },
 )

--- a/templates/setup.py.in
+++ b/templates/setup.py.in
@@ -86,6 +86,7 @@ setup (
             'qtpy>=2.0',
             'pyqtgraph>=0.13',
             'pyte>=0.8',
+            'ipython',
         ],
     },
 )

--- a/tests/interfaces/test_interfaces_virtual.py
+++ b/tests/interfaces/test_interfaces_virtual.py
@@ -16,8 +16,9 @@ import pyrogue.interfaces._Virtual as virtual_mod
 
 
 class FakeThread:
-    def __init__(self, target):
+    def __init__(self, target, daemon=False):
         self.target = target
+        self.daemon = daemon
         self.started = False
 
     def start(self):

--- a/tests/interfaces/test_interfaces_virtual_integration.py
+++ b/tests/interfaces/test_interfaces_virtual_integration.py
@@ -8,6 +8,9 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import subprocess
+import sys
+
 import pyrogue as pr
 import pyrogue.interfaces as pr_interfaces
 import pytest
@@ -16,6 +19,10 @@ import pytest
 pytestmark = pytest.mark.integration
 
 ZMQ_UPDATE_TIMEOUT = 2.0
+
+# Generous, because the child has to import pyrogue and connect before it can
+# reach the exit this is timing. Anything short of a hang finishes well inside it.
+CLIENT_EXIT_TIMEOUT = 60.0
 
 
 class ZmqIntegrationDevice(pr.Device):
@@ -122,3 +129,33 @@ def test_virtual_client_respects_noserve_update_filter(wait_until, free_zmq_port
         finally:
             client.stop()
             pr_interfaces.VirtualClient.ClientCache.clear()
+
+
+def test_client_process_exits_without_an_explicit_stop(free_zmq_port):
+    # The monitor thread has to be a daemon for a process that holds a connected
+    # client to be able to exit at all. As a normal thread it is joined during
+    # interpreter shutdown, and that join never returns: the loop only ends when
+    # stop() clears its flag, and atexit callbacks run after the join, too late to
+    # clear it. Anything that connects and then falls off the end hangs, including
+    # the one-line client the server banner suggests and an interactive session
+    # the user exits.
+    code = (
+        "import pyrogue.interfaces as pri\n"
+        f"pri.VirtualClient(addr='127.0.0.1', port={free_zmq_port})\n"
+    )
+
+    with ZmqIntegrationRoot(port=free_zmq_port):
+        child = subprocess.Popen([sys.executable, '-c', code],
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT,
+                                 text=True)
+        try:
+            out, _ = child.communicate(timeout=CLIENT_EXIT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            child.kill()
+            out, _ = child.communicate()
+            pytest.fail(f"a process holding a connected client did not exit: {out[-400:]!r}")
+
+    # A non-zero status means the client never connected, which would make the
+    # exit above prove nothing.
+    assert child.returncode == 0, out

--- a/tests/interfaces/test_pydm_ipython_core.py
+++ b/tests/interfaces/test_pydm_ipython_core.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Exercises the command line and startup code of the embedded IPython console.
+# This half imports no Qt on purpose, so these tests run in CI environments that
+# have no Qt binding and no display. The end of the file spawns a real console on
+# a pseudo-terminal, which is what pins the '-i -c' behaviour the whole design
+# rests on: that the startup code runs and the session then stays alive with what
+# it defined still in scope.
+
+import ast
+import importlib.util
+import os
+import select
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+posixOnly = pytest.mark.skipif(os.name != 'posix', reason="pseudo-terminals are POSIX only")
+
+
+def _loadByPath(name, relative):
+    """Load a widget module without importing the Qt-dependent widget package.
+
+    ``pyrogue.pydm.widgets.__init__`` imports every widget, so the ordinary
+    import path drags in pydm and a Qt binding even for modules that need
+    neither.
+    """
+    path = Path(__file__).resolve().parents[2] / relative
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+ic = _loadByPath("rogue_test_ipython_core", "python/pyrogue/pydm/widgets/ipython_core.py")
+tc = _loadByPath("rogue_test_terminal_core", "python/pyrogue/pydm/widgets/terminal_core.py")
+
+
+def _drain(fd, seconds=1.0):
+    """Read from a non-blocking descriptor for a bounded time."""
+    out = b''
+    end = time.monotonic() + seconds
+
+    while time.monotonic() < end:
+        ready, _, _ = select.select([fd], [], [], 0.05)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            continue
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Startup code
+# ---------------------------------------------------------------------------
+
+def test_startup_code_connects_a_client():
+    code = ic.startupCode('localhost', 9099)
+    assert 'pr.interfaces.VirtualClient' in code
+    assert "addr='localhost'" in code
+    assert 'port=9099' in code
+
+
+def test_startup_code_imports_the_interfaces_submodule():
+    # 'import pyrogue as pr' does not bind pr.interfaces. Without the submodule
+    # import the client construction raises AttributeError, which the guard below
+    # it then reports as a connection failure: the console looks like it merely
+    # could not reach the server, on every server.
+    assert 'import pyrogue.interfaces' in ic.startupCode('localhost', 9099)
+
+
+def test_startup_code_binds_the_conventional_names():
+    # 'client' and 'root' are what the server suggests at startup and what the
+    # notebooks and docs use, so a session must land on the same names.
+    code = ic.startupCode('localhost', 9099)
+    assert 'client = ' in code
+    assert 'root = client.root' in code
+
+
+def test_startup_code_carries_the_requested_server():
+    code = ic.startupCode('rogue-host.example', 12345)
+    assert "addr='rogue-host.example'" in code
+    assert 'port=12345' in code
+    assert 'localhost' not in code
+
+
+def test_startup_code_survives_a_connection_failure():
+    # Without this the console would come up dead: the exception from a missing
+    # server would leave no prompt worth having.
+    code = ic.startupCode('localhost', 9099)
+    assert 'except Exception' in code
+    assert 'Retry with' in code
+
+
+def test_startup_code_is_valid_python():
+    compile(ic.startupCode('localhost', 9099), '<startup>', 'exec')
+
+
+def test_startup_code_quotes_the_address():
+    # Every interpolation of the address goes through repr(), so an address can
+    # neither terminate the literal it sits in nor smuggle in a statement.
+    code = ic.startupCode("host'; import os", 9099)
+    tree = ast.parse(code)
+    imported = [alias.name
+                for node in ast.walk(tree) if isinstance(node, (ast.Import, ast.ImportFrom))
+                for alias in node.names]
+    assert imported == ['pyrogue', 'pyrogue.interfaces']
+
+
+# ---------------------------------------------------------------------------
+# Command line
+# ---------------------------------------------------------------------------
+
+def test_argv_runs_ipython_on_the_gui_interpreter():
+    # An 'ipython' from PATH could belong to another interpreter, which would
+    # import a different pyrogue, or none, and would miss the PYTHONPATH of a
+    # local build.
+    argv = ic.ipythonArgv('localhost', 9099)
+    assert argv[0] == sys.executable
+    assert argv[1:3] == ['-m', 'IPython']
+
+
+def test_argv_stays_interactive_after_the_startup_code():
+    argv = ic.ipythonArgv('localhost', 9099)
+    assert '-i' in argv
+    assert argv[-2] == '-c'
+    assert argv[-1] == ic.startupCode('localhost', 9099)
+
+
+def test_argv_does_not_ask_to_confirm_exit():
+    # Exiting is how the session is restarted, so a confirmation would be in the
+    # way rather than a safeguard.
+    assert '--no-confirm-exit' in ic.ipythonArgv('localhost', 9099)
+
+
+def test_argv_turns_jedi_off():
+    # jedi cannot complete the tree. Its static analysis crashes on the dynamic
+    # __getattr__ nodes, and IPython then offers the crash text as the only
+    # candidate, so Tab does nothing after 'root.'. IPython's own completer works
+    # from dir(), which the tree answers.
+    assert '--IPCompleter.use_jedi=False' in ic.ipythonArgv('localhost', 9099)
+
+
+def test_argv_accepts_an_explicit_interpreter():
+    argv = ic.ipythonArgv('localhost', 9099, executable='/usr/bin/python3')
+    assert argv[0] == '/usr/bin/python3'
+
+
+def test_startup_code_is_a_single_argument():
+    # It reaches the child through '/bin/sh -c ... "$@"', so a multi-line string
+    # has to stay one argv element rather than being split into words.
+    argv = ic.ipythonArgv('localhost', 9099)
+    assert len([a for a in argv if 'VirtualClient' in a]) == 1
+    assert '\n' in argv[-1]
+
+
+# ---------------------------------------------------------------------------
+# Real console on a pseudo-terminal
+# ---------------------------------------------------------------------------
+
+@posixOnly
+@pytest.mark.skipif(importlib.util.find_spec('IPython') is None, reason="IPython is not installed")
+def test_console_reaches_a_prompt_with_no_server():
+    # No Rogue server is running, so this also covers the failure path: the
+    # startup code must report the problem and still hand over a live session.
+    argv = ic.ipythonArgv('localhost', 9099)
+    proc, master = tc.spawnShell(30, 100, argv=argv)
+
+    try:
+        out = _drain(master, 25.0).decode(errors='replace')
+        assert 'In [' in out, f"no IPython prompt in output: {out[-400:]!r}"
+        assert 'Rogue console' in out, f"startup code did not run: {out[-400:]!r}"
+
+        # The session is alive and everything needed to build a client resolves.
+        # Asserting on the class rather than on the connection means this fails
+        # for a missing import even though no server is present to connect to.
+        os.write(master, b'print("PROBE", pr.interfaces.VirtualClient.__name__)\r')
+        typed = _drain(master, 15.0).decode(errors='replace')
+        assert 'PROBE VirtualClient' in typed, f"names did not resolve: {typed[-400:]!r}"
+    finally:
+        tc.closeShell(proc, master)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_ipython_panel.py
+++ b/tests/interfaces/test_pydm_ipython_panel.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Checks the IPython console tab: that it targets the server the rest of the GUI
+# is pointed at, that it is labelled and titled as a console rather than a
+# terminal, and that detaching does not restart the session. The generic
+# detach/reattach behaviour it inherits is covered by
+# test_pydm_terminal_panel.py. Needs a QApplication, so it self-skips without Qt.
+#
+# Most of it involves no Rogue server: the console reports that it cannot connect
+# and hands over a prompt anyway, which is all those tests need. The integration
+# tests at the end do run one, because reading the tree and completing on it only
+# mean something against a server that is really there.
+
+import importlib.util
+import time
+
+import pytest
+
+try:
+    import pyte  # noqa: F401
+    from qtpy.QtWidgets import QApplication, QTabWidget, QWidget
+    # The widget package imports pydm, which needs more of the Qt stack than the
+    # modules above. Import it here so a partial Qt install skips the module
+    # rather than erroring inside every fixture.
+    from pyrogue.pydm import widgets  # noqa: F401
+except Exception as exc:
+    pytest.skip(
+        f"PyDM/Qt test dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+needsIPython = pytest.mark.skipif(importlib.util.find_spec('IPython') is None,
+                                  reason="IPython is not installed")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def server(monkeypatch):
+    """Point the GUI at a server address, as runPyDM does."""
+    monkeypatch.setenv('ROGUE_SERVERS', 'rogue-host.example:9123')
+    return ('rogue-host.example', 9123)
+
+
+@pytest.fixture
+def panel(qapp, server):
+    """An unshown panel, so no console has been started yet."""
+    from pyrogue.pydm.widgets import IPythonPanel
+
+    widget = IPythonPanel(parent=None)
+    yield widget
+    widget.shutdown()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.fixture
+def tabbed(qapp, server):
+    """A panel sitting in a tab widget, with its console started."""
+    from pyrogue.pydm.widgets import IPythonPanel
+
+    tabs = QTabWidget()
+    tabs.addTab(QWidget(), 'Other')
+    widget = IPythonPanel(parent=None)
+    tabs.addTab(widget, 'IPython')
+    tabs.resize(700, 400)
+    tabs.show()
+    tabs.setCurrentIndex(1)
+    qapp.processEvents()
+
+    yield (tabs, widget)
+
+    widget.shutdown()
+    tabs.deleteLater()
+    qapp.processEvents()
+
+
+# ---------------------------------------------------------------------------
+# Server targeting
+# ---------------------------------------------------------------------------
+
+def test_console_targets_the_gui_server(panel, server):
+    # The console must reach the same server the System and Debug Tree tabs are
+    # bound to. A hardcoded localhost:9099 would silently connect somewhere else
+    # whenever the GUI was launched against a remote server.
+    addr, port = server
+    startup = panel.terminal._argv[-1]
+    assert f"addr='{addr}'" in startup
+    assert f'port={port}' in startup
+
+
+def test_explicit_channel_overrides_the_default(qapp, server):
+    from pyrogue.pydm.widgets import IPythonPanel
+
+    widget = IPythonPanel(parent=None, init_channel='rogue://other-host:9500/root')
+    try:
+        startup = widget.terminal._argv[-1]
+        assert "addr='other-host'" in startup
+        assert 'port=9500' in startup
+    finally:
+        widget.shutdown()
+        widget.deleteLater()
+        qapp.processEvents()
+
+
+# ---------------------------------------------------------------------------
+# Presentation
+# ---------------------------------------------------------------------------
+
+def test_tab_is_labelled_ipython(panel):
+    assert panel._tabLabel == 'IPython'
+
+
+def test_detached_window_names_the_server(panel, server):
+    # Two consoles against two servers are otherwise indistinguishable once
+    # detached, which is exactly when it matters that the window says which one
+    # it is.
+    addr, port = server
+    assert f'{addr}:{port}' in panel._windowTitle
+
+
+def test_button_tooltips_say_console(panel):
+    assert 'console' in panel._attachTip
+    assert 'console' in panel._detachTip
+    assert 'terminal' not in panel._attachTip
+
+
+def test_console_is_not_started_until_shown(panel):
+    # Enabling the tab costs nothing until it is opened, and the connection
+    # attempt never delays the GUI coming up.
+    assert panel.terminal._proc is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+@needsIPython
+def test_showing_the_tab_starts_the_console(tabbed):
+    _tabs, widget = tabbed
+    assert widget.terminal._proc is not None
+    assert widget.terminal._proc.poll() is None
+
+
+@needsIPython
+def test_detach_and_reattach_keep_the_same_session(tabbed):
+    # The whole point of detaching is reading a long session comfortably, which
+    # would be pointless if it restarted the interpreter and lost the namespace.
+    _tabs, widget = tabbed
+    pid = widget.terminal._proc.pid
+
+    widget.detach()
+    assert widget.terminal._proc.pid == pid
+
+    widget.reattach()
+    assert widget.terminal._proc.pid == pid
+    assert widget.terminal._proc.poll() is None
+
+
+@needsIPython
+def test_shutdown_terminates_the_console(tabbed):
+    _tabs, widget = tabbed
+    proc = widget.terminal._proc
+
+    widget.shutdown()
+
+    assert proc.poll() is not None
+
+
+# ---------------------------------------------------------------------------
+# Real session
+# ---------------------------------------------------------------------------
+
+def _pump(qapp, terminal, needle, seconds):
+    """Drive the event loop until ``needle`` appears in the view."""
+    deadline = time.monotonic() + seconds
+
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if needle in terminal.toPlainText():
+            return True
+        time.sleep(0.05)
+
+    return False
+
+
+@pytest.mark.integration
+@needsIPython
+def test_console_reaches_a_prompt_in_the_widget(tabbed, qapp):
+    # End to end through the widget rather than the pty alone: IPython starts,
+    # the startup code runs, and prompt_toolkit's output renders into the view.
+    _tabs, widget = tabbed
+
+    assert _pump(qapp, widget.terminal, 'In [', 60.0), \
+        f"no prompt rendered: {widget.terminal.toPlainText()[-400:]!r}"
+    assert 'Rogue console' in widget.terminal.toPlainText()
+
+
+@pytest.mark.integration
+@needsIPython
+def test_cursor_position_requests_are_answered(tabbed, qapp):
+    # prompt_toolkit asks the terminal where the cursor is and warns when nothing
+    # answers. TerminalScreen.write_process_input is what replies, so this is the
+    # check that the emulator is complete enough to host a real readline UI.
+    _tabs, widget = tabbed
+
+    assert _pump(qapp, widget.terminal, 'In [', 60.0), \
+        f"no prompt rendered: {widget.terminal.toPlainText()[-400:]!r}"
+    assert 'cursor position' not in widget.terminal.toPlainText()
+
+
+@pytest.fixture
+def liveTree(monkeypatch, free_zmq_port):
+    """A running Rogue server, with the GUI pointed at it."""
+    import pyrogue as pr
+    import pyrogue.interfaces as pri
+
+    class Dev(pr.Device):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.add(pr.LocalVariable(name='Value', value=1234, mode='RW'))
+
+    class Top(pr.Root):
+        def __init__(self):
+            super().__init__(name='Top', pollEn=False)
+            self.add(Dev(name='Dev'))
+            self.zmqServer = pri.ZmqServer(root=self, addr='*', port=free_zmq_port)
+            self.addInterface(self.zmqServer)
+
+    monkeypatch.setenv('ROGUE_SERVERS', f'localhost:{free_zmq_port}')
+
+    with Top() as root:
+        yield root
+
+
+@pytest.fixture
+def connected(qapp, liveTree, monkeypatch, tmp_path):
+    """A shown console that has reached its prompt with the client connected."""
+    from pyrogue.pydm.widgets import IPythonPanel
+
+    # An empty history for the child. IPython otherwise uses the history of
+    # whoever runs the suite, and prompt_toolkit renders a suggestion drawn from
+    # it as ghost text in the view, which reads exactly like a completion.
+    monkeypatch.setenv('IPYTHONDIR', str(tmp_path / 'ipython'))
+
+    panel = IPythonPanel(parent=None)
+    # Wide enough that a typed command is not wrapped by the emulator.
+    panel.resize(1100, 500)
+    panel.show()
+    qapp.processEvents()
+
+    assert _pump(qapp, panel.terminal, 'are ready', 90.0), \
+        f"client never connected: {panel.terminal.toPlainText()[-600:]!r}"
+
+    yield panel
+
+    panel.shutdown()
+    panel.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.mark.integration
+@needsIPython
+def test_console_reads_and_writes_a_real_tree(qapp, liveTree, connected):
+    # The whole point of the tab, end to end: a real server, a real client in a
+    # real IPython process, a value read back through the tree and one written
+    # that the server side then sees. Nothing else covers the actual purpose.
+    connected.terminal.writeBytes(b'print("READBACK", root.Dev.Value.get())\r')
+    assert _pump(qapp, connected.terminal, 'READBACK 1234', 60.0), \
+        f"read did not come back: {connected.terminal.toPlainText()[-600:]!r}"
+
+    connected.terminal.writeBytes(b'root.Dev.Value.set(777)\r')
+    assert _pump(qapp, connected.terminal, 'In [3]', 60.0), \
+        f"write did not complete: {connected.terminal.toPlainText()[-600:]!r}"
+    assert liveTree.Dev.Value.get() == 777
+
+
+@pytest.mark.integration
+@needsIPython
+def test_tab_completes_on_the_tree(qapp, connected):
+    # Completing on the tree is why the console exists, and it is the one thing
+    # the default completer cannot do: jedi crashes on the dynamic __getattr__
+    # nodes and IPython then has nothing to offer, so Tab does nothing. A live
+    # server is required because there is no tree to complete against without one.
+    connected.terminal.sendInput(b'root.De')
+    assert _pump(qapp, connected.terminal, 'root.De', 30.0), \
+        f"input never echoed: {connected.terminal.toPlainText()[-600:]!r}"
+
+    connected.terminal.sendInput(b'\t')
+    assert _pump(qapp, connected.terminal, 'root.Dev', 30.0), \
+        f"Tab did not complete: {connected.terminal.toPlainText()[-600:]!r}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_ipython_panel.py
+++ b/tests/interfaces/test_pydm_ipython_panel.py
@@ -17,8 +17,9 @@
 #
 # Most of it involves no Rogue server: the console reports that it cannot connect
 # and hands over a prompt anyway, which is all those tests need. The integration
-# tests at the end do run one, because reading the tree and completing on it only
-# mean something against a server that is really there.
+# tests at the end do run one, because reading the tree, completing on it, and
+# exiting a session that holds a connected client only mean something against a
+# server that is really there.
 
 import importlib.util
 import time
@@ -301,6 +302,32 @@ def test_tab_completes_on_the_tree(qapp, connected):
     connected.terminal.sendInput(b'\t')
     assert _pump(qapp, connected.terminal, 'root.Dev', 30.0), \
         f"Tab did not complete: {connected.terminal.toPlainText()[-600:]!r}"
+
+
+@pytest.mark.integration
+@needsIPython
+def test_exiting_a_connected_session_starts_a_fresh_one(qapp, connected):
+    # Restarting on exit only works if the interpreter can exit, and a connected
+    # client used to keep it alive: the widget learns the session ended from the
+    # pty reporting end of file, which never comes while the child is still there.
+    first = connected.terminal._proc.pid
+
+    connected.terminal.sendInput(b'exit\r')
+
+    deadline = time.monotonic() + 90.0
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        proc = connected.terminal._proc
+        if proc is not None and proc.pid != first:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"console never restarted: {connected.terminal.toPlainText()[-600:]!r}")
+
+    # A restarted session is only useful if it reconnected, and it starts from a
+    # cleared view, so this needle can only come from the new one.
+    assert _pump(qapp, connected.terminal, 'are ready', 90.0), \
+        f"fresh session did not connect: {connected.terminal.toPlainText()[-600:]!r}"
 
 
 if __name__ == "__main__":

--- a/tests/interfaces/test_pydm_run_config.py
+++ b/tests/interfaces/test_pydm_run_config.py
@@ -175,3 +175,22 @@ def test_run_pydm_forwards_enable_terminal(monkeypatch):
     # Pins the exact string DefaultTop._parseBoolArg has to consume. This is the
     # only part of the option plumbing that spans two files.
     assert "enableTerminal=True" in _runPyDMArgs(monkeypatch, enableTerminal=True)
+
+
+def test_run_pydm_defaults_enable_ipython_to_false(monkeypatch):
+    assert "enableIPython=False" in _runPyDMArgs(monkeypatch)
+
+
+def test_run_pydm_forwards_enable_ipython(monkeypatch):
+    assert "enableIPython=True" in _runPyDMArgs(monkeypatch, enableIPython=True)
+
+
+def test_run_pydm_forwards_the_two_tab_options_independently(monkeypatch):
+    # Either option on its own must not drag the other along.
+    args = _runPyDMArgs(monkeypatch, enableIPython=True)
+    assert "enableIPython=True" in args
+    assert "enableTerminal=False" in args
+
+    args = _runPyDMArgs(monkeypatch, enableTerminal=True)
+    assert "enableTerminal=True" in args
+    assert "enableIPython=False" in args

--- a/tests/interfaces/test_pydm_run_config.py
+++ b/tests/interfaces/test_pydm_run_config.py
@@ -9,18 +9,60 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
+import contextlib
 import importlib.util
 import sys
 import types
 from pathlib import Path
 
 
-def _load_pydm_module(call_log):
+def _load_pydm_module(call_log, app_log=None):
+    """Load the module under stubs and return it with the stubs removed again.
+
+    Suitable for entry points that resolve everything they need at import time.
+    Use :func:`_stubbedPydmModule` for ``runPyDM``, which imports lazily inside
+    the function body and so needs the stubs to still be present when called.
+    """
+    with _stubbedPydmModule(call_log, app_log=app_log) as module:
+        return module
+
+
+@contextlib.contextmanager
+def _stubbedPydmModule(call_log, app_log=None):
     module_path = Path(__file__).resolve().parents[2] / "python/pyrogue/pydm/__init__.py"
 
+    class FakeMainWindow:
+        home_widget = None
+
+        def set_display_widget(self, widget):
+            pass
+
+    class FakeApp:
+        """Records the display arguments runPyDM assembles."""
+
+        def __init__(self, **kwargs):
+            if app_log is not None:
+                app_log.append(kwargs)
+            self.main_window = FakeMainWindow()
+
+        @staticmethod
+        def instance():
+            return None
+
+        def exec(self):
+            return 0
+
     fake_pydm = types.ModuleType("pydm")
-    fake_pydm.PyDMApplication = type("FakeApp", (), {"instance": staticmethod(lambda: None)})
+    fake_pydm.PyDMApplication = FakeApp
     fake_pydm.Display = type("FakeDisplay", (), {})
+
+    # runPyDM checks for a pre-existing QApplication before building its own.
+    fake_qtpy = types.ModuleType("qtpy")
+    fake_qtpy.__path__ = []
+    fake_qtpy_widgets = types.ModuleType("qtpy.QtWidgets")
+    fake_qtpy_widgets.QApplication = type(
+        "FakeQApplication", (), {"instance": staticmethod(lambda: None)})
+    fake_qtpy.QtWidgets = fake_qtpy_widgets
 
     fake_pydm_data_plugins = types.ModuleType("pydm.data_plugins")
     fake_pydm_data_plugins.plugin_modules = {}
@@ -61,6 +103,8 @@ def _load_pydm_module(call_log):
         "pydm.widgets": fake_pydm_widgets,
         "pydm.widgets.rules": fake_pydm_widgets_rules,
         "pydm.utilities": fake_pydm_utilities,
+        "qtpy": fake_qtpy,
+        "qtpy.QtWidgets": fake_qtpy_widgets,
         "pyrogue": fake_pyrogue,
         "pyrogue.interfaces": fake_pyrogue_interfaces,
         "pyrogue.pydm": fake_pyrogue_pydm,
@@ -74,7 +118,7 @@ def _load_pydm_module(call_log):
         module = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
         spec.loader.exec_module(module)
-        return module
+        yield module
     finally:
         for name, original in saved_modules.items():
             if original is None:
@@ -107,3 +151,27 @@ def test_configure_virtual_clients_applies_timeouts_to_each_server():
             "requestStallTimeout": None,
         },
     ]
+
+
+def _runPyDMArgs(monkeypatch, **kwargs):
+    """Run runPyDM against stubs and return the display argument list."""
+    app_log = []
+
+    with _stubbedPydmModule([], app_log=app_log) as module:
+        # runPyDM installs process-wide handlers; keep them out of the session.
+        monkeypatch.setattr(module.signal, "signal", lambda *a: None)
+        monkeypatch.setenv("ROGUE_SERVERS", "")
+        module.runPyDM(serverList="localhost:9099", **kwargs)
+
+    assert len(app_log) == 1
+    return app_log[0]["command_line_args"]
+
+
+def test_run_pydm_defaults_enable_terminal_to_false(monkeypatch):
+    assert "enableTerminal=False" in _runPyDMArgs(monkeypatch)
+
+
+def test_run_pydm_forwards_enable_terminal(monkeypatch):
+    # Pins the exact string DefaultTop._parseBoolArg has to consume. This is the
+    # only part of the option plumbing that spans two files.
+    assert "enableTerminal=True" in _runPyDMArgs(monkeypatch, enableTerminal=True)

--- a/tests/interfaces/test_pydm_system_window.py
+++ b/tests/interfaces/test_pydm_system_window.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Guards the System tab layout. The terminal is a top level tab, so the system
+# log must stay exactly as it was: added straight to the vertical layout, with no
+# tab bar wrapped around it and no terminal nested inside. Needs a real
+# QApplication because SystemWindow is a PyDMFrame, so it self-skips without Qt.
+# The Rogue node is stubbed, so no server and no hardware are involved.
+
+import pytest
+
+try:
+    from qtpy.QtWidgets import QApplication, QTabWidget
+    # The widget package imports pydm, which needs more of the Qt stack than the
+    # modules above. Import it here so a partial Qt install skips the module
+    # rather than erroring inside every fixture.
+    from pyrogue.pydm import widgets  # noqa: F401
+except Exception as exc:
+    pytest.skip(
+        f"PyDM/Qt test dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def systemWindow(qapp, monkeypatch):
+    """A SystemWindow that has completed its lazy build."""
+    from pyrogue.pydm.widgets import system_window as sw
+
+    class FakeNode:
+        def getNodes(self, typ=None):
+            return {}
+
+    monkeypatch.setattr(sw, 'nodeFromAddress', lambda channel: FakeNode())
+    monkeypatch.setattr(sw, 'RootControl', lambda parent=None, init_channel=None: sw.QWidget())
+    monkeypatch.setattr(sw, 'SystemLog', lambda parent=None, init_channel=None: sw.QWidget())
+
+    window = sw.SystemWindow(parent=None, init_channel='rogue://0/root')
+    window._connected = False
+    window.connection_changed(True)
+
+    yield window
+
+    window.deleteLater()
+    qapp.processEvents()
+
+
+def test_system_tab_has_no_tab_bar(systemWindow):
+    # A nested tab set here was the earlier design. The terminal moved to the top
+    # level precisely so this view keeps its original full height layout.
+    assert systemWindow.findChild(QTabWidget) is None
+
+
+def test_system_window_takes_no_terminal_option(systemWindow):
+    from pyrogue.pydm.widgets import SystemWindow
+    import inspect
+
+    assert 'enableTerminal' not in inspect.signature(SystemWindow.__init__).parameters
+
+
+def test_system_window_does_not_own_a_terminal(systemWindow):
+    from pyrogue.pydm.widgets import LinuxTerminal
+    assert systemWindow.findChild(LinuxTerminal) is None
+
+
+def test_build_runs_only_once(systemWindow):
+    # connection_changed is gated on _node, so a reconnect must not rebuild the
+    # layout and duplicate the log.
+    before = len(systemWindow.children())
+
+    systemWindow.connection_changed(False)
+    systemWindow.connection_changed(True)
+
+    assert len(systemWindow.children()) == before
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_terminal.py
+++ b/tests/interfaces/test_pydm_terminal.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Exercises the key translation of the embedded terminal widget. keyToBytes is
+# a pure function, so no QApplication and no display are needed; importing
+# qtpy.QtCore for the key constants does not require an application instance.
+# The pseudo-terminal and screen behaviour is covered by
+# test_pydm_terminal_core.py, which needs no Qt at all.
+
+import pytest
+
+try:
+    import pyte  # noqa: F401
+    from qtpy.QtCore import Qt
+    from pyrogue.pydm.widgets.terminal import keyToBytes
+except Exception as exc:
+    pytest.skip(
+        f"PyDM/Qt test dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.parametrize("key,expected", [
+    (Qt.Key_Return,    b'\r'),
+    (Qt.Key_Enter,     b'\r'),
+    (Qt.Key_Backspace, b'\x7f'),
+    (Qt.Key_Tab,       b'\t'),
+    (Qt.Key_Backtab,   b'\x1b[Z'),
+    (Qt.Key_Escape,    b'\x1b'),
+    (Qt.Key_Up,        b'\x1b[A'),
+    (Qt.Key_Down,      b'\x1b[B'),
+    (Qt.Key_Right,     b'\x1b[C'),
+    (Qt.Key_Left,      b'\x1b[D'),
+    (Qt.Key_Home,      b'\x1b[H'),
+    (Qt.Key_End,       b'\x1b[F'),
+    (Qt.Key_Insert,    b'\x1b[2~'),
+    (Qt.Key_Delete,    b'\x1b[3~'),
+    (Qt.Key_PageUp,    b'\x1b[5~'),
+    (Qt.Key_PageDown,  b'\x1b[6~'),
+    (Qt.Key_F1,        b'\x1bOP'),
+    (Qt.Key_F4,        b'\x1bOS'),
+    (Qt.Key_F5,        b'\x1b[15~'),
+    (Qt.Key_F10,       b'\x1b[21~'),
+    (Qt.Key_F12,       b'\x1b[24~'),
+])
+def test_special_keys(key, expected):
+    assert keyToBytes(key, Qt.NoModifier, '') == expected
+
+
+def test_backspace_sends_delete_not_backspace():
+    # readline and the xterm terminfo entry expect DEL here. Sending BS instead
+    # is the classic mistake and makes backspace stop working at the prompt.
+    assert keyToBytes(Qt.Key_Backspace, Qt.NoModifier, '\x08') == b'\x7f'
+
+
+def test_printable_text_passes_through():
+    assert keyToBytes(Qt.Key_A, Qt.NoModifier, 'a') == b'a'
+    assert keyToBytes(Qt.Key_Space, Qt.NoModifier, ' ') == b' '
+
+
+def test_non_ascii_text_is_utf8_encoded():
+    assert keyToBytes(Qt.Key_unknown, Qt.NoModifier, 'µ') == 'µ'.encode('utf-8')
+
+
+@pytest.mark.parametrize("key,expected", [
+    (Qt.Key_A, b'\x01'),
+    (Qt.Key_C, b'\x03'),
+    (Qt.Key_D, b'\x04'),
+    (Qt.Key_U, b'\x15'),
+    (Qt.Key_Z, b'\x1a'),
+])
+def test_control_letters_map_to_control_codes(key, expected):
+    # Ctrl-C in particular must reach the shell as an interrupt rather than
+    # being swallowed as a copy shortcut.
+    assert keyToBytes(key, Qt.ControlModifier, '') == expected
+
+
+def test_control_space_and_bracket_group():
+    assert keyToBytes(Qt.Key_Space, Qt.ControlModifier, '') == b'\x00'
+    assert keyToBytes(Qt.Key_BracketLeft, Qt.ControlModifier, '') == b'\x1b'
+    assert keyToBytes(Qt.Key_Backslash, Qt.ControlModifier, '') == b'\x1c'
+    assert keyToBytes(Qt.Key_BracketRight, Qt.ControlModifier, '') == b'\x1d'
+
+
+def test_ctrl_shift_copy_paste_send_nothing():
+    # These are handled as clipboard actions by the widget, so the translation
+    # must not also forward them to the shell.
+    mods = Qt.ControlModifier | Qt.ShiftModifier
+    assert keyToBytes(Qt.Key_C, mods, '') == b''
+    assert keyToBytes(Qt.Key_V, mods, '') == b''
+
+
+def test_alt_prefixes_escape():
+    assert keyToBytes(Qt.Key_B, Qt.AltModifier, 'b') == b'\x1bb'
+    assert keyToBytes(Qt.Key_Left, Qt.AltModifier, '') == b'\x1b\x1b[D'
+
+
+@pytest.mark.parametrize("key", [
+    Qt.Key_Shift, Qt.Key_Control, Qt.Key_Alt, Qt.Key_Meta,
+    Qt.Key_CapsLock, Qt.Key_NumLock, Qt.Key_ScrollLock,
+])
+def test_bare_modifier_keys_send_nothing(key):
+    assert keyToBytes(key, Qt.NoModifier, '') == b''
+
+
+def test_unmapped_key_without_text_sends_nothing():
+    assert keyToBytes(Qt.Key_unknown, Qt.NoModifier, '') == b''
+
+
+def test_every_result_is_bytes():
+    # A str slipping into the table would only fail later at os.write().
+    for key in (Qt.Key_Return, Qt.Key_Up, Qt.Key_F7, Qt.Key_A, Qt.Key_Shift):
+        assert isinstance(keyToBytes(key, Qt.NoModifier, ''), bytes)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_terminal_core.py
+++ b/tests/interfaces/test_pydm_terminal_core.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Exercises the pseudo-terminal and screen-emulation half of the embedded
+# terminal. This half imports no Qt on purpose, so these tests run in CI
+# environments that have no Qt binding and no display, which is where the
+# behaviour with the least obvious failure modes lives: controlling-terminal
+# setup, child reaping and descriptor cleanup.
+
+import errno
+import importlib.util
+import os
+import select
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+try:
+    import pyte
+except Exception as exc:
+    pytest.skip(f"pyte unavailable: {exc}", allow_module_level=True)
+
+
+def _loadTerminalCore():
+    """Load ``terminal_core`` without importing the widget package.
+
+    ``pyrogue.pydm.widgets.__init__`` imports every widget, so the ordinary
+    import path drags in pydm and a Qt binding even for a module that needs
+    neither. Loading the file directly is what keeps these tests running in a
+    CI environment that has no Qt binding.
+    """
+    path = Path(__file__).resolve().parents[2] / "python/pyrogue/pydm/widgets/terminal_core.py"
+    spec = importlib.util.spec_from_file_location("rogue_test_terminal_core", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+tc = _loadTerminalCore()
+
+posixOnly = pytest.mark.skipif(os.name != 'posix', reason="pseudo-terminals are POSIX only")
+
+
+def _drain(fd, seconds=1.0):
+    """Read from a non-blocking descriptor for a bounded time."""
+    out = b''
+    end = time.monotonic() + seconds
+
+    while time.monotonic() < end:
+        ready, _, _ = select.select([fd], [], [], 0.05)
+        if not ready:
+            continue
+        try:
+            chunk = os.read(fd, 4096)
+        except BlockingIOError:
+            continue
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk
+
+    return out
+
+
+def _feed(data, columns=20, lines=4):
+    """Return a screen with ``data`` fed through a byte stream."""
+    screen = pyte.Screen(columns, lines)
+    stream = pyte.ByteStream(screen)
+    stream.feed(data)
+    return screen
+
+
+# ---------------------------------------------------------------------------
+# Grid arithmetic
+# ---------------------------------------------------------------------------
+
+def test_compute_grid_exact_fit():
+    assert tc.computeGrid(800.0, 400.0, 8.0, 16.0) == (100, 25)
+
+
+def test_compute_grid_rounds_down_partial_cells():
+    assert tc.computeGrid(805.0, 407.0, 8.0, 16.0) == (100, 25)
+
+
+def test_compute_grid_clamps_to_minimum():
+    assert tc.computeGrid(10.0, 10.0, 8.0, 16.0) == (tc.MIN_COLS, tc.MIN_ROWS)
+
+
+def test_compute_grid_falls_back_on_zero_cell():
+    assert tc.computeGrid(800.0, 400.0, 0.0, 16.0) == (tc.DEFAULT_COLS, tc.DEFAULT_ROWS)
+
+
+# ---------------------------------------------------------------------------
+# Shell and environment resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_shell_returns_executable():
+    path = tc.resolveShell()
+    assert os.path.isabs(path)
+    assert os.access(path, os.X_OK)
+
+
+def test_resolve_shell_falls_back_when_shell_is_bogus(monkeypatch):
+    monkeypatch.setenv('SHELL', '/nonexistent/definitely/not/a/shell')
+    assert os.access(tc.resolveShell(), os.X_OK)
+
+
+def test_build_env_strips_columns_and_lines(monkeypatch):
+    monkeypatch.setenv('COLUMNS', '999')
+    monkeypatch.setenv('LINES', '999')
+    env = tc.buildEnv()
+    # TIOCSWINSZ must be the only source of geometry, otherwise a stale
+    # COLUMNS wins and the shell wraps at the wrong column.
+    assert 'COLUMNS' not in env
+    assert 'LINES' not in env
+    assert env['TERM'] == 'xterm'
+
+
+# ---------------------------------------------------------------------------
+# Screen emulation
+# ---------------------------------------------------------------------------
+
+def test_plain_text_renders():
+    assert tc.screenToText(_feed(b'hello')).split('\n')[0].startswith('hello')
+
+
+def test_newline_advances_a_line():
+    lines = tc.screenToText(_feed(b'one\r\ntwo')).split('\n')
+    assert lines[0].startswith('one')
+    assert lines[1].startswith('two')
+
+
+def test_color_escape_is_consumed_not_rendered():
+    # v1 renders monochrome, but pyte must still swallow the SGR sequence so
+    # escape bytes never leak into the displayed text.
+    text = tc.screenToText(_feed(b'\x1b[31mred\x1b[0m'))
+    assert 'red' in text
+    assert '\x1b' not in text
+    assert '31m' not in text
+
+
+def test_color_attribute_is_still_parsed():
+    # Pins the contract a future colour-capable renderer would consume.
+    assert _feed(b'\x1b[31mR').buffer[0][0].fg == 'red'
+
+
+def test_cursor_addressing_positions_text():
+    # CSI 2;3 H moves to row 2, column 3, both 1-based.
+    screen = _feed(b'\x1b[2;3Hx')
+    assert screen.cursor.y == 1
+    assert tc.screenToText(screen).split('\n')[1][2] == 'x'
+
+
+def test_carriage_return_overwrites_in_place():
+    assert tc.screenToText(_feed(b'abc\rZ')).split('\n')[0].startswith('Zbc')
+
+
+def test_erase_display_clears_text():
+    assert 'junk' not in tc.screenToText(_feed(b'junk\x1b[2J'))
+
+
+def test_rendered_geometry_matches_screen():
+    lines = tc.screenToText(_feed(b'x', columns=20, lines=4)).split('\n')
+    assert len(lines) == 4
+    # Padding is retained so a string column matches a screen column, which is
+    # what makes the widget's cursor placement exact.
+    assert all(len(line) == 20 for line in lines)
+
+
+def test_partial_utf8_across_feeds():
+    # The single most important decoding regression: a multi-byte character
+    # split across two reads must not become two replacement characters.
+    screen = pyte.Screen(20, 4)
+    stream = pyte.ByteStream(screen)
+    stream.feed(b'\xc3')
+    stream.feed(b'\xa9')
+    assert tc.screenToText(screen).split('\n')[0][0] == 'é'
+
+
+def test_invalid_utf8_is_replaced_not_raised():
+    assert tc.screenToText(_feed(b'\xff'))[0] == '�'
+
+
+def test_dirty_tracks_changed_lines():
+    screen = pyte.Screen(20, 4)
+    stream = pyte.ByteStream(screen)
+    screen.dirty.clear()
+    stream.feed(b'hi')
+    assert screen.dirty == {0}
+
+
+def test_resize_keyword_ordering():
+    # pyte.Screen() takes columns first but resize() takes lines first. Getting
+    # this backwards transposes the screen.
+    screen = pyte.Screen(20, 4)
+    screen.resize(lines=10, columns=40)
+    assert (screen.lines, screen.columns) == (10, 40)
+
+
+# ---------------------------------------------------------------------------
+# Terminal query replies
+# ---------------------------------------------------------------------------
+
+def _reply(data):
+    """Return the bytes a TerminalScreen writes back in answer to ``data``."""
+    sent = []
+    screen = tc.TerminalScreen(20, 4, sent.append)
+    pyte.ByteStream(screen).feed(data)
+    return b''.join(sent)
+
+
+def test_screen_answers_cursor_position_report():
+    # Without this, readline, less and many shell prompts hang waiting for a
+    # reply that pyte's default no-op write_process_input never sends. The
+    # introducer is left unasserted because whether pyte emits the 7-bit
+    # "\x1b[" or the 8-bit "\x9b" form is its internal choice; both are valid
+    # and terminals accept either.
+    reply = _reply(b'\x1b[6n')
+    assert reply.endswith(b'1;1R')
+
+
+def test_screen_reports_moved_cursor_position():
+    assert _reply(b'\x1b[2;3H\x1b[6n').endswith(b'2;3R')
+
+
+def test_screen_answers_device_attributes():
+    assert _reply(b'\x1b[c') != b''
+
+
+# ---------------------------------------------------------------------------
+# Scrollback capture
+# ---------------------------------------------------------------------------
+
+def _scrolled(data, columns=20, lines=3, scrollback=100):
+    screen = tc.TerminalScreen(columns, lines, lambda b: None, scrollback=scrollback)
+    pyte.ByteStream(screen).feed(data)
+    return screen
+
+
+def _text(runs):
+    """Flatten a row of runs back to plain text."""
+    return ''.join(text for text, _attrs in runs)
+
+
+def _scrollbackText(screen):
+    return [_text(runs) for runs in screen.scrolledOff]
+
+
+def test_nothing_scrolls_off_until_the_screen_fills():
+    screen = _scrolled(b'a\r\nb\r\nc')
+    assert list(screen.scrolledOff) == []
+
+
+def test_lines_scrolling_off_the_top_are_kept():
+    # A 3 line screen: writing 5 lines pushes the first two into scrollback.
+    screen = _scrolled(b'one\r\ntwo\r\nthree\r\nfour\r\nfive')
+    assert _scrollbackText(screen) == ['one', 'two']
+    # The live screen keeps only what still fits.
+    assert [line.rstrip() for line in tc.screenLines(screen)] == ['three', 'four', 'five']
+
+
+def test_scrollback_lines_are_stripped_of_padding():
+    screen = _scrolled(b'x\r\n\r\n\r\n\r\n')
+    assert all(line == line.rstrip() for line in _scrollbackText(screen))
+
+
+def test_scrollback_is_bounded():
+    # The deque bound is what stops a long-lived terminal growing without end.
+    screen = _scrolled(b''.join(b'line%d\r\n' % i for i in range(50)), scrollback=10)
+    # Feeding 50 terminated lines onto a 3 line screen scrolls off line0..line47,
+    # leaving line48 and line49 plus the trailing empty line live. Only the most
+    # recent 10 scrolled-off lines are kept.
+    assert _scrollbackText(screen) == [f'line{i}' for i in range(38, 48)]
+
+
+def test_scrollback_survives_a_resize():
+    screen = _scrolled(b'one\r\ntwo\r\nthree\r\nfour\r\nfive')
+    before = list(screen.scrolledOff)
+    screen.resize(lines=6, columns=30)
+    assert list(screen.scrolledOff) == before
+
+
+def test_shrinking_the_screen_keeps_the_lost_rows():
+    # pyte's own resize deletes the excess rows off the top outright rather than
+    # scrolling them, so they never reach index(). Making a window shorter has to
+    # move that content into the scrollback, not destroy it.
+    screen = _scrolled(b'one\r\ntwo\r\nthree', lines=4)
+    assert list(screen.scrolledOff) == []
+
+    screen.resize(lines=2, columns=20)
+
+    assert _scrollbackText(screen)[:2] == ['one', 'two']
+
+
+def test_growing_the_screen_keeps_scrollback_untouched():
+    screen = _scrolled(b'one\r\ntwo\r\nthree\r\nfour\r\nfive')
+    before = list(screen.scrolledOff)
+    screen.resize(lines=10, columns=40)
+    assert list(screen.scrolledOff) == before
+
+
+def test_scrollback_keeps_color_attributes():
+    # Without this a colored line would turn grey the moment it scrolled out of
+    # the live screen, which is a very visible artifact.
+    screen = _scrolled(b'\x1b[31mRED\x1b[0m\r\nb\r\nc\r\nd\r\ne')
+    first = screen.scrolledOff[0]
+    assert _text(first) == 'RED'
+    assert first[0][1][0] == 'red'
+
+
+# ---------------------------------------------------------------------------
+# Run-length encoding
+# ---------------------------------------------------------------------------
+
+def test_row_runs_collapses_uniform_text_to_one_run():
+    runs = tc.rowRuns(_feed(b'hello', columns=20, lines=2), 0, trim=True)
+    assert runs == [('hello', _feed(b'x', 20, 2).buffer[0][0][1:])]
+
+
+def test_row_runs_splits_on_attribute_change():
+    screen = _feed(b'ab\x1b[31mcd\x1b[0mef', columns=20, lines=2)
+    runs = tc.rowRuns(screen, 0, trim=True)
+    assert [text for text, _ in runs] == ['ab', 'cd', 'ef']
+    assert [attrs[0] for _, attrs in runs] == ['default', 'red', 'default']
+
+
+def test_row_runs_untrimmed_covers_every_column():
+    # The live screen must stay column exact, because the renderer maps a string
+    # column onto a screen column when it places the cursor.
+    screen = _feed(b'hi', columns=20, lines=2)
+    assert sum(len(text) for text, _ in tc.rowRuns(screen, 0)) == 20
+
+
+def test_row_runs_trimmed_drops_trailing_blanks():
+    screen = _feed(b'hi', columns=20, lines=2)
+    assert sum(len(text) for text, _ in tc.rowRuns(screen, 0, trim=True)) == 2
+
+
+def test_row_runs_trim_keeps_a_colored_background():
+    # A blank cell with a background color is visible, so it must survive the
+    # trim even though it holds no character.
+    screen = _feed(b'\x1b[44m   ', columns=10, lines=2)
+    runs = tc.rowRuns(screen, 0, trim=True)
+    assert runs and runs[0][1][1] == 'blue'
+
+
+def test_real_output_collapses_to_few_runs():
+    # Colorized output is long stretches of one attribute, which is what keeps
+    # per-run rendering cheap. This pins that assumption.
+    body = b''.join(b'\x1b[32mok\x1b[0m plain text here\r\n' for _ in range(10))
+    screen = _feed(body, columns=80, lines=12)
+    assert max(len(tc.rowRuns(screen, y)) for y in range(screen.lines)) <= 6
+
+
+def test_screen_runs_returns_one_entry_per_row():
+    screen = _feed(b'a\r\nb', columns=10, lines=4)
+    runs = tc.screenRuns(screen)
+    assert len(runs) == 4
+    assert _text(runs[0]).startswith('a')
+
+
+def test_history_screen_is_not_used():
+    # pyte.HistoryScreen hooks __getattribute__ and rebuilds a wrapper closure
+    # on every access to a wrapped event, including draw, which the stream calls
+    # once per character. Scrollback is captured in index() instead.
+    assert not issubclass(tc.TerminalScreen, pyte.HistoryScreen)
+
+
+# ---------------------------------------------------------------------------
+# Window size
+# ---------------------------------------------------------------------------
+
+@posixOnly
+def test_winsize_roundtrips_through_the_pty():
+    proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+    try:
+        _drain(master, 0.5)
+        tc.setWinSize(master, 30, 100)
+        os.write(master, b'stty size\n')
+        out = _drain(master, 1.5)
+        assert b'30 100' in out
+    finally:
+        tc.closeShell(proc, master)
+
+
+# ---------------------------------------------------------------------------
+# Controlling terminal and job control
+# ---------------------------------------------------------------------------
+
+# Reports the child's real controlling-terminal state. Deliberately a Python
+# child rather than a shell: an interactive bash acquires a controlling terminal
+# by itself, which would mask whether spawnShell provided one.
+_CTTY_PROBE = (
+    'import os,sys\n'
+    'try:\n'
+    '    fd=os.open("/dev/tty", os.O_RDWR); os.close(fd); c="YES"\n'
+    'except OSError: c="NO"\n'
+    'try: f=str(os.tcgetpgrp(0)==os.getpgrp())\n'
+    'except OSError: f="ENOTTY"\n'
+    'sys.stdout.write("PROBE CTTY=%s FG=%s\\n"%(c,f)); sys.stdout.flush()\n'
+)
+
+
+def _probeCtty(useCtty):
+    """Return the probe output line for a child spawned with or without a ctty."""
+    proc, master = tc.spawnShell(24, 80, argv=[sys.executable, '-c', _CTTY_PROBE],
+                                 useCtty=useCtty)
+    try:
+        out = _drain(master, 5.0).decode(errors='replace')
+    finally:
+        tc.closeShell(proc, master)
+
+    for line in out.splitlines():
+        if 'PROBE' in line:
+            return line.strip()
+
+    pytest.fail(f"probe produced no output: {out!r}")
+
+
+@posixOnly
+def test_child_gets_a_controlling_terminal():
+    # A controlling terminal is what gives the pty a foreground process group.
+    # Without one the line discipline has nothing to signal, so Ctrl-C, Ctrl-Z
+    # and shell job control all silently stop working.
+    assert _probeCtty(True) == 'PROBE CTTY=YES FG=True'
+
+
+@posixOnly
+def test_without_the_reopen_step_there_is_no_controlling_terminal():
+    # Negative control. subprocess(start_new_session=True) on its own cannot
+    # give the child a controlling terminal: the parent opened the slave, and a
+    # ctty is only acquired when a session leader opens a tty itself. This test
+    # exists so that nobody "simplifies away" the /bin/sh reopen step in
+    # spawnShell without noticing what it buys.
+    assert _probeCtty(False) == 'PROBE CTTY=NO FG=ENOTTY'
+
+
+@posixOnly
+def test_sigint_interrupts_the_foreground_job():
+    # End-to-end proof that the controlling terminal works: writing ETX must
+    # make the line discipline signal the foreground process group, so the shell
+    # returns to a prompt instead of waiting out the sleep.
+    #
+    # The prompt is set to a unique token first. The pty echoes back everything
+    # written to it, so matching on anything that is also typed would match the
+    # echo rather than the shell's own output.
+    proc, master = tc.spawnShell(24, 80)
+    try:
+        _drain(master, 1.0)
+        os.write(master, b"PS1='<<RDY>>'\n")
+        _drain(master, 1.0)
+
+        os.write(master, b'sleep 30\n')
+        _drain(master, 0.5)
+
+        os.write(master, b'\x03')
+        # The sleep is far longer than this window, so a prompt appearing here
+        # can only mean the foreground job was actually interrupted.
+        out = _drain(master, 5.0)
+
+        assert b'<<RDY>>' in out, "the shell never returned to a prompt"
+        assert proc.poll() is None, "the shell itself must survive the interrupt"
+    finally:
+        tc.closeShell(proc, master)
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+@posixOnly
+def test_master_reports_eof_or_eio_when_child_exits():
+    # Documents the platform split the read loop has to handle: Linux raises
+    # EIO on the master once the child is gone, macOS returns an empty read.
+    proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+    os.write(master, b'exit\n')
+
+    sawEnd = False
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        select.select([master], [], [], 0.1)
+        try:
+            if os.read(master, 4096) == b'':
+                sawEnd = True
+                break
+        except BlockingIOError:
+            continue
+        except OSError as exc:
+            assert exc.errno in (errno.EIO, errno.EBADF)
+            sawEnd = True
+            break
+
+    tc.closeShell(proc, master)
+    assert sawEnd
+
+
+@posixOnly
+def test_close_reaps_child_leaving_no_zombie():
+    proc, master = tc.spawnShell(24, 80)
+    pid = proc.pid
+    tc.closeShell(proc, master)
+
+    with pytest.raises(ChildProcessError):
+        os.waitpid(pid, os.WNOHANG)
+
+
+@posixOnly
+def test_close_kills_a_shell_that_ignores_hangup():
+    proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+    _drain(master, 0.5)
+    os.write(master, b'trap "" HUP TERM; sleep 60\n')
+    _drain(master, 0.5)
+
+    started = time.monotonic()
+    tc.closeShell(proc, master)
+    elapsed = time.monotonic() - started
+
+    assert proc.poll() is not None, "SIGKILL escalation must terminate it"
+    assert elapsed < 3.0
+
+
+@posixOnly
+def test_close_is_idempotent():
+    proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+    assert tc.closeShell(proc, master) == -1
+    assert tc.closeShell(proc, -1) == -1
+
+
+@posixOnly
+@pytest.mark.skipif(not sys.platform.startswith('linux'), reason="reads /proc/self/fd")
+def test_repeated_spawn_and_close_does_not_leak_descriptors():
+    before = len(os.listdir('/proc/self/fd'))
+
+    for _ in range(10):
+        proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+        tc.closeShell(proc, master)
+
+    assert len(os.listdir('/proc/self/fd')) == before
+
+
+@posixOnly
+def test_spawn_does_not_warn_about_forking(recwarn):
+    # os.forkpty() raises a DeprecationWarning in a multi-threaded process from
+    # Python 3.12, and the Rogue GUI always has Rogue, ZeroMQ and Qt threads.
+    # That is why this spawns through subprocess instead of pty.fork().
+    proc, master = tc.spawnShell(24, 80, argv=['/bin/sh', '-i'])
+    tc.closeShell(proc, master)
+
+    assert [w for w in recwarn if issubclass(w.category, DeprecationWarning)] == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_terminal_panel.py
+++ b/tests/interfaces/test_pydm_terminal_panel.py
@@ -228,5 +228,21 @@ def test_shutdown_terminates_the_shell(tabbed):
     assert panel.terminal._proc is None
 
 
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+def test_defaults_are_a_login_shell_terminal(tabbed):
+    # The panel is parameterized so the IPython tab can reuse it. Nothing about
+    # the terminal's own presentation may drift as a result.
+    _tabs, panel = tabbed
+
+    assert panel.terminal._argv is None
+    assert panel._tabLabel == 'Terminal'
+    assert panel._windowTitle == 'Rogue Terminal'
+    assert panel._attachTip == 'Move the terminal into its own window'
+    assert panel._detachTip == 'Put the terminal back in the main window'
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_terminal_panel.py
+++ b/tests/interfaces/test_pydm_terminal_panel.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Checks detaching the terminal into its own window and putting it back. The
+# property that matters most is that reparenting does not disturb the running
+# shell, since the whole feature would be pointless if detaching restarted it.
+# Needs a QApplication, so it self-skips without Qt.
+
+import pytest
+
+try:
+    import pyte  # noqa: F401
+    from qtpy.QtCore import Qt
+    from qtpy.QtGui import QCloseEvent
+    from qtpy.QtWidgets import QApplication, QPushButton, QTabWidget, QWidget
+    # The widget package imports pydm, which needs more of the Qt stack than the
+    # modules above. Import it here so a partial Qt install skips the module
+    # rather than erroring inside every fixture.
+    from pyrogue.pydm import widgets  # noqa: F401
+except Exception as exc:
+    pytest.skip(
+        f"PyDM/Qt test dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def tabbed(qapp):
+    """A panel sitting in a tab widget, with its shell started."""
+    from pyrogue.pydm.widgets import TerminalPanel
+
+    tabs = QTabWidget()
+    tabs.addTab(QWidget(), 'Other')
+    panel = TerminalPanel(parent=None)
+    tabs.addTab(panel, 'Terminal')
+    tabs.resize(700, 400)
+    tabs.show()
+    tabs.activateWindow()
+    tabs.setCurrentIndex(1)
+    qapp.processEvents()
+
+    yield (tabs, panel)
+
+    panel.shutdown()
+    tabs.deleteLater()
+    qapp.processEvents()
+
+
+def _labels(tabs):
+    return [tabs.tabText(i) for i in range(tabs.count())]
+
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+def test_panel_exposes_the_terminal(tabbed):
+    from pyrogue.pydm.widgets import LinuxTerminal
+    _tabs, panel = tabbed
+    assert isinstance(panel.terminal, LinuxTerminal)
+
+
+def test_panel_has_a_button(tabbed):
+    _tabs, panel = tabbed
+    button = panel.findChild(QPushButton)
+    assert button is not None
+    assert button.text() == 'Detach'
+
+
+def test_button_does_not_take_keyboard_focus(tabbed):
+    # Otherwise clicking it would steal the keyboard from the shell, and Tab
+    # completion could land on the button instead of being sent to the pty.
+    _tabs, panel = tabbed
+    assert panel.findChild(QPushButton).focusPolicy() == Qt.NoFocus
+
+
+def test_starts_attached(tabbed):
+    _tabs, panel = tabbed
+    assert not panel.isDetached()
+    assert not panel.isWindow()
+
+
+# ---------------------------------------------------------------------------
+# Detach and reattach
+# ---------------------------------------------------------------------------
+
+def test_detach_removes_the_tab_and_makes_a_window(tabbed):
+    tabs, panel = tabbed
+    panel.detach()
+
+    assert panel.isDetached()
+    assert panel.isWindow()
+    assert _labels(tabs) == ['Other']
+
+
+def test_detached_window_stays_owned_by_the_gui(tabbed):
+    # Parented to the main window rather than to nothing, so closing the GUI
+    # takes the detached terminal with it instead of leaving a stray window
+    # holding the process open.
+    tabs, panel = tabbed
+    owner = tabs.window()
+    panel.detach()
+    assert panel.parent() is owner
+
+
+def test_detach_keeps_the_same_shell(tabbed):
+    _tabs, panel = tabbed
+    pid = panel.terminal._proc.pid
+
+    panel.detach()
+
+    assert panel.terminal._proc.pid == pid
+    assert panel.terminal._proc.poll() is None
+
+
+def test_reattach_restores_the_tab_at_its_original_position(tabbed):
+    tabs, panel = tabbed
+    index = tabs.indexOf(panel)
+
+    panel.detach()
+    panel.reattach()
+
+    assert not panel.isDetached()
+    assert tabs.indexOf(panel) == index
+    assert tabs.currentIndex() == index
+    assert _labels(tabs) == ['Other', 'Terminal']
+
+
+def test_reattach_keeps_the_same_shell(tabbed):
+    _tabs, panel = tabbed
+    pid = panel.terminal._proc.pid
+
+    panel.detach()
+    panel.reattach()
+
+    assert panel.terminal._proc.pid == pid
+    assert panel.terminal._proc.poll() is None
+
+
+def test_button_label_tracks_the_state(tabbed):
+    _tabs, panel = tabbed
+    button = panel.findChild(QPushButton)
+
+    panel.detach()
+    assert button.text() == 'Reattach'
+
+    panel.reattach()
+    assert button.text() == 'Detach'
+
+
+def test_toggle_switches_both_ways(tabbed):
+    _tabs, panel = tabbed
+
+    panel.toggleDetached()
+    assert panel.isDetached()
+
+    panel.toggleDetached()
+    assert not panel.isDetached()
+
+
+def test_detach_is_idempotent(tabbed):
+    tabs, panel = tabbed
+    panel.detach()
+    panel.detach()
+    assert panel.isDetached()
+    assert _labels(tabs) == ['Other']
+
+
+def test_reattach_when_attached_does_nothing(tabbed):
+    tabs, panel = tabbed
+    panel.reattach()
+    assert not panel.isDetached()
+    assert _labels(tabs) == ['Other', 'Terminal']
+
+
+def test_detach_outside_a_tab_widget_is_a_no_op(qapp):
+    # A panel used directly in a custom screen has nowhere to detach from, so
+    # the button must not strand it in a window it cannot return from.
+    from pyrogue.pydm.widgets import TerminalPanel
+
+    panel = TerminalPanel(parent=None)
+    try:
+        panel.detach()
+        assert not panel.isDetached()
+    finally:
+        panel.shutdown()
+        panel.deleteLater()
+        qapp.processEvents()
+
+
+# ---------------------------------------------------------------------------
+# Closing the detached window
+# ---------------------------------------------------------------------------
+
+def test_closing_the_detached_window_reattaches(tabbed):
+    # Closing it must not be a way to lose the terminal, so the close is turned
+    # into a reattach and the shell keeps running.
+    tabs, panel = tabbed
+    pid = panel.terminal._proc.pid
+    panel.detach()
+
+    event = QCloseEvent()
+    panel.closeEvent(event)
+
+    assert not event.isAccepted()
+    assert not panel.isDetached()
+    assert _labels(tabs) == ['Other', 'Terminal']
+    assert panel.terminal._proc.pid == pid
+    assert panel.terminal._proc.poll() is None
+
+
+def test_shutdown_terminates_the_shell(tabbed):
+    _tabs, panel = tabbed
+    panel.shutdown()
+    assert panel.terminal._proc is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_terminal_view.py
+++ b/tests/interfaces/test_pydm_terminal_view.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Checks how the terminal widget renders: what is actually on screen, where the
+# cursor row lands, scroll behaviour, and the dark theme. Bytes are fed straight
+# into the emulator rather than through a real shell, so there is no process and
+# no timing involved. Needs a QApplication, so it self-skips without Qt.
+
+import time
+
+import pytest
+
+try:
+    import pyte  # noqa: F401
+    from qtpy.QtCore import Qt
+    from qtpy.QtGui import QPalette
+    from qtpy.QtWidgets import QApplication
+    # The widget package imports pydm, which needs more of the Qt stack than the
+    # modules above. Import it here so a partial Qt install skips the module
+    # rather than erroring inside every fixture.
+    from pyrogue.pydm import widgets  # noqa: F401
+except Exception as exc:
+    pytest.skip(
+        f"PyDM/Qt test dependencies unavailable: {exc}",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def term(qapp):
+    """A shown terminal widget with no shell attached."""
+    from pyrogue.pydm.widgets import LinuxTerminal
+
+    widget = LinuxTerminal()
+    widget.resize(700, 300)
+    widget.show()
+    qapp.processEvents()
+
+    # Resizes are debounced behind a timer that a test event loop will not
+    # necessarily run, so apply the new geometry directly to keep this
+    # deterministic.
+    widget._applyGeometry()
+    qapp.processEvents()
+
+    yield widget
+    widget.shutdown()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _feed(widget, data):
+    """Push bytes through the emulator and repaint synchronously."""
+    widget._stream.feed(data)
+    widget._repaintTimer.stop()
+    widget._repaint()
+
+
+def _onScreen(widget):
+    """Return the rows currently visible, which is what a user sees."""
+    lines = widget.toPlainText().split('\n')
+    first = widget.firstVisibleBlock().blockNumber()
+    return lines[first:first + widget._viewportRows()]
+
+
+def _text(widget):
+    return [line.rstrip() for line in _onScreen(widget) if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Geometry
+# ---------------------------------------------------------------------------
+
+def test_emulated_grid_matches_the_visible_rows(term):
+    # If the emulated screen were taller than the viewport, its top row would be
+    # permanently scrolled out of sight.
+    assert term._screen.lines == term._viewportRows()
+
+
+def test_full_grid_fills_the_viewport_with_nothing_hidden(term):
+    _feed(term, b'hello')
+    assert term.document().blockCount() == term._screen.lines
+    assert term.verticalScrollBar().maximum() == 0
+
+
+def test_blank_rows_below_the_output_are_kept(term):
+    # The grid is fixed height, so a single line of output still occupies one
+    # row with the rest of the grid blank beneath it.
+    _feed(term, b'hello')
+    assert len(_onScreen(term)) == term._screen.lines
+    assert _text(term) == ['hello']
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+def test_erase_display_leaves_the_screen_blank(term):
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 2)))
+    assert _text(term) != []
+
+    # What `clear` does: home the cursor and erase the display.
+    _feed(term, b'\x1b[H\x1b[2J')
+    assert _text(term) == []
+
+
+def test_reset_leaves_the_screen_blank(term):
+    # Some clear implementations emit RIS instead of a home plus erase.
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 2)))
+    _feed(term, b'\x1bc')
+    assert _text(term) == []
+
+
+def test_clear_keeps_earlier_output_in_scrollback(term):
+    # Clearing the screen must not destroy history; it should still be reachable
+    # by scrolling up, which is how a terminal with scrollback behaves.
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 2)))
+    _feed(term, b'\x1bc')
+
+    assert 'LINE0' not in '\n'.join(_onScreen(term))
+    assert 'LINE0' in term.toPlainText()
+
+
+def test_output_after_clear_starts_at_the_top(term):
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 2)))
+    _feed(term, b'\x1bc')
+    _feed(term, b'AFTER')
+    assert _onScreen(term)[0].rstrip() == 'AFTER'
+
+
+# ---------------------------------------------------------------------------
+# Scrolling
+# ---------------------------------------------------------------------------
+
+def test_prompt_reaches_the_bottom_row_once_the_screen_fills(term):
+    # Enough output to scroll, then a prompt with no trailing newline, which is
+    # what a shell leaves on screen while waiting for input.
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 3)) + b'PROMPT$ ')
+
+    onScreen = _onScreen(term)
+    lastText = max(i for i, line in enumerate(onScreen) if line.strip())
+    assert onScreen[lastText].startswith('PROMPT$')
+    assert lastText == rows - 1
+
+
+def test_scrollback_accumulates_above_the_screen(term):
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 3)))
+
+    assert term.document().blockCount() > rows
+    assert term.verticalScrollBar().maximum() > 0
+    assert 'LINE0' in term.toPlainText()
+
+
+def test_view_stays_put_when_scrolled_up(term):
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 3)))
+
+    bar = term.verticalScrollBar()
+    bar.setValue(2)
+    _feed(term, b'MORE\r\n')
+
+    assert bar.value() == 2
+
+
+def test_view_follows_when_already_at_the_bottom(term):
+    rows = term._screen.lines
+    _feed(term, b''.join(b'LINE%d\r\n' % i for i in range(rows * 3)))
+
+    bar = term.verticalScrollBar()
+    bar.setValue(bar.maximum())
+    _feed(term, b'MORE\r\n')
+
+    assert bar.value() == bar.maximum()
+
+
+# ---------------------------------------------------------------------------
+# Appearance
+# ---------------------------------------------------------------------------
+
+def test_scrollbar_is_always_visible(term):
+    # An as-needed bar would appear and disappear as content crosses the
+    # viewport height, and because it consumes width that changes the column
+    # count, which can oscillate.
+    assert term.verticalScrollBarPolicy() == Qt.ScrollBarAlwaysOn
+
+
+def test_dark_theme_is_applied(term):
+    palette = term.palette()
+    background = palette.color(QPalette.Base)
+    foreground = palette.color(QPalette.Text)
+
+    assert background.lightness() < 60, "background should be dark"
+    assert foreground.lightness() > 150, "foreground should be light"
+
+
+# ---------------------------------------------------------------------------
+# Restarting after the shell exits
+# ---------------------------------------------------------------------------
+
+def _waitFor(qapp, predicate, timeout=8.0):
+    """Pump the event loop until ``predicate`` holds or the timeout expires."""
+    end = time.monotonic() + timeout
+
+    while time.monotonic() < end:
+        if predicate():
+            return True
+        qapp.processEvents()
+        time.sleep(0.02)
+
+    return predicate()
+
+
+def _waitReady(qapp, term):
+    """Wait until the shell has printed something, so it is reading input.
+
+    Sending Ctrl-D before the shell reaches its prompt proves nothing, because
+    the shell has not started reading yet.
+    """
+    assert _waitFor(qapp, lambda: term.toPlainText().strip() != ''), "shell never produced a prompt"
+
+
+def test_shell_exit_starts_a_fresh_session(qapp, term):
+    _waitReady(qapp, term)
+    # Ctrl-D and `exit` are easy to hit by accident. Leaving a dead terminal
+    # behind would mean restarting the whole GUI to get a shell back.
+    first = term._proc.pid
+    term.sendInput(b'echo BEFORE_EXIT\n')
+    assert _waitFor(qapp, lambda: 'BEFORE_EXIT' in term.toPlainText())
+
+    term.sendInput(b'\x04')                       # Ctrl-D
+    assert _waitFor(qapp, lambda: term._proc is not None and term._proc.pid != first)
+
+    assert term._proc.poll() is None, "the replacement shell must be running"
+
+
+def test_restarted_session_starts_clean(qapp, term):
+    _waitReady(qapp, term)
+    term.sendInput(b'echo OLD_OUTPUT\n')
+    assert _waitFor(qapp, lambda: 'OLD_OUTPUT' in term.toPlainText())
+
+    first = term._proc.pid
+    term.sendInput(b'\x04')
+    assert _waitFor(qapp, lambda: term._proc is not None and term._proc.pid != first)
+
+    # Same state as a freshly opened terminal: no leftover output, no scrollback.
+    assert _waitFor(qapp, lambda: 'OLD_OUTPUT' not in term.toPlainText())
+    assert term.verticalScrollBar().maximum() == 0
+
+
+def test_restarted_session_is_usable(qapp, term):
+    _waitReady(qapp, term)
+    first = term._proc.pid
+    term.sendInput(b'\x04')
+    assert _waitFor(qapp, lambda: term._proc is not None and term._proc.pid != first)
+
+    term.sendInput(b'echo AFTER_RESTART\n')
+    assert _waitFor(qapp, lambda: 'AFTER_RESTART' in term.toPlainText())
+
+
+def test_restart_can_happen_repeatedly(qapp, term):
+    _waitReady(qapp, term)
+    seen = {term._proc.pid}
+
+    for _ in range(3):
+        previous = term._proc.pid
+        term.sendInput(b'exit\n')
+        assert _waitFor(qapp, lambda: term._proc is not None and term._proc.pid != previous)
+        seen.add(term._proc.pid)
+
+    assert len(seen) == 4, "each exit should produce a distinct shell"
+    # A shell that lived long enough is not counted as a failure to start.
+    assert term._startupFailures == 0
+
+
+def test_a_shell_that_dies_instantly_is_not_restarted_forever(qapp, monkeypatch):
+    # Guards against spawning processes in a loop when the shell cannot start,
+    # for example a bogus $SHELL.
+    from pyrogue.pydm.widgets import terminal as module
+    from pyrogue.pydm.widgets import terminal_core
+
+    attempts = []
+    real = terminal_core.spawnShell
+
+    def instantExit(rows, cols, argv=None, useCtty=True):
+        attempts.append(1)
+        return real(rows, cols, argv=['/bin/true'], useCtty=useCtty)
+
+    monkeypatch.setattr(module, 'spawnShell', instantExit)
+
+    widget = module.LinuxTerminal()
+    widget.resize(700, 300)
+    widget.show()
+
+    try:
+        assert _waitFor(qapp, lambda: widget._startupFailures >= module._MAX_STARTUP_FAILURES)
+        # Let any runaway restart loop reveal itself.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            qapp.processEvents()
+            time.sleep(0.02)
+
+        assert len(attempts) <= module._MAX_STARTUP_FAILURES
+        assert widget._proc is None, "it should stop rather than hold a dead child"
+        assert 'not restarting' in ' '.join(widget.toPlainText().split())
+    finally:
+        widget.shutdown()
+        widget.deleteLater()
+        qapp.processEvents()
+
+
+def test_restart_rebinds_the_read_notifier(qapp, term):
+    _waitReady(qapp, term)
+    # The old notifier watches a descriptor that restart closes, so a stale one
+    # would either do nothing or fire on a recycled descriptor.
+    before = term._readNotifier
+    term.restart()
+
+    assert term._readNotifier is not before
+    term.sendInput(b'echo REBOUND\n')
+    assert _waitFor(qapp, lambda: 'REBOUND' in term.toPlainText())
+
+
+# ---------------------------------------------------------------------------
+# Keyboard focus
+# ---------------------------------------------------------------------------
+
+def test_terminal_takes_focus_when_its_tab_is_selected(qapp):
+    # Clicking a tab leaves the keyboard focus on the tab bar, so without the
+    # widget claiming it the terminal looks ready but ignores typing until it is
+    # clicked a second time.
+    from qtpy.QtWidgets import QTabWidget, QWidget
+    from pyrogue.pydm.widgets import LinuxTerminal
+
+    tabs = QTabWidget()
+    tabs.addTab(QWidget(), 'Other')
+    terminal = LinuxTerminal(parent=None)
+    tabs.addTab(terminal, 'Terminal')
+    tabs.resize(700, 300)
+    tabs.show()
+    tabs.activateWindow()
+    qapp.processEvents()
+
+    try:
+        assert not terminal.hasFocus(), "the other tab is selected at this point"
+
+        tabs.setCurrentIndex(1)
+        qapp.processEvents()
+        assert terminal.hasFocus()
+
+        # Leaving and returning has to focus it again, not just the first time.
+        tabs.setCurrentIndex(0)
+        qapp.processEvents()
+        tabs.setCurrentIndex(1)
+        qapp.processEvents()
+        assert terminal.hasFocus()
+    finally:
+        terminal.shutdown()
+        tabs.deleteLater()
+        qapp.processEvents()
+
+
+def test_terminal_accepts_keyboard_focus(term):
+    assert term.focusPolicy() == Qt.StrongFocus
+
+
+# ---------------------------------------------------------------------------
+# Color
+# ---------------------------------------------------------------------------
+
+def _formatAt(widget, needle):
+    """Return the character format applied to the first char of ``needle``."""
+    from qtpy.QtGui import QTextCursor
+
+    index = widget.toPlainText().index(needle)
+    cursor = QTextCursor(widget.document())
+    cursor.setPosition(index)
+    cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor)
+    return cursor.charFormat()
+
+
+def test_named_color_is_applied(term):
+    _feed(term, b'\x1b[31mRED\x1b[0m')
+    assert _formatAt(term, 'RED').foreground().color().name() == '#cd0000'
+
+
+def test_bold_renders_the_bright_shade_and_bold_weight(term):
+    # Colorizing tools emit bold plus a color meaning the bright variant, so
+    # bold has to brighten as well as embolden or their output looks wrong.
+    from qtpy.QtGui import QFont
+
+    _feed(term, b'\x1b[1;31mBOLD\x1b[0m')
+    fmt = _formatAt(term, 'BOLD')
+    assert fmt.foreground().color().name() == '#ff0000'
+    assert fmt.fontWeight() == QFont.Bold
+
+
+def test_aixterm_bright_color_is_applied(term):
+    _feed(term, b'\x1b[91mBRIGHT\x1b[0m')
+    assert _formatAt(term, 'BRIGHT').foreground().color().name() == '#ff0000'
+
+
+def test_256_color_is_applied(term):
+    _feed(term, b'\x1b[38;5;208mORANGE\x1b[0m')
+    assert _formatAt(term, 'ORANGE').foreground().color().name() == '#ff8700'
+
+
+def test_true_color_is_applied(term):
+    _feed(term, b'\x1b[38;2;10;20;30mTRUE\x1b[0m')
+    assert _formatAt(term, 'TRUE').foreground().color().name() == '#0a141e'
+
+
+def test_background_color_is_applied(term):
+    _feed(term, b'\x1b[44mONBLUE\x1b[0m')
+    assert _formatAt(term, 'ONBLUE').background().color().name() == '#0000ee'
+
+
+def test_reverse_swaps_foreground_and_background(term):
+    _feed(term, b'\x1b[7mREV\x1b[0m')
+    fmt = _formatAt(term, 'REV')
+    assert fmt.foreground().color().name() == '#1e1e1e'
+    assert fmt.background().color().name() == '#d4d4d4'
+
+
+def test_underline_and_italic_are_applied(term):
+    _feed(term, b'\x1b[4mUL\x1b[0m \x1b[3mIT\x1b[0m')
+    assert _formatAt(term, 'UL').fontUnderline()
+    assert _formatAt(term, 'IT').fontItalic()
+
+
+def test_plain_text_uses_the_theme_foreground(term):
+    _feed(term, b'PLAIN')
+    assert _formatAt(term, 'PLAIN').foreground().color().name() == '#d4d4d4'
+
+
+def test_unrecognised_color_falls_back_to_the_theme(term):
+    # pyte's own aixterm background table contains a misspelled name, so an
+    # unknown value must not raise or produce a black-on-black cell.
+    from pyrogue.pydm.widgets.terminal import resolveColor
+    assert resolveColor('bfightmagenta') is None
+    assert resolveColor('default') is None
+    assert resolveColor('') is None
+
+
+def test_color_survives_scrolling_into_scrollback(term):
+    # The whole point of keeping attributes in the scrollback: a colored line
+    # must not turn grey when it scrolls off the live screen.
+    rows = term._screen.lines
+    _feed(term, b'\x1b[32mGREENLINE\x1b[0m\r\n')
+    _feed(term, b''.join(b'filler%d\r\n' % i for i in range(rows * 2)))
+
+    assert 'GREENLINE' in term.toPlainText()
+    assert _formatAt(term, 'GREENLINE').foreground().color().name() == '#00cd00'
+
+
+def test_format_cache_is_small_for_real_output(term):
+    _feed(term, b''.join(b'\x1b[32mok\x1b[0m plain \x1b[31mbad\x1b[0m\r\n' for _ in range(20)))
+    # A handful of distinct attribute combinations, not one per cell.
+    assert len(term._formatCache) <= 8
+
+
+def test_escape_sequences_never_reach_the_view(term):
+    _feed(term, b'\x1b[31mred\x1b[0m\x1b[1mbold\x1b[0m')
+    text = term.toPlainText()
+    assert '\x1b' not in text
+    assert '31m' not in text
+    assert 'red' in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/interfaces/test_pydm_tools_widgets_smoke.py
+++ b/tests/interfaces/test_pydm_tools_widgets_smoke.py
@@ -99,6 +99,18 @@ def test_terminal_not_registered_in_designer():
     assert not hasattr(designer, 'LinuxTerminal')
 
 
+def test_import_ipython_panel():
+    from pyrogue.pydm.widgets.ipython import IPythonPanel
+    assert IPythonPanel is not None
+
+
+def test_ipython_not_registered_in_designer():
+    # Same reasoning as the terminal: a registered widget is instantiated by
+    # Designer, which would start an IPython session inside the design tool.
+    from pyrogue.pydm.widgets import designer
+    assert not hasattr(designer, 'IPythonPanel')
+
+
 def test_import_time_plotter():
     from pyrogue.pydm.widgets.time_plotter import DebugDev as TimePlotDebugDev
     assert TimePlotDebugDev is not None

--- a/tests/interfaces/test_pydm_tools_widgets_smoke.py
+++ b/tests/interfaces/test_pydm_tools_widgets_smoke.py
@@ -12,6 +12,7 @@
 import pytest
 
 try:
+    import pyte  # noqa: F401
     from pydm import Display  # noqa: F401
     from qtpy.QtWidgets import QWidget  # noqa: F401
 except Exception as exc:
@@ -83,6 +84,19 @@ def test_import_system_log():
 def test_import_system_window():
     from pyrogue.pydm.widgets.system_window import SystemWindow
     assert SystemWindow is not None
+
+
+def test_import_terminal():
+    from pyrogue.pydm.widgets.terminal import LinuxTerminal
+    assert LinuxTerminal is not None
+
+
+def test_terminal_not_registered_in_designer():
+    # Qt Designer eagerly instantiates every registered widget, which would
+    # fork a pseudo-terminal and a shell inside the design tool. Keep the
+    # terminal out of the Designer plugin group.
+    from pyrogue.pydm.widgets import designer
+    assert not hasattr(designer, 'LinuxTerminal')
 
 
 def test_import_time_plotter():

--- a/tests/interfaces/test_pydm_top_tab_options.py
+++ b/tests/interfaces/test_pydm_top_tab_options.py
@@ -9,9 +9,11 @@
 # contained in the LICENSE.txt file.
 #-----------------------------------------------------------------------------
 
-# Checks how DefaultTop parses the enableTerminal display argument and where the
-# resulting tab lands. pydm, qtpy and the widget package are stubbed, so this
-# needs no Qt binding and no display.
+# Checks how DefaultTop parses the enableTerminal and enableIPython display
+# arguments and where the resulting tabs land. The two options are independent,
+# so the cases that matter most are the ones with only one of them on: neither
+# may move a tab the other added. pydm, qtpy and the widget package are stubbed,
+# so this needs no Qt binding and no display.
 
 import contextlib
 import importlib.util
@@ -37,7 +39,7 @@ class FakeTabWidget:
 
 
 @contextlib.contextmanager
-def _stubbedPydmTop(terminalLog, tabLog):
+def _stubbedPydmTop(terminalLog, ipythonLog, tabLog):
     modulePath = Path(__file__).resolve().parents[2] / "python/pyrogue/pydm/pydmTop.py"
 
     fakePydm = types.ModuleType("pydm")
@@ -82,10 +84,18 @@ def _stubbedPydmTop(terminalLog, tabLog):
         terminalLog.append(terminal)
         return terminal
 
+    def makeIPython(parent=None, init_channel=None):
+        # Records the channel, because the console resolving the wrong server is
+        # a failure that looks like success until a register read goes to the
+        # wrong place.
+        ipythonLog.append(init_channel)
+        return object()
+
     fakeWidgets = types.ModuleType("pyrogue.pydm.widgets")
     fakeWidgets.SystemWindow = lambda parent=None, init_channel=None: object()
     fakeWidgets.DebugTree = lambda parent=None, init_channel=None: object()
     fakeWidgets.TerminalPanel = makeTerminal
+    fakeWidgets.IPythonPanel = makeIPython
 
     fakePyrogue = types.ModuleType("pyrogue")
     fakePyrogue.__path__ = []
@@ -121,12 +131,30 @@ def _stubbedPydmTop(terminalLog, tabLog):
 def _build(args):
     """Construct DefaultTop with the given display args."""
     terminalLog = []
+    ipythonLog = []
     tabLog = []
 
-    with _stubbedPydmTop(terminalLog, tabLog) as module:
+    with _stubbedPydmTop(terminalLog, ipythonLog, tabLog) as module:
         top = module.DefaultTop(parent=None, args=args, macros=None)
 
     return (top, terminalLog, tabLog[0])
+
+
+def _buildIPython(args):
+    """Construct DefaultTop and return the channels the console was given."""
+    terminalLog = []
+    ipythonLog = []
+    tabLog = []
+
+    with _stubbedPydmTop(terminalLog, ipythonLog, tabLog) as module:
+        top = module.DefaultTop(parent=None, args=args, macros=None)
+
+    return (top, ipythonLog, tabLog[0])
+
+
+def _module():
+    """Load pydmTop under stubs, for tests that only need module scope."""
+    return _stubbedPydmTop([], [], [])
 
 
 def _labels(tab):
@@ -149,18 +177,18 @@ def _labels(tab):
     ("", False),
 ])
 def test_parse_bool_arg_values(value, expected):
-    with _stubbedPydmTop([], []) as module:
+    with _module() as module:
         assert module._parseBoolArg([f"enableTerminal={value}"], "enableTerminal") is expected
 
 
 def test_parse_bool_arg_absent_returns_none():
     # None rather than False so the caller keeps its own default.
-    with _stubbedPydmTop([], []) as module:
+    with _module() as module:
         assert module._parseBoolArg(["sizeX=800"], "enableTerminal") is None
 
 
 def test_parse_bool_arg_ignores_quotes():
-    with _stubbedPydmTop([], []) as module:
+    with _module() as module:
         assert module._parseBoolArg(["enableTerminal='True'"], "enableTerminal") is True
 
 
@@ -193,7 +221,8 @@ def test_terminal_is_the_last_tab():
 
 
 def test_default_tab_is_still_debug_tree():
-    for args in (["enableTerminal=True"], ["enableTerminal=False"], []):
+    for args in (["enableTerminal=True"], ["enableTerminal=False"], [],
+                 ["enableIPython=True"], ["enableTerminal=True", "enableIPython=True"]):
         _top, _terminals, tab = _build(args)
         assert tab.currentIndex == 1
 
@@ -206,6 +235,89 @@ def test_enable_terminal_inside_title_does_not_enable_it():
     assert _labels(tab) == ['System', 'Debug Tree']
     assert terminals == []
     assert top.terminal is None
+
+
+# ---------------------------------------------------------------------------
+# IPython tab
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value,expected", [
+    ("True", True),
+    ("true", True),
+    ("1", True),
+    ("yes", True),
+    ("on", True),
+    ("False", False),
+    ("false", False),
+    ("0", False),
+    ("", False),
+])
+def test_parse_enable_ipython_values(value, expected):
+    with _module() as module:
+        assert module._parseBoolArg([f"enableIPython={value}"], "enableIPython") is expected
+
+
+def test_ipython_is_off_by_default():
+    top, ipythons, tab = _buildIPython([])
+    assert _labels(tab) == ['System', 'Debug Tree']
+    assert ipythons == []
+    assert top.ipython is None
+
+
+def test_ipython_is_added_as_a_top_level_tab():
+    top, ipythons, tab = _buildIPython(["enableIPython=True"])
+    assert _labels(tab) == ['System', 'Debug Tree', 'IPython']
+    assert len(ipythons) == 1
+    assert top.ipython is not None
+
+
+def test_ipython_gets_the_same_channel_as_the_other_tabs():
+    # A console pointed somewhere other than the tabs above it would read
+    # registers from a different server than the display is showing.
+    _top, ipythons, _tab = _buildIPython(["enableIPython=True"])
+    assert ipythons == ['rogue://0/root']
+
+
+def test_enable_ipython_inside_title_does_not_enable_it():
+    top, ipythons, tab = _buildIPython(["title='enableIPython=True'"])
+    assert _labels(tab) == ['System', 'Debug Tree']
+    assert ipythons == []
+    assert top.ipython is None
+
+
+# ---------------------------------------------------------------------------
+# The two options are independent
+# ---------------------------------------------------------------------------
+
+def test_ipython_alone_does_not_add_a_terminal():
+    top, terminals, tab = _build(["enableIPython=True"])
+    assert _labels(tab) == ['System', 'Debug Tree', 'IPython']
+    assert terminals == []
+    assert top.terminal is None
+
+
+def test_terminal_alone_does_not_add_a_console():
+    top, ipythons, tab = _buildIPython(["enableTerminal=True"])
+    assert _labels(tab) == ['System', 'Debug Tree', 'Terminal']
+    assert ipythons == []
+    assert top.ipython is None
+
+
+def test_both_tabs_can_be_enabled_together():
+    top, terminals, tab = _build(["enableTerminal=True", "enableIPython=True"])
+    assert _labels(tab) == ['System', 'Debug Tree', 'Terminal', 'IPython']
+    assert len(terminals) == 1
+    assert top.terminal is not None
+    assert top.ipython is not None
+
+
+def test_enabling_ipython_does_not_move_the_terminal():
+    # Both are appended, so the terminal keeps index 2 whether or not the console
+    # is also on. Anything that reorders these breaks a user's muscle memory and
+    # any saved window state.
+    _top, _terminals, withConsole = _build(["enableTerminal=True", "enableIPython=True"])
+    _top2, _terminals2, alone = _build(["enableTerminal=True"])
+    assert _labels(withConsole).index('Terminal') == _labels(alone).index('Terminal')
 
 
 if __name__ == "__main__":

--- a/tests/interfaces/test_pydm_top_terminal_option.py
+++ b/tests/interfaces/test_pydm_top_terminal_option.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+#-----------------------------------------------------------------------------
+# This file is part of the rogue software platform. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the rogue software platform, including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+#-----------------------------------------------------------------------------
+
+# Checks how DefaultTop parses the enableTerminal display argument and where the
+# resulting tab lands. pydm, qtpy and the widget package are stubbed, so this
+# needs no Qt binding and no display.
+
+import contextlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+class FakeTabWidget:
+    """Records tabs and the selected index."""
+
+    def __init__(self):
+        self.tabs = []
+        self.currentIndex = None
+
+    def addTab(self, widget, label):
+        self.tabs.append((widget, label))
+
+    def setCurrentIndex(self, index):
+        self.currentIndex = index
+
+
+@contextlib.contextmanager
+def _stubbedPydmTop(terminalLog, tabLog):
+    modulePath = Path(__file__).resolve().parents[2] / "python/pyrogue/pydm/pydmTop.py"
+
+    fakePydm = types.ModuleType("pydm")
+
+    class FakeDisplay:
+        def __init__(self, parent=None, args=None, macros=None):
+            pass
+
+        def setWindowTitle(self, title):
+            self.windowTitle = title
+
+        def setLayout(self, layout):
+            pass
+
+        def resize(self, x, y):
+            self.size = (x, y)
+
+    fakePydm.Display = FakeDisplay
+
+    class FakeLayout:
+        def __init__(self):
+            self.widgets = []
+
+        def addWidget(self, widget, stretch=0):
+            self.widgets.append(widget)
+
+    def makeTab():
+        tab = FakeTabWidget()
+        tabLog.append(tab)
+        return tab
+
+    fakeQtpy = types.ModuleType("qtpy")
+    fakeQtpy.__path__ = []
+    fakeQtWidgets = types.ModuleType("qtpy.QtWidgets")
+    fakeQtWidgets.QVBoxLayout = FakeLayout
+    fakeQtWidgets.QTabWidget = makeTab
+    fakeQtWidgets.QWidget = type("FakeQWidget", (), {})
+    fakeQtpy.QtWidgets = fakeQtWidgets
+
+    def makeTerminal(parent=None):
+        terminal = object()
+        terminalLog.append(terminal)
+        return terminal
+
+    fakeWidgets = types.ModuleType("pyrogue.pydm.widgets")
+    fakeWidgets.SystemWindow = lambda parent=None, init_channel=None: object()
+    fakeWidgets.DebugTree = lambda parent=None, init_channel=None: object()
+    fakeWidgets.TerminalPanel = makeTerminal
+
+    fakePyrogue = types.ModuleType("pyrogue")
+    fakePyrogue.__path__ = []
+    fakePyroguePydm = types.ModuleType("pyrogue.pydm")
+    fakePyroguePydm.__path__ = []
+
+    saved = {}
+    for name, module in {
+        "pydm": fakePydm,
+        "qtpy": fakeQtpy,
+        "qtpy.QtWidgets": fakeQtWidgets,
+        "pyrogue": fakePyrogue,
+        "pyrogue.pydm": fakePyroguePydm,
+        "pyrogue.pydm.widgets": fakeWidgets,
+    }.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    try:
+        spec = importlib.util.spec_from_file_location("rogue_test_pydm_top", modulePath)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def _build(args):
+    """Construct DefaultTop with the given display args."""
+    terminalLog = []
+    tabLog = []
+
+    with _stubbedPydmTop(terminalLog, tabLog) as module:
+        top = module.DefaultTop(parent=None, args=args, macros=None)
+
+    return (top, terminalLog, tabLog[0])
+
+
+def _labels(tab):
+    return [label for _widget, label in tab.tabs]
+
+
+# ---------------------------------------------------------------------------
+# Boolean argument parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value,expected", [
+    ("True", True),
+    ("true", True),
+    ("1", True),
+    ("yes", True),
+    ("on", True),
+    ("False", False),
+    ("false", False),
+    ("0", False),
+    ("", False),
+])
+def test_parse_bool_arg_values(value, expected):
+    with _stubbedPydmTop([], []) as module:
+        assert module._parseBoolArg([f"enableTerminal={value}"], "enableTerminal") is expected
+
+
+def test_parse_bool_arg_absent_returns_none():
+    # None rather than False so the caller keeps its own default.
+    with _stubbedPydmTop([], []) as module:
+        assert module._parseBoolArg(["sizeX=800"], "enableTerminal") is None
+
+
+def test_parse_bool_arg_ignores_quotes():
+    with _stubbedPydmTop([], []) as module:
+        assert module._parseBoolArg(["enableTerminal='True'"], "enableTerminal") is True
+
+
+# ---------------------------------------------------------------------------
+# Tab layout
+# ---------------------------------------------------------------------------
+
+def test_default_tabs_are_unchanged_when_disabled():
+    # Nothing about an existing GUI changes unless the terminal is asked for.
+    top, terminals, tab = _build(["sizeX=800", "enableTerminal=False"])
+    assert _labels(tab) == ['System', 'Debug Tree']
+    assert terminals == []
+    assert top.terminal is None
+
+
+def test_terminal_is_added_as_a_top_level_tab():
+    top, terminals, tab = _build(["enableTerminal=True"])
+    assert _labels(tab) == ['System', 'Debug Tree', 'Terminal']
+    assert len(terminals) == 1
+    assert top.terminal is terminals[0]
+
+
+def test_terminal_is_the_last_tab():
+    # Appended last so the System and Debug Tree indexes are the same whether or
+    # not the terminal is enabled.
+    _top, _terminals, tab = _build(["enableTerminal=True"])
+    assert _labels(tab).index('System') == 0
+    assert _labels(tab).index('Debug Tree') == 1
+    assert _labels(tab).index('Terminal') == 2
+
+
+def test_default_tab_is_still_debug_tree():
+    for args in (["enableTerminal=True"], ["enableTerminal=False"], []):
+        _top, _terminals, tab = _build(args)
+        assert tab.currentIndex == 1
+
+
+def test_enable_terminal_inside_title_does_not_enable_it():
+    # The older size and title arguments are matched with a substring test, so a
+    # title containing the argument name would false-positive. _parseBoolArg
+    # matches on a leading prefix instead.
+    top, terminals, tab = _build(["title='enableTerminal=True'"])
+    assert _labels(tab) == ['System', 'Debug Tree']
+    assert terminals == []
+    assert top.terminal is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
### Description

Adds two optional tabs to the default PyDM GUI, both off by default and
independent of each other. Both are appended after the existing tabs, so no tab
position changes and `Debug Tree` is still shown on startup.

- **`Terminal`**, an interactive local shell, enabled with
  `runPyDM(enableTerminal=True)` or `python -m pyrogue gui --terminal`. Job
  control works, so `Ctrl-C`, `Ctrl-Z`, `fg` and `jobs` behave normally, as do
  full-screen programs such as `vim` and `htop`. Color output, 2000 lines of
  scrollback that retains color, and a dark theme.
- **`IPython`**, an IPython session with a Rogue client already connected,
  enabled with `runPyDM(enableIPython=True)` or `python -m pyrogue gui --ipython`.
  `client`, `root` and `pr` are in scope against the same server the rest of the
  GUI is using, which is the session the Rogue server suggests at startup opened
  rather than typed out. Tab completion on the tree, highlighting, history search
  and `%magics` all work. Rich output does not, so no inline plotting, because the
  view is a text screen.

Both start their process the first time the tab is displayed, detach into their
own window and reattach without disturbing the running session, and start a fresh
session if the old one exits.

Both run on the machine displaying the GUI, as the user who launched it, **not**
on the Rogue server. Anyone who can reach the window gets a shell, or arbitrary
Python, with that user's privileges, and PyDM read-only mode restricts neither.
That is why they are opt-in, and the documentation covers the considerations.

Also fixes a `VirtualClient` bug this work exposed: its link monitor was not a
daemon thread, so a process that connected a client and never called `stop()`
could not exit. That hangs the one-line client the server banner suggests when it
is used from `python -i`, and any script that connects and falls off the end.

Adds `pyte` and `ipython` as dependencies, declared with the rest of the GUI
stack.

### Details

- **Emulation.** Qt has no terminal widget, so `pyte` does the VT emulation and
  the result is painted into a `QPlainTextEdit`. `TerminalScreen` overrides
  `write_process_input`, a `pyte` no-op that cursor position reports reply
  through, and keeps the scrollback rows `pyte` would otherwise drop.
- **Spawn.** `openpty` plus `subprocess`, since `os.forkpty` warns in a
  multi-threaded process from Python 3.12 on. `start_new_session` cannot grant a
  controlling terminal, so the child goes through `/bin/sh` reopening the pty
  slave inside the new session; without that there is no foreground process group
  and `Ctrl-C` stops working. A negative-control test pins it.
- **Console.** IPython on the same pty rather than an embedded `qtconsole`: no
  new dependency, and it is a `TerminalPanel` subclass supplying an argv. Started
  as `sys.executable -m IPython -i -c` so it imports the same `pyrogue`, with the
  address interpolated only through `repr()` and its own client in its own
  process. Neither widget is registered for Qt Designer, which instantiates
  eagerly.
- **Tree completion.** jedi cannot follow the tree's `__getattr__` and crashes on
  its nodes, after which IPython offers only the crash text, so Tab looked
  ignored while ordinary objects completed fine. `--IPCompleter.use_jedi=False`
  falls back to IPython's own `dir()` based completer; the cost is jedi's type
  inference on ordinary Python.
- **Client shutdown.** The monitor thread is joined before `atexit` runs, so only
  a daemon thread or an explicit `stop()` lets the process exit. That join is why
  exiting the console did not restart it: the child stayed alive, so the pty never
  reported end of file.
- **Docker.** Quotes the `pydm` specifier in `docker/rogue/Dockerfile`. Unquoted,
  `>=1.18.0` was a shell redirection and the image installed `pydm` unpinned.
- **Docs.** New `terminal_tab.rst` and `ipython_tab.rst`, with
  `starting_gui.rst`, `rogue_widgets.rst` and new API pages updated.

**Testing.** 8 new test files collecting 205 tests, 4 extended: controlling
terminal and job control, descriptor and zombie leaks over repeated spawn and
close cycles, key translation, screen and color rendering, detach and reattach,
option plumbing for both tabs, and for the console the Qt-free startup code, a
real session on a pty, tree completion at a real prompt, exiting with a client
attached, and reads and writes against a real server. Full suite: 863 pass, 10
skip, 3 fail. `scripts/run_linters.sh` clean.

Two failures are pre-existing and unrelated, confirmed with this branch's changes
stashed: `test_pydm_rogue_plugin.py` calls `object.__new__` on a class that
overrides it, which Python 3.14 rejects, and `test_epicsV7.py` needs `softioc`,
absent from `conda.yml`. The third,
`test_terminal_takes_focus_when_its_tab_is_selected`, is added here; it passes
alone and fails when the rest of its file runs in one process against a forwarded
X display, which points at Qt tests competing for focus rather than at the
widget. It skips in CI, which installs `pydm` but no Qt binding.
