### PR TITLE
Fix float display value parsing

### DIFF
--- a/python/pyrogue/_Variable.py
+++ b/python/pyrogue/_Variable.py
@@ -877,7 +877,7 @@ class BaseVariable(pr.Node):
         """
         try:
             if not isinstance(sValue,str):
-                return sValue
+                value = sValue
             elif self.nativeType is np.ndarray:
                 return np.array(ast.literal_eval(sValue),self._ndType)
             elif self.disp == 'enum':
@@ -885,7 +885,14 @@ class BaseVariable(pr.Node):
             elif self.nativeType is str:
                 return sValue
             else:
-                return ast.literal_eval(sValue)
+                value = ast.literal_eval(sValue)
+
+            if self.nativeType is float:
+                if isinstance(value, bool):
+                    raise ValueError('Boolean display values are not valid for float variables')
+                return float(value)
+
+            return value
 
         except Exception as e:
             msg = "Invalid value {} for variable {} with type {}: {}".format(sValue,self.name,self.nativeType,e)

--- a/tests/core/test_model_variables.py
+++ b/tests/core/test_model_variables.py
@@ -234,13 +234,20 @@ def test_local_variables_exercise_public_variable_api():
         root.Dev.LocalString.set("updated")
         root.Dev.LocalFloat.set(2.5)
 
+        # Display channels carry text. A whole-number entry still has to retain
+        # the target variable's float type after parsing.
+        root.Dev.LocalFloat.setDisp("10")
+        with pytest.raises(pr.VariableError, match="Boolean display values"):
+            root.Dev.LocalFloat.setDisp("True")
+
         assert root.Dev.LocalInt.get() == 12
         assert root.Dev.LocalInt.typeStr == "int"
         assert root.Dev.LocalBool.get() is True
         assert root.Dev.LocalBool.typeStr == "bool"
         assert root.Dev.LocalString.get() == "updated"
         assert root.Dev.LocalString.typeStr == "str"
-        assert root.Dev.LocalFloat.get() == 2.5
+        assert root.Dev.LocalFloat.get() == 10.0
+        assert type(root.Dev.LocalFloat.get()) is float
         assert root.Dev.LocalFloat.typeStr == "float"
 
 


### PR DESCRIPTION
### Description
Ensure float variables coerce display-parsed values to Python float, including whole-number input, and reject boolean display values instead of accepting them as numeric floats.

### Details
Added regression coverage for whole-number and boolean display input.

Validation:
- `tests/core/test_model_variables.py`: 8 passed
- Python compile checks passed for both changed files
- `git diff --check` passed